### PR TITLE
chore: configure renovate to track toolhive releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,18 @@
   "labels": ["dependencies"],
   "prConcurrentLimit": 3,
   "timezone": "Europe/London",
-  "schedule": ["after 01:00 and before 07:00 on every weekday"]
+  "schedule": ["after 01:00 and before 07:00 on every weekday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update ToolHive version in constants.ts",
+      "managerFilePatterns": ["^utils/constants\\.ts$"],
+      "matchStrings": [
+        "export const TOOLHIVE_VERSION = process\\.env\\.THV_VERSION \\?\\? '(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)'"
+      ],
+      "depNameTemplate": "stacklok/toolhive",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ]
 }


### PR DESCRIPTION
Adds a custom regex manager to Renovate configuration to automatically track ToolHive releases from `stacklok/toolhive` and update the `TOOLHIVE_VERSION` constant in `utils/constants.ts`.

Currently tracking version `v0.2.3`, will create PRs when new versions are released.