### PR TITLE
build(icon-gen): replace tsx with ts-node for script execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "update-api": "ts-node scripts/update-api.ts",
     "generate-client": "pnpm run update-api && cd api && openapi-ts",
     "generate-client:nofetch": "cd api && openapi-ts",
-    "generate-icons": "tsx scripts/generate-icons.ts",
+    "generate-icons": "ts-node scripts/generate-icons.ts",
     "knip": "knip",
     "playwright": "playwright"
   },
@@ -82,7 +82,6 @@
     "prettier-plugin-tailwindcss": "^0.6.12",
     "tar": "^7.4.3",
     "ts-node": "^10.9.2",
-    "tsx": "^4.20.3",
     "typescript": "5.9.2",
     "typescript-eslint": "^8.30.1",
     "unzipper": "^0.12.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,9 +276,6 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.13.2)(@types/node@22.17.2)(typescript@5.9.2)
-      tsx:
-        specifier: ^4.20.3
-        version: 4.20.3
       typescript:
         specifier: 5.9.2
         version: 5.9.2

--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -1,12 +1,14 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node
 
 import { copyFile } from 'node:fs'
 import { join } from 'node:path'
+import * as iconGenModule from 'icon-gen'
 
 const INPUT_PATH = './icons/source-files/app-icons'
 const OUTPUT_PATH = './icons'
 
-import iconGen from 'icon-gen'
+const iconGen =
+  'default' in iconGenModule ? iconGenModule.default : iconGenModule
 
 async function main() {
   // Mac


### PR DESCRIPTION
Just a cleanup, we had both tsx and ts-node, it seemed a little bit overcomplicated