### PR TITLE
fix: registry cards accessibility

### DIFF
--- a/renderer/src/features/registry-servers/components/card-registry-server.tsx
+++ b/renderer/src/features/registry-servers/components/card-registry-server.tsx
@@ -27,9 +27,9 @@ export function CardRegistryServer({
       )}
     >
       <CardHeader>
-        <CardTitle className="flex items-center justify-between text-xl">
+        <CardTitle className="grid grid-cols-[auto_calc(var(--spacing)_*_5)] items-center text-xl">
           <button
-            className="!outline-none select-none"
+            className="truncate text-left !outline-none select-none"
             onClick={() => onClick?.()}
           >
             {server.name}


### PR DESCRIPTION
The registry cards weren't fully accessible — because they were `<div>` elements with an `onClick` handler, they weren't able to be focused using the keyboard.

To fix this, I have done the following:
- Inside the card title, is a `<button>` element containing the name of the server
- The card itself has `position: relative` and inside the `<button>` is a span with `position absolute; inset: 0` — this scales the hit-target of the button up to the dimensions of the card

Now, the card can be focused using the keyboard, and if a user is using assistive technologies like a screen reader, they will only get the name of the server read out, rather than the entire text content of the card.

https://github.com/user-attachments/assets/37412a07-fdc7-49d5-b130-cdeb91827abd




