### PR TITLE
feat: remove excessive description from "Add a secret" dialog

### DIFF
--- a/renderer/src/features/secrets/components/dialog-form-secret.tsx
+++ b/renderer/src/features/secrets/components/dialog-form-secret.tsx
@@ -86,20 +86,11 @@ export function DialogFormSecret({
       >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
-          {secretKey ? (
-            <>
-              <DialogDescription className="sr-only">
-                Update secret dialog
-              </DialogDescription>
-              <DialogDescription>
-                Update the secret value below.
-              </DialogDescription>
-            </>
-          ) : (
-            <DialogDescription className="sr-only">
-              Add a secret dialog
-            </DialogDescription>
-          )}
+          <DialogDescription className="sr-only">
+            {secretKey
+              ? 'Update the secret value below.'
+              : 'Enter a name and value for your new secret.'}
+          </DialogDescription>
         </DialogHeader>
 
         <SecretForm

--- a/renderer/src/features/secrets/components/dialog-form-secret.tsx
+++ b/renderer/src/features/secrets/components/dialog-form-secret.tsx
@@ -86,11 +86,15 @@ export function DialogFormSecret({
       >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>
-            {secretKey
-              ? 'Update the secret value below.'
-              : 'Enter a name and value for your new secret.'}
-          </DialogDescription>
+          {secretKey ? (
+            <DialogDescription>
+              Update the secret value below.
+            </DialogDescription>
+          ) : (
+            <DialogDescription className="sr-only">
+              Add a secret dialog
+            </DialogDescription>
+          )}
         </DialogHeader>
 
         <SecretForm

--- a/renderer/src/features/secrets/components/dialog-form-secret.tsx
+++ b/renderer/src/features/secrets/components/dialog-form-secret.tsx
@@ -116,7 +116,7 @@ function SecretForm({ form, isEditMode, onSubmit, onCancel }: SecretFormProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleFormSubmit)}>
-        <div className="space-y-4 py-8">
+        <div className="space-y-4 pt-4 pb-8">
           {!isEditMode && (
             <FormField
               control={form.control}

--- a/renderer/src/features/secrets/components/dialog-form-secret.tsx
+++ b/renderer/src/features/secrets/components/dialog-form-secret.tsx
@@ -87,9 +87,14 @@ export function DialogFormSecret({
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {secretKey ? (
-            <DialogDescription>
-              Update the secret value below.
-            </DialogDescription>
+            <>
+              <DialogDescription className="sr-only">
+                Update secret dialog
+              </DialogDescription>
+              <DialogDescription>
+                Update the secret value below.
+              </DialogDescription>
+            </>
           ) : (
             <DialogDescription className="sr-only">
               Add a secret dialog

--- a/renderer/src/routes/__tests__/secrets.test.tsx
+++ b/renderer/src/routes/__tests__/secrets.test.tsx
@@ -54,31 +54,18 @@ it('renders add secret dialog when clicking add secret button', async () => {
   expect(screen.getByPlaceholderText('Secret')).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
-})
 
-it('add secret dialog includes a screen-reader-only description and is linked via aria-describedby', async () => {
-  renderRoute(router)
-
-  await waitFor(() => {
-    expect(
-      screen.getByRole('heading', { name: /secrets/i })
-    ).toBeInTheDocument()
-  })
-
-  const addSecretButton = screen.getByRole('button', { name: /add secret/i })
-  await userEvent.click(addSecretButton)
-
+  // Accessibility: check sr-only description and aria-describedby
   const dialog = screen.getByRole('dialog')
-  const description = Array.from(dialog.querySelectorAll('p,div,span')).find(
+  const srDescription = Array.from(dialog.querySelectorAll('p,div,span')).find(
     (el) =>
       el.className.includes('sr-only') &&
-      el.textContent?.includes('Add a secret dialog')
+      el.textContent?.includes('Enter a name and value for your new secret.')
   )
-  expect(description).toBeTruthy()
-
+  expect(srDescription).toBeTruthy()
   const ariaDescribedBy = dialog.getAttribute('aria-describedby')
   expect(ariaDescribedBy).toBeTruthy()
-  expect(description?.id).toBe(ariaDescribedBy)
+  expect(srDescription?.id).toBe(ariaDescribedBy)
 })
 
 it('renders edit secret dialog when clicking edit from dropdown', async () => {
@@ -100,38 +87,15 @@ it('renders edit secret dialog when clicking edit from dropdown', async () => {
   expect(screen.getByPlaceholderText('Secret')).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /update/i })).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
-})
 
-it('edit secret dialog includes a screen-reader-only description and is linked via aria-describedby', async () => {
-  renderRoute(router)
-
-  await waitFor(() => {
-    expect(
-      screen.getByRole('heading', { name: /secrets/i })
-    ).toBeInTheDocument()
-  })
-  const dropdownTriggers = screen.getAllByLabelText('Secret options')
-  await userEvent.click(dropdownTriggers[0]!)
-  const editButton = screen.getByText('Update secret')
-  await userEvent.click(editButton)
-
+  // Accessibility: check sr-only and aria-describedby
   const dialog = screen.getByRole('dialog')
   const srDescription = Array.from(dialog.querySelectorAll('p,div,span')).find(
     (el) =>
       el.className.includes('sr-only') &&
-      el.textContent?.includes('Update secret dialog')
-  )
-  expect(srDescription).toBeTruthy()
-
-  const visibleDescription = Array.from(
-    dialog.querySelectorAll('p,div,span')
-  ).find(
-    (el) =>
-      !el.className.includes('sr-only') &&
       el.textContent?.includes('Update the secret value below.')
   )
-  expect(visibleDescription).toBeTruthy()
-
+  expect(srDescription).toBeTruthy()
   const ariaDescribedBy = dialog.getAttribute('aria-describedby')
   expect(ariaDescribedBy).toBeTruthy()
   expect(srDescription?.id).toBe(ariaDescribedBy)

--- a/renderer/src/routes/__tests__/secrets.test.tsx
+++ b/renderer/src/routes/__tests__/secrets.test.tsx
@@ -50,13 +50,35 @@ it('renders add secret dialog when clicking add secret button', async () => {
   const addSecretButton = screen.getByRole('button', { name: /add secret/i })
   await userEvent.click(addSecretButton)
 
-  expect(
-    screen.getByText('Enter a name and value for your new secret.')
-  ).toBeInTheDocument()
   expect(screen.getByPlaceholderText('Name')).toBeInTheDocument()
   expect(screen.getByPlaceholderText('Secret')).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+})
+
+it('add secret dialog includes a screen-reader-only description and is linked via aria-describedby', async () => {
+  renderRoute(router)
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole('heading', { name: /secrets/i })
+    ).toBeInTheDocument()
+  })
+
+  const addSecretButton = screen.getByRole('button', { name: /add secret/i })
+  await userEvent.click(addSecretButton)
+
+  const dialog = screen.getByRole('dialog')
+  const description = Array.from(dialog.querySelectorAll('p,div,span')).find(
+    (el) =>
+      el.className.includes('sr-only') &&
+      el.textContent?.includes('Add a secret dialog')
+  )
+  expect(description).toBeTruthy()
+
+  const ariaDescribedBy = dialog.getAttribute('aria-describedby')
+  expect(ariaDescribedBy).toBeTruthy()
+  expect(description?.id).toBe(ariaDescribedBy)
 })
 
 it('renders edit secret dialog when clicking edit from dropdown', async () => {

--- a/renderer/src/routes/__tests__/secrets.test.tsx
+++ b/renderer/src/routes/__tests__/secrets.test.tsx
@@ -101,3 +101,38 @@ it('renders edit secret dialog when clicking edit from dropdown', async () => {
   expect(screen.getByRole('button', { name: /update/i })).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
 })
+
+it('edit secret dialog includes a screen-reader-only description and is linked via aria-describedby', async () => {
+  renderRoute(router)
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole('heading', { name: /secrets/i })
+    ).toBeInTheDocument()
+  })
+  const dropdownTriggers = screen.getAllByLabelText('Secret options')
+  await userEvent.click(dropdownTriggers[0]!)
+  const editButton = screen.getByText('Update secret')
+  await userEvent.click(editButton)
+
+  const dialog = screen.getByRole('dialog')
+  const srDescription = Array.from(dialog.querySelectorAll('p,div,span')).find(
+    (el) =>
+      el.className.includes('sr-only') &&
+      el.textContent?.includes('Update secret dialog')
+  )
+  expect(srDescription).toBeTruthy()
+
+  const visibleDescription = Array.from(
+    dialog.querySelectorAll('p,div,span')
+  ).find(
+    (el) =>
+      !el.className.includes('sr-only') &&
+      el.textContent?.includes('Update the secret value below.')
+  )
+  expect(visibleDescription).toBeTruthy()
+
+  const ariaDescribedBy = dialog.getAttribute('aria-describedby')
+  expect(ariaDescribedBy).toBeTruthy()
+  expect(srDescription?.id).toBe(ariaDescribedBy)
+})


### PR DESCRIPTION
note: the description is an accessibility requirement for screen readers and our tests will fail without it, because radix ui issues console warnings for it, and we fail our tests on console warnings.

this behavior makes sense, so instead of disabling it, I decided to keep the description for screen readers (hence the sr-only class).

In order to make the behavior less confusing when refactoring/debugging this area of the app, I also added a test case that verifies the screen-reader behavior.


fixes: https://github.com/stacklok/toolhive-studio/issues/468


<img width="1915" height="1037" alt="Screenshot_select-area_20250711124156" src="https://github.com/user-attachments/assets/fe5397b3-69e5-4e7d-842d-2efd66f2cfd4" />
