### PR TITLE
fix: layout shift when scrollbar appears

### DIFF
--- a/renderer/src/common/components/layout/main.tsx
+++ b/renderer/src/common/components/layout/main.tsx
@@ -6,9 +6,14 @@ export function Main(props: { children: ReactNode; className?: string }) {
     <main
       {...props}
       className={twMerge(
-        'flex min-h-0 w-full flex-1 flex-col px-6 py-4',
+        'flex min-h-0 w-full flex-1 flex-col',
+        'max-h-[calc(100dvh-calc(var(--spacing)_*_16))] overflow-y-auto',
+        'px-3 py-4',
         props.className
       )}
+      style={{
+        scrollbarGutter: 'stable both-edges',
+      }}
     />
   )
 }

--- a/renderer/src/common/components/layout/top-nav.tsx
+++ b/renderer/src/common/components/layout/top-nav.tsx
@@ -37,8 +37,7 @@ function TopNavContainer(props: HTMLProps<HTMLElement>) {
       {...props}
       className={twMerge(
         props.className,
-        'sticky top-0 z-50',
-        'bg-muted/50 backdrop-blur-2xl',
+        'bg-muted/50',
         'border-mid h-16 border-b',
         'px-6',
         'grid grid-cols-[auto_1fr_auto] items-center gap-7',

--- a/renderer/src/feature-flags/toggles.json
+++ b/renderer/src/feature-flags/toggles.json
@@ -1,4 +1,4 @@
 {
   "update-on-restart": false,
-  "logs": false
+  "logs": true
 }


### PR DESCRIPTION
- adds `scrollbar-gutter: stable both-edges` to the `<main>` element — so the scrollbar gutter is always taken into account when calculating layout
- compensates for the extra gutter by reducing the horizontal padding 
- makes the main element a self contained element with a fixed height and it's own scroll — so the scrollbar no longer extends into the app navigation — this means removing the sticky positioning & blur from the nav
- fairly confident there are no weird side effects from the fixed height `<main>` element

closes #231 
closes #269 — this seems to be gone now too

https://github.com/user-attachments/assets/d11e60c9-37a3-445a-8101-277d748a6779



