### PR TITLE
chore: refactor app name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to ToolHive Studio <!-- omit from toc -->
+# Contributing to ToolHive <!-- omit from toc -->
 
-First off, thank you for taking the time to contribute to ToolHive Studio! :+1:
-:tada: ToolHive Studio is released under the Apache 2.0 license. If you would
+First off, thank you for taking the time to contribute to ToolHive! :+1:
+:tada: ToolHive is released under the Apache 2.0 license. If you would
 like to contribute something or want to hack on the code, this document should
 help you get started. You can find some hints for starting development in
-ToolHive Studio's [developer guide](./docs/README.md).
+ToolHive's [developer guide](./docs/README.md).
 
 ## Table of contents <!-- omit from toc -->
 
@@ -26,7 +26,7 @@ unacceptable behavior to
 
 ## Reporting security vulnerabilities
 
-If you think you have found a security vulnerability in ToolHive Studio please
+If you think you have found a security vulnerability in ToolHive please
 DO NOT disclose it publicly until we've had a chance to fix it. Please don't
 report security vulnerabilities using GitHub issues; instead, please follow this
 [process](./SECURITY.MD)
@@ -55,7 +55,7 @@ are a great place to start!
   message to indicate that the contributor agrees to the Developer Certificate
   of Origin. For additional details, check out the [DCO instructions](./DCO.md).
 - Create an issue outlining the fix or feature.
-- Fork the ToolHive Studio repository to your own GitHub account and clone it
+- Fork the ToolHive repository to your own GitHub account and clone it
   locally.
 - Hack on your changes.
 - Correctly format your commit messages, see

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p float="left">
   <picture>
-    <img src="./icons/source-files/app-icons/mac/512.png" alt="ToolHive Studio logo" height="100" align="middle" />
+    <img src="./icons/source-files/app-icons/mac/512.png" alt="ToolHive logo" height="100" align="middle" />
   </picture>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/images/toolhive-wordmark-white.png">
@@ -80,10 +80,10 @@ setup, no security headaches, no runtime hassles.
 Download and install the latest release of the ToolHive for your platform:
 
 - macOS (Apple Silicon):
