### PR TITLE
fix(top-nav): adjust padding for windows

### DIFF
--- a/renderer/src/common/components/layout/top-nav.tsx
+++ b/renderer/src/common/components/layout/top-nav.tsx
@@ -19,7 +19,7 @@ import { isFeatureEnabled } from '@/feature-flags'
 function getPlatformSpecificHeaderClasses() {
   const platformClasses = {
     darwin: 'pl-26', // Left padding for traffic light buttons
-    win32: 'pr-7', // Right padding for visual spacing with window edge
+    win32: 'pr-2', // Right padding for visual spacing with window edge
     linux: '', // No padding needed - custom controls are part of the layout
   }
 


### PR DESCRIPTION
visually align the `x` instead of the entire button with padding and the padding

before:
![Screenshot 2025-06-23 174330](https://github.com/user-attachments/assets/a541ed30-1943-4573-9895-dfac263e64c9)


after:
![Screenshot 2025-06-23 174456](https://github.com/user-attachments/assets/7184a43e-5663-40be-9333-9ea8e24c27ae)
