### PR TITLE
fix: cmd args when running from registry

### DIFF
--- a/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
@@ -302,6 +302,28 @@ export function FormRunFromRegistry({
                 )}
               />
 
+              <FormField
+                control={form.control}
+                name="cmd_arguments"
+                render={({ field }) => (
+                  <FormItem className="mb-10">
+                    <FormLabel>Command arguments</FormLabel>
+                    <FormDescription>
+                      Space separated arguments for the command.
+                    </FormDescription>
+                    <FormControl>
+                      <Input
+                        placeholder="e.g. -y --oauth-setup"
+                        defaultValue={field.value}
+                        onChange={(e) => field.onChange(e.target.value)}
+                        name={field.name}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
               {groupedEnvVars.secrets[0] ? (
                 <section className="mb-10">
                   <Label className="mb-2" htmlFor="secrets.0.value">

--- a/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
+++ b/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
@@ -1,76 +1,562 @@
+import { it, expect, vi } from 'vitest'
 import type { QueryClient } from '@tanstack/react-query'
-import { orchestrateRunRegistryServer } from '../orchestrate-run-registry-server'
+
+import { getApiV1BetaWorkloadsQueryKey } from '@/common/api/generated/@tanstack/react-query.gen'
+import { toast } from 'sonner'
+import { server } from '@/common/mocks/node'
+import { http, HttpResponse } from 'msw'
+import { mswEndpoint } from '@/common/mocks/msw-endpoint'
 import type { FormSchemaRunFromRegistry } from '../get-form-schema-run-from-registry'
+import { orchestrateRunRegistryServer } from '../orchestrate-run-registry-server'
 import type { RegistryImageMetadata } from '@/common/api/generated'
 
-test('happy path', async () => {
-  const mockSaveSecret = vi.fn().mockResolvedValue({ key: 'GITHUB_API_TOKEN' })
-  const mockCreateWorkload = vi.fn().mockResolvedValue({})
+vi.mock('sonner', async () => {
+  const original = await vi.importActual<typeof import('sonner')>('sonner')
+  return {
+    ...original,
+    toast: {
+      loading: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  }
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+it('should submit without any optional fields', async () => {
+  const mockSaveSecret = vi.fn()
+  const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
   const mockQueryClient = {
-    fetchQuery: vi.fn().mockResolvedValue({ status: 'Running' }),
     invalidateQueries: vi.fn(),
   } as unknown as QueryClient
 
-  const server: RegistryImageMetadata = {
+  const SERVER: RegistryImageMetadata = {
     name: 'test-server',
     image: 'test-image',
     transport: 'stdio',
   }
 
-  const formData: FormSchemaRunFromRegistry = {
+  const DATA: FormSchemaRunFromRegistry = {
     serverName: 'Test Server',
-    envVars: [{ name: 'TEST_ENV', value: 'foo-bar' }],
-    secrets: [
-      {
-        name: 'GITHUB_API_TOKEN',
-        value: { secret: 'foo-bar', isFromStore: false },
-      },
-      {
-        name: 'GRAFANA_API_TOKEN',
-        value: { secret: 'GRAFANA_API_TOKEN', isFromStore: true },
-      },
-      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
-    ],
+    envVars: [],
+    secrets: [],
   }
 
   await orchestrateRunRegistryServer({
     createWorkload: mockCreateWorkload,
-    data: formData,
+    data: DATA,
     getIsServerReady: mockGetIsServerReady,
     queryClient: mockQueryClient,
     saveSecret: mockSaveSecret,
-    server,
+    server: SERVER,
   })
 
-  expect(mockSaveSecret).toHaveBeenCalledTimes(1)
-  expect(mockSaveSecret).toHaveBeenCalledWith(
-    { body: { key: 'GITHUB_API_TOKEN', value: 'foo-bar' } },
-    expect.objectContaining({
-      onError: expect.any(Function),
-      onSuccess: expect.any(Function),
-    })
-  )
-
+  expect(mockSaveSecret).toHaveBeenCalledTimes(0)
+  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
   expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
   expect(mockCreateWorkload).toHaveBeenCalledWith({
     body: {
       name: 'Test Server',
       image: 'test-image',
       transport: 'stdio',
-      env_vars: ['TEST_ENV=foo-bar'],
-      secrets: [
-        { name: 'GITHUB_API_TOKEN', target: 'GITHUB_API_TOKEN' },
-        {
-          name: 'GRAFANA_API_TOKEN',
-          target: 'GRAFANA_API_TOKEN',
-        },
-      ],
+      secrets: [],
+      cmd_arguments: [],
+      env_vars: [],
     },
   })
-
-  // Verify invalidateQueries called to refresh server lists
   expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-    queryKey: expect.anything(),
+    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
   })
+
+  expect(toast.success).toHaveBeenCalledWith(
+    '"Test Server" started successfully.',
+    expect.any(Object)
+  )
+})
+
+it('should handle new secrets properly', async () => {
+  server.use(
+    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
+      return HttpResponse.json({ keys: [] })
+    })
+  )
+
+  const mockSaveSecret = vi.fn()
+  const mockCreateWorkload = vi.fn()
+  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient
+
+  const SERVER: RegistryImageMetadata = {
+    name: 'test-server',
+    image: 'test-image',
+    transport: 'stdio',
+  }
+
+  const DATA = {
+    serverName: 'Test Server',
+    envVars: [],
+    secrets: [
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'foo-bar', isFromStore: false },
+      },
+      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
+    ],
+  } as const satisfies FormSchemaRunFromRegistry
+
+  mockSaveSecret.mockResolvedValueOnce({ key: DATA.secrets[0].name })
+
+  await orchestrateRunRegistryServer({
+    createWorkload: mockCreateWorkload,
+    data: DATA,
+    getIsServerReady: mockGetIsServerReady,
+    queryClient: mockQueryClient,
+    saveSecret: mockSaveSecret,
+    server: SERVER,
+  })
+
+  expect(mockSaveSecret).toHaveBeenCalledWith(
+    { body: { key: 'GITHUB_API_TOKEN', value: 'foo-bar' } },
+    expect.any(Object)
+  )
+
+  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
+  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
+  expect(mockCreateWorkload).toHaveBeenCalledWith({
+    body: {
+      name: 'Test Server',
+      image: 'test-image',
+      transport: 'stdio',
+      secrets: [
+        {
+          name: 'GITHUB_API_TOKEN',
+          target: 'GITHUB_API_TOKEN',
+        },
+      ],
+      cmd_arguments: [],
+      env_vars: [],
+    },
+  })
+  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+  })
+
+  expect(toast.success).toHaveBeenCalledWith(
+    '"Test Server" started successfully.',
+    expect.any(Object)
+  )
+})
+
+it('should handle existing secrets from the store properly', async () => {
+  server.use(
+    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
+      return HttpResponse.json({ keys: [{ key: 'GITHUB_API_TOKEN' }] })
+    })
+  )
+
+  const mockSaveSecret = vi.fn()
+  const mockCreateWorkload = vi.fn()
+  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient
+
+  const SERVER: RegistryImageMetadata = {
+    name: 'test-server',
+    image: 'test-image',
+    transport: 'stdio',
+  }
+
+  const DATA = {
+    serverName: 'Test Server',
+    envVars: [],
+    secrets: [
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'GITHUB_API_TOKEN', isFromStore: true },
+      },
+      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
+    ],
+  } as const satisfies FormSchemaRunFromRegistry
+
+  await orchestrateRunRegistryServer({
+    createWorkload: mockCreateWorkload,
+    data: DATA,
+    getIsServerReady: mockGetIsServerReady,
+    queryClient: mockQueryClient,
+    saveSecret: mockSaveSecret,
+    server: SERVER,
+  })
+
+  expect(mockSaveSecret).not.toHaveBeenCalled()
+
+  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
+  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
+  expect(mockCreateWorkload).toHaveBeenCalledWith({
+    body: {
+      name: 'Test Server',
+      image: 'test-image',
+      transport: 'stdio',
+      secrets: [
+        {
+          name: 'GITHUB_API_TOKEN',
+          target: 'GITHUB_API_TOKEN',
+        },
+      ],
+      cmd_arguments: [],
+      env_vars: [],
+    },
+  })
+  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+  })
+
+  expect(toast.success).toHaveBeenCalledWith(
+    '"Test Server" started successfully.',
+    expect.any(Object)
+  )
+})
+
+it('should handle naming collisions with secrets from the store', async () => {
+  server.use(
+    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
+      return HttpResponse.json({ keys: [{ key: 'GITHUB_API_TOKEN' }] })
+    })
+  )
+
+  const mockSaveSecret = vi.fn()
+  const mockCreateWorkload = vi.fn()
+  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient
+
+  const SERVER: RegistryImageMetadata = {
+    name: 'test-server',
+    image: 'test-image',
+    transport: 'stdio',
+  }
+
+  const DATA = {
+    serverName: 'Test Server',
+    envVars: [],
+    secrets: [
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'foo-bar', isFromStore: false },
+      },
+      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
+    ],
+  } as const satisfies FormSchemaRunFromRegistry
+
+  mockSaveSecret.mockResolvedValueOnce({ key: 'GITHUB_API_TOKEN_2' })
+
+  await orchestrateRunRegistryServer({
+    createWorkload: mockCreateWorkload,
+    data: DATA,
+    getIsServerReady: mockGetIsServerReady,
+    queryClient: mockQueryClient,
+    saveSecret: mockSaveSecret,
+    server: SERVER,
+  })
+
+  expect(mockSaveSecret).toHaveBeenCalledWith(
+    { body: { key: 'GITHUB_API_TOKEN_2', value: 'foo-bar' } },
+    expect.any(Object)
+  )
+
+  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
+  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
+  expect(mockCreateWorkload).toHaveBeenCalledWith({
+    body: {
+      name: 'Test Server',
+      image: 'test-image',
+      transport: 'stdio',
+      secrets: [
+        {
+          name: 'GITHUB_API_TOKEN_2',
+          target: 'GITHUB_API_TOKEN',
+        },
+      ],
+      cmd_arguments: [],
+      env_vars: [],
+    },
+  })
+  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+  })
+
+  expect(toast.success).toHaveBeenCalledWith(
+    '"Test Server" started successfully.',
+    expect.any(Object)
+  )
+})
+
+it('should handle both new and existing secrets', async () => {
+  server.use(
+    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
+      return HttpResponse.json({ keys: [{ key: 'ATLASSIAN_API_TOKEN' }] })
+    })
+  )
+
+  const mockSaveSecret = vi.fn()
+  const mockCreateWorkload = vi.fn()
+  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient
+
+  const SERVER: RegistryImageMetadata = {
+    name: 'test-server',
+    image: 'test-image',
+    transport: 'stdio',
+  }
+
+  const DATA = {
+    serverName: 'Test Server',
+    envVars: [],
+    secrets: [
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'foo-bar', isFromStore: false },
+      },
+      {
+        name: 'ATLASSIAN_API_TOKEN',
+        value: { secret: 'ATLASSIAN_API_TOKEN', isFromStore: true },
+      },
+      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
+    ],
+  } as const satisfies FormSchemaRunFromRegistry
+
+  mockSaveSecret.mockResolvedValueOnce({ key: DATA.secrets[0].name })
+
+  await orchestrateRunRegistryServer({
+    createWorkload: mockCreateWorkload,
+    data: DATA,
+    getIsServerReady: mockGetIsServerReady,
+    queryClient: mockQueryClient,
+    saveSecret: mockSaveSecret,
+    server: SERVER,
+  })
+
+  expect(mockSaveSecret).toHaveBeenCalledWith(
+    { body: { key: 'GITHUB_API_TOKEN', value: 'foo-bar' } },
+    expect.any(Object)
+  )
+
+  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
+  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
+  expect(mockCreateWorkload).toHaveBeenCalledWith({
+    body: {
+      name: 'Test Server',
+      image: 'test-image',
+      transport: 'stdio',
+      secrets: [
+        {
+          name: 'GITHUB_API_TOKEN',
+          target: 'GITHUB_API_TOKEN',
+        },
+        {
+          name: 'ATLASSIAN_API_TOKEN',
+          target: 'ATLASSIAN_API_TOKEN',
+        },
+      ],
+      cmd_arguments: [],
+      env_vars: [],
+    },
+  })
+  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+  })
+
+  expect(toast.success).toHaveBeenCalledWith(
+    '"Test Server" started successfully.',
+    expect.any(Object)
+  )
+})
+
+it('should handle error when saving a secret fails', async () => {
+  const mockError = new Error('Failed to save secret')
+  const mockSaveSecret = vi.fn().mockRejectedValue(mockError)
+  const mockCreateWorkload = vi.fn()
+  const mockGetIsServerReady = vi.fn()
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient
+
+  const SERVER: RegistryImageMetadata = {
+    name: 'test-server',
+    image: 'test-image',
+    transport: 'stdio',
+  }
+
+  const DATA = {
+    serverName: 'Test Server',
+    envVars: [],
+    secrets: [
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'foo-bar', isFromStore: false },
+      },
+      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
+    ],
+  } as const satisfies FormSchemaRunFromRegistry
+
+  await orchestrateRunRegistryServer({
+    createWorkload: mockCreateWorkload,
+    data: DATA,
+    getIsServerReady: mockGetIsServerReady,
+    queryClient: mockQueryClient,
+    saveSecret: mockSaveSecret,
+    server: SERVER,
+  })
+
+  // createWorkload should not be called if saving secrets fails
+  expect(mockCreateWorkload).not.toHaveBeenCalled()
+  expect(mockGetIsServerReady).not.toHaveBeenCalled()
+
+  // Error toast should be shown
+  expect(toast.error).toHaveBeenCalledWith(
+    'An error occurred while starting the server.\nFailed to save secret',
+    expect.any(Object)
+  )
+})
+
+it('should handle environment variables properly', async () => {
+  const mockSaveSecret = vi.fn()
+  const mockCreateWorkload = vi.fn()
+  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient
+
+  const SERVER: RegistryImageMetadata = {
+    name: 'test-server',
+    image: 'test-image',
+    transport: 'stdio',
+  }
+
+  const DATA = {
+    serverName: 'Test Server',
+    envVars: [
+      { name: 'DEBUG', value: 'true' },
+      { name: 'PORT', value: '8080' },
+    ],
+    secrets: [
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'foo-bar', isFromStore: true },
+      },
+      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
+    ],
+  } as const satisfies FormSchemaRunFromRegistry
+
+  await orchestrateRunRegistryServer({
+    createWorkload: mockCreateWorkload,
+    data: DATA,
+    getIsServerReady: mockGetIsServerReady,
+    queryClient: mockQueryClient,
+    saveSecret: mockSaveSecret,
+    server: SERVER,
+  })
+
+  expect(mockCreateWorkload).toHaveBeenCalledWith({
+    body: expect.objectContaining({
+      env_vars: ['DEBUG=true', 'PORT=8080'],
+    }),
+  })
+})
+
+it('should handle command arguments properly', async () => {
+  const mockSaveSecret = vi.fn()
+  const mockCreateWorkload = vi.fn()
+  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient
+
+  const SERVER: RegistryImageMetadata = {
+    name: 'test-server',
+    image: 'test-image',
+    transport: 'stdio',
+  }
+
+  const DATA = {
+    serverName: 'Test Server',
+    envVars: [
+      { name: 'DEBUG', value: 'true' },
+      { name: 'PORT', value: '8080' },
+    ],
+    secrets: [
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'foo-bar', isFromStore: true },
+      },
+      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
+    ],
+    cmd_arguments: '--debug --port 8080',
+  } as const satisfies FormSchemaRunFromRegistry
+
+  await orchestrateRunRegistryServer({
+    createWorkload: mockCreateWorkload,
+    data: DATA,
+    getIsServerReady: mockGetIsServerReady,
+    queryClient: mockQueryClient,
+    saveSecret: mockSaveSecret,
+    server: SERVER,
+  })
+
+  expect(mockCreateWorkload).toHaveBeenCalledWith({
+    body: expect.objectContaining({
+      cmd_arguments: ['--debug', '--port', '8080'],
+    }),
+  })
+})
+
+it('should show warning toast when server is not ready', async () => {
+  const mockSaveSecret = vi.fn()
+  const mockCreateWorkload = vi.fn()
+  const mockGetIsServerReady = vi.fn().mockResolvedValue(false)
+  const mockQueryClient = {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient
+
+  const SERVER: RegistryImageMetadata = {
+    name: 'test-server',
+    image: 'test-image',
+    transport: 'stdio',
+  }
+
+  const DATA: FormSchemaRunFromRegistry = {
+    serverName: 'Test Server',
+    envVars: [],
+    secrets: [],
+  }
+
+  await orchestrateRunRegistryServer({
+    createWorkload: mockCreateWorkload,
+    data: DATA,
+    getIsServerReady: mockGetIsServerReady,
+    queryClient: mockQueryClient,
+    saveSecret: mockSaveSecret,
+    server: SERVER,
+  })
+
+  expect(toast.loading).toHaveBeenCalledWith(
+    'Starting "Test Server"...',
+    expect.any(Object)
+  )
+  expect(toast.warning).toHaveBeenCalledWith(
+    'Server "Test Server" was created but may still be starting up. Check the servers list to monitor its status.',
+    expect.any(Object)
+  )
+  expect(toast.success).not.toHaveBeenCalled()
 })

--- a/renderer/src/features/registry-servers/lib/get-form-schema-run-from-registry.ts
+++ b/renderer/src/features/registry-servers/lib/get-form-schema-run-from-registry.ts
@@ -55,6 +55,7 @@ export function getFormSchemaRunFromRegistry({
         (value) => !workloads.some((w) => w.name === value),
         'This name is already in use'
       ),
+    cmd_arguments: z.string().optional(),
     secrets: z
       .object({
         name: z.union(secrets.map(({ name }) => z.literal(name ?? ''))),

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
@@ -150,7 +150,9 @@ function prepareCreateWorkloadData(
     transport: server.transport,
     env_vars: envVars,
     secrets,
-    cmd_arguments: server.args,
+    cmd_arguments: data.cmd_arguments
+      ? data.cmd_arguments?.split(' ').filter(Boolean)
+      : [],
     target_port: server.target_port,
   }
 }
@@ -287,6 +289,7 @@ export async function orchestrateRunRegistryServer({
         body: createRequest,
       })
     } catch (error) {
+      console.debug('👉 error:', error)
       toast.error(
         [
           'An error occurred while starting the server.',


### PR DESCRIPTION
Adds the ability to pass cmd_args when running servers from registry. 
Also fills some gaps in testing when running servers from registry. 

https://github.com/user-attachments/assets/ed73d5d8-6209-42ef-b86e-af864dac9b5c

closes #311
closes #305 
closes #306 

