### PR TITLE
feat(theme): sync internal theme with the native one for the window

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "clsx": "^2.1.1",
     "electron-squirrel-startup": "^1.0.1",
     "lucide-react": "^0.511.0",
-    "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "7.56.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.1.0)
-      next-themes:
-        specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3577,12 +3574,6 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  next-themes@0.4.6:
-    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -8618,11 +8609,6 @@ snapshots:
   negotiator@0.6.4: {}
 
   neo-async@2.6.2: {}
-
-  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   nice-try@1.0.5: {}
 

--- a/src/common/components/theme/theme-toggle.tsx
+++ b/src/common/components/theme/theme-toggle.tsx
@@ -11,6 +11,14 @@ import { Sun, Moon, Monitor } from "lucide-react";
 export function ThemeToggle() {
   const { setTheme } = useTheme();
 
+  const handleThemeChange = async (theme: "light" | "dark" | "system") => {
+    try {
+      await setTheme(theme);
+    } catch (error) {
+      console.error("Failed to change theme:", error);
+    }
+  };
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -22,21 +30,21 @@ export function ThemeToggle() {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-24">
         <DropdownMenuItem
-          onClick={() => setTheme("light")}
+          onClick={() => handleThemeChange("light")}
           className="cursor-pointer"
         >
           <Sun className="size-4 mr-2" />
           Light
         </DropdownMenuItem>
         <DropdownMenuItem
-          onClick={() => setTheme("dark")}
+          onClick={() => handleThemeChange("dark")}
           className="cursor-pointer"
         >
           <Moon className="size-4 mr-2" />
           Dark
         </DropdownMenuItem>
         <DropdownMenuItem
-          onClick={() => setTheme("system")}
+          onClick={() => handleThemeChange("system")}
           className="cursor-pointer"
         >
           <Monitor className="size-4 mr-2" />

--- a/src/common/components/ui/sonner.tsx
+++ b/src/common/components/ui/sonner.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from "next-themes";
+import { useTheme } from "../../hooks/use-theme";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {

--- a/src/common/contexts/theme-context.tsx
+++ b/src/common/contexts/theme-context.tsx
@@ -4,12 +4,12 @@ export type Theme = "dark" | "light" | "system";
 
 type ThemeProviderState = {
   theme: Theme;
-  setTheme: (theme: Theme) => void;
+  setTheme: (theme: Theme) => Promise<void>;
 };
 
 const initialState: ThemeProviderState = {
   theme: "system",
-  setTheme: () => null,
+  setTheme: async () => {},
 };
 
 export const ThemeProviderContext =

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,7 @@
 }
 
 :root {
+  color-scheme: light dark;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Tray, ipcMain } from "electron";
+import { app, BrowserWindow, Tray, ipcMain, nativeTheme } from "electron";
 import path from "node:path";
 import { existsSync } from "node:fs";
 import started from "electron-squirrel-startup";
@@ -139,6 +139,36 @@ app.on("will-quit", () => {
   if (tray) {
     tray.destroy();
   }
+});
+
+// IPC handlers for theme management
+ipcMain.handle("dark-mode:toggle", () => {
+  if (nativeTheme.shouldUseDarkColors) {
+    nativeTheme.themeSource = "light";
+  } else {
+    nativeTheme.themeSource = "dark";
+  }
+  return nativeTheme.shouldUseDarkColors;
+});
+
+ipcMain.handle("dark-mode:system", () => {
+  nativeTheme.themeSource = "system";
+  return nativeTheme.shouldUseDarkColors;
+});
+
+ipcMain.handle(
+  "dark-mode:set",
+  (_event, theme: "light" | "dark" | "system") => {
+    nativeTheme.themeSource = theme;
+    return nativeTheme.shouldUseDarkColors;
+  },
+);
+
+ipcMain.handle("dark-mode:get", () => {
+  return {
+    shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
+    themeSource: nativeTheme.themeSource,
+  };
 });
 
 // IPC handlers for auto-launch management

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -17,6 +17,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // ToolHive port
   getToolhivePort: () => ipcRenderer.invoke("get-toolhive-port"),
+
+  // Theme management
+  darkMode: {
+    toggle: () => ipcRenderer.invoke("dark-mode:toggle"),
+    system: () => ipcRenderer.invoke("dark-mode:system"),
+    set: (theme: "light" | "dark" | "system") =>
+      ipcRenderer.invoke("dark-mode:set", theme),
+    get: () => ipcRenderer.invoke("dark-mode:get"),
+  },
 });
 
 // Type definitions for the exposed API
@@ -27,6 +36,15 @@ export interface ElectronAPI {
   hideApp: () => Promise<void>;
   quitApp: () => Promise<void>;
   getToolhivePort: () => Promise<number | undefined>;
+  darkMode: {
+    toggle: () => Promise<boolean>;
+    system: () => Promise<boolean>;
+    set: (theme: "light" | "dark" | "system") => Promise<boolean>;
+    get: () => Promise<{
+      shouldUseDarkColors: boolean;
+      themeSource: "system" | "light" | "dark";
+    }>;
+  };
 }
 
 declare global {


### PR DESCRIPTION
I was reading this [doc](https://www.electronjs.org/docs/latest/tutorial/dark-mode) and we should sync the internal theme with os theme native for window

https://github.com/user-attachments/assets/72a0a90f-0be3-4440-95cc-c5834fc3fe44

