### PR TITLE
fix: switch renovate to track docker images instead of github releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,14 +9,13 @@
     {
       "customType": "regex",
       "description": "Update ToolHive version in constants.ts",
-      "managerFilePatterns": ["^utils/constants\\.ts$"],
+      "managerFilePatterns": ["utils/constants\\.ts"],
       "matchStrings": [
-        "export\\s+const\\s+TOOLHIVE_VERSION\\s*=\\s*process\\.env\\.THV_VERSION\\s*\\?\\?\\s*'(?<currentValue>v\\d+\\.\\d+\\.\\d+)'"
+        "export\\s+const\\s+TOOLHIVE_VERSION\\s*=\\s*process\\.env\\.THV_VERSION\\s*\\?\\?\\s*'v?(?<currentValue>\\d+\\.\\d+\\.\\d+)'"
       ],
-      "depNameTemplate": "toolhive",
-      "packageNameTemplate": "stacklok/toolhive",
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "semver"
+      "depNameTemplate": "ghcr.io/stacklok/toolhive",
+      "datasourceTemplate": "docker",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
Switches Renovate configuration from tracking GitHub releases to tracking Docker container images at `ghcr.io/stacklok/toolhive`.

## Changes:
- Changed datasource from `github-releases` to `docker`
- Updated `depNameTemplate` to use the full Docker image path `ghcr.io/stacklok/toolhive`
- Removed unnecessary `packageNameTemplate` and `versioningTemplate`
- Added `extractVersionTemplate` to handle the `v` prefix in Docker tags
- Updated regex to handle versions with or without the `v` prefix
- Simplified `managerFilePatterns` pattern

This should properly track ToolHive Docker images which are tagged as `v0.2.5`, etc.