### PR TITLE
fix: wait toolhive cmd before creating the window

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -228,8 +228,8 @@ function createWindow() {
 
 let mainWindow: BrowserWindow | null = null
 
-app.on('ready', () => {
-  startToolhive()
+app.on('ready', async () => {
+  await startToolhive()
   mainWindow = createWindow()
 })
 


### PR DESCRIPTION
At application startup, the thv command and window creation were starting together. The thv command was asynchronously finding an available port, which led to a first batch of API calls failing with connection errors because the API wasn’t available yet. With this change, we now wait to execute the command before creating the window