### PR TITLE
fix: dismiss toast in case of shutting down

### DIFF
--- a/renderer/src/common/hooks/use-toast-mutation.ts
+++ b/renderer/src/common/hooks/use-toast-mutation.ts
@@ -17,11 +17,13 @@ export function useToastMutation<
   successMsg,
   errorMsg,
   loadingMsg,
+  toastId,
   ...options
 }: UseMutationOptions<TData, TError, TVariables, TContext> & {
   successMsg?: ((variables: TVariables) => string) | string
   loadingMsg?: string
   errorMsg?: string
+  toastId?: string
 }) {
   const {
     mutateAsync: originalMutateAsync,
@@ -60,9 +62,10 @@ export function useToastMutation<
 
           return 'An error occurred'
         },
+        ...(toastId ? { id: toastId } : {}),
       })
     },
-    [errorMsg, loadingMsg, originalMutateAsync, successMsg]
+    [errorMsg, loadingMsg, originalMutateAsync, successMsg, toastId]
   )
 
   return { mutateAsync, ...rest }

--- a/renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts
@@ -11,6 +11,9 @@ import {
 import { useToastMutation } from '@/common/hooks/use-toast-mutation'
 import { pollBatchServerStatus } from '@/common/lib/polling'
 import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+const TOAST_ID = 'restart-servers-startup'
 
 const getMutationData = (name: string) => ({
   ...postApiV1BetaWorkloadsByNameRestartMutation(),
@@ -23,10 +26,15 @@ export function useMutationRestartServerAtStartup() {
   const queryClient = useQueryClient()
   const queryKey = getApiV1BetaWorkloadsQueryKey({ query: { all: true } })
 
+  window.electronAPI.onServerShutdown(() => {
+    toast.dismiss(TOAST_ID)
+  })
+
   return useToastMutation({
     successMsg: 'Servers restarted successfully',
     errorMsg: 'Failed to restart servers',
     loadingMsg: 'Restarting servers...',
+    toastId: TOAST_ID,
     ...postApiV1BetaWorkloadsRestartMutation(),
     onMutate: async (variables) => {
       await queryClient.cancelQueries({ queryKey })

--- a/renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts
@@ -11,6 +11,7 @@ import {
 import { useToastMutation } from '@/common/hooks/use-toast-mutation'
 import { pollBatchServerStatus } from '@/common/lib/polling'
 import { useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
 import { toast } from 'sonner'
 
 const TOAST_ID = 'restart-servers-startup'
@@ -26,9 +27,13 @@ export function useMutationRestartServerAtStartup() {
   const queryClient = useQueryClient()
   const queryKey = getApiV1BetaWorkloadsQueryKey({ query: { all: true } })
 
-  window.electronAPI.onServerShutdown(() => {
-    toast.dismiss(TOAST_ID)
-  })
+  useEffect(() => {
+    const cleanup = window.electronAPI.onServerShutdown(() => {
+      toast.dismiss(TOAST_ID)
+    })
+
+    return cleanup
+  }, [])
 
   return useToastMutation({
     successMsg: 'Servers restarted successfully',

--- a/renderer/src/routes/__tests__/index.test.tsx
+++ b/renderer/src/routes/__tests__/index.test.tsx
@@ -16,6 +16,7 @@ Object.defineProperty(window, 'electronAPI', {
       getLastShutdownServers: vi.fn().mockResolvedValue([]),
       clearShutdownHistory: vi.fn().mockResolvedValue(undefined),
     },
+    onServerShutdown: vi.fn().mockReturnValue(() => {}),
   },
   writable: true,
 })


### PR DESCRIPTION
Enhanced the useMutationRestartServerAtStartup hook to automatically dismiss the restart servers toast when a server shutdown event occurs.

**Key Improvements**
- Toast ID Management: Added dedicated TOAST_ID constant ('restart-servers-startup') for consistent toast identification
- Automatic Cleanup: Implemented onServerShutdown event listener to dismiss active restart toast when servers are shut down
- Better UX: Prevents lingering "Restarting servers..." notifications when the application or servers are being shut down

https://github.com/user-attachments/assets/f2913763-26d6-4670-ae8d-78e361e3f06f

