### PR TITLE
fix: scale down root font size by 10%

### DIFF
--- a/renderer/src/index.css
+++ b/renderer/src/index.css
@@ -42,6 +42,7 @@
 }
 
 :root {
+  font-size: 14.4px; /* 90% of 16px, scales down the entire app as everything is calculated in rem units */
   color-scheme: light dark;
   --radius: 0.625rem;
   --background: oklch(1 0 0);


### PR DESCRIPTION
Changes the root font-size to 14.4px.
As everything is calculated in rem units, this decreases the size of UI elements across-the-board.
This isn't a panacea for all of our UI issues (see #232) but it should help.


### Before

<img width="1258" alt="Screenshot 2025-06-19 at 4 08 50 PM" src="https://github.com/user-attachments/assets/087a8363-bccb-464d-884a-0c937fc6d54e" />

### After

<img width="1258" alt="Screenshot 2025-06-19 at 4 09 13 PM" src="https://github.com/user-attachments/assets/1667b04b-163f-4ca2-9aaa-6a49384c6995" />


