### PR TITLE
test: simplify test names

### DIFF
--- a/renderer/src/common/hooks/__tests__/use-filter-sort.test.ts
+++ b/renderer/src/common/hooks/__tests__/use-filter-sort.test.ts
@@ -27,27 +27,27 @@ describe('useFilterSort', () => {
         filter: 'apple',
         expectedLength: 1,
         expectedNames: ['Apple'],
-        description: 'filter data based on name field',
+        description: 'filters data based on name field',
       },
       {
         filter: 'fruit',
         expectedLength: 3,
         expectedNames: ['Apple', 'Banana', 'Cherry'],
-        description: 'filter data based on description field',
+        description: 'filters data based on description field',
       },
       {
         filter: 'APPLE',
         expectedLength: 1,
         expectedNames: ['Apple'],
-        description: 'be case insensitive when filtering',
+        description: 'is case insensitive when filtering',
       },
       {
         filter: 'red',
         expectedLength: 2,
         expectedNames: ['Apple', 'Cherry'],
-        description: 'filter across multiple description matches',
+        description: 'filters across multiple description matches',
       },
-    ])('should $description', ({ filter, expectedLength, expectedNames }) => {
+    ])('$description', ({ filter, expectedLength, expectedNames }) => {
       const { result } = renderHook(() => useFilterSort(defaultOptions))
 
       act(() => {
@@ -66,14 +66,14 @@ describe('useFilterSort', () => {
       {
         sortOrder: 'asc' as const,
         expectedNames: ['Apple', 'Banana', 'Cherry', 'Zebra'],
-        description: 'sort data alphabetically in ascending order by default',
+        description: 'sorts data alphabetically in ascending order by default',
       },
       {
         sortOrder: 'desc' as const,
         expectedNames: ['Zebra', 'Cherry', 'Banana', 'Apple'],
-        description: 'sort data in descending order when sortOrder is desc',
+        description: 'sorts data in descending order when sortOrder is desc',
       },
-    ])('should $description', ({ sortOrder, expectedNames }) => {
+    ])('$description', ({ sortOrder, expectedNames }) => {
       const { result } = renderHook(() =>
         useFilterSort({ ...defaultOptions, sortOrder })
       )

--- a/renderer/src/common/lib/__tests__/polling.test.ts
+++ b/renderer/src/common/lib/__tests__/polling.test.ts
@@ -13,7 +13,7 @@ describe('Polling Utility', () => {
   })
 
   describe('pollServerStatus', () => {
-    it('should return true when server reaches desired status', async () => {
+    it('returns true when server reaches desired status', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce({ status: 'starting' } as WorkloadsWorkload)
@@ -31,7 +31,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(2)
     })
 
-    it('should return false when server never reaches desired status', async () => {
+    it('returns false when server never reaches desired status', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValue({ status: 'starting' } as WorkloadsWorkload)
@@ -48,7 +48,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(3)
     })
 
-    it('should handle fetch errors and continue polling', async () => {
+    it('handles fetch errors and continue polling', async () => {
       const mockFetchServer = vi
         .fn()
         .mockRejectedValueOnce(new Error('Network error'))
@@ -66,7 +66,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(2)
     })
 
-    it('should return true immediately if first attempt matches', async () => {
+    it('returns true immediately if first attempt matches', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce({ status: 'running' } as WorkloadsWorkload)
@@ -80,7 +80,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(1)
     })
 
-    it('should work with different status values', async () => {
+    it('works with different status values', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce({ status: 'starting' } as WorkloadsWorkload)
@@ -98,7 +98,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(2)
     })
 
-    it('should respect custom configuration', async () => {
+    it('respects custom configuration', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValue({ status: 'starting' } as WorkloadsWorkload)
@@ -117,7 +117,7 @@ describe('Polling Utility', () => {
   })
 
   describe('pollServerDelete', () => {
-    it('should return true when server fetch fails (server deleted)', async () => {
+    it('returns true when server fetch fails (server deleted)', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce({ status: 'running' } as WorkloadsWorkload)
@@ -135,7 +135,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(2)
     })
 
-    it('should return true immediately if first attempt fails', async () => {
+    it('returns true immediately if first attempt fails', async () => {
       const mockFetchServer = vi
         .fn()
         .mockRejectedValueOnce(new Error('Not found'))
@@ -149,7 +149,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(1)
     })
 
-    it('should return false if server never gets deleted', async () => {
+    it('returns false if server never gets deleted', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValue({ status: 'running' } as WorkloadsWorkload)
@@ -166,7 +166,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(3)
     })
 
-    it('should handle mixed scenarios (running then deleted)', async () => {
+    it('handles mixed scenarios (running then deleted)', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce({ status: 'running' } as WorkloadsWorkload)
@@ -187,7 +187,7 @@ describe('Polling Utility', () => {
   })
 
   describe('Configuration Options', () => {
-    it('should respect delayFirst option', async () => {
+    it('respects delayFirst option', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValue({ status: 'running' } as WorkloadsWorkload)
@@ -204,7 +204,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(1)
     })
 
-    it('should use default configuration when none provided', async () => {
+    it('uses default configuration when none provided', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValue({ status: 'running' } as WorkloadsWorkload)
@@ -217,7 +217,7 @@ describe('Polling Utility', () => {
   })
 
   describe('Edge Cases', () => {
-    it('should handle undefined server data', async () => {
+    it('handles undefined server data', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce(undefined as unknown as WorkloadsWorkload)
@@ -235,7 +235,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(2)
     })
 
-    it('should handle null server data', async () => {
+    it('handles null server data', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce(null as unknown as WorkloadsWorkload)
@@ -253,7 +253,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(2)
     })
 
-    it('should handle server with missing status', async () => {
+    it('handles server with missing status', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce({} as WorkloadsWorkload)
@@ -271,7 +271,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(2)
     })
 
-    it('should handle zero maxAttempts', async () => {
+    it('handles zero maxAttempts', async () => {
       const mockFetchServer = vi.fn()
 
       const result = await pollServerStatus(mockFetchServer, 'running', {
@@ -285,7 +285,7 @@ describe('Polling Utility', () => {
   })
 
   describe('Performance and Timing', () => {
-    it('should not delay before first attempt by default', async () => {
+    it('does not delay before first attempt by default', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValue({ status: 'running' } as WorkloadsWorkload)
@@ -301,7 +301,7 @@ describe('Polling Utility', () => {
       expect(mockFetchServer).toHaveBeenCalledTimes(1)
     })
 
-    it('should respect interval timing between attempts', async () => {
+    it('respects interval timing between attempts', async () => {
       const mockFetchServer = vi
         .fn()
         .mockResolvedValueOnce({ status: 'starting' } as WorkloadsWorkload)

--- a/renderer/src/common/lib/secrets/__tests__/prepare-secrets-without-naming-collision.test.ts
+++ b/renderer/src/common/lib/secrets/__tests__/prepare-secrets-without-naming-collision.test.ts
@@ -2,7 +2,7 @@ import { prepareSecretsWithoutNamingCollision } from '../prepare-secrets-without
 
 import { test, expect } from 'vitest'
 
-test('should use original names when no collisions exist', () => {
+test('uses original names when no collisions exist', () => {
   expect(
     prepareSecretsWithoutNamingCollision(
       [
@@ -33,7 +33,7 @@ test('should use original names when no collisions exist', () => {
   ])
 })
 
-test('should append number suffix on collision', () => {
+test('appends number suffix on collision', () => {
   expect(
     prepareSecretsWithoutNamingCollision(
       [
@@ -67,7 +67,7 @@ test('should append number suffix on collision', () => {
   ])
 })
 
-test('should increment number suffix when collision exists with numbered secret', () => {
+test('increments number suffix when collision exists with numbered secret', () => {
   expect(
     prepareSecretsWithoutNamingCollision(
       [
@@ -103,7 +103,7 @@ test('should increment number suffix when collision exists with numbered secret'
   ])
 })
 
-test('should throw when secret from store is passed', () => {
+test('throws when secret from store is passed', () => {
   expect(() =>
     prepareSecretsWithoutNamingCollision(
       [

--- a/renderer/src/features/mcp-servers/components/__tests__/dialog-form-run-mcp-command.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/dialog-form-run-mcp-command.test.tsx
@@ -32,7 +32,7 @@ const queryClient = new QueryClient({
   },
 })
 
-it('should be able to run an MCP server while omitting optional fields', async () => {
+it('is able to run an MCP server while omitting optional fields', async () => {
   render(
     <QueryClientProvider client={queryClient}>
       <Dialog open>
@@ -69,7 +69,7 @@ it('should be able to run an MCP server while omitting optional fields', async (
   })
 })
 
-it('should be able to run an MCP server with docker', async () => {
+it('is able to run an MCP server with docker', async () => {
   render(
     <QueryClientProvider client={queryClient}>
       <Dialog open>
@@ -169,7 +169,7 @@ it('should be able to run an MCP server with docker', async () => {
   ])
 })
 
-it('should be able to run an MCP server with npx', async () => {
+it('is able to run an MCP server with npx', async () => {
   render(
     <QueryClientProvider client={queryClient}>
       <Dialog open>
@@ -273,7 +273,7 @@ it('should be able to run an MCP server with npx', async () => {
   ])
 })
 
-it('should be able to run an MCP server with uvx', async () => {
+it('is able to run an MCP server with uvx', async () => {
   render(
     <QueryClientProvider client={queryClient}>
       <Dialog open>
@@ -377,7 +377,7 @@ it('should be able to run an MCP server with uvx', async () => {
   ])
 })
 
-it('should be able to run an MCP server with go', async () => {
+it('is able to run an MCP server with go', async () => {
   render(
     <QueryClientProvider client={queryClient}>
       <Dialog open>

--- a/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
+++ b/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-it('should submit without any optional fields', async () => {
+it('submits without any optional fields', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
@@ -75,7 +75,7 @@ it('should submit without any optional fields', async () => {
   )
 })
 
-it('should handle new secrets properly', async () => {
+it('handles new secrets properly', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
       return HttpResponse.json({ keys: [] })
@@ -145,7 +145,7 @@ it('should handle new secrets properly', async () => {
   )
 })
 
-it('should handle existing secrets from the store properly', async () => {
+it('handles existing secrets from the store properly', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
       return HttpResponse.json({
@@ -197,7 +197,7 @@ it('should handle existing secrets from the store properly', async () => {
   })
 })
 
-it('should handle naming collisions with secrets from the store', async () => {
+it('handles naming collisions with secrets from the store', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
       return HttpResponse.json({
@@ -256,7 +256,7 @@ it('should handle naming collisions with secrets from the store', async () => {
   })
 })
 
-it('should handle both new and existing secrets', async () => {
+it('handles both new and existing secrets', async () => {
   const mockSaveSecret = vi.fn().mockResolvedValue({ key: 'new_secret_key' })
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
@@ -309,7 +309,7 @@ it('should handle both new and existing secrets', async () => {
   })
 })
 
-it('should handle error when saving a secret fails', async () => {
+it('handles error when saving a secret fails', async () => {
   const mockError = new Error('Failed to save secret')
   const mockSaveSecret = vi.fn().mockRejectedValue(mockError)
   const mockCreateWorkload = vi.fn()
@@ -352,7 +352,7 @@ it('should handle error when saving a secret fails', async () => {
   )
 })
 
-it('should handle environment variables properly', async () => {
+it('handles environment variables properly', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
@@ -388,7 +388,7 @@ it('should handle environment variables properly', async () => {
   })
 })
 
-it('should handle command arguments properly', async () => {
+it('handles command arguments properly', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
@@ -421,7 +421,7 @@ it('should handle command arguments properly', async () => {
   })
 })
 
-it('should show warning toast when server is not ready', async () => {
+it('shows warning toast when server is not ready', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(false)
@@ -458,7 +458,7 @@ it('should show warning toast when server is not ready', async () => {
   expect(toast.success).not.toHaveBeenCalled()
 })
 
-it('should handle package manager type properly', async () => {
+it('handles package manager type properly', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)

--- a/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
@@ -76,7 +76,7 @@ const ENV_VARS_REQUIRED = [
   },
 ] as const satisfies RegistryEnvVar[]
 
-it('should allow form submission with "inline" secret', async () => {
+it('allows form submission with "inline" secret', async () => {
   const server = REGISTRY_SERVER
   server.env_vars = ENV_VARS_OPTIONAL
 
@@ -142,7 +142,7 @@ it('should allow form submission with "inline" secret', async () => {
   expect(onOpenChange).toHaveBeenCalledWith(false)
 })
 
-it('should allow form submission with secret from store', async () => {
+it('allows form submission with secret from store', async () => {
   const mockServer = REGISTRY_SERVER
   mockServer.env_vars = ENV_VARS_OPTIONAL
 
@@ -224,7 +224,7 @@ it('should allow form submission with secret from store', async () => {
   expect(onOpenChange).toHaveBeenCalledWith(false)
 })
 
-it('should allow form submission without optional vars', async () => {
+it('allows form submission without optional vars', async () => {
   const server = REGISTRY_SERVER
   server.env_vars = ENV_VARS_OPTIONAL
 
@@ -283,7 +283,7 @@ it('should allow form submission without optional vars', async () => {
   expect(onOpenChange).toHaveBeenCalledWith(false)
 })
 
-it('should allow form submission with populated required vars', async () => {
+it('allows form submission with populated required vars', async () => {
   const server = REGISTRY_SERVER
   server.env_vars = ENV_VARS_REQUIRED
 
@@ -349,7 +349,7 @@ it('should allow form submission with populated required vars', async () => {
   expect(onOpenChange).toHaveBeenCalledWith(false)
 })
 
-it('should render validation errors when required variables missing', async () => {
+it('renders validation errors when required variables missing', async () => {
   const server = REGISTRY_SERVER
   server.env_vars = ENV_VARS_REQUIRED
 

--- a/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
+++ b/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
@@ -28,7 +28,7 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-it('should submit without any optional fields', async () => {
+it('submits without any optional fields', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
@@ -80,7 +80,7 @@ it('should submit without any optional fields', async () => {
   )
 })
 
-it('should handle new secrets properly', async () => {
+it('handles new secrets properly', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
       return HttpResponse.json({ keys: [] })
@@ -155,7 +155,7 @@ it('should handle new secrets properly', async () => {
   )
 })
 
-it('should handle existing secrets from the store properly', async () => {
+it('handles existing secrets from the store properly', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
       return HttpResponse.json({ keys: [{ key: 'GITHUB_API_TOKEN' }] })
@@ -225,7 +225,7 @@ it('should handle existing secrets from the store properly', async () => {
   )
 })
 
-it('should handle naming collisions with secrets from the store', async () => {
+it('handles naming collisions with secrets from the store', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
       return HttpResponse.json({ keys: [{ key: 'GITHUB_API_TOKEN' }] })
@@ -300,7 +300,7 @@ it('should handle naming collisions with secrets from the store', async () => {
   )
 })
 
-it('should handle both new and existing secrets', async () => {
+it('handles both new and existing secrets', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
       return HttpResponse.json({ keys: [{ key: 'ATLASSIAN_API_TOKEN' }] })
@@ -383,7 +383,7 @@ it('should handle both new and existing secrets', async () => {
   )
 })
 
-it('should handle error when saving a secret fails', async () => {
+it('handles error when saving a secret fails', async () => {
   const mockError = new Error('Failed to save secret')
   const mockSaveSecret = vi.fn().mockRejectedValue(mockError)
   const mockCreateWorkload = vi.fn()
@@ -430,7 +430,7 @@ it('should handle error when saving a secret fails', async () => {
   )
 })
 
-it('should handle environment variables properly', async () => {
+it('handles environment variables properly', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
@@ -475,7 +475,7 @@ it('should handle environment variables properly', async () => {
   })
 })
 
-it('should handle command arguments properly', async () => {
+it('handles command arguments properly', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
@@ -521,7 +521,7 @@ it('should handle command arguments properly', async () => {
   })
 })
 
-it('should show warning toast when server is not ready', async () => {
+it('shows warning toast when server is not ready', async () => {
   const mockSaveSecret = vi.fn()
   const mockCreateWorkload = vi.fn()
   const mockGetIsServerReady = vi.fn().mockResolvedValue(false)

--- a/renderer/src/features/registry-servers/lib/__tests__/secret-name-regex.test.ts
+++ b/renderer/src/features/registry-servers/lib/__tests__/secret-name-regex.test.ts
@@ -1,26 +1,26 @@
 import { expect, it } from 'vitest'
 import { SECRET_NAME_REGEX } from '../secret-name-regex'
 
-it('should return undefined for no suffix', () => {
+it('returns undefined for no suffix', () => {
   expect('MY_SECRET'.match(SECRET_NAME_REGEX)).toStrictEqual(
     expect.arrayContaining(['MY_SECRET', 'MY_SECRET', undefined])
   )
 })
 
-it('should handle single digit number suffix', () => {
+it('handles single digit number suffix', () => {
   expect('MY_SECRET_2'.match(SECRET_NAME_REGEX)).toStrictEqual(
     expect.arrayContaining(['MY_SECRET_2', 'MY_SECRET', '2'])
   )
 })
 
-it('should handle multiple digits in number suffix', () => {
+it('handles multiple digits in number suffix', () => {
   expect(
     'MY_SECRET_10'.match(SECRET_NAME_REGEX),
     'should handle multiple digits in number suffix'
   ).toStrictEqual(expect.arrayContaining(['MY_SECRET_10', 'MY_SECRET', '10']))
 })
 
-it('should not treat multiple underscored secrets as suffixed', () => {
+it('does not treat multiple underscored secrets as suffixed', () => {
   expect(
     'MY_SECRET_2_3'.match(SECRET_NAME_REGEX),
     'multiple underscores should not be matched as a number suffix'

--- a/renderer/src/routes/__tests__/index.test.tsx
+++ b/renderer/src/routes/__tests__/index.test.tsx
@@ -13,7 +13,7 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-it('should render list of MCP servers', async () => {
+it('renders list of MCP servers', async () => {
   renderRoute(router)
   await waitFor(() => {
     for (const mcpServer of MOCK_MCP_SERVERS) {
@@ -25,7 +25,7 @@ it('should render list of MCP servers', async () => {
   })
 })
 
-it('should contain the menu to run an MCP server', async () => {
+it('contains the menu to run an MCP server', async () => {
   renderRoute(router)
   await waitFor(() => {
     expect(
@@ -51,7 +51,7 @@ it('should contain the menu to run an MCP server', async () => {
   ).toBeVisible()
 })
 
-it('should restart server', async () => {
+it('restarts server', async () => {
   renderRoute(router)
 
   await waitFor(() => {
@@ -74,7 +74,7 @@ it('should restart server', async () => {
   })
 })
 
-it('should stop server', async () => {
+it('stops server', async () => {
   renderRoute(router)
 
   await waitFor(() => {
@@ -97,7 +97,7 @@ it('should stop server', async () => {
   })
 })
 
-it('should show dropdown menu with remove option when clicking more options button', async () => {
+it('shows dropdown menu with remove option when clicking more options button', async () => {
   renderRoute(router)
 
   await waitFor(() => {
@@ -119,7 +119,7 @@ it('should show dropdown menu with remove option when clicking more options butt
   expect(screen.getByRole('menuitem', { name: /remove/i })).toBeVisible()
 })
 
-it('should allow deleting a server through the dropdown menu', async () => {
+it('allows deleting a server through the dropdown menu', async () => {
   renderRoute(router)
 
   await waitFor(() => {

--- a/renderer/src/routes/__tests__/registry.test.tsx
+++ b/renderer/src/routes/__tests__/registry.test.tsx
@@ -16,7 +16,7 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-it('should render list of MCP servers', async () => {
+it('renders list of MCP servers', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/registry/:name/servers'), () => {
       return HttpResponse.json({ servers: MOCK_REGISTRY_RESPONSE })
@@ -60,7 +60,7 @@ const REGISTRY_SERVER = {
   tags: ['foo', 'bar'],
 } as const satisfies RegistryImageMetadata
 
-it('should launch dialog with form when clicking on server', async () => {
+it('launches dialog with form when clicking on server', async () => {
   server.use(
     http.get(mswEndpoint('/api/v1beta/registry/:name/servers'), () => {
       return HttpResponse.json({

--- a/renderer/src/routes/__tests__/secrets.test.tsx
+++ b/renderer/src/routes/__tests__/secrets.test.tsx
@@ -11,7 +11,7 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-it('should render the table with secrets', async () => {
+it('renders the table with secrets', async () => {
   renderRoute(router)
 
   await waitFor(() => {
@@ -38,7 +38,7 @@ it('should render the table with secrets', async () => {
   expect(screen.getByText('Delete')).toBeInTheDocument()
 })
 
-it('should render add secret dialog when clicking add secret button', async () => {
+it('renders add secret dialog when clicking add secret button', async () => {
   renderRoute(router)
 
   await waitFor(() => {
@@ -59,7 +59,7 @@ it('should render add secret dialog when clicking add secret button', async () =
   expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
 })
 
-it('should render edit secret dialog when clicking edit from dropdown', async () => {
+it('renders edit secret dialog when clicking edit from dropdown', async () => {
   renderRoute(router)
 
   await waitFor(() => {


### PR DESCRIPTION
This PR simplifies test case names. Example:

```diff
-should be case insensitive when filtering
+is case insensitive when filtering
```

This is better because:
- The fact that these are test cases already implies the expectation of behavior, so the word "should" becomes effectively redundant/meaningless
- Just a nit: the word "should" does not only imply an expectation, but is also frequently used as a hedging word to signal uncertainty. Test names should generally describe something that is certain, and when we *do* use the word _should_, it should be an intentional signaling of lack of certainty (i. e. "this should be future proof")`*`
- The test names are less verbose, fit more easily on the screen, are faster to read when looking at the failures etc etc
- In some cases, words like should can encourage the creation of more complex sentence structure/poorly written sentences, that generally lead to worse reading comprehension and information retention. Good (technical) writing is extremely hard, but skipping the word _should_ is basically a free way to improve the readability of the test names`*`




<sup>
`*` Steven Pinker is a cognitive linguist. <a href="https://en.wikipedia.org/wiki/The_Sense_of_Style" target="_blank">He wrote a book</a> that looks at non-fiction writing not only from a stylistic perspective, but also from the perspective of cognitive science. That book is my reference for these claims. The entire book is interesting, but Chapter 4 is the most relevant for these claims about structure.
</sup>