### PR TITLE
fix: modal close button

### DIFF
--- a/renderer/src/common/components/ui/dialog.tsx
+++ b/renderer/src/common/components/ui/dialog.tsx
@@ -62,10 +62,10 @@ function DialogContent({
         className={cn(
           `bg-background data-[state=open]:animate-in data-[state=closed]:animate-out
           data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
-          data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%]
-          left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%]
-          translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200
-          sm:max-w-lg`,
+          data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 app-region-no-drag
+          fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)]
+          translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg
+          duration-200 sm:max-w-lg`,
           className
         )}
         {...props}


### PR DESCRIPTION
adds `app-region-no-drag` to the `DialogContent` component so that it's content continues to be clickable when it overlays the nav.