### PR TITLE
feat(registry): registry detail page

### DIFF
--- a/renderer/src/common/components/layout/top-nav/index.tsx
+++ b/renderer/src/common/components/layout/top-nav/index.tsx
@@ -105,8 +105,9 @@ function TopNavLinks() {
 
 export function TopNav(props: HTMLProps<HTMLElement>) {
   const confirmQuit = useConfirmQuit()
+
   useEffect(() => {
-    window.electronAPI.onUpdateDownloaded(() => {
+    const cleanup = window.electronAPI.onUpdateDownloaded(() => {
       toast.info('Update downloaded and ready to install', {
         duration: Infinity,
         dismissible: true,
@@ -126,6 +127,9 @@ export function TopNav(props: HTMLProps<HTMLElement>) {
         },
       })
     })
+
+    // Cleanup function to remove the event listener
+    return cleanup
   }, [confirmQuit])
 
   return (

--- a/renderer/src/common/components/settings/settings-dropdown.tsx
+++ b/renderer/src/common/components/settings/settings-dropdown.tsx
@@ -90,7 +90,7 @@ export function SettingsDropdown({ className }: { className?: string }) {
           onClick={() => (isTelemetryEnabled ? sentryOptOut() : sentryOptIn())}
           disabled={isSentryPending}
         >
-          <span>Telemetry</span>
+          <span>Error reporting</span>
           {isSentryPending ? (
             <Loader className="ml-auto h-4 w-4 animate-spin" />
           ) : isTelemetryEnabled ? (

--- a/renderer/src/common/mocks/fixtures/registry_server.ts
+++ b/renderer/src/common/mocks/fixtures/registry_server.ts
@@ -5,11 +5,25 @@ export const registryServerFixture = {
     description:
       'MCP server for time info and IANA timezone conversions with auto system timezone detection.',
     transport: 'stdio',
+    tier: 'official',
+    status: 'active',
     permissions: {
       network: { outbound: { allow_transport: ['tcp'], allow_port: [443] } },
     },
     tools: ['get_current_time', 'convert_time'],
-    env_vars: [],
+    env_vars: [
+      {
+        name: 'ENV_VAR',
+        description: 'foo bar',
+        required: false,
+      },
+
+      {
+        name: 'SECRET',
+        description: 'foo bar',
+        secret: true,
+      },
+    ],
     args: [],
     metadata: {
       stars: 52153,
@@ -29,5 +43,13 @@ export const registryServerFixture = {
       'example',
       'examples',
     ],
+    provenance: {
+      sigstore_url: 'tuf-repo-cdn.sigstore.dev',
+      repository_uri: 'https://github.com/test/server',
+      repository_ref: 'refs/heads/main',
+      signer_identity: '/.github/workflows/release.yml',
+      runner_environment: 'github-hosted',
+      cert_issuer: 'https://token.actions.githubusercontent.com',
+    },
   },
 }

--- a/renderer/src/features/registry-servers/components/Stars.tsx
+++ b/renderer/src/features/registry-servers/components/Stars.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/common/lib/utils'
+import { StarIcon } from 'lucide-react'
+
+export function Stars({
+  stars,
+  className,
+}: {
+  stars: number | undefined
+  className?: string
+}) {
+  if (!stars) return null
+
+  return (
+    <>
+      <StarIcon className={cn('text-muted-foreground size-3', className)} />
+      <span className="text-muted-foreground text-sm select-none">
+        {Intl.NumberFormat().format(stars)}
+      </span>
+    </>
+  )
+}

--- a/renderer/src/features/registry-servers/components/card-registry-server.tsx
+++ b/renderer/src/features/registry-servers/components/card-registry-server.tsx
@@ -6,9 +6,10 @@ import {
   CardFooter,
 } from '@/common/components/ui/card'
 import type { RegistryImageMetadata } from '@/common/api/generated/types.gen'
-import { Github, Plus, StarIcon } from 'lucide-react'
+import { Github, Plus } from 'lucide-react'
 import { cn } from '@/common/lib/utils'
 import { Button } from '@/common/components/ui/button'
+import { Stars } from './Stars'
 
 const statusMap = {
   deprecated: 'Deprecated',
@@ -65,10 +66,7 @@ export function CardRegistryServer({
       <CardFooter className="mt-auto flex items-center gap-2">
         {server?.metadata?.stars ? (
           <div className="flex items-center gap-2">
-            <StarIcon className="text-muted-foreground size-3" />
-            <span className="text-muted-foreground text-sm select-none">
-              {Intl.NumberFormat().format(server.metadata.stars)}
-            </span>
+            <Stars stars={server.metadata.stars} />
           </div>
         ) : null}
         {server?.repository_url ? (

--- a/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
+++ b/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
@@ -1,19 +1,16 @@
 import type { RegistryImageMetadata } from '@/common/api/generated/types.gen'
 import { CardRegistryServer } from './card-registry-server'
-import { FormRunFromRegistry } from './form-run-from-registry'
-import { useState, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useFilterSort } from '@/common/hooks/use-filter-sort'
 import { InputSearch } from '@/common/components/ui/input-search'
+import { useNavigate } from '@tanstack/react-router'
 
 export function GridCardsRegistryServer({
   servers,
 }: {
   servers: RegistryImageMetadata[]
 }) {
-  const [selectedServer, setSelectedServer] =
-    useState<RegistryImageMetadata | null>(null)
-  const [isModalOpen, setIsModalOpen] = useState(false)
-
+  const navigate = useNavigate()
   // Filter out filesystem servers
   const filteredServers = useMemo(() => {
     return servers.filter((server) => server.name !== 'filesystem')
@@ -29,11 +26,6 @@ export function GridCardsRegistryServer({
     sortBy: (server) => server.name || '',
   })
 
-  const handleCardClick = (server: RegistryImageMetadata) => {
-    setSelectedServer(server)
-    setIsModalOpen(true)
-  }
-
   return (
     <div className="space-y-6">
       <InputSearch
@@ -46,7 +38,12 @@ export function GridCardsRegistryServer({
           <CardRegistryServer
             key={server.name}
             server={server}
-            onClick={() => handleCardClick(server)}
+            onClick={() => {
+              navigate({
+                to: '/registry/$name',
+                params: { name: server.name! },
+              })
+            }}
           />
         ))}
       </div>
@@ -57,13 +54,6 @@ export function GridCardsRegistryServer({
           </p>
         </div>
       )}
-
-      <FormRunFromRegistry
-        key={selectedServer?.name}
-        server={selectedServer}
-        isOpen={isModalOpen}
-        onOpenChange={setIsModalOpen}
-      />
     </div>
   )
 }

--- a/renderer/src/route-tree.gen.ts
+++ b/renderer/src/route-tree.gen.ts
@@ -11,10 +11,11 @@
 import { Route as rootRouteImport } from "./routes/__root"
 import { Route as ShutdownRouteImport } from "./routes/shutdown"
 import { Route as SecretsRouteImport } from "./routes/secrets"
-import { Route as RegistryRouteImport } from "./routes/registry"
 import { Route as ClientsRouteImport } from "./routes/clients"
 import { Route as IndexRouteImport } from "./routes/index"
 import { Route as LogsServerNameRouteImport } from "./routes/logs.$serverName"
+import { Route as registryRegistryRouteImport } from "./routes/(registry)/registry"
+import { Route as registryRegistryNameRouteImport } from "./routes/(registry)/registry_.$name"
 
 const ShutdownRoute = ShutdownRouteImport.update({
   id: "/shutdown",
@@ -24,11 +25,6 @@ const ShutdownRoute = ShutdownRouteImport.update({
 const SecretsRoute = SecretsRouteImport.update({
   id: "/secrets",
   path: "/secrets",
-  getParentRoute: () => rootRouteImport,
-} as any)
-const RegistryRoute = RegistryRouteImport.update({
-  id: "/registry",
-  path: "/registry",
   getParentRoute: () => rootRouteImport,
 } as any)
 const ClientsRoute = ClientsRouteImport.update({
@@ -46,66 +42,83 @@ const LogsServerNameRoute = LogsServerNameRouteImport.update({
   path: "/logs/$serverName",
   getParentRoute: () => rootRouteImport,
 } as any)
+const registryRegistryRoute = registryRegistryRouteImport.update({
+  id: "/(registry)/registry",
+  path: "/registry",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const registryRegistryNameRoute = registryRegistryNameRouteImport.update({
+  id: "/(registry)/registry_/$name",
+  path: "/registry/$name",
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute
   "/clients": typeof ClientsRoute
-  "/registry": typeof RegistryRoute
   "/secrets": typeof SecretsRoute
   "/shutdown": typeof ShutdownRoute
+  "/registry": typeof registryRegistryRoute
   "/logs/$serverName": typeof LogsServerNameRoute
+  "/registry/$name": typeof registryRegistryNameRoute
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute
   "/clients": typeof ClientsRoute
-  "/registry": typeof RegistryRoute
   "/secrets": typeof SecretsRoute
   "/shutdown": typeof ShutdownRoute
+  "/registry": typeof registryRegistryRoute
   "/logs/$serverName": typeof LogsServerNameRoute
+  "/registry/$name": typeof registryRegistryNameRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   "/": typeof IndexRoute
   "/clients": typeof ClientsRoute
-  "/registry": typeof RegistryRoute
   "/secrets": typeof SecretsRoute
   "/shutdown": typeof ShutdownRoute
+  "/(registry)/registry": typeof registryRegistryRoute
   "/logs/$serverName": typeof LogsServerNameRoute
+  "/(registry)/registry_/$name": typeof registryRegistryNameRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | "/"
     | "/clients"
-    | "/registry"
     | "/secrets"
     | "/shutdown"
+    | "/registry"
     | "/logs/$serverName"
+    | "/registry/$name"
   fileRoutesByTo: FileRoutesByTo
   to:
     | "/"
     | "/clients"
-    | "/registry"
     | "/secrets"
     | "/shutdown"
+    | "/registry"
     | "/logs/$serverName"
+    | "/registry/$name"
   id:
     | "__root__"
     | "/"
     | "/clients"
-    | "/registry"
     | "/secrets"
     | "/shutdown"
+    | "/(registry)/registry"
     | "/logs/$serverName"
+    | "/(registry)/registry_/$name"
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ClientsRoute: typeof ClientsRoute
-  RegistryRoute: typeof RegistryRoute
   SecretsRoute: typeof SecretsRoute
   ShutdownRoute: typeof ShutdownRoute
+  registryRegistryRoute: typeof registryRegistryRoute
   LogsServerNameRoute: typeof LogsServerNameRoute
+  registryRegistryNameRoute: typeof registryRegistryNameRoute
 }
 
 declare module "@tanstack/react-router" {
@@ -122,13 +135,6 @@ declare module "@tanstack/react-router" {
       path: "/secrets"
       fullPath: "/secrets"
       preLoaderRoute: typeof SecretsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/registry": {
-      id: "/registry"
-      path: "/registry"
-      fullPath: "/registry"
-      preLoaderRoute: typeof RegistryRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/clients": {
@@ -152,16 +158,31 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof LogsServerNameRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/(registry)/registry": {
+      id: "/(registry)/registry"
+      path: "/registry"
+      fullPath: "/registry"
+      preLoaderRoute: typeof registryRegistryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/(registry)/registry_/$name": {
+      id: "/(registry)/registry_/$name"
+      path: "/registry/$name"
+      fullPath: "/registry/$name"
+      preLoaderRoute: typeof registryRegistryNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ClientsRoute: ClientsRoute,
-  RegistryRoute: RegistryRoute,
   SecretsRoute: SecretsRoute,
   ShutdownRoute: ShutdownRoute,
+  registryRegistryRoute: registryRegistryRoute,
   LogsServerNameRoute: LogsServerNameRoute,
+  registryRegistryNameRoute: registryRegistryNameRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/renderer/src/routes/(registry)/registry.tsx
+++ b/renderer/src/routes/(registry)/registry.tsx
@@ -7,7 +7,7 @@ import { ExternalLinkIcon } from 'lucide-react'
 import { Button } from '@/common/components/ui/button'
 import { IllustrationNoConnection } from '@/common/components/illustrations/illustration-no-connection'
 
-export const Route = createFileRoute('/registry')({
+export const Route = createFileRoute('/(registry)/registry')({
   loader: async ({ context: { queryClient } }) =>
     queryClient.ensureQueryData(
       getApiV1BetaRegistryByNameServersOptions({ path: { name: 'default' } })

--- a/renderer/src/routes/(registry)/registry_.$name.tsx
+++ b/renderer/src/routes/(registry)/registry_.$name.tsx
@@ -71,7 +71,7 @@ export function RegistryServerDetail() {
   return (
     <div className="flex max-h-full w-full flex-1 flex-col">
       <div className="mb-2">
-        <LinkViewTransition to="/">
+        <LinkViewTransition to="/registry">
           <Button
             variant="ghost"
             aria-label="Back"

--- a/renderer/src/routes/(registry)/registry_.$name.tsx
+++ b/renderer/src/routes/(registry)/registry_.$name.tsx
@@ -1,0 +1,159 @@
+import { LinkViewTransition } from '@/common/components/link-view-transition'
+import { Button } from '@/common/components/ui/button'
+import { Separator } from '@/common/components/ui/separator'
+import { createFileRoute, Link, useParams } from '@tanstack/react-router'
+import { ChevronLeft, GithubIcon, ShieldCheck, Wrench } from 'lucide-react'
+import { getApiV1BetaRegistryByNameServersByServerNameOptions } from '@/common/api/generated/@tanstack/react-query.gen'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { Stars } from '@/features/registry-servers/components/Stars'
+import { Badge } from '@/common/components/ui/badge'
+import type { RegistryImageMetadata } from '@/common/api/generated/types.gen'
+import { useState } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { FormRunFromRegistry } from '@/features/registry-servers/components/form-run-from-registry'
+
+const statusMap = {
+  deprecated: 'Deprecated',
+  active: 'Active',
+} as const satisfies Record<string, RegistryImageMetadata['status']>
+
+const INITIAL_TOOLS_LIMIT = 10
+
+export const Route = createFileRoute('/(registry)/registry_/$name')({
+  loader: ({ context: { queryClient }, params }) => {
+    return queryClient.ensureQueryData(
+      getApiV1BetaRegistryByNameServersByServerNameOptions({
+        path: {
+          name: 'default',
+          serverName: params.name,
+        },
+      })
+    )
+  },
+  component: RegistryServerDetail,
+})
+
+export function RegistryServerDetail() {
+  const { name } = useParams({ from: '/(registry)/registry_/$name' })
+  const {
+    data: { server },
+  } = useSuspenseQuery(
+    getApiV1BetaRegistryByNameServersByServerNameOptions({
+      path: {
+        name: 'default',
+        serverName: name,
+      },
+    })
+  )
+  const [showAllTools, setShowAllTools] = useState(false)
+  const [selectedServer, setSelectedServer] =
+    useState<RegistryImageMetadata | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  if (!server) return null
+
+  const handleCardClick = (server: RegistryImageMetadata) => {
+    setSelectedServer(server)
+    setIsModalOpen(true)
+  }
+
+  const toolsToShow = showAllTools
+    ? server.tools
+    : server.tools?.slice(0, INITIAL_TOOLS_LIMIT)
+
+  const hasMoreTools = server.tools && server.tools.length > INITIAL_TOOLS_LIMIT
+  const repositoryUrl = server.repository_url
+
+  return (
+    <div className="flex max-h-full w-full flex-1 flex-col">
+      <div className="mb-2">
+        <LinkViewTransition to="/">
+          <Button
+            variant="ghost"
+            aria-label="Back"
+            className="text-muted-foreground"
+          >
+            <ChevronLeft className="size-5" />
+            Back
+          </Button>
+        </LinkViewTransition>
+      </div>
+      <div className="flex flex-col gap-5">
+        <h1 className="m-0 mb-0 p-0 text-3xl font-bold">{name}</h1>
+        <div className="flex items-center gap-3">
+          <Badge variant="default">{server.tier}</Badge>
+          {server.status === statusMap.deprecated && (
+            <Badge variant="outline">{server.status}</Badge>
+          )}
+          <Badge variant="secondary">{server.transport}</Badge>
+          <Stars stars={server.metadata?.stars} className="size-4" />
+          <Tooltip>
+            <TooltipTrigger className="text-muted-foreground flex items-center gap-2">
+              <ShieldCheck className="size-4" />
+              <span className="text-sm">Provenance signed by Sigstore</span>
+            </TooltipTrigger>
+            <TooltipContent className="w-96">
+              <p>
+                The {name} MCP server has been cryptographically signed and its
+                build provenance verified through Sigstore, confirming its
+                authenticity and integrity
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+      <div className="my-8 flex w-3/5 flex-col gap-8">
+        <div className="text-muted-foreground flex-[2] select-none">
+          {server.description}
+        </div>
+
+        {server?.tools?.length && (
+          <div className="flex w-3/5 flex-[3] flex-col gap-4">
+            <p className="text-base font-bold">Tools listed</p>
+            <div className="flex flex-wrap gap-2">
+              {toolsToShow?.map((tool) => (
+                <Badge key={tool} variant="outline">
+                  {tool}
+                </Badge>
+              ))}
+              {hasMoreTools && (
+                <Badge
+                  variant="default"
+                  className="hover:bg-primary/80 cursor-pointer transition-colors"
+                  onClick={() => setShowAllTools(!showAllTools)}
+                >
+                  {!showAllTools ? 'Show more' : 'Show less'}
+                </Badge>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Separator className="my-6" />
+      <div className="flex gap-5">
+        <Button variant="default" onClick={() => handleCardClick(server)}>
+          <Wrench className="size-4" />
+          Install server
+        </Button>
+        <Link to={repositoryUrl} target="_blank">
+          <Button variant="outline">
+            <GithubIcon className="size-4" />
+            GitHub
+          </Button>
+        </Link>
+      </div>
+
+      <FormRunFromRegistry
+        key={selectedServer?.name}
+        server={selectedServer}
+        isOpen={isModalOpen}
+        onOpenChange={setIsModalOpen}
+      />
+    </div>
+  )
+}

--- a/renderer/src/routes/__tests__/registry.test.tsx
+++ b/renderer/src/routes/__tests__/registry.test.tsx
@@ -6,9 +6,7 @@ import { server } from '@/common/mocks/node'
 import { http, HttpResponse } from 'msw'
 import { MOCK_REGISTRY_RESPONSE } from '@/common/mocks/fixtures/registry'
 import { mswEndpoint } from '@/common/mocks/msw-endpoint'
-import { Registry } from '../registry'
-import userEvent from '@testing-library/user-event'
-import type { RegistryImageMetadata } from '@/common/api/generated'
+import { Registry } from '../(registry)/registry'
 
 const router = createTestRouter(Registry)
 beforeEach(() => {
@@ -45,64 +43,4 @@ it('renders list of MCP servers', async () => {
     screen.queryByText('filesystem'),
     'Expected filesystem to NOT be in the document'
   ).not.toBeInTheDocument()
-})
-
-const REGISTRY_SERVER = {
-  name: 'foo-bar-server',
-  image: 'ghcr.io/foo/bar:latest',
-  description: 'foo bar',
-  transport: 'stdio',
-  permissions: {},
-  tools: ['tool-1'],
-  env_vars: [
-    {
-      name: 'ENV_VAR',
-      description: 'foo bar',
-      required: false,
-    },
-
-    {
-      name: 'SECRET',
-      description: 'foo bar',
-      secret: true,
-    },
-  ],
-  args: [],
-  metadata: {},
-  repository_url: 'https://github.com/foo/bar',
-  tags: ['foo', 'bar'],
-} as const satisfies RegistryImageMetadata
-
-it('launches dialog with form when clicking on server', async () => {
-  server.use(
-    http.get(mswEndpoint('/api/v1beta/registry/:name/servers'), () => {
-      return HttpResponse.json({
-        servers: [REGISTRY_SERVER],
-      })
-    })
-  )
-
-  renderRoute(router)
-  await waitFor(() => {
-    expect(
-      screen.queryByText(REGISTRY_SERVER.name),
-      `Expected ${REGISTRY_SERVER.name} to be in the document`
-    ).toBeVisible()
-  })
-
-  await userEvent.click(screen.getByText(REGISTRY_SERVER.name))
-
-  await waitFor(() => {
-    expect(screen.getByRole('dialog')).toBeVisible()
-    expect(screen.getByText(`Configure ${REGISTRY_SERVER.name}`)).toBeVisible()
-  })
-
-  expect(
-    screen.getByLabelText('Server name', { selector: 'input' })
-  ).toBeVisible()
-
-  expect(screen.getByLabelText('Secrets', { selector: 'input' })).toBeVisible()
-  expect(
-    screen.getByLabelText('Environment variables', { selector: 'input' })
-  ).toBeVisible()
 })

--- a/renderer/src/routes/__tests__/registry_.$name.test.tsx
+++ b/renderer/src/routes/__tests__/registry_.$name.test.tsx
@@ -1,0 +1,97 @@
+import { screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { RegistryServerDetail } from '@/routes/(registry)/registry_.$name'
+import { createTestRouter } from '@/common/test/create-test-router'
+import { renderRoute } from '@/common/test/render-route'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router')
+  return {
+    ...actual,
+    useParams: () => ({ name: 'time' }),
+  }
+})
+
+function WrapperComponent() {
+  return (
+    <>
+      <RegistryServerDetail />{' '}
+    </>
+  )
+}
+
+describe('Registry Server Detail Route', () => {
+  it('displays server details correctly', async () => {
+    const router = createTestRouter(WrapperComponent)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'time' })).toBeVisible()
+    })
+
+    expect(screen.getByRole('button', { name: /back/i })).toBeVisible()
+    expect(
+      screen.getByRole('button', {
+        name: /provenance signed by sigstore/i,
+      })
+    ).toBeVisible()
+    expect(screen.getByText(/official/i)).toBeVisible()
+    expect(screen.getByText(/stdio/i)).toBeVisible()
+    expect(screen.getByText(/52,153/i)).toBeVisible()
+    expect(screen.getByText(/get_current_time/i)).toBeVisible()
+    expect(screen.getByText(/convert_time/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /install server/i })
+    ).toBeVisible()
+
+    expect(screen.getByRole('button', { name: /github/i })).toBeVisible()
+  })
+
+  it('has a back button that navigates to root route', async () => {
+    const router = createTestRouter(WrapperComponent)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'time' })).toBeVisible()
+    })
+
+    const backButton = screen.getByRole('button', { name: /back/i })
+    expect(backButton).toBeVisible()
+    expect(backButton.closest('a')).toHaveAttribute('href', '/')
+
+    await userEvent.click(backButton)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/')
+    })
+  })
+
+  it('launches dialog with form when clicking on Install server', async () => {
+    const router = createTestRouter(WrapperComponent)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'time' })).toBeVisible()
+    })
+    await userEvent.click(
+      screen.getByRole('button', { name: /install server/i })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+      expect(screen.getByText(`Configure time`)).toBeVisible()
+    })
+
+    expect(
+      screen.getByLabelText('Server name', { selector: 'input' })
+    ).toBeVisible()
+
+    expect(
+      screen.getByLabelText('Secrets', { selector: 'input' })
+    ).toBeVisible()
+    expect(
+      screen.getByLabelText('Environment variables', { selector: 'input' })
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION

**Add Registry Server Detail Page**
This PR implements a comprehensive registry server detail page that allows users to view detailed information about individual MCP servers from the registry.

**Key Features:**
- Registry Detail Page: New dedicated page (registry_.$name.tsx) displaying server information, tools, badges, and installation options
- Enhanced Navigation: Reorganized routes with proper grouping under (registry) folder structure
- Shared Components: Added Stars component for displaying GitHub star counts
- Comprehensive Testing: Added full test coverage for the registry detail page functionality
- UI Improvements: Updated navigation and settings menu items for better user experience

**Changes:**
- Added registry server detail view with tool listings, badges, and installation modal
- Implemented proper back navigation between registry list and detail pages
- Refactored existing registry components for better reusability
- Added comprehensive test fixtures and test cases
- Enhanced route organization with grouped routes

The implementation provides users with a complete view of registry servers before installation, improving the overall user experience when browsing and selecting MCP servers.

https://github.com/user-attachments/assets/5346a070-eae3-4987-b419-a3b67dc16c3c


