### PR TITLE
ci: add GitHub Pages release assets mirror workflow

### DIFF
--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -1,19 +1,16 @@
-name: Mirror release assets to GitHub Pages
+name: Mirror latest release to GitHub Pages with LFS
 
 on:
-  # Temporary test triggers - remove before merging
+  # Test trigger only - RESTORE BEFORE MERGING:
+  # release:
+  #   types: [published]
+  # workflow_dispatch:
+  #   inputs:
+  #     tag:
+  #       description: 'Release tag to mirror (e.g., v0.4.0)'
+  #       required: false
   push:
     branches: [gh-page-assets]
-  pull_request:
-    branches: [main]
-  # Original triggers
-  release:
-    types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag to mirror (e.g., v0.4.0)'
-        required: false
 
 permissions:
   contents: write
@@ -25,10 +22,11 @@ jobs:
       - name: Get release info
         id: release
         run: |
-          # For testing: use fixed tag if no input provided
-          TAG="${{ github.event.inputs.tag || github.event.release.tag_name || 'v0.4.0' }}"
+          # TESTING: Use fixed tag - RESTORE BEFORE MERGING:
+          # TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          TAG="v0.4.0"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
+          
           # Get release metadata
           RELEASE_DATA=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG")
           echo "prerelease=$(echo "$RELEASE_DATA" | jq -r '.prerelease')" >> "$GITHUB_OUTPUT"
@@ -42,11 +40,17 @@ jobs:
           BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
           TIMESTAMP=$(date +%s)
 
-          # Download assets
-          mkdir -p "releases/$TAG"
-          gh release download "$TAG" -R "${{ github.repository }}" --dir "releases/$TAG"
-
-          cd "releases/$TAG"
+                    # TESTING: Skip prerelease check - RESTORE BEFORE MERGING:
+          # if [[ "${{ steps.release.outputs.prerelease }}" == "true" ]]; then
+          #   echo "Skipping prerelease $TAG"
+          #   exit 0
+          # fi
+          
+          # Download assets for latest release only
+          mkdir -p "latest"
+          gh release download "$TAG" -R "${{ github.repository }}" --dir "latest"
+          
+          cd "latest"
 
           # Generate checksums
           sha256sum * > SHA256SUMS.txt
@@ -84,9 +88,11 @@ jobs:
               exit 1
             fi
             
+            # Include all files (Git LFS will handle large ones automatically)
+            echo "Including file: $file (${SIZE} bytes)"
             SHA=$(cat "$file.sha256")
             jq --arg name "$file" \
-               --arg url "$BASE_URL/releases/$TAG/$file" \
+               --arg url "$BASE_URL/latest/$file" \
                --arg sha256 "$SHA" \
                --argjson size "$SIZE" \
                '.assets += [{name: $name, url: $url, size: $size, sha256: $sha256}]' \
@@ -95,31 +101,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update latest (stable releases only)
-        if: steps.release.outputs.prerelease == 'false'
+      - name: Setup Git LFS attributes
         run: |
