### PR TITLE
fix(server details): tabs hover state color

### DIFF
--- a/src/features/mcp-servers/components/detail-mcp-server.tsx
+++ b/src/features/mcp-servers/components/detail-mcp-server.tsx
@@ -46,14 +46,14 @@ export function DetailMcpServer({
         <TabsList className="flex flex-col h-fit w-48 space-y-1 bg-transparent p-0 shrink-0">
           <TabsTrigger
             value="health"
-            className="w-full justify-start py-2 px-4 data-[state=active]:bg-gray-100 !shadow-none border-none hover:bg-gray-100 transition-colors cursor-pointer"
+            className="w-full justify-start py-2 px-4 !shadow-none border-none hover:bg-muted transition-colors cursor-pointer"
           >
             Health
           </TabsTrigger>
 
           <TabsTrigger
             value="description"
-            className="w-full justify-start py-2 px-4 data-[state=active]:bg-gray-100 !shadow-none border-none hover:bg-gray-100 transition-colors cursor-pointer"
+            className="w-full justify-start py-2 px-4 !shadow-none border-none hover:bg-muted transition-colors cursor-pointer"
           >
             Description
           </TabsTrigger>


### PR DESCRIPTION
Uses the `bg-muted` design token from shadcn/ui for the hover state of the tabs on the server details page.

### Before

https://github.com/user-attachments/assets/1c3d4f47-bd7e-40a2-b3a3-2868f3888bc4

### After

https://github.com/user-attachments/assets/54e4a511-7db8-466b-b561-9436478eea47

