### PR TITLE
fix: shutdown confirmation dialog

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -389,7 +389,17 @@ app.on('will-finish-launching', () => {
   log.info('App will finish launching - preparing for potential restart')
 })
 
-app.on('before-quit', (e) => blockQuit('before-quit', e))
+app.on('before-quit', (e) => {
+  if (mainWindow) {
+    mainWindow.show()
+    mainWindow.focus()
+    mainWindow.webContents.send('show-quit-confirmation')
+  }
+
+  if (!isQuitting) {
+    e.preventDefault()
+  }
+})
 app.on('will-quit', (e) => blockQuit('will-quit', e))
 
 // Docker / Ctrl-C etc.
@@ -457,8 +467,8 @@ ipcMain.handle('hide-app', () => {
   mainWindow?.hide()
 })
 
-ipcMain.handle('quit-app', () => {
-  app.quit()
+ipcMain.handle('quit-app', (e) => {
+  blockQuit('before-quit', e)
 })
 
 ipcMain.handle('get-toolhive-port', () => getToolhivePort())

--- a/renderer/src/common/components/settings/tabs/__tests__/general-tab.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/general-tab.test.tsx
@@ -25,7 +25,6 @@ const mockElectronAPI = {
     optIn: vi.fn(),
     optOut: vi.fn(),
   },
-  quitApp: vi.fn(),
 }
 
 Object.defineProperty(window, 'electronAPI', {

--- a/renderer/src/common/components/settings/tabs/__tests__/settings-tabs.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/settings-tabs.test.tsx
@@ -16,7 +16,6 @@ const mockElectronAPI = {
     optIn: vi.fn(),
     optOut: vi.fn(),
   },
-  quitApp: vi.fn(),
 }
 
 Object.defineProperty(window, 'electronAPI', {
@@ -33,10 +32,6 @@ vi.mock('@/common/hooks/use-auto-launch', () => ({
     mutateAsync: vi.fn(),
     isPending: false,
   }),
-}))
-
-vi.mock('@/common/hooks/use-confirm-quit', () => ({
-  useConfirmQuit: vi.fn().mockReturnValue(vi.fn().mockResolvedValue(true)),
 }))
 
 const renderWithProviders = (component: React.ReactElement) => {


### PR DESCRIPTION
Currently we are showing the quit confirmation dialog only using tray qui, but we want to be consistent, showing it for all use cases.

We need to stop the quit flow `e.preventDefault()` in `app.on('before-quit')` callback in order to show the confirmation dialog and let the `quit-app` ipc handle the `blockQuit`