-          TAG="${{ steps.release.outputs.tag }}"
-          TIMESTAMP=$(date +%s)
+          # Create .gitattributes for LFS tracking of large files
+          cat > .gitattributes << 'EOF'
+          # Track large binary files with Git LFS
+          latest/*.dmg filter=lfs diff=lfs merge=lfs -text
+          latest/*.exe filter=lfs diff=lfs merge=lfs -text
+          latest/*.zip filter=lfs diff=lfs merge=lfs -text
+          latest/*.deb filter=lfs diff=lfs merge=lfs -text
+          latest/*.rpm filter=lfs diff=lfs merge=lfs -text
+          latest/*.nupkg filter=lfs diff=lfs merge=lfs -text
+          latest/*.flatpak filter=lfs diff=lfs merge=lfs -text
+          latest/*.tar.gz filter=lfs diff=lfs merge=lfs -text
+          EOF
 
-          # Copy to latest
-          rm -rf releases/latest
-          cp -r "releases/$TAG" "releases/latest"
-
-          # Update latest manifest with cache-busting URLs
-          jq --arg timestamp "$TIMESTAMP" \
-             --arg source_tag "$TAG" \
-             '
-             .latest = true 
-             | .source_tag = $source_tag
-             | .cache_buster = $timestamp
-             | .assets = (.assets | map(.url |= sub("/releases/[^/]+/"; "/releases/latest/") + "?v=" + $timestamp))
-             ' "releases/$TAG/index.json" > "releases/latest/index.json"
-
-      - name: Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages with LFS
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./releases
-          destination_dir: releases
-          keep_files: true
-          commit_message: 'Mirror ${{ steps.release.outputs.tag }} (prerelease=${{ steps.release.outputs.prerelease }})'
+          publish_dir: ./
+          keep_files: false
+          commit_message: 'Update latest release to ${{ steps.release.outputs.tag }}'

--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -66,16 +66,24 @@ jobs:
 
           # Add asset info to manifest
           for file in *; do
-            [ -f "$file" ] && [ "$file" != "index.json" ] && [ "$file" != "SHA256SUMS.txt" ] && [[ ! "$file" =~ \.sha256$ ]] && {
-              SIZE=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file")
-              SHA=$(cat "$file.sha256")
-              jq --arg name "$file" \
-                 --arg url "$BASE_URL/releases/$TAG/$file" \
-                 --arg sha256 "$SHA" \
-                 --argjson size "$SIZE" \
-                 '.assets += [{name: $name, url: $url, size: $size, sha256: $sha256}]' \
-                 index.json > tmp.json && mv tmp.json index.json
-            }
+            # Skip non-files and excluded files
+            [ -f "$file" ] || continue
+            [[ "$file" == "index.json" || "$file" == "SHA256SUMS.txt" || "$file" == *.sha256 ]] && continue
+            
+            # Get file size portably
+            SIZE=$(wc -c < "$file" | tr -d '[:space:]')
+            if ! [[ "$SIZE" =~ ^[0-9]+$ ]]; then
+              echo "Error: Could not determine size of $file" >&2
+              exit 1
+            fi
+            
+            SHA=$(cat "$file.sha256")
+            jq --arg name "$file" \
+               --arg url "$BASE_URL/releases/$TAG/$file" \
+               --arg sha256 "$SHA" \
+               --argjson size "$SIZE" \
+               '.assets += [{name: $name, url: $url, size: $size, sha256: $sha256}]' \
+               index.json > tmp.json && mv tmp.json index.json
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -1,0 +1,110 @@
+name: Mirror release assets to GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to mirror (e.g., v0.4.0)"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release info
+        id: release
+        run: |
+          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          
+          # Get release metadata
+          RELEASE_DATA=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG")
+          echo "prerelease=$(echo "$RELEASE_DATA" | jq -r '.prerelease')" >> "$GITHUB_OUTPUT"
+          echo "published_at=$(echo "$RELEASE_DATA" | jq -r '.published_at // .created_at')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download and process release assets
+        run: |
+          TAG="${{ steps.release.outputs.tag }}"
+          BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+          TIMESTAMP=$(date +%s)
+          
+          # Download assets
+          mkdir -p "releases/$TAG"
+          gh release download "$TAG" -R "${{ github.repository }}" --dir "releases/$TAG"
+          
+          cd "releases/$TAG"
+          
+          # Generate checksums
+          sha256sum * > SHA256SUMS.txt
+          for file in *; do
+            [ -f "$file" ] && sha256sum "$file" | cut -d' ' -f1 > "$file.sha256"
+          done
+          
+          # Create manifest
+          jq -n \
+            --arg tag "$TAG" \
+            --arg published_at "${{ steps.release.outputs.published_at }}" \
+            --argjson prerelease ${{ steps.release.outputs.prerelease }} \
+            --arg base_url "$BASE_URL" \
+            --arg timestamp "$TIMESTAMP" \
+            '
+            {
+              tag: $tag,
+              prerelease: $prerelease,
+              published_at: $published_at,
+              base_url: $base_url,
+              assets: []
+            }
+            ' > index.json
+          
+          # Add asset info to manifest
+          for file in *; do
+            [ -f "$file" ] && [ "$file" != "index.json" ] && [ "$file" != "SHA256SUMS.txt" ] && [[ ! "$file" =~ \.sha256$ ]] && {
+              SIZE=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file")
+              SHA=$(cat "$file.sha256")
+              jq --arg name "$file" \
+                 --arg url "$BASE_URL/releases/$TAG/$file" \
+                 --arg sha256 "$SHA" \
+                 --argjson size "$SIZE" \
+                 '.assets += [{name: $name, url: $url, size: $size, sha256: $sha256}]' \
+                 index.json > tmp.json && mv tmp.json index.json
+            }
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update latest (stable releases only)
+        if: steps.release.outputs.prerelease == 'false'
+        run: |
+          TAG="${{ steps.release.outputs.tag }}"
+          TIMESTAMP=$(date +%s)
+          
+          # Copy to latest
+          rm -rf releases/latest
+          cp -r "releases/$TAG" "releases/latest"
+          
+          # Update latest manifest with cache-busting URLs
+          jq --arg timestamp "$TIMESTAMP" \
+             --arg source_tag "$TAG" \
+             '
+             .latest = true 
+             | .source_tag = $source_tag
+             | .cache_buster = $timestamp
+             | .assets = (.assets | map(.url |= sub("/releases/[^/]+/"; "/releases/latest/") + "?v=" + $timestamp))
+             ' "releases/$TAG/index.json" > "releases/latest/index.json"
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./releases
+          destination_dir: releases
+          keep_files: true
+          commit_message: "Mirror ${{ steps.release.outputs.tag }} (prerelease=${{ steps.release.outputs.prerelease }})"

--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -1,6 +1,12 @@
 name: Mirror release assets to GitHub Pages
 
 on:
+  # Temporary test triggers - remove before merging
+  push:
+    branches: [gh-page-assets]
+  pull_request:
+    branches: [main]
+  # Original triggers
   release:
     types: [published]
   workflow_dispatch:
@@ -19,7 +25,8 @@ jobs:
       - name: Get release info
         id: release
         run: |
-          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          # For testing: use fixed tag if no input provided
+          TAG="${{ github.event.inputs.tag || github.event.release.tag_name || 'v0.4.0' }}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
           # Get release metadata

--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to mirror (e.g., v0.4.0)"
+        description: 'Release tag to mirror (e.g., v0.4.0)'
         required: false
 
 permissions:
@@ -21,7 +21,7 @@ jobs:
         run: |
           TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          
+
           # Get release metadata
           RELEASE_DATA=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG")
           echo "prerelease=$(echo "$RELEASE_DATA" | jq -r '.prerelease')" >> "$GITHUB_OUTPUT"
@@ -34,19 +34,19 @@ jobs:
           TAG="${{ steps.release.outputs.tag }}"
           BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
           TIMESTAMP=$(date +%s)
-          
+
           # Download assets
           mkdir -p "releases/$TAG"
           gh release download "$TAG" -R "${{ github.repository }}" --dir "releases/$TAG"
-          
+
           cd "releases/$TAG"
-          
+
           # Generate checksums
           sha256sum * > SHA256SUMS.txt
           for file in *; do
             [ -f "$file" ] && sha256sum "$file" | cut -d' ' -f1 > "$file.sha256"
           done
-          
+
           # Create manifest
           jq -n \
             --arg tag "$TAG" \
@@ -63,7 +63,7 @@ jobs:
               assets: []
             }
             ' > index.json
-          
+
           # Add asset info to manifest
           for file in *; do
             [ -f "$file" ] && [ "$file" != "index.json" ] && [ "$file" != "SHA256SUMS.txt" ] && [[ ! "$file" =~ \.sha256$ ]] && {
@@ -85,11 +85,11 @@ jobs:
         run: |
           TAG="${{ steps.release.outputs.tag }}"
           TIMESTAMP=$(date +%s)
-          
+
           # Copy to latest
           rm -rf releases/latest
           cp -r "releases/$TAG" "releases/latest"
-          
+
           # Update latest manifest with cache-busting URLs
           jq --arg timestamp "$TIMESTAMP" \
              --arg source_tag "$TAG" \
@@ -107,4 +107,4 @@ jobs:
           publish_dir: ./releases
           destination_dir: releases
           keep_files: true
-          commit_message: "Mirror ${{ steps.release.outputs.tag }} (prerelease=${{ steps.release.outputs.prerelease }})"
+          commit_message: 'Mirror ${{ steps.release.outputs.tag }} (prerelease=${{ steps.release.outputs.prerelease }})'

--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -1,16 +1,13 @@
 name: Mirror latest release to GitHub Pages with LFS
 
 on:
-  # Test trigger only - RESTORE BEFORE MERGING:
-  # release:
-  #   types: [published]
-  # workflow_dispatch:
-  #   inputs:
-  #     tag:
-  #       description: 'Release tag to mirror (e.g., v0.4.0)'
-  #       required: false
-  push:
-    branches: [gh-page-assets]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to mirror (e.g., v0.4.0)'
+        required: false
 
 permissions:
   contents: write
@@ -22,11 +19,9 @@ jobs:
       - name: Get release info
         id: release
         run: |
-          # TESTING: Use fixed tag - RESTORE BEFORE MERGING:
-          # TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
-          TAG="v0.4.0"
+          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          
+
           # Get release metadata
           RELEASE_DATA=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG")
           echo "prerelease=$(echo "$RELEASE_DATA" | jq -r '.prerelease')" >> "$GITHUB_OUTPUT"
@@ -40,16 +35,16 @@ jobs:
           BASE_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
           TIMESTAMP=$(date +%s)
 
-                    # TESTING: Skip prerelease check - RESTORE BEFORE MERGING:
-          # if [[ "${{ steps.release.outputs.prerelease }}" == "true" ]]; then
-          #   echo "Skipping prerelease $TAG"
-          #   exit 0
-          # fi
-          
+          # Skip prereleases to only mirror stable releases
+          if [[ "${{ steps.release.outputs.prerelease }}" == "true" ]]; then
+            echo "Skipping prerelease $TAG"
+            exit 0
+          fi
+
           # Download assets for latest release only
           mkdir -p "latest"
           gh release download "$TAG" -R "${{ github.repository }}" --dir "latest"
-          
+
           cd "latest"
 
           # Generate checksums


### PR DESCRIPTION
- Add workflow to automatically mirror release assets to GitHub Pages CDN
- Include SHA256 checksums for all assets (individual .sha256 files + SHA256SUMS.txt)
- Generate JSON manifest with asset metadata (name, url, size, sha256)
- Support latest-only deployment (/latest/) due to 1GB GitHub Pages limit
- Use Git LFS for large binary files (>100MB) to bypass file size limits
- Skip prerelease versions to only mirror stable releases
- Support manual trigger via workflow_dispatch for any release tag
- Use peaceiris/actions-gh-pages for reliable deployment
- Solves GitHub Releases rate limiting issues with dedicated CDN endpoint