### PR TITLE
fix: form validation for host port fields

### DIFF
--- a/renderer/src/features/mcp-servers/components/__tests__/dialog-form-run-mcp-command.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/dialog-form-run-mcp-command.test.tsx
@@ -510,8 +510,8 @@ describe('DialogFormRunMcpServerWithCommand', () => {
         transport: 'stdio',
         image: 'ghcr.io/test/server',
         networkIsolation: true,
-        allowedHosts: ['example.com'],
-        allowedPorts: ['8080'],
+        allowedHosts: [{ value: 'example.com' }],
+        allowedPorts: [{ value: '8080' }],
       })
     })
 

--- a/renderer/src/features/mcp-servers/components/__tests__/network-isolation-tab-content.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/network-isolation-tab-content.test.tsx
@@ -114,7 +114,7 @@ describe('NetworkIsolationTabContent', () => {
         <TestWrapper
           initialValues={{
             networkIsolation: true,
-            allowedHosts: ['example.com'],
+            allowedHosts: [{ value: 'example.com' }],
             allowedPorts: [],
           }}
         />
@@ -141,7 +141,7 @@ describe('NetworkIsolationTabContent', () => {
           initialValues={{
             networkIsolation: true,
             allowedHosts: [],
-            allowedPorts: ['8080'],
+            allowedPorts: [{ value: '8080' }],
           }}
         />
       ))
@@ -166,8 +166,8 @@ describe('NetworkIsolationTabContent', () => {
         <TestWrapper
           initialValues={{
             networkIsolation: true,
-            allowedHosts: ['example.com'],
-            allowedPorts: ['8080'],
+            allowedHosts: [{ value: 'example.com' }],
+            allowedPorts: [{ value: '8080' }],
           }}
         />
       ))

--- a/renderer/src/features/mcp-servers/components/network-isolation-tab-content.tsx
+++ b/renderer/src/features/mcp-servers/components/network-isolation-tab-content.tsx
@@ -58,9 +58,8 @@ export function NetworkIsolationTabContent({
                       label="Allowed hosts"
                       inputLabelPrefix="Host"
                       addButtonText="Add a host"
-                      control={form.control}
-                      isValid={form.formState.isValid}
                       tooltipContent={`Specify domain names or IP addresses. To include subdomains, use a leading period (".")`}
+                      form={form}
                     />
                   )}
                 />
@@ -71,11 +70,10 @@ export function NetworkIsolationTabContent({
                     <DynamicArrayField<FormSchemaRunMcpCommand>
                       name="allowedPorts"
                       label="Allowed ports"
-                      control={form.control}
-                      isValid={form.formState.isValid}
                       inputLabelPrefix="Port"
                       addButtonText="Add a port"
                       type="number"
+                      form={form}
                     />
                   )}
                 />

--- a/renderer/src/features/mcp-servers/components/network-isolation-tab-content.tsx
+++ b/renderer/src/features/mcp-servers/components/network-isolation-tab-content.tsx
@@ -20,8 +20,8 @@ export function NetworkIsolationTabContent({
         const hosts = form.watch('allowedHosts') || []
         const ports = form.watch('allowedPorts') || []
         const showAlert =
-          !hosts.some((host) => host.trim() !== '') &&
-          !ports.some((port) => port.trim() !== '')
+          !hosts.some((host) => host.value.trim() !== '') &&
+          !ports.some((port) => port.value.trim() !== '')
         return (
           <div className="p-6">
             <div
@@ -54,13 +54,12 @@ export function NetworkIsolationTabContent({
                   name="allowedHosts"
                   render={() => (
                     <DynamicArrayField<FormSchemaRunMcpCommand>
-                      /*
-                         // @ts-expect-error no time to fix this */
                       name="allowedHosts"
                       label="Allowed hosts"
                       inputLabelPrefix="Host"
                       addButtonText="Add a host"
                       control={form.control}
+                      isValid={form.formState.isValid}
                       tooltipContent={`Specify domain names or IP addresses. To include subdomains, use a leading period (".")`}
                     />
                   )}
@@ -70,11 +69,10 @@ export function NetworkIsolationTabContent({
                   name="allowedPorts"
                   render={() => (
                     <DynamicArrayField<FormSchemaRunMcpCommand>
-                      /*
-                         // @ts-expect-error no time to fix this */
                       name="allowedPorts"
                       label="Allowed ports"
                       control={form.control}
+                      isValid={form.formState.isValid}
                       inputLabelPrefix="Port"
                       addButtonText="Add a port"
                       type="number"

--- a/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
+++ b/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
@@ -275,8 +275,8 @@ describe('prepareCreateWorkloadData', () => {
       secrets: [],
       cmd_arguments: [],
       networkIsolation: true,
-      allowedHosts: ['example.com', '.subdomain.com'],
-      allowedPorts: ['8080', '443'],
+      allowedHosts: [{ value: 'example.com' }, { value: '.subdomain.com' }],
+      allowedPorts: [{ value: '8080' }, { value: '443' }],
     }
 
     const result = prepareCreateWorkloadData(data)
@@ -303,8 +303,8 @@ describe('prepareCreateWorkloadData', () => {
       secrets: [],
       cmd_arguments: [],
       networkIsolation: false,
-      allowedHosts: ['example.com'],
-      allowedPorts: ['8080'],
+      allowedHosts: [{ value: 'example.com' }],
+      allowedPorts: [{ value: '8080' }],
     }
 
     const result = prepareCreateWorkloadData(data)

--- a/renderer/src/features/mcp-servers/lib/form-schema-run-mcp-server-with-command.ts
+++ b/renderer/src/features/mcp-servers/lib/form-schema-run-mcp-server-with-command.ts
@@ -41,24 +41,32 @@ const getCommonFields = (workloads: WorkloadsWorkload[]) =>
       })
       .array(),
     networkIsolation: z.boolean(),
-    allowedHosts: z
-      .string()
-      .refine((val) => /^\.?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(val), {
-        message: 'Invalid host format',
+    allowedHosts: z.array(
+      z.object({
+        value: z.string().refine(
+          (val) => {
+            if (val.trim() === '') return true
+            return /^\.?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(val)
+          },
+          {
+            message: 'Invalid host format',
+          }
+        ),
       })
-      .array(),
-    allowedPorts: z
-      .string()
-      .refine(
-        (val) => {
-          const num = parseInt(val, 10)
-          return !isNaN(num) && num >= 1 && num <= 65535
-        },
-        {
-          message: 'Port must be a number between 1 and 65535',
-        }
-      )
-      .array(),
+    ),
+    allowedPorts: z.array(
+      z.object({
+        value: z.string().refine(
+          (val) => {
+            const num = parseInt(val, 10)
+            return !isNaN(num) && num >= 1 && num <= 65535
+          },
+          {
+            message: 'Port must be a number between 1 and 65535',
+          }
+        ),
+      })
+    ),
   })
 
 export const getFormSchemaRunMcpCommand = (workloads: WorkloadsWorkload[]) =>

--- a/renderer/src/features/mcp-servers/lib/orchestrate-run-custom-server.tsx
+++ b/renderer/src/features/mcp-servers/lib/orchestrate-run-custom-server.tsx
@@ -139,8 +139,8 @@ export function prepareCreateWorkloadData(
     ? {
         network: {
           outbound: {
-            allow_host: allowedHosts,
-            allow_port: allowedPorts.map((port) => parseInt(port, 10)),
+            allow_host: allowedHosts.map((host) => host.value),
+            allow_port: allowedPorts.map((port) => parseInt(port.value, 10)),
             insecure_allow_all: false,
           } as PermissionsOutboundNetworkPermissions,
         },

--- a/renderer/src/features/network-isolation/components/network-isolation-tab-content.tsx
+++ b/renderer/src/features/network-isolation/components/network-isolation-tab-content.tsx
@@ -20,8 +20,8 @@ export function NetworkIsolationTabContent({
         const hosts = form.watch('allowedHosts') || []
         const ports = form.watch('allowedPorts') || []
         const showAlert =
-          !hosts.some((host) => host.trim() !== '') &&
-          !ports.some((port) => port.trim() !== '')
+          !hosts.some((host) => host.value.trim() !== '') &&
+          !ports.some((port) => port.value.trim() !== '')
         return (
           <div className="p-6">
             <div
@@ -54,13 +54,12 @@ export function NetworkIsolationTabContent({
                   name="allowedHosts"
                   render={() => (
                     <DynamicArrayField<FormSchemaRunFromRegistry>
-                      /*
-                         // @ts-expect-error no time to fix this */
                       name="allowedHosts"
                       label="Allowed hosts"
                       inputLabelPrefix="Host"
                       addButtonText="Add a host"
                       control={form.control}
+                      isValid={form.formState.isValid}
                       tooltipContent="Specify domain names or IP addresses. To include subdomains, use a leading period (“.”)"
                     />
                   )}
@@ -70,11 +69,10 @@ export function NetworkIsolationTabContent({
                   name="allowedPorts"
                   render={() => (
                     <DynamicArrayField<FormSchemaRunFromRegistry>
-                      /*
-                         // @ts-expect-error no time to fix this */
                       name="allowedPorts"
                       label="Allowed ports"
                       control={form.control}
+                      isValid={form.formState.isValid}
                       inputLabelPrefix="Port"
                       addButtonText="Add a port"
                       type="number"

--- a/renderer/src/features/network-isolation/components/network-isolation-tab-content.tsx
+++ b/renderer/src/features/network-isolation/components/network-isolation-tab-content.tsx
@@ -58,9 +58,8 @@ export function NetworkIsolationTabContent({
                       label="Allowed hosts"
                       inputLabelPrefix="Host"
                       addButtonText="Add a host"
-                      control={form.control}
-                      isValid={form.formState.isValid}
                       tooltipContent="Specify domain names or IP addresses. To include subdomains, use a leading period (“.”)"
+                      form={form}
                     />
                   )}
                 />
@@ -71,11 +70,10 @@ export function NetworkIsolationTabContent({
                     <DynamicArrayField<FormSchemaRunFromRegistry>
                       name="allowedPorts"
                       label="Allowed ports"
-                      control={form.control}
-                      isValid={form.formState.isValid}
                       inputLabelPrefix="Port"
                       addButtonText="Add a port"
                       type="number"
+                      form={form}
                     />
                   )}
                 />

--- a/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
@@ -1003,7 +1003,7 @@ describe('Allowed Hosts field', () => {
           server: expect.any(Object),
           data: expect.objectContaining({
             serverName: 'my-network-server',
-            allowedHosts: ['foo.bar.com'],
+            allowedHosts: [{ value: 'foo.bar.com' }],
             networkIsolation: true,
           }),
         }),

--- a/renderer/src/features/registry-servers/components/dynamic-array-field.tsx
+++ b/renderer/src/features/registry-servers/components/dynamic-array-field.tsx
@@ -34,6 +34,7 @@ interface DynamicArrayFieldProps<
   addButtonText?: string
   type?: 'text' | 'number'
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>
+  isValid: boolean
 }
 
 export function DynamicArrayField<TFieldValues extends FieldValues>({
@@ -45,6 +46,7 @@ export function DynamicArrayField<TFieldValues extends FieldValues>({
   addButtonText = 'Add',
   type = 'text',
   inputProps = {},
+  isValid,
 }: DynamicArrayFieldProps<TFieldValues>) {
   const { fields, append, remove } = useFieldArray<
     TFieldValues,
@@ -73,7 +75,7 @@ export function DynamicArrayField<TFieldValues extends FieldValues>({
           <div key={field.id} className="flex items-start gap-2">
             <FormField
               control={control}
-              name={`${name}.${idx}` as Path<TFieldValues>}
+              name={`${name}.${idx}.value` as Path<TFieldValues>}
               render={({
                 field,
               }: {
@@ -90,7 +92,7 @@ export function DynamicArrayField<TFieldValues extends FieldValues>({
                       {...inputProps}
                     />
                   </FormControl>
-                  <FormMessage />
+                  {!isValid && <FormMessage />}
                 </FormItem>
               )}
             />
@@ -110,8 +112,9 @@ export function DynamicArrayField<TFieldValues extends FieldValues>({
           variant="secondary"
           className="mt-1 w-fit"
           onClick={() => {
-            // @ts-expect-error no time to fix it
-            append('')
+            append({
+              value: '',
+            } as TFieldValues[ArrayPath<TFieldValues>][number])
           }}
         >
           {addButtonText}

--- a/renderer/src/features/registry-servers/components/dynamic-array-field.tsx
+++ b/renderer/src/features/registry-servers/components/dynamic-array-field.tsx
@@ -138,6 +138,8 @@ export function DynamicArrayField<TFieldValues extends FieldValues>({
                       {...inputProps}
                       onChange={async (e) => {
                         field.onChange(e)
+                        // There is an issue with react-hook-form about error validation for array fields
+                        // take a look to the PR for detail https://github.com/stacklok/toolhive-studio/pull/664
                         await resetValidation(idx)
                       }}
                     />

--- a/renderer/src/features/registry-servers/components/dynamic-array-field.tsx
+++ b/renderer/src/features/registry-servers/components/dynamic-array-field.tsx
@@ -56,6 +56,16 @@ export function DynamicArrayField<TFieldValues extends FieldValues>({
     name: name as ArrayPath<TFieldValues>,
   })
 
+  const isInvalid = useCallback(
+    (idx: number) => {
+      return (
+        formState.errors[`${name}.${idx}.value`] ||
+        formState.errors[name as Path<TFieldValues>]
+      )
+    },
+    [formState.errors, name]
+  )
+
   const setInputRef = useCallback(
     (idx: number) => {
       return (el: HTMLInputElement | null) => {
@@ -132,7 +142,7 @@ export function DynamicArrayField<TFieldValues extends FieldValues>({
                       }}
                     />
                   </FormControl>
-                  {!formState.isValid && <FormMessage />}
+                  {isInvalid(idx) && <FormMessage />}
                 </FormItem>
               )}
             />

--- a/renderer/src/features/registry-servers/components/form-run-from-registry/index.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry/index.tsx
@@ -118,11 +118,16 @@ export function FormRunFromRegistry({
         value: e.default || '',
       })),
       networkIsolation: false,
-      allowedPorts:
-        server?.permissions?.network?.outbound?.allow_port?.map((port) =>
-          port.toString()
-        ) || [],
-      allowedHosts: server?.permissions?.network?.outbound?.allow_host || [],
+      allowedHosts: server?.permissions?.network?.outbound?.allow_host
+        ? server.permissions.network.outbound.allow_host.map((host) => ({
+            value: host,
+          }))
+        : [],
+      allowedPorts: server?.permissions?.network?.outbound?.allow_port
+        ? server.permissions.network.outbound.allow_port.map((port) => ({
+            value: port.toString(),
+          }))
+        : [],
     },
     reValidateMode: 'onChange',
     mode: 'onChange',

--- a/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
+++ b/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
@@ -450,8 +450,8 @@ describe('saveSecrets', () => {
       secrets: [],
       envVars: [],
       networkIsolation: true,
-      allowedHosts: ['example.com', '.subdomain.com'],
-      allowedPorts: ['8080', '443'],
+      allowedHosts: [{ value: 'example.com' }, { value: '.subdomain.com' }],
+      allowedPorts: [{ value: '8080' }, { value: '443' }],
     }
 
     const result = prepareCreateWorkloadData(REGISTRY_SERVER, data)
@@ -475,8 +475,8 @@ describe('saveSecrets', () => {
       secrets: [],
       envVars: [],
       networkIsolation: false,
-      allowedHosts: ['example.com'],
-      allowedPorts: ['8080'],
+      allowedHosts: [{ value: 'example.com' }],
+      allowedPorts: [{ value: '8080' }],
     }
 
     const result = prepareCreateWorkloadData(REGISTRY_SERVER, data)

--- a/renderer/src/features/registry-servers/lib/get-form-schema-run-from-registry.ts
+++ b/renderer/src/features/registry-servers/lib/get-form-schema-run-from-registry.ts
@@ -82,25 +82,32 @@ export function getFormSchemaRunFromRegistry({
       })
       .array(),
     networkIsolation: z.boolean(),
-    allowedHosts: z
-      .string()
-      .refine((val) => /^\.?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(val), {
-        message: 'Invalid host format',
+    allowedHosts: z.array(
+      z.object({
+        value: z.string().refine(
+          (val) => {
+            if (val.trim() === '') return true
+            return /^\.?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(val)
+          },
+          {
+            message: 'Invalid host format',
+          }
+        ),
       })
-      .array(),
-    allowedPorts: z
-      .string()
-
-      .refine(
-        (val) => {
-          const num = parseInt(val, 10)
-          return !isNaN(num) && num >= 1 && num <= 65535
-        },
-        {
-          message: 'Port must be a number between 1 and 65535',
-        }
-      )
-      .array(),
+    ),
+    allowedPorts: z.array(
+      z.object({
+        value: z.string().refine(
+          (val) => {
+            const num = parseInt(val, 10)
+            return !isNaN(num) && num >= 1 && num <= 65535
+          },
+          {
+            message: 'Port must be a number between 1 and 65535',
+          }
+        ),
+      })
+    ),
   })
 }
 

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
@@ -119,8 +119,8 @@ export function prepareCreateWorkloadData(
     ? {
         network: {
           outbound: {
-            allow_host: allowedHosts,
-            allow_port: allowedPorts.map((port) => parseInt(port, 10)),
+            allow_host: allowedHosts.map(({ value }) => value),
+            allow_port: allowedPorts.map(({ value }) => parseInt(value, 10)),
             insecure_allow_all: false,
           } as PermissionsOutboundNetworkPermissions,
         },


### PR DESCRIPTION
This is a wel know issue with `react-hook-form` + `zod` + `useFieldArray`
detail https://github.com/orgs/react-hook-form/discussions/9875

The only way for now to solve it is to reset the form state manually `form.reset(form.getValues())` allowing to reset from state and set as default values the current form values, so basically it is simulating that the form was initialized with the current values.


https://github.com/user-attachments/assets/8560f559-3b74-4ae9-8dc5-b4bea8e21c44

