### PR TITLE
fix: remove thv check on e2e gh action

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -43,11 +43,7 @@ jobs:
         run: |
           sudo systemctl start docker
           sudo systemctl status docker
-
-      - name: Verify that `thv` binary works
-        run: |
-          pnpm run thv list
-
+          
       - name: Pre-build app
         run: |
           pnpm tsc -b --clean 


### PR DESCRIPTION
Every time we used a `thv` command, using the CLI, we are sending an heart beat to telemetry.
In the `e2e` action we are checking if thv is available running `thv list`, this generates at every run a new ID, that it will be considered as a new user at every run.
In the `e2e` we don't need to check if thv is available, there are several check in the application.