### PR TITLE
chore: rename repo

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -38,7 +38,7 @@ const config: ForgeConfig = {
       config: {
         repository: {
           owner: 'StacklokLabs',
-          name: 'toolhive-react',
+          name: 'toolhive-studio',
         },
         draft: false,
         prerelease: false,


### PR DESCRIPTION
Tidies up out-of-date reference to `toolhive-react`