### PR TITLE
fix(logs): flash of empty page

### DIFF
--- a/renderer/src/features/mcp-servers/components/card-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/common/components/ui/dropdown-menu'
 import { Button } from '@/common/components/ui/button'
 import { MoreVertical, Trash2, Github, Text } from 'lucide-react'
-import { useNavigate } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
 
 import type { WorkloadsWorkload } from '@/common/api/generated'
 import { ActionsMcpServer } from './actions-mcp-server'
@@ -83,7 +83,6 @@ export function CardMcpServer({
   statusContext: WorkloadsWorkload['status_context']
 }) {
   const confirm = useConfirm()
-  const navigate = useNavigate()
   const { mutateAsync: deleteServer, isPending: isDeletePending } =
     useDeleteServer({ name })
 
@@ -197,16 +196,13 @@ export function CardMcpServer({
               )}
               {isFeatureEnabled('logs') ? (
                 <DropdownMenuItem
-                  onClick={() =>
-                    navigate({
-                      to: '/logs/$serverName',
-                      params: { serverName: name },
-                    })
-                  }
+                  asChild
                   className="flex cursor-pointer items-center"
                 >
-                  <Text className="mr-2 h-4 w-4" />
-                  Logs
+                  <Link to="/logs/$serverName" params={{ serverName: name }}>
+                    <Text className="mr-2 h-4 w-4" />
+                    Logs
+                  </Link>
                 </DropdownMenuItem>
               ) : null}
               <DropdownMenuItem

--- a/renderer/src/features/mcp-servers/sub-pages/logs-page.tsx
+++ b/renderer/src/features/mcp-servers/sub-pages/logs-page.tsx
@@ -38,9 +38,9 @@ export function LogsPage() {
   const { serverName } = useParams({ from: '/logs/$serverName' })
   const [search, setSearch] = useState('')
 
-  const { data: logs, refetch } = useSuspenseQuery({
-    ...getApiV1BetaWorkloadsByNameLogsOptions({ path: { name: serverName } }),
-  })
+  const { data: logs, refetch } = useSuspenseQuery(
+    getApiV1BetaWorkloadsByNameLogsOptions({ path: { name: serverName } })
+  )
 
   const logLines =
     typeof logs === 'string'

--- a/renderer/src/routes/logs.$serverName.tsx
+++ b/renderer/src/routes/logs.$serverName.tsx
@@ -1,6 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { LogsPage } from '@/features/mcp-servers/sub-pages/logs-page'
+import { getApiV1BetaWorkloadsByNameLogsOptions } from '@/common/api/generated/@tanstack/react-query.gen'
 
 export const Route = createFileRoute('/logs/$serverName')({
+  loader: async ({ context: { queryClient }, params }) =>
+    queryClient.ensureQueryData(
+      getApiV1BetaWorkloadsByNameLogsOptions({
+        path: { name: params.serverName },
+      })
+    ),
   component: LogsPage,
 })


### PR DESCRIPTION
Fixes a nit with the logs route, where on first load, there would be a flash of an empty page.

The root causes were:
- using `navigate(...)` instead of `<Link to="..." />` — the Link component enables pre-fetching of the routes loader data
- missing a `loader` fn in the route — the data didn't begin fetching until the route had mounted