### PR TITLE
fix: ensure toast doesn't collide with header

### DIFF
--- a/renderer/src/routes/__root.tsx
+++ b/renderer/src/routes/__root.tsx
@@ -46,7 +46,7 @@ function RootComponent() {
         <Toaster
           duration={2_000}
           position="top-right"
-          offset={{ top: 50 }}
+          offset={{ top: 64 + 16 }}
           closeButton
         />
         <TanStackRouterDevtools />


### PR DESCRIPTION
Updates the offset of the toast notifications to be `64 (header height) + 16 (sensible margin)`

<img width="1418" alt="Screenshot 2025-06-25 at 10 45 05 AM" src="https://github.com/user-attachments/assets/19b2c43e-bd2f-4b18-9956-db4c3a1e91f3" />
