### PR TITLE
chore: add privacy policy link and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,30 @@ Kubernetes Operator. Learn more in the
 
 ---
 
+## Privacy and Telemetry
+
+ToolHive uses [Sentry](https://sentry.io/) for error tracking and performance
+monitoring to help us identify and fix issues, improve stability, and enhance
+the user experience. This telemetry is enabled by default but completely
+optional.
+
+### What data is collected?
+
+- Error reports and crash logs
+- Performance metrics
+- Usage patterns
+
+### How to opt out
+
+You can easily disable telemetry at any time:
+
+1. Open ToolHive
+2. Go to **Settings** (gear icon in the top navigation)
+3. Find the **Telemetry** section
+4. Toggle off telemetry collection
+
+---
+
 ## Contributing
 
 We welcome contributions and feedback from the community!

--- a/renderer/src/common/components/help/help-dropdown.tsx
+++ b/renderer/src/common/components/help/help-dropdown.tsx
@@ -62,6 +62,16 @@ export function HelpDropdown({ className }: { className?: string }) {
             GitHub Repository
           </a>
         </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <a
+            href="https://www.iubenda.com/privacy-policy/29074746"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cursor-pointer"
+          >
+            Privacy Policy
+          </a>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )


### PR DESCRIPTION
Add privacy policy link to settings menu. Update readme with the Sentry section
<img width="1021" height="624" alt="Screenshot 2025-07-10 at 15 45 17" src="https://github.com/user-attachments/assets/6fee955f-fba7-42d3-a552-29accead327a" />