-  [download the DMG file](https://github.com/stacklok/toolhive-studio/releases/latest/download/ToolHive.Studio.dmg),
+  [download the DMG file](https://github.com/stacklok/toolhive-studio/releases/latest/download/ToolHive.dmg),
   open it, and drag the ToolHive app to your Applications folder.
 - Windows:
-  [download the installer](https://github.com/stacklok/toolhive-studio/releases/latest/download/ToolHive.Studio.Setup.exe)
+  [download the installer](https://github.com/stacklok/toolhive-studio/releases/latest/download/ToolHive.Setup.exe)
   and run it.
   > [!NOTE]  
   > The Windows installer is not digitally signed yet, so you might need to

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# ToolHive Studio developer guide
+# ToolHive developer guide
 
-This is the front-end for ToolHive Studio, an Electron application built with
+This is the front-end for ToolHive, an Electron application built with
 React, TypeScript, and Vite.
 
 ## Getting started

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # ToolHive developer guide
 
-This is the front-end for ToolHive, an Electron application built with
-React, TypeScript, and Vite.
+This is the front-end for ToolHive, an Electron application built with React,
+TypeScript, and Vite.
 
 ## Getting started
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -123,6 +123,7 @@ const config: ForgeConfig = {
         icon: './icons/icon.png',
         requires: ['docker >= 20.10'],
         license: 'Apache-2.0',
+        bin: 'ToolHive',
       },
     }),
     new MakerDeb({
@@ -135,6 +136,7 @@ const config: ForgeConfig = {
         maintainer: 'Stacklok',
         homepage: 'https://github.com/stacklok/toolhive-studio',
         section: 'devel',
+        bin: 'ToolHive',
       },
     }),
     // Requirements: install elfutils package and add Flathub remote

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -24,7 +24,7 @@ const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
     icon: './icons/icon',
-    executableName: 'toolhive-studio',
+    executableName: 'ToolHive',
     /**
      * Everything under bin/ is copied into
      * <app>/Contents/Resources/bin/ (macOS)
@@ -34,10 +34,10 @@ const config: ForgeConfig = {
     // Windows specific options
     win32metadata: {
       CompanyName: 'Stacklok',
-      FileDescription: 'ToolHive Studio',
-      OriginalFilename: 'ToolHive Studio.exe',
-      ProductName: 'ToolHive Studio',
-      InternalName: 'ToolHive Studio',
+      FileDescription: 'ToolHive',
+      OriginalFilename: 'ToolHive.exe',
+      ProductName: 'ToolHive',
+      InternalName: 'ToolHive',
     },
 
     // MacOS Code Signing Configuration
@@ -89,16 +89,16 @@ const config: ForgeConfig = {
     new MakerSquirrel({
       // Windows Squirrel installer configuration
       setupIcon: './icons/icon.ico', // Setup.exe icon
-      setupExe: 'ToolHive Studio Setup.exe',
+      setupExe: 'ToolHive Setup.exe',
       noMsi: true, // Don't create MSI installer
       authors: 'Stacklok',
-      exe: 'toolhive-studio.exe',
-      name: 'toolhive-studio',
+      exe: 'ToolHive.exe',
+      name: 'ToolHive',
     }),
     new MakerDMG(
       {
-        name: 'toolhive-studio',
-        title: 'ToolHive Studio',
+        name: 'ToolHive',
+        title: 'ToolHive',
         icon: './icons/icon.icns',
         overwrite: true,
         background: './assets/dmg-installer-background.png',
@@ -117,9 +117,9 @@ const config: ForgeConfig = {
     new MakerTarGz({}, ['linux']),
     new MakerRpm({
       options: {
-        name: 'toolhive-studio',
-        productName: 'ToolHive Studio',
-        genericName: 'ToolHive Studio',
+        name: 'ToolHive',
+        productName: 'ToolHive',
+        genericName: 'ToolHive',
         icon: './icons/icon.png',
         requires: ['docker >= 20.10'],
         license: 'Apache-2.0',
@@ -127,9 +127,9 @@ const config: ForgeConfig = {
     }),
     new MakerDeb({
       options: {
-        name: 'toolhive-studio',
-        productName: 'ToolHive Studio',
-        genericName: 'ToolHive Studio',
+        name: 'ToolHive',
+        productName: 'ToolHive',
+        genericName: 'ToolHive',
         icon: './icons/icon.png',
         depends: [],
         maintainer: 'Stacklok',

--- a/main/src/auto-launch.ts
+++ b/main/src/auto-launch.ts
@@ -17,12 +17,12 @@ interface DesktopEntry {
 export function createDesktopEntry(execPath: string): string {
   const entry: DesktopEntry = {
     Type: 'Application',
-    Name: 'ToolHive Studio',
+    Name: 'ToolHive',
     Exec: `"${execPath}" --hidden`,
     Hidden: 'false',
     NoDisplay: 'false',
     'X-GNOME-Autostart-enabled': 'true',
-    Comment: 'ToolHive Studio Auto-Launch',
+    Comment: 'ToolHive Auto-Launch',
   }
 
   return Object.entries(entry)

--- a/main/src/system-tray.ts
+++ b/main/src/system-tray.ts
@@ -224,7 +224,7 @@ function setupTrayMenu(tray: Tray, toolHiveIsRunning: boolean) {
   const menuTemplate = createMenuTemplate(tray, toolHiveIsRunning)
   const contextMenu = Menu.buildFromTemplate(menuTemplate)
 
-  tray.setToolTip('ToolHive Studio')
+  tray.setToolTip('ToolHive')
   tray.setContextMenu(contextMenu)
 
   // Windows-specific click handling

--- a/main/src/tests/auto-launch.test.ts
+++ b/main/src/tests/auto-launch.test.ts
@@ -4,12 +4,12 @@ import { createDesktopEntry } from '../auto-launch'
 describe('Linux desktop-entry generation', () => {
   it('quotes the Exec path when it contains spaces', () => {
     // context: https://stacklok.slack.com/archives/C072SGY78TS/p1750688399690469?thread_ts=1750674636.806059&cid=C072SGY78TS
-    const execPath = '/home/alice/My Apps/Tool Hive/toolhive-studio'
+    const execPath = '/home/alice/My Apps/Tool Hive/ToolHive'
 
     const entry = createDesktopEntry(execPath)
 
     expect(entry).toContain(
-      `Exec="/home/alice/My Apps/Tool Hive/toolhive-studio" --hidden`
+      `Exec="/home/alice/My Apps/Tool Hive/ToolHive" --hidden`
     )
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "toolhive-studio",
-  "productName": "ToolHive Studio",
+  "productName": "ToolHive",
   "version": "0.0.5",
-  "description": "ToolHive Studio is an application that allows you to install, manage and run MCP servers and connect them to AI agents and clients",
+  "description": "ToolHive is an application that allows you to install, manage and run MCP servers and connect them to AI agents and clients",
   "main": ".vite/build/main.js",
   "repository": "https://github.com/stacklok/toolhive-studio",
   "engines": {

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>ToolHive Studio</title>
+    <title>ToolHive</title>
   </head>
   <body id="root" class="font-sans">
     <script type="module" src="/src/renderer.tsx"></script>

--- a/renderer/src/common/components/error/__tests__/index.test.tsx
+++ b/renderer/src/common/components/error/__tests__/index.test.tsx
@@ -35,7 +35,7 @@ describe('Error', () => {
 
     expect(screen.getByText('System Keyring Cannot be Reached')).toBeVisible()
     expect(
-      screen.getByText(/ToolHive Studio needs to access your system keyring/)
+      screen.getByText(/ToolHive needs to access your system keyring/)
     ).toBeVisible()
   })
 
@@ -55,7 +55,7 @@ describe('Error', () => {
       screen.queryByText('System Keyring Cannot be Reached')
     ).not.toBeInTheDocument()
     expect(
-      screen.queryByText(/ToolHive Studio needs to access your system keyring/)
+      screen.queryByText(/ToolHive needs to access your system keyring/)
     ).not.toBeInTheDocument()
   })
 

--- a/renderer/src/common/components/error/connection-refused-error.tsx
+++ b/renderer/src/common/components/error/connection-refused-error.tsx
@@ -122,7 +122,7 @@ export function ConnectionRefusedError() {
       icon={<IllustrationPackage className="size-20" />}
     >
       <p>
-        ToolHive Studio requires either <strong>Docker</strong> or{' '}
+        ToolHive requires either <strong>Docker</strong> or{' '}
         <strong>Podman</strong> to be installed and running to manage
         containerized tools and services.
       </p>

--- a/renderer/src/common/components/error/keyring-error.tsx
+++ b/renderer/src/common/components/error/keyring-error.tsx
@@ -8,8 +8,8 @@ export function KeyringError() {
       icon={<FolderKey className="text-destructive size-12" />}
     >
       <p>
-        ToolHive Studio needs to access your system keyring in order to securely
-        store and manage your secrets.
+        ToolHive needs to access your system keyring in order to securely store
+        and manage your secrets.
       </p>
 
       <p>Most Linux distributions have a system keyring out of the box.</p>

--- a/renderer/src/common/hooks/use-confirm-quit.ts
+++ b/renderer/src/common/hooks/use-confirm-quit.ts
@@ -4,7 +4,7 @@ export function useConfirmQuit() {
   const confirm = useConfirm()
   return async () => {
     return confirm(
-      'Shutting down ToolHive Studio will also shut down all your MCP servers.',
+      'Shutting down ToolHive will also shut down all your MCP servers.',
       {
         title: 'Quitting will shut MCPs down',
         isDestructive: true,


### PR DESCRIPTION
We decided to refactor the name from ToolHive Studio to ToolHive, having product consistency with the CLI


 