### PR TITLE
feat: display secret name when editing it

### DIFF
--- a/renderer/src/common/components/ui/form.tsx
+++ b/renderer/src/common/components/ui/form.tsx
@@ -87,8 +87,10 @@ function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
 
 function FormLabel({
   className,
+  readOnly,
+  children,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: React.ComponentProps<typeof LabelPrimitive.Root> & { readOnly?: boolean }) {
   const { error, formItemId } = useFormField()
 
   return (
@@ -98,7 +100,12 @@ function FormLabel({
       className={cn('data-[error=true]:text-destructive', className)}
       htmlFor={formItemId}
       {...props}
-    />
+    >
+      {children}
+      {readOnly && (
+        <span className="text-muted-foreground text-xs">(read-only)</span>
+      )}
+    </Label>
   )
 }
 

--- a/renderer/src/features/secrets/components/dialog-form-secret.tsx
+++ b/renderer/src/features/secrets/components/dialog-form-secret.tsx
@@ -40,6 +40,7 @@ interface SecretFormProps {
   isEditMode: boolean
   onSubmit: (data: SecretFormData) => void
   onCancel: () => void
+  secretKey?: string
 }
 
 interface SecretDialogProps {
@@ -98,13 +99,20 @@ export function DialogFormSecret({
           isEditMode={isEditMode}
           onSubmit={handleSubmit}
           onCancel={handleCancel}
+          secretKey={secretKey}
         />
       </DialogContent>
     </Dialog>
   )
 }
 
-function SecretForm({ form, isEditMode, onSubmit, onCancel }: SecretFormProps) {
+function SecretForm({
+  form,
+  isEditMode,
+  onSubmit,
+  onCancel,
+  secretKey,
+}: SecretFormProps) {
   const [showPassword, setShowPassword] = useState(false)
   const secretContentsLabel = isEditMode ? 'New value' : 'Secret value'
   const submitButtonText = isEditMode ? 'Update' : 'Save'
@@ -117,6 +125,14 @@ function SecretForm({ form, isEditMode, onSubmit, onCancel }: SecretFormProps) {
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleFormSubmit)}>
         <div className="space-y-4 pt-4 pb-8">
+          {isEditMode && (
+            <FormItem>
+              <FormLabel>Secret name</FormLabel>
+              <FormControl>
+                <Input value={secretKey} readOnly disabled />
+              </FormControl>
+            </FormItem>
+          )}
           {!isEditMode && (
             <FormField
               control={form.control}

--- a/renderer/src/features/secrets/components/dialog-form-secret.tsx
+++ b/renderer/src/features/secrets/components/dialog-form-secret.tsx
@@ -125,29 +125,25 @@ function SecretForm({
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleFormSubmit)}>
         <div className="space-y-4 pt-4 pb-8">
-          {isEditMode && (
-            <FormItem>
-              <FormLabel readOnly>Secret name</FormLabel>
-              <FormControl>
-                <Input value={secretKey} readOnly disabled />
-              </FormControl>
-            </FormItem>
-          )}
-          {!isEditMode && (
-            <FormField
-              control={form.control}
-              name="key"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Secret name</FormLabel>
-                  <FormControl>
-                    <Input placeholder="Name" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
+          <FormField
+            control={form.control}
+            name="key"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel readOnly={isEditMode}>Secret name</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Name"
+                    {...field}
+                    value={isEditMode ? secretKey : field.value}
+                    readOnly={isEditMode}
+                    disabled={isEditMode}
+                  />
+                </FormControl>
+                {!isEditMode && <FormMessage />}
+              </FormItem>
+            )}
+          />
 
           <FormField
             control={form.control}

--- a/renderer/src/features/secrets/components/dialog-form-secret.tsx
+++ b/renderer/src/features/secrets/components/dialog-form-secret.tsx
@@ -127,7 +127,7 @@ function SecretForm({
         <div className="space-y-4 pt-4 pb-8">
           {isEditMode && (
             <FormItem>
-              <FormLabel>Secret name</FormLabel>
+              <FormLabel readOnly>Secret name</FormLabel>
               <FormControl>
                 <Input value={secretKey} readOnly disabled />
               </FormControl>

--- a/renderer/src/routes/__tests__/secrets.test.tsx
+++ b/renderer/src/routes/__tests__/secrets.test.tsx
@@ -83,7 +83,6 @@ it('renders edit secret dialog when clicking edit from dropdown', async () => {
   await userEvent.click(editButton)
 
   expect(screen.getByText('Update the secret value below.')).toBeInTheDocument()
-  expect(screen.queryByPlaceholderText('Name')).not.toBeInTheDocument()
   expect(screen.getByPlaceholderText('Secret')).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /update/i })).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()

--- a/renderer/src/routes/__tests__/secrets.test.tsx
+++ b/renderer/src/routes/__tests__/secrets.test.tsx
@@ -100,3 +100,22 @@ it('renders edit secret dialog when clicking edit from dropdown', async () => {
   expect(ariaDescribedBy).toBeTruthy()
   expect(srDescription?.id).toBe(ariaDescribedBy)
 })
+
+it('displays the secret name in a read-only input when editing a secret', async () => {
+  renderRoute(router)
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole('heading', { name: /secrets/i })
+    ).toBeInTheDocument()
+  })
+  const dropdownTriggers = screen.getAllByLabelText('Secret options')
+  await userEvent.click(dropdownTriggers[0]!)
+  const editButton = screen.getByText('Update secret')
+  await userEvent.click(editButton)
+
+  const secretNameInput = screen.getByDisplayValue('Github')
+  expect(secretNameInput).toBeInTheDocument()
+  expect(secretNameInput).toHaveAttribute('readonly')
+  expect(secretNameInput).toBeDisabled()
+})


### PR DESCRIPTION
fixes #469

<img width="1266" height="688" alt="Screenshot_select-area_20250711133722" src="https://github.com/user-attachments/assets/23c96447-6677-4f24-87f9-fc0154470506" />
