### PR TITLE
chore: add log for failing check command

### DIFF
--- a/main/src/container-engine.ts
+++ b/main/src/container-engine.ts
@@ -1,5 +1,6 @@
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
+import log from './logger'
 
 const execAsync = promisify(exec)
 
@@ -30,6 +31,7 @@ const checkCommand = async (
     await execAsync(command, { timeout })
     return true
   } catch {
+    log.error(`container engine command failed: ${command}`)
     return false
   }
 }

--- a/main/src/container-engine.ts
+++ b/main/src/container-engine.ts
@@ -30,8 +30,8 @@ const checkCommand = async (
   try {
     await execAsync(command, { timeout })
     return true
-  } catch {
-    log.error(`container engine command failed: ${command}`)
+  } catch (error) {
+    log.error(`container engine command failed: ${command}`, error)
     return false
   }
 }


### PR DESCRIPTION
Add an extra error log when the container engine command fails