### PR TITLE
fix: remove unneeded logic

### DIFF
--- a/main/src/util.ts
+++ b/main/src/util.ts
@@ -23,7 +23,6 @@ export async function pollWindowReady(window: BrowserWindow): Promise<void> {
 export function isOfficialReleaseBuild(): boolean {
   try {
     const version = getAppVersion()
-    console.log('version', version)
     return /^\d+\.\d+\.\d+$/.test(version)
   } catch {
     log.error('Failed to get app version')


### PR DESCRIPTION
We don't need `getVersionFromGit` logic for app version, we can leverage directly app version from electron