### PR TITLE
fix: sticky header disappears on long page

### DIFF
--- a/renderer/src/routes/__root.tsx
+++ b/renderer/src/routes/__root.tsx
@@ -39,7 +39,7 @@ function RootComponent() {
   const isShutdownRoute = matches.some((match) => match.routeId === '/shutdown')
 
   return (
-    <div className="flex h-screen min-h-0 flex-col">
+    <>
       {!isShutdownRoute && <TopNav />}
       <Main>
         <Outlet />
@@ -51,7 +51,7 @@ function RootComponent() {
         />
         <TanStackRouterDevtools />
       </Main>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
### Before

https://github.com/user-attachments/assets/68f90a20-aad0-42dd-a33a-189285719fe7

### After

https://github.com/user-attachments/assets/2c44e94d-a23c-41f6-8760-ecceddb664a8

