### PR TITLE
chore: download thv bin based on constant version

### DIFF
--- a/utils/fetch-thv.ts
+++ b/utils/fetch-thv.ts
@@ -87,10 +87,7 @@ async function checkBinaryVersion(binPath: string): Promise<boolean> {
       latestTag
     )
     const constantThvVersion = normalizeVersion(TOOLHIVE_VERSION)
-    if (
-      isBinVersionOlder &&
-      constantThvVersion === normalizeVersion(currentBinVersion)
-    ) {
+    if (isBinVersionOlder) {
       console.log(
         `A new version of ToolHive is available: ${latestTag} (current binary: ${currentBinVersion})`
       )
@@ -99,7 +96,7 @@ async function checkBinaryVersion(binPath: string): Promise<boolean> {
       )
     }
     const shouldDownload =
-      isBinVersionOlder && constantThvVersion === normalizeVersion(latestTag)
+      constantThvVersion !== normalizeVersion(currentBinVersion)
     return shouldDownload
   } catch {
     return true


### PR DESCRIPTION
There are 3 use cases:
**Missing binary**
Download TOOLHIVE_VERSION constant
 <img width="603" alt="Screenshot 2025-06-10 at 13 21 05" src="https://github.com/user-attachments/assets/0776fd04-488d-433f-83b6-b8fc392a7993" />

**Thv bin exist**
The thv binary version is older than latest one + TOOLHIVE_VERSION equal to thv bin version.
Show log about new version, without downloading the new version
<img width="586" alt="Screenshot 2025-06-10 at 13 21 29" src="https://github.com/user-attachments/assets/af5e4655-81e3-44a5-85ab-b036b1e6fcc2" />

thv binary version older than latest one and  TOOLHIVE_VERSION  > bin one 
Download the TOOLHIVE_VERSION



