### PR TITLE
fix: show traffic lights on the right side for win

### DIFF
--- a/renderer/src/common/components/layout/top-nav/minimal.tsx
+++ b/renderer/src/common/components/layout/top-nav/minimal.tsx
@@ -4,7 +4,7 @@ import { WindowControls } from './window-controls'
 
 export function TopNavMinimal() {
   return (
-    <TopNavContainer className="fixed top-0 !flex justify-between">
+    <TopNavContainer className="fixed top-0 !flex justify-end">
       <WindowControls />
       <QuitConfirmationListener />
     </TopNavContainer>


### PR DESCRIPTION
**BEFORE**
<img width="1300" height="875" alt="473182873-9f8f97e1-ede3-43c5-9fe9-99f5f043780a" src="https://github.com/user-attachments/assets/43ea363d-66aa-47a5-9cab-be7cd636d0c2" />

**AFTER**

<img width="1227" height="713" alt="Screenshot 2025-08-06 at 12 11 19" src="https://github.com/user-attachments/assets/66fba444-94d4-4957-9e7d-d5c4bf99c6e8" />
