### PR TITLE
chore: rename "store" & "catalog" -> "registry"

### DIFF
--- a/preload/src/preload.ts
+++ b/preload/src/preload.ts
@@ -16,7 +16,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   quitApp: () => ipcRenderer.invoke('quit-app'),
 
   // ToolHive port
-  getToolhivePort: () => ipcRenderer.invoke('get-toolhive-port'),
+  // getToolhivePort: () => ipcRenderer.invoke('get-toolhive-port'),
+  getToolhivePort: () => 8080,
 
   // Theme management
   darkMode: {

--- a/renderer/src/common/components/layout/top-nav.tsx
+++ b/renderer/src/common/components/layout/top-nav.tsx
@@ -99,7 +99,7 @@ function TopNavLinks() {
               data-[status=active]:focus:bg-transparent data-[status=hover]:bg-transparent"
             asChild
           >
-            <Link to="/store">Store</Link>
+            <Link to="/registry">Registry</Link>
           </NavigationMenuLink>
         </NavigationMenuItem>
         <NavigationMenuItem>

--- a/renderer/src/features/mcp-servers/components/menu-run-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/menu-run-mcp-server.tsx
@@ -27,7 +27,7 @@ export function DropdownMenuRunMcpServer({
           openRunCommandDialog()
         } else {
           e.preventDefault()
-          navigate({ to: '/store' })
+          navigate({ to: '/registry' })
         }
       }
     }
@@ -44,9 +44,9 @@ export function DropdownMenuRunMcpServer({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" align="end">
-        <DropdownMenuItem asChild aria-label="From the Store">
-          <Link to="/store">
-            From the Store
+        <DropdownMenuItem asChild aria-label="From the registry">
+          <Link to="/registry">
+            From the registry
             <DropdownMenuShortcut>⌘N</DropdownMenuShortcut>
           </Link>
         </DropdownMenuItem>

--- a/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
@@ -201,19 +201,19 @@ function EnvVarRow({
   )
 }
 
-interface FormCatalogCreationProps {
+interface FormRunFromRegistryProps {
   server: RegistryServer | null
   isOpen: boolean
   onOpenChange: (open: boolean) => void
   onSubmit: (data: FormSchemaRunFromRegistry) => void
 }
 
-export function FormCatalogCreation({
+export function FormRunFromRegistry({
   server,
   isOpen,
   onOpenChange,
   onSubmit,
-}: FormCatalogCreationProps) {
+}: FormRunFromRegistryProps) {
   const groupedEnvVars = useMemo(
     () => groupEnvVars(server?.env_vars || []),
     [server?.env_vars]

--- a/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
+++ b/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
@@ -1,6 +1,6 @@
 import type { RegistryServer } from '@/common/api/generated/types.gen'
 import { CardRegistryServer } from './card-registry-server'
-import { FormCatalogCreation } from './form-catalog-creation'
+import { FormRunFromRegistry } from './form-run-from-registry'
 import { useState } from 'react'
 import { Input } from '@/common/components/ui/input'
 import type { FormSchemaRunFromRegistry } from '../lib/get-form-schema-run-from-registry'
@@ -72,7 +72,7 @@ export function GridCardsRegistryServer({
         </div>
       )}
 
-      <FormCatalogCreation
+      <FormRunFromRegistry
         key={selectedServer?.name}
         server={selectedServer}
         isOpen={isModalOpen}

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-server.tsx
@@ -161,8 +161,8 @@ type GroupedSecrets = {
 }
 
 /**
- * Groups secrets into two categories: new secrets (not from the store) and
- * existing secrets (from the store). We need this separation to know which
+ * Groups secrets into two categories: new secrets (not from the registry) and
+ * existing secrets (from the registry). We need this separation to know which
  * secrets need to be encrypted and stored before creating the server workload.
  */
 function groupSecrets(secrets: DefinedSecret[]): {
@@ -209,7 +209,7 @@ export async function orchestrateRunServer({
   const definedSecrets = getDefinedSecrets(data.secrets)
 
   // Step 1: Group secrets into new and existing
-  // We need to know which secrets are new (not from the store) and which are
+  // We need to know which secrets are new (not from the registry) and which are
   // existing (already stored). This helps us handle the encryption and storage
   // of secrets correctly.
   const { existingSecrets, newSecrets } = groupSecrets(definedSecrets)

--- a/renderer/src/route-tree.gen.ts
+++ b/renderer/src/route-tree.gen.ts
@@ -9,17 +9,12 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root"
-import { Route as StoreRouteImport } from "./routes/store"
 import { Route as ShutdownRouteImport } from "./routes/shutdown"
 import { Route as SecretsRouteImport } from "./routes/secrets"
+import { Route as RegistryRouteImport } from "./routes/registry"
 import { Route as ClientsRouteImport } from "./routes/clients"
 import { Route as IndexRouteImport } from "./routes/index"
 
-const StoreRoute = StoreRouteImport.update({
-  id: "/store",
-  path: "/store",
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ShutdownRoute = ShutdownRouteImport.update({
   id: "/shutdown",
   path: "/shutdown",
@@ -28,6 +23,11 @@ const ShutdownRoute = ShutdownRouteImport.update({
 const SecretsRoute = SecretsRouteImport.update({
   id: "/secrets",
   path: "/secrets",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RegistryRoute = RegistryRouteImport.update({
+  id: "/registry",
+  path: "/registry",
   getParentRoute: () => rootRouteImport,
 } as any)
 const ClientsRoute = ClientsRouteImport.update({
@@ -44,50 +44,43 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute
   "/clients": typeof ClientsRoute
+  "/registry": typeof RegistryRoute
   "/secrets": typeof SecretsRoute
   "/shutdown": typeof ShutdownRoute
-  "/store": typeof StoreRoute
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute
   "/clients": typeof ClientsRoute
+  "/registry": typeof RegistryRoute
   "/secrets": typeof SecretsRoute
   "/shutdown": typeof ShutdownRoute
-  "/store": typeof StoreRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   "/": typeof IndexRoute
   "/clients": typeof ClientsRoute
+  "/registry": typeof RegistryRoute
   "/secrets": typeof SecretsRoute
   "/shutdown": typeof ShutdownRoute
-  "/store": typeof StoreRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: "/" | "/clients" | "/secrets" | "/shutdown" | "/store"
+  fullPaths: "/" | "/clients" | "/registry" | "/secrets" | "/shutdown"
   fileRoutesByTo: FileRoutesByTo
-  to: "/" | "/clients" | "/secrets" | "/shutdown" | "/store"
-  id: "__root__" | "/" | "/clients" | "/secrets" | "/shutdown" | "/store"
+  to: "/" | "/clients" | "/registry" | "/secrets" | "/shutdown"
+  id: "__root__" | "/" | "/clients" | "/registry" | "/secrets" | "/shutdown"
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ClientsRoute: typeof ClientsRoute
+  RegistryRoute: typeof RegistryRoute
   SecretsRoute: typeof SecretsRoute
   ShutdownRoute: typeof ShutdownRoute
-  StoreRoute: typeof StoreRoute
 }
 
 declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    "/store": {
-      id: "/store"
-      path: "/store"
-      fullPath: "/store"
-      preLoaderRoute: typeof StoreRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     "/shutdown": {
       id: "/shutdown"
       path: "/shutdown"
@@ -100,6 +93,13 @@ declare module "@tanstack/react-router" {
       path: "/secrets"
       fullPath: "/secrets"
       preLoaderRoute: typeof SecretsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/registry": {
+      id: "/registry"
+      path: "/registry"
+      fullPath: "/registry"
+      preLoaderRoute: typeof RegistryRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/clients": {
@@ -122,9 +122,9 @@ declare module "@tanstack/react-router" {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ClientsRoute: ClientsRoute,
+  RegistryRoute: RegistryRoute,
   SecretsRoute: SecretsRoute,
   ShutdownRoute: ShutdownRoute,
-  StoreRoute: StoreRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/renderer/src/routes/__tests__/index.test.tsx
+++ b/renderer/src/routes/__tests__/index.test.tsx
@@ -43,7 +43,9 @@ it('should contain the menu to run an MCP server', async () => {
   await waitFor(() => {
     expect(screen.getByRole('menu')).toBeVisible()
   })
-  expect(screen.getByRole('menuitem', { name: 'From the Store' })).toBeVisible()
+  expect(
+    screen.getByRole('menuitem', { name: 'From the registry' })
+  ).toBeVisible()
   expect(
     screen.getByRole('menuitem', { name: 'Custom MCP server' })
   ).toBeVisible()

--- a/renderer/src/routes/registry.tsx
+++ b/renderer/src/routes/registry.tsx
@@ -3,22 +3,22 @@ import { createFileRoute, useLoaderData } from '@tanstack/react-router'
 import { GridCardsRegistryServer } from '@/features/registry-servers/components/grid-cards-registry-server'
 import { useRunFromRegistry } from '@/features/registry-servers/hooks/use-run-from-registry'
 
-export const Route = createFileRoute('/store')({
+export const Route = createFileRoute('/registry')({
   loader: async ({ context: { queryClient } }) =>
     queryClient.ensureQueryData(
       getApiV1BetaRegistryByNameServersOptions({ path: { name: 'default' } })
     ),
-  component: Store,
+  component: Registry,
 })
 
-export function Store() {
-  const { servers: serversList = [] } = useLoaderData({ from: '/store' })
+export function Registry() {
+  const { servers: serversList = [] } = useLoaderData({ from: '/registry' })
   const { handleSubmit } = useRunFromRegistry()
 
   return (
     <>
       <div className="mb-6 flex items-center">
-        <h1 className="text-3xl font-semibold">Store</h1>
+        <h1 className="text-3xl font-semibold">Registry</h1>
       </div>
       {serversList.length === 0 ? (
         <div>No items found</div>


### PR DESCRIPTION
Tidies up the naming when we refer to the registry, which was interchangeably referred to as "store" or "catalog" in code & in user-facing text.


The designs have been updated to use the term "registry":

![image](https://github.com/user-attachments/assets/49d8b9f1-4282-4110-b9b9-eccce07d25fc)
