### PR TITLE
Add CI=true env var to all E2E runs so it works locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "electron-forge start",
-    "e2e": "tsc -b --clean && tsc -b && electron-forge package && playwright test",
+    "e2e": "CI=true tsc -b --clean && tsc -b && electron-forge package && playwright test",
     "start:mockUpdate": "MOCK_UPDATE_SERVER=true ELECTRON_IS_DEV=0 electron-forge start",
     "package": "tsc -b --clean && tsc -b && electron-forge package",
     "make": "tsc -b --clean && tsc -b && electron-forge make",


### PR DESCRIPTION
We don't want to call the update service when running the E2E tests locally to avoid weird behaviour. This sets the CI env var to true on all E2E runs, including locally, to avoid calling the update service.