### PR TITLE
fix: bin path for toolhive was not correct in dev

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -24,7 +24,6 @@ const binPath = app.isPackaged
       __dirname,
       "..",
       "..",
-      "..",
       "bin",
       `${process.platform}-${process.arch}`,
       binName,


### PR DESCRIPTION
The path comes from the Vite build, not from where main.ts is located, so we don’t need to change it.