### PR TITLE
feat: add refresh button to index page

### DIFF
--- a/renderer/src/common/components/refresh-button.tsx
+++ b/renderer/src/common/components/refresh-button.tsx
@@ -1,0 +1,56 @@
+import { RefreshCwIcon } from 'lucide-react'
+import { cn } from '../lib/utils'
+import { Button } from './ui/button'
+import { useState, useEffect } from 'react'
+
+/**
+ * A custom hook that resets a boolean value after a specified delay.
+ */
+const useDelayedReset = (initialValue = false, delayMs = 1000) => {
+  const [value, setValue] = useState<boolean>(initialValue)
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | undefined
+
+    if (value) {
+      timeoutId = setTimeout(() => {
+        setValue(false)
+      }, delayMs)
+    }
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+    }
+  }, [value, delayMs])
+
+  return [value, setValue] as const
+}
+
+export function RefreshButton({
+  refresh,
+  className,
+}: {
+  refresh: () => void
+  className?: string
+}) {
+  const [isAnimating, setIsAnimating] = useDelayedReset(false, 500)
+
+  function handleRefresh() {
+    refresh()
+    setIsAnimating(true)
+  }
+
+  return (
+    <Button
+      className={cn('text-muted-foreground', className)}
+      variant="ghost"
+      size="icon"
+      type="button"
+      onClick={() => handleRefresh()}
+    >
+      <RefreshCwIcon className={isAnimating ? 'animate-spin' : ''} />
+    </Button>
+  )
+}

--- a/renderer/src/common/components/secrets/form-combobox-secrets-store.tsx
+++ b/renderer/src/common/components/secrets/form-combobox-secrets-store.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, RefreshCwIcon } from 'lucide-react'
+import { Check, ChevronDown } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import type { FieldValues, Path, UseFormReturn } from 'react-hook-form'
@@ -14,7 +14,7 @@ import {
 import { cn } from '@/common/lib/utils'
 import { useQuery } from '@tanstack/react-query'
 import { getApiV1BetaSecretsDefaultKeysOptions } from '@/common/api/generated/@tanstack/react-query.gen'
-import { useEffect, useState } from 'react'
+import { RefreshButton } from '../refresh-button'
 
 type ConstrainedFieldValues = FieldValues & {
   secrets: {
@@ -27,31 +27,6 @@ type ConstrainedFieldValues = FieldValues & {
 }
 
 /**
- * A custom hook that resets a boolean value after a specified delay.
- */
-const useDelayedReset = (initialValue = false, delayMs = 1000) => {
-  const [value, setValue] = useState<boolean>(initialValue)
-
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout | undefined
-
-    if (value) {
-      timeoutId = setTimeout(() => {
-        setValue(false)
-      }, delayMs)
-    }
-
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId)
-      }
-    }
-  }, [value, delayMs])
-
-  return [value, setValue] as const
-}
-
-/**
  * A combobox for selecting a secret from the secret store.
  * NOTE: This component expects that the form has a field named `secrets` which
  * is an array of objects with a `key` & `value` property.
@@ -60,13 +35,6 @@ export function FormComboboxSecretStore<
   T extends ConstrainedFieldValues = ConstrainedFieldValues,
 >({ form, name }: { form: UseFormReturn<T>; name: Path<T> }) {
   const { data, refetch } = useQuery(getApiV1BetaSecretsDefaultKeysOptions())
-
-  const [isAnimating, setIsAnimating] = useDelayedReset(false, 500)
-
-  function handleRefresh() {
-    refetch()
-    setIsAnimating(true)
-  }
 
   return (
     <FormField
@@ -104,16 +72,7 @@ export function FormComboboxSecretStore<
                     className="ml-auto flex size-9 shrink-0 grow-0 items-center justify-center self-end
                       border-b"
                   >
-                    <Button
-                      className={cn('text-muted-foreground size-7')}
-                      variant="ghost"
-                      type="button"
-                      onClick={() => handleRefresh()}
-                    >
-                      <RefreshCwIcon
-                        className={isAnimating ? 'animate-spin' : ''}
-                      />
-                    </Button>
+                    <RefreshButton refresh={refetch} className="size-7" />
                   </div>
                 </div>
                 <CommandList>

--- a/renderer/src/routes/index.tsx
+++ b/renderer/src/routes/index.tsx
@@ -4,6 +4,7 @@ import {
   getApiV1BetaWorkloadsQueryKey,
   getApiV1BetaWorkloadsByNameOptions,
 } from '@/common/api/generated/@tanstack/react-query.gen'
+import { RefreshButton } from '@/common/components/refresh-button'
 import { useToastMutation } from '@/common/hooks/use-toast-mutation'
 import { pollServerStatus } from '@/common/lib/polling'
 import { DialogFormRunMcpServerWithCommand } from '@/features/mcp-servers/components/dialog-form-run-mcp-command'
@@ -22,7 +23,7 @@ export const Route = createFileRoute('/')({
 })
 
 export function Index() {
-  const { data } = useSuspenseQuery({
+  const { data, refetch } = useSuspenseQuery({
     ...getApiV1BetaWorkloadsOptions({ query: { all: true } }),
   })
   const workloads = data?.workloads ?? []
@@ -34,10 +35,12 @@ export function Index() {
     <>
       <div className="mb-6 flex items-center">
         <h1 className="text-3xl font-semibold">Installed</h1>
-        <DropdownMenuRunMcpServer
-          openRunCommandDialog={() => setIsRunWithCommandOpen(true)}
-          className="ml-auto"
-        />
+        <div className="ml-auto flex gap-2">
+          <RefreshButton refresh={refetch} />
+          <DropdownMenuRunMcpServer
+            openRunCommandDialog={() => setIsRunWithCommandOpen(true)}
+          />
+        </div>
         <DialogFormRunMcpServerWithCommand
           isOpen={isRunWithCommandOpen}
           onOpenChange={setIsRunWithCommandOpen}


### PR DESCRIPTION
A straightforward feature that addresses the problem in [[Task] Auto-refresh UI on server status change](https://github.com/StacklokLabs/toolhive-studio/issues/28)

Closes #28 

https://github.com/user-attachments/assets/98862473-746f-4112-a22f-ae64525fdc52

