### PR TITLE
fix: make dmg name

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -97,7 +97,7 @@ const config: ForgeConfig = {
     }),
     new MakerDMG(
       {
-        name: 'ToolHive Studio',
+        name: 'toolhive-studio',
       },
       ['darwin']
     ),


### PR DESCRIPTION
After a reboot I wasn't able to run a build, I got the issue below. It seems that I didn't have the `/Volumes/ToolHive \Studio` folder and the force command for dmg was failing.
I fixed it removing the space using the snake case `toolhive-studio`

**Issue**

![Screenshot 2025-06-25 at 12 33 22](https://github.com/user-attachments/assets/08d9baf0-73dd-4d65-bbd7-a264c6cc0261)
