### PR TITLE
fix: prevent running workloads with duplicate names

### DIFF
--- a/renderer/src/features/mcp-servers/components/dialog-form-run-mcp-command.tsx
+++ b/renderer/src/features/mcp-servers/components/dialog-form-run-mcp-command.tsx
@@ -1,6 +1,6 @@
 import { Form } from '@/common/components/ui/form'
 import {
-  formSchemaRunMcpCommand,
+  getFormSchemaRunMcpCommand,
   type FormSchemaRunMcpCommand,
 } from '../lib/form-schema-run-mcp-server-with-command'
 import { useForm } from 'react-hook-form'
@@ -18,6 +18,8 @@ import { Button } from '@/common/components/ui/button'
 import { zodV4Resolver } from '@/common/lib/zod-v4-resolver'
 import { FormFieldsArrayCustomEnvVars } from './form-fields-array-custom-env-vars'
 import { FormFieldsArrayCustomSecrets } from './form-fields-array-custom-secrets'
+import { useQuery } from '@tanstack/react-query'
+import { getApiV1BetaWorkloadsOptions } from '@/common/api/generated/@tanstack/react-query.gen'
 
 export function DialogFormRunMcpServerWithCommand({
   onSubmit,
@@ -28,8 +30,14 @@ export function DialogFormRunMcpServerWithCommand({
   isOpen: boolean
   onOpenChange: (open: boolean) => void
 }) {
+  const { data } = useQuery({
+    ...getApiV1BetaWorkloadsOptions({ query: { all: true } }),
+  })
+
+  const workloads = data?.workloads ?? []
+
   const form = useForm<FormSchemaRunMcpCommand>({
-    resolver: zodV4Resolver(formSchemaRunMcpCommand),
+    resolver: zodV4Resolver(getFormSchemaRunMcpCommand(workloads)),
     defaultValues: {
       type: 'docker_image',
     },

--- a/renderer/src/features/mcp-servers/lib/__tests__/form-schema-run-mcp-server-with-command.test.ts
+++ b/renderer/src/features/mcp-servers/lib/__tests__/form-schema-run-mcp-server-with-command.test.ts
@@ -1,5 +1,5 @@
 import { it, expect } from 'vitest'
-import { formSchemaRunMcpCommand } from '../form-schema-run-mcp-server-with-command'
+import { getFormSchemaRunMcpCommand } from '../form-schema-run-mcp-server-with-command'
 
 it('passes with valid docker image', () => {
   const validInput = {
@@ -20,7 +20,7 @@ it('passes with valid docker image', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(validInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(validInput)
   expect(result.success, `${result.error}`).toBe(true)
   expect(result.data).toStrictEqual({
     name: 'github',
@@ -66,7 +66,7 @@ it('passes with valid npx command', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(validInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(validInput)
   expect(result.success, `${result.error}`).toBe(true)
   expect(result.data).toStrictEqual({
     name: 'server-everything',
@@ -108,7 +108,7 @@ it('passes with valid uvx command', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(validInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(validInput)
   expect(result.success, `${result.error}`).toBe(true)
   // NOTE: cmd_arguments is transformed to an array
   expect(result.data).toStrictEqual({
@@ -150,11 +150,42 @@ it('fails when name is empty', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
         name: ['Name is required'],
+      }),
+    })
+  )
+})
+
+it('fails when name is not unique', () => {
+  const invalidInput = {
+    name: 'foo-bar',
+    transport: 'stdio',
+    type: 'docker_image',
+    image: 'ghcr.io/github/github-mcp-server',
+    cmd_arguments: '-y --oauth-setup',
+    envVars: [{ name: 'GITHUB_ORG', value: 'StacklokLabs' }],
+    secrets: [
+      {
+        name: 'GITHUB_PERSONAL_ACCESS_TOKEN',
+        value: {
+          secret: 'foo-bar',
+          isFromStore: false,
+        },
+      },
+    ],
+  }
+
+  const result = getFormSchemaRunMcpCommand([{ name: 'foo-bar' }]).safeParse(
+    invalidInput
+  )
+  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+    expect.objectContaining({
+      fieldErrors: expect.objectContaining({
+        name: ['This name is already in use'],
       }),
     })
   )
@@ -179,7 +210,7 @@ it('fails when transport is empty', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -208,7 +239,7 @@ it('fails when transport is invalid', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -237,7 +268,7 @@ it('fails when type is empty', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -266,7 +297,7 @@ it('fails when type is invalid', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -285,7 +316,7 @@ it('fails when envVars is missing name', () => {
     cmd_arguments: '-y --oauth-setup',
     envVars: [{ value: 'some-value' }], // Missing name
   }
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -305,7 +336,7 @@ it('fails when envVars is missing value', () => {
     envVars: [{ name: 'SOME_KEY' }], // Missing value
     secrets: [],
   }
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -324,7 +355,7 @@ it('fails when secrets is missing', () => {
     cmd_arguments: '-y --oauth-setup',
     envVars: [{ name: 'GITHUB_ORG', value: 'StacklokLabs' }],
   }
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -344,7 +375,7 @@ it('fails when secrets is missing key', () => {
     envVars: [{ name: 'GITHUB_ORG', value: 'StacklokLabs' }],
     secrets: [{ value: { secret: 'foo-bar', isFromStore: false } }],
   }
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -364,7 +395,7 @@ it('fails when secrets is missing value', () => {
     envVars: [{ name: 'GITHUB_ORG', value: 'StacklokLabs' }],
     secrets: [{ name: 'GITHUB_PERSONAL_ACCESS_TOKEN' }], // Missing value
   }
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -391,7 +422,7 @@ it('fails when secrets is missing inner secret value', () => {
       },
     ],
   }
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -418,7 +449,7 @@ it('fails when secrets is missing `isFromStore`', () => {
       },
     ],
   }
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -447,7 +478,7 @@ it('docker > fails when image is empty', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -477,7 +508,7 @@ it('package_manager > fails when protocol is empty', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -507,7 +538,7 @@ it('package_manager > fails when protocol is invalid', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({
@@ -537,7 +568,7 @@ it('package_manager > fails when package_name is empty', () => {
     ],
   }
 
-  const result = formSchemaRunMcpCommand.safeParse(invalidInput)
+  const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
   expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
     expect.objectContaining({
       fieldErrors: expect.objectContaining({

--- a/renderer/src/features/mcp-servers/lib/form-schema-run-mcp-server-with-command.ts
+++ b/renderer/src/features/mcp-servers/lib/form-schema-run-mcp-server-with-command.ts
@@ -1,44 +1,55 @@
+import type { WorkloadsWorkload } from '@/common/api/generated'
 import z from 'zod/v4'
 
-const commonFields = z.object({
-  name: z.string().nonempty('Name is required'),
-  transport: z.union(
-    [z.literal('sse'), z.literal('stdio')],
-    'Please select either SSE or stdio.'
-  ),
-  cmd_arguments: z.string().optional(),
-  envVars: z
-    .object({
-      name: z.string().nonempty('Name is required'),
-      value: z.string().nonempty('Value is required'),
-    })
-    .array(),
-  secrets: z
-    .object({
-      name: z.string().nonempty('Name is required'),
-      value: z.object({
-        secret: z.string().nonempty('Value is required'),
-        isFromStore: z.boolean(),
-      }),
-    })
-    .array(),
-})
-
-export const formSchemaRunMcpCommand = z.discriminatedUnion('type', [
+const getCommonFields = (workloads: WorkloadsWorkload[]) =>
   z.object({
-    type: z.literal('docker_image'),
-    image: z.string().nonempty('Docker image is required'),
-    ...commonFields.shape,
-  }),
-  z.object({
-    type: z.literal('package_manager'),
-    protocol: z.union(
-      [z.literal('npx'), z.literal('uvx'), z.literal('go')],
-      'Please select either npx, uvx, or go.'
+    name: z
+      .string()
+      .nonempty('Name is required')
+      .refine(
+        (value) => !workloads.some((w) => w.name === value),
+        'This name is already in use'
+      ),
+    transport: z.union(
+      [z.literal('sse'), z.literal('stdio')],
+      'Please select either SSE or stdio.'
     ),
-    package_name: z.string().nonempty('Package name is required'),
-    ...commonFields.shape,
-  }),
-])
+    cmd_arguments: z.string().optional(),
+    envVars: z
+      .object({
+        name: z.string().nonempty('Name is required'),
+        value: z.string().nonempty('Value is required'),
+      })
+      .array(),
+    secrets: z
+      .object({
+        name: z.string().nonempty('Name is required'),
+        value: z.object({
+          secret: z.string().nonempty('Value is required'),
+          isFromStore: z.boolean(),
+        }),
+      })
+      .array(),
+  })
 
-export type FormSchemaRunMcpCommand = z.infer<typeof formSchemaRunMcpCommand>
+export const getFormSchemaRunMcpCommand = (workloads: WorkloadsWorkload[]) =>
+  z.discriminatedUnion('type', [
+    z.object({
+      type: z.literal('docker_image'),
+      image: z.string().nonempty('Docker image is required'),
+      ...getCommonFields(workloads).shape,
+    }),
+    z.object({
+      type: z.literal('package_manager'),
+      protocol: z.union(
+        [z.literal('npx'), z.literal('uvx'), z.literal('go')],
+        'Please select either npx, uvx, or go.'
+      ),
+      package_name: z.string().nonempty('Package name is required'),
+      ...getCommonFields(workloads).shape,
+    }),
+  ])
+
+export type FormSchemaRunMcpCommand = z.infer<
+  ReturnType<typeof getFormSchemaRunMcpCommand>
+>

--- a/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
@@ -38,6 +38,8 @@ import {
   type FormSchemaRunFromRegistry,
 } from '../lib/get-form-schema-run-from-registry'
 import { FormComboboxSecretStore } from '@/common/components/secrets/form-combobox-secrets-store'
+import { useQuery } from '@tanstack/react-query'
+import { getApiV1BetaWorkloadsOptions } from '@/common/api/generated/@tanstack/react-query.gen'
 
 /**
  * Renders an asterisk icon & tooltip for required fields.
@@ -218,9 +220,19 @@ export function FormRunFromRegistry({
     () => groupEnvVars(server?.env_vars || []),
     [server?.env_vars]
   )
+
+  const { data } = useQuery({
+    ...getApiV1BetaWorkloadsOptions({ query: { all: true } }),
+  })
+
   const formSchema = useMemo(
-    () => getFormSchemaRunFromRegistry(groupedEnvVars),
-    [groupedEnvVars]
+    () =>
+      getFormSchemaRunFromRegistry({
+        envVars: groupedEnvVars.envVars,
+        secrets: groupedEnvVars.secrets,
+        workloads: data?.workloads ?? [],
+      }),
+    [groupedEnvVars, data?.workloads]
   )
 
   const form = useForm<FormSchemaRunFromRegistry>({


### PR DESCRIPTION
Fetches the list of installed servers and uses that as part of the form validation when running new ones.

Closes #247 

https://github.com/user-attachments/assets/cdd61568-0781-4245-91ba-773b9a26ffdb

