### PR TITLE
fix: switch styling inconsistent between pages

### DIFF
--- a/renderer/src/common/components/ui/switch.tsx
+++ b/renderer/src/common/components/ui/switch.tsx
@@ -11,12 +11,12 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        `peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input
-        focus-visible:border-ring focus-visible:ring-ring/50
-        dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0
-        items-center rounded-full border border-transparent shadow-xs transition-all
-        outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed
-        disabled:opacity-50`,
+        `peer data-[state=unchecked]:bg-input focus-visible:border-ring
+        focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex
+        h-[1.15rem] w-8 shrink-0 cursor-pointer items-center rounded-full border
+        border-transparent shadow-xs transition-all outline-none
+        focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50
+        data-[state=checked]:bg-green-600`,
         className
       )}
       {...props}
@@ -25,10 +25,10 @@ function Switch({
         data-slot="switch-thumb"
         className={cn(
           `bg-background dark:data-[state=unchecked]:bg-foreground
-          dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4
-          rounded-full ring-0 transition-transform
-          data-[state=checked]:translate-x-[calc(100%-2px)]
-          data-[state=unchecked]:translate-x-0`
+          dark:data-[state=checked]:bg-foreground pointer-events-none block
+          size-[calc(calc(var(--spacing)_*_4_-_1px))] rounded-full ring-0
+          transition-transform data-[state=checked]:translate-x-[calc(100%-0.5px)]
+          data-[state=unchecked]:translate-x-[0.5px]`
         )}
       />
     </SwitchPrimitive.Root>

--- a/renderer/src/features/clients/components/card-client.tsx
+++ b/renderer/src/features/clients/components/card-client.tsx
@@ -38,7 +38,6 @@ export function CardClient({ client }: { client: ClientMcpClientStatus }) {
       </CardHeader>
       <CardContent className="flex items-center gap-2">
         <Switch
-          className="cursor-pointer"
           checked={client.registered}
           onCheckedChange={() => {
             if (client.registered) {

--- a/renderer/src/features/mcp-servers/components/actions-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/actions-mcp-server.tsx
@@ -1,6 +1,5 @@
 import type { WorkloadsWorkload } from '@/common/api/generated/types.gen'
 import { Switch } from '@/common/components/ui/switch'
-import { cn } from '@/common/lib/utils'
 
 function getStatusText(status: WorkloadsWorkload['status']) {
   // There is an issue with openAPI generator in BE - https://github.com/stacklok/toolhive/issues/780
@@ -32,11 +31,6 @@ export function ActionsMcpServer({
       <div onClick={(e) => e.preventDefault()}>
         <Switch
           aria-label="Mutate server"
-          className={cn(
-            'cursor-pointer',
-            isRunning &&
-              'dark:data-[state=checked]:bg-primary data-[state=checked]:bg-green-600'
-          )}
           checked={isRunning || isPending}
           disabled={isStarting}
           onCheckedChange={() => mutate()}


### PR DESCRIPTION
Fixes a minor nit, where the switch was styled differently on different pages.

Also addresses feedback from Dan Barr about the green being inconsistently applied in light/dark mode.

### Before

https://github.com/user-attachments/assets/1314457f-0ea9-492a-9421-4bcc0d470f3a

### After

https://github.com/user-attachments/assets/720afb2f-16e2-4be3-9253-eb3a0a9e5ed7

