### PR TITLE
fix: logs broken in dark mode

### DIFF
--- a/renderer/src/features/mcp-servers/sub-pages/logs-page.tsx
+++ b/renderer/src/features/mcp-servers/sub-pages/logs-page.tsx
@@ -53,8 +53,8 @@ export function LogsPage() {
           aria-label="Search log"
         />
       </div>
-      <div className="flex-1 overflow-auto rounded-md border border-gray-200">
-        <div className="p-5 font-mono text-[13px] leading-[22px] font-normal text-gray-900">
+      <div className="flex-1 overflow-auto rounded-md border">
+        <div className="text-foreground bg-card p-5 font-mono text-[13px] leading-[22px] font-normal">
           {filteredLogs.map((log, index) => (
             <div key={index}>{log}</div>
           ))}


### PR DESCRIPTION
### Before

<img width="1418" alt="Screenshot 2025-06-25 at 11 29 51 AM" src="https://github.com/user-attachments/assets/6fa9784c-e1a6-46c1-a025-28ebf47176e7" />

### After

<img width="1418" alt="Screenshot 2025-06-25 at 11 30 27 AM" src="https://github.com/user-attachments/assets/73d96752-702d-49d0-97a2-41bfcd1acca7" />
