### PR TITLE
fix: stopping status workload

### DIFF
--- a/renderer/src/features/mcp-servers/components/actions-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/actions-mcp-server.tsx
@@ -32,8 +32,8 @@ export function ActionsMcpServer({
       <div onClick={(e) => e.preventDefault()}>
         <Switch
           aria-label="Mutate server"
-          checked={isRunning || isPending}
-          disabled={isStarting}
+          checked={isRunning || isStarting}
+          disabled={isStarting || isPending}
           onCheckedChange={() => mutate()}
         />
       </div>


### PR DESCRIPTION
After stopping a workload, the status remain wrong, we need to handle it with polling and replace the status from `stopping` to `stopped` once the polling finish.


BEFORE

https://github.com/user-attachments/assets/d0b178e5-5c77-4a36-a280-6de5ea40078f

AFTER

https://github.com/user-attachments/assets/4b7ad166-8b3f-4efe-a101-9f7aae345bca


