### PR TITLE
fix: app update from toast notification

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -553,8 +553,6 @@ ipcMain.handle('install-update-and-restart', async () => {
   log.info('🛑 Starting graceful shutdown before update...')
   mainWindow?.webContents.send('graceful-exit')
 
-  await delay(500)
-
   try {
     const port = getToolhivePort()
     if (port) {


### PR DESCRIPTION
Clicking on restart button from toast notification causes uncaught exception, because we destroy the tray system in `before-quit` & `will-quit` listeners.
We was also not showing the graceful-exit from toast notification restart flow

**Issue**
<img width="326" height="336" alt="Screenshot 2025-07-25 at 14 46 14" src="https://github.com/user-attachments/assets/4bcee6b9-6b45-4a8b-84a4-e196a9755acb" />

**Fix**

https://github.com/user-attachments/assets/468d60ce-7f39-4733-8843-7d8d86a08000


