### PR TITLE
fix(workload-status): handle properly stopped action status

### DIFF
--- a/renderer/src/features/mcp-servers/components/actions-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/actions-mcp-server.tsx
@@ -8,6 +8,7 @@ function getStatusText(status: WorkloadsWorkload['status']) {
   if (status === 'restarting') return 'Restarting'
   if (status === 'starting') return 'Starting'
   if (status === 'stopped') return 'Stopped'
+  if (status === 'stopping') return 'Stopping'
   return 'Unknown'
 }
 


### PR DESCRIPTION
Until we don't have a clear enum map in BE for mcp status, we can use optmistic approach for handle the `stopping` status.


**Mcp server detail page**

https://github.com/user-attachments/assets/67d5f1a7-df05-4658-87c2-066c90371180

**Mcp server list**

https://github.com/user-attachments/assets/c8ed532b-76be-4bec-b7c2-619726c9657e



