### PR TITLE
refactor(electron): single instance enforcement and CSP adjustment for sentry

### DIFF
--- a/main/src/csp.ts
+++ b/main/src/csp.ts
@@ -1,22 +1,29 @@
-const getCspMap = (port: number) => ({
-  'default-src': "'self'",
-  'script-src': "'self'",
-  'style-src': "'self' 'unsafe-inline'",
-  'img-src': "'self' data: blob:",
-  'font-src': "'self' data:",
-  'connect-src': `'self' http://localhost:${port}`,
-  'frame-src': "'none'",
-  'object-src': "'none'",
-  'base-uri': "'self'",
-  'form-action': "'self'",
-  'frame-ancestors': "'none'",
-  'manifest-src': "'self'",
-  'media-src': "'self' blob: data:",
-  'worker-src': "'self'",
-  'child-src': "'none'",
-})
+const getCspMap = (port: number, sentryDsn?: string) => {
+  // In production with Sentry enabled, allow blob workers for replay
+  const hasSentry = Boolean(sentryDsn)
+  const workerSrc = hasSentry ? "'self' blob:" : "'self'"
 
-export const getCspString = (port: number) =>
-  Object.entries(getCspMap(port))
+  return {
+    'default-src': "'self'",
+    'script-src': "'self'",
+    'style-src': "'self' 'unsafe-inline'",
+    'img-src': "'self' data: blob:",
+    'font-src': "'self' data:",
+    'connect-src': `'self' http://localhost:${port}${hasSentry ? ' https://*.sentry.io' : ''}`,
+    'frame-src': "'none'",
+    'object-src': "'none'",
+    'base-uri': "'self'",
+    'form-action': "'self'",
+    'frame-ancestors': "'none'",
+    'manifest-src': "'self'",
+    'media-src': "'self' blob: data:",
+    // Allow blob: workers only when Sentry is configured
+    'worker-src': workerSrc,
+    'child-src': "'none'",
+  }
+}
+
+export const getCspString = (port: number, sentryDsn?: string) =>
+  Object.entries(getCspMap(port, sentryDsn))
     .map(([key, value]) => `${key} ${value}`)
     .join('; ')


### PR DESCRIPTION
- Fix CSP worker-src policy to allow blob workers for Sentry integration (I need to test in the final build=
- Add single instance enforcement to prevent multiple app conflicts
- Improve ToolHive process management to prevent orphaned processes
- Remove process.unref() to ensure proper cleanup on app exit

Fixes issues where production .exe had CSP violations and multiple instances caused port conflicts and connection refused errors