### PR TITLE
fix(tray-icon): refactor and adjust win32 click

### DIFF
--- a/main/src/system-tray.ts
+++ b/main/src/system-tray.ts
@@ -75,7 +75,11 @@ const createTrayWithSetup =
     }
   }
 
-export const initTray = createTrayWithSetup(setupTrayMenu)
+export const initTray = ({
+  toolHiveIsRunning,
+}: {
+  toolHiveIsRunning: boolean
+}) => createTrayWithSetup(setupTrayMenu)(toolHiveIsRunning)
 
 const getMainWindow = () => BrowserWindow.getAllWindows()[0]
 


### PR DESCRIPTION
## Fix Windows tray icon flickering and refactor to functional composition

**Problem:** Clicking the Windows system tray icon caused the window to rapidly show/hide, creating a flickering effect due to multiple rapid click events being fired.

**Solution:** 
- Implemented debounced click handling with state tracking to prevent rapid show/hide cycles
- Added proper timing delays for Windows `setAlwaysOnTop` calls to avoid visual flickering
- Refactored system tray code to use functional composition with pure functions and higher-order functions for better maintainability

**Changes:**
- Fixed tray click handler to use stored state instead of current window state
- Added 300ms click debouncing to ignore rapid successive events  
- Separated `setAlwaysOnTop` calls across event loop ticks using `setTimeout`
- Refactored into composable functions: menu factories, window operations, and click handlers

The tray icon now reliably toggles window visibility on single clicks without flickering

https://github.com/user-attachments/assets/37d107f2-c8b2-4650-99e4-da490773c4fd

