### PR TITLE
fix: on linux, auto start is broken when path has spaces

### DIFF
--- a/main/src/auto-launch.ts
+++ b/main/src/auto-launch.ts
@@ -13,11 +13,11 @@ interface DesktopEntry {
   Comment: string
 }
 
-function createDesktopEntry(execPath: string): string {
+export function createDesktopEntry(execPath: string): string {
   const entry: DesktopEntry = {
     Type: 'Application',
     Name: 'ToolHive Studio',
-    Exec: `${execPath} --hidden`,
+    Exec: `"${execPath}" --hidden`,
     Hidden: 'false',
     NoDisplay: 'false',
     'X-GNOME-Autostart-enabled': 'true',

--- a/main/src/tests/auto-launch.test.ts
+++ b/main/src/tests/auto-launch.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { createDesktopEntry } from '../auto-launch'
+
+describe('Linux desktop-entry generation', () => {
+  it('quotes the Exec path when it contains spaces', () => {
+    // context: https://stacklok.slack.com/archives/C072SGY78TS/p1750688399690469?thread_ts=1750674636.806059&cid=C072SGY78TS
+    const execPath = '/home/alice/My Apps/Tool Hive/toolhive-studio'
+
+    const entry = createDesktopEntry(execPath)
+
+    expect(entry).toContain(
+      `Exec="/home/alice/My Apps/Tool Hive/toolhive-studio" --hidden`
+    )
+  })
+})


### PR DESCRIPTION
see: https://stacklok.slack.com/archives/C072SGY78TS/p1750688399690469?thread_ts=1750674636.806059&cid=C072SGY78TS