### PR TITLE
feat(graceful-exit): improve with better status checking and testing

### DIFF
--- a/main/src/graceful-exit.ts
+++ b/main/src/graceful-exit.ts
@@ -166,7 +166,7 @@ export async function stopAllServers(
 
 /** Get the list of servers that were shut down in the last shutdown */
 export function getLastShutdownServers(): string[] {
-  return shutdownStore.get('lastShutdownServers', []) as string[]
+  return shutdownStore.get('lastShutdownServers', [])
 }
 
 /** Clear the shutdown history */

--- a/main/src/graceful-exit.ts
+++ b/main/src/graceful-exit.ts
@@ -153,8 +153,9 @@ export async function stopAllServers(
   // Then poll until all servers are stopped
   const serverNames = servers
     .map((server) => server.name)
-    .filter(Boolean) as string[]
+    .filter((name): name is string => typeof name === 'string')
   const allStopped = await pollUntilAllStopped(client, serverNames)
+
   if (!allStopped) {
     log.error('Some servers failed to stop within timeout')
     throw new Error('Some servers failed to stop within timeout')

--- a/main/src/tests/graceful-exit.test.ts
+++ b/main/src/tests/graceful-exit.test.ts
@@ -104,7 +104,7 @@ describe('graceful-exit', () => {
       { name: 'server2', status: 'stopped', port: 3002 },
     ]
 
-    it('should handle no running servers gracefully', async () => {
+    it('handles no running servers gracefully', async () => {
       mockGetApiV1BetaWorkloads.mockResolvedValue(
         createMockWorkloadsResponse([])
       )
@@ -117,7 +117,7 @@ describe('graceful-exit', () => {
       expect(mockPostApiV1BetaWorkloadsByNameStop).not.toHaveBeenCalled()
     })
 
-    it('should stop all running servers successfully', async () => {
+    it('stops all running servers successfully', async () => {
       // Mock getting running servers initially
       mockGetApiV1BetaWorkloads
         .mockResolvedValueOnce(createMockWorkloadsResponse(mockRunningServers))
@@ -148,7 +148,7 @@ describe('graceful-exit', () => {
       expect(mockLog.info).toHaveBeenCalledWith('All servers stopped cleanly')
     })
 
-    it('should handle servers with final statuses (error, unknown, unhealthy)', async () => {
+    it('handles servers with final statuses (error, unknown, unhealthy)', async () => {
       const serversWithFinalStatuses: CoreWorkload[] = [
         { name: 'server1', status: 'error', port: 3001 },
         { name: 'server2', status: 'unknown', port: 3002 },
@@ -173,7 +173,7 @@ describe('graceful-exit', () => {
       expect(mockLog.info).toHaveBeenCalledWith('All servers stopped cleanly')
     })
 
-    it('should handle stop command failures', async () => {
+    it('handles stop command failures', async () => {
       mockGetApiV1BetaWorkloads.mockResolvedValue(
         createMockWorkloadsResponse(mockRunningServers)
       )
@@ -187,7 +187,7 @@ describe('graceful-exit', () => {
       )
     })
 
-    it('should handle timeout when servers do not stop', async () => {
+    it('handles timeout when servers do not stop', async () => {
       const stuckServers: CoreWorkload[] = [
         { name: 'server1', status: 'stopping', port: 3001 },
       ]
@@ -210,7 +210,7 @@ describe('graceful-exit', () => {
       )
     })
 
-    it('should store shutdown servers in electron store', async () => {
+    it('stores shutdown servers in electron store', async () => {
       mockGetApiV1BetaWorkloads
         .mockResolvedValueOnce(createMockWorkloadsResponse(mockRunningServers))
         .mockResolvedValueOnce(createMockWorkloadsResponse(mockStoppedServers))
@@ -227,7 +227,7 @@ describe('graceful-exit', () => {
       )
     })
 
-    it('should handle servers without names', async () => {
+    it('handles servers without names', async () => {
       const serversWithoutNames: CoreWorkload[] = [
         { name: undefined, status: 'running', port: 3001 },
         { name: 'server2', status: 'running', port: 3002 },
@@ -257,7 +257,7 @@ describe('graceful-exit', () => {
   })
 
   describe('getLastShutdownServers', () => {
-    it('should return servers from electron store', () => {
+    it('returns servers from electron store', () => {
       const mockServers = ['server1', 'server2']
       mockStoreInstance.get.mockReturnValue(mockServers)
 
@@ -270,7 +270,7 @@ describe('graceful-exit', () => {
       )
     })
 
-    it('should return empty array when no servers in store', () => {
+    it('returns empty array when no servers in store', () => {
       mockStoreInstance.get.mockReturnValue([])
 
       const result = getLastShutdownServers()
@@ -280,7 +280,7 @@ describe('graceful-exit', () => {
   })
 
   describe('clearShutdownHistory', () => {
-    it('should clear shutdown history in electron store', () => {
+    it('clears shutdown history in electron store', () => {
       clearShutdownHistory()
 
       expect(mockStoreInstance.set).toHaveBeenCalledWith(
@@ -292,7 +292,7 @@ describe('graceful-exit', () => {
   })
 
   describe('polling behavior', () => {
-    it('should log server status during polling', async () => {
+    it('logs server status during polling', async () => {
       const runningServer: CoreWorkload[] = [
         { name: 'server1', status: 'running', port: 3001 },
       ]
@@ -324,7 +324,7 @@ describe('graceful-exit', () => {
       )
     })
 
-    it('should respect polling intervals', async () => {
+    it('respects polling intervals', async () => {
       const runningServer: CoreWorkload[] = [
         { name: 'server1', status: 'running', port: 3001 },
       ]

--- a/main/src/tests/graceful-exit.test.ts
+++ b/main/src/tests/graceful-exit.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  stopAllServers,
+  getLastShutdownServers,
+  clearShutdownHistory,
+} from '../graceful-exit'
+import * as sdkGen from '@api/sdk.gen'
+import * as clientGen from '@api/client'
+import * as headers from '../headers'
+import * as logger from '../logger'
+import * as delay from '../../../utils/delay'
+import type { CoreWorkload, V1WorkloadListResponse } from '@api/types.gen'
+
+// Mock dependencies
+vi.mock('@api/sdk.gen')
+vi.mock('@api/client')
+vi.mock('../headers')
+vi.mock('../logger')
+vi.mock('../../../utils/delay')
+vi.mock('electron-store')
+
+const mockGetApiV1BetaWorkloads = vi.mocked(sdkGen.getApiV1BetaWorkloads)
+const mockPostApiV1BetaWorkloadsByNameStop = vi.mocked(
+  sdkGen.postApiV1BetaWorkloadsByNameStop
+)
+const mockCreateClient = vi.mocked(clientGen.createClient)
+const mockGetHeaders = vi.mocked(headers.getHeaders)
+const mockLog = vi.mocked(logger.default)
+const mockDelay = vi.mocked(delay.delay)
+
+// Mock electron-store
+vi.mock('electron-store', () => {
+  const mockStoreInstance = {
+    get: vi.fn(),
+    set: vi.fn(),
+  }
+
+  // Export the instance so we can access it in tests
+  ;(
+    globalThis as typeof globalThis & {
+      __mockStoreInstance: typeof mockStoreInstance
+    }
+  ).__mockStoreInstance = mockStoreInstance
+
+  return {
+    default: vi.fn().mockImplementation(() => mockStoreInstance),
+  }
+})
+
+describe('graceful-exit', () => {
+  const mockClient = {} as ReturnType<typeof clientGen.createClient>
+  const mockHeaders = {
+    'X-Client-Type': 'test',
+    'X-Client-Version': '1.0.0',
+    'X-Client-Platform': 'darwin' as NodeJS.Platform,
+    'X-Client-Release-Build': false,
+  }
+
+  // Get reference to the mocked store instance
+  const mockStoreInstance = (
+    globalThis as typeof globalThis & {
+      __mockStoreInstance: {
+        get: ReturnType<typeof vi.fn>
+        set: ReturnType<typeof vi.fn>
+      }
+    }
+  ).__mockStoreInstance
+
+  const createMockWorkloadsResponse = (workloads: CoreWorkload[]) => ({
+    data: { workloads } as V1WorkloadListResponse,
+    request: {} as Request,
+    response: {} as Response,
+  })
+
+  const createMockStopResponse = () => ({
+    data: '',
+    request: {} as Request,
+    response: {} as Response,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateClient.mockReturnValue(mockClient)
+    mockGetHeaders.mockReturnValue(mockHeaders)
+    mockDelay.mockResolvedValue(undefined)
+
+    // Mock logger methods
+    mockLog.info = vi.fn()
+    mockLog.error = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('stopAllServers', () => {
+    const mockRunningServers: CoreWorkload[] = [
+      { name: 'server1', status: 'running', port: 3001 },
+      { name: 'server2', status: 'running', port: 3002 },
+    ]
+
+    const mockStoppedServers: CoreWorkload[] = [
+      { name: 'server1', status: 'stopped', port: 3001 },
+      { name: 'server2', status: 'stopped', port: 3002 },
+    ]
+
+    it('should handle no running servers gracefully', async () => {
+      mockGetApiV1BetaWorkloads.mockResolvedValue(
+        createMockWorkloadsResponse([])
+      )
+
+      await stopAllServers('', 3000)
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        'No running servers – teardown complete'
+      )
+      expect(mockPostApiV1BetaWorkloadsByNameStop).not.toHaveBeenCalled()
+    })
+
+    it('should stop all running servers successfully', async () => {
+      // Mock getting running servers initially
+      mockGetApiV1BetaWorkloads
+        .mockResolvedValueOnce(createMockWorkloadsResponse(mockRunningServers))
+        // Mock polling - first call shows servers still stopping, second shows stopped
+        .mockResolvedValueOnce(
+          createMockWorkloadsResponse([
+            { name: 'server1', status: 'stopping', port: 3001 },
+            { name: 'server2', status: 'stopping', port: 3002 },
+          ])
+        )
+        .mockResolvedValueOnce(createMockWorkloadsResponse(mockStoppedServers))
+
+      mockPostApiV1BetaWorkloadsByNameStop.mockResolvedValue(
+        createMockStopResponse()
+      )
+
+      await stopAllServers('', 3000)
+
+      expect(mockPostApiV1BetaWorkloadsByNameStop).toHaveBeenCalledTimes(2)
+      expect(mockPostApiV1BetaWorkloadsByNameStop).toHaveBeenCalledWith({
+        client: mockClient,
+        path: { name: 'server1' },
+      })
+      expect(mockPostApiV1BetaWorkloadsByNameStop).toHaveBeenCalledWith({
+        client: mockClient,
+        path: { name: 'server2' },
+      })
+      expect(mockLog.info).toHaveBeenCalledWith('All servers stopped cleanly')
+    })
+
+    it('should handle servers with final statuses (error, unknown, unhealthy)', async () => {
+      const serversWithFinalStatuses: CoreWorkload[] = [
+        { name: 'server1', status: 'error', port: 3001 },
+        { name: 'server2', status: 'unknown', port: 3002 },
+        { name: 'server3', status: 'unhealthy', port: 3003 },
+      ]
+
+      mockGetApiV1BetaWorkloads
+        .mockResolvedValueOnce(createMockWorkloadsResponse(mockRunningServers))
+        .mockResolvedValueOnce(
+          createMockWorkloadsResponse(serversWithFinalStatuses)
+        )
+
+      mockPostApiV1BetaWorkloadsByNameStop.mockResolvedValue(
+        createMockStopResponse()
+      )
+
+      await stopAllServers('', 3000)
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        'All servers have reached final state'
+      )
+      expect(mockLog.info).toHaveBeenCalledWith('All servers stopped cleanly')
+    })
+
+    it('should handle stop command failures', async () => {
+      mockGetApiV1BetaWorkloads.mockResolvedValue(
+        createMockWorkloadsResponse(mockRunningServers)
+      )
+
+      mockPostApiV1BetaWorkloadsByNameStop
+        .mockResolvedValueOnce(createMockStopResponse()) // server1 succeeds
+        .mockRejectedValueOnce(new Error('Stop failed')) // server2 fails
+
+      await expect(stopAllServers('', 3000)).rejects.toThrow(
+        '1 server(s) failed to initiate stop'
+      )
+    })
+
+    it('should handle timeout when servers do not stop', async () => {
+      const stuckServers: CoreWorkload[] = [
+        { name: 'server1', status: 'stopping', port: 3001 },
+      ]
+
+      mockGetApiV1BetaWorkloads
+        .mockResolvedValueOnce(
+          createMockWorkloadsResponse([
+            { name: 'server1', status: 'running', port: 3001 },
+          ])
+        )
+        // Keep returning stopping status to simulate timeout
+        .mockResolvedValue(createMockWorkloadsResponse(stuckServers))
+
+      mockPostApiV1BetaWorkloadsByNameStop.mockResolvedValue(
+        createMockStopResponse()
+      )
+
+      await expect(stopAllServers('', 3000)).rejects.toThrow(
+        'Some servers failed to stop within timeout'
+      )
+    })
+
+    it('should store shutdown servers in electron store', async () => {
+      mockGetApiV1BetaWorkloads
+        .mockResolvedValueOnce(createMockWorkloadsResponse(mockRunningServers))
+        .mockResolvedValueOnce(createMockWorkloadsResponse(mockStoppedServers))
+
+      mockPostApiV1BetaWorkloadsByNameStop.mockResolvedValue(
+        createMockStopResponse()
+      )
+
+      await stopAllServers('', 3000)
+
+      expect(mockStoreInstance.set).toHaveBeenCalledWith(
+        'lastShutdownServers',
+        mockRunningServers
+      )
+    })
+
+    it('should handle servers without names', async () => {
+      const serversWithoutNames: CoreWorkload[] = [
+        { name: undefined, status: 'running', port: 3001 },
+        { name: 'server2', status: 'running', port: 3002 },
+      ]
+
+      mockGetApiV1BetaWorkloads
+        .mockResolvedValueOnce(createMockWorkloadsResponse(serversWithoutNames))
+        .mockResolvedValueOnce(
+          createMockWorkloadsResponse([
+            { name: 'server2', status: 'stopped', port: 3002 },
+          ])
+        )
+
+      mockPostApiV1BetaWorkloadsByNameStop.mockResolvedValue(
+        createMockStopResponse()
+      )
+
+      await stopAllServers('', 3000)
+
+      // Should only try to stop the server with a name
+      expect(mockPostApiV1BetaWorkloadsByNameStop).toHaveBeenCalledTimes(1)
+      expect(mockPostApiV1BetaWorkloadsByNameStop).toHaveBeenCalledWith({
+        client: mockClient,
+        path: { name: 'server2' },
+      })
+    })
+  })
+
+  describe('getLastShutdownServers', () => {
+    it('should return servers from electron store', () => {
+      const mockServers = ['server1', 'server2']
+      mockStoreInstance.get.mockReturnValue(mockServers)
+
+      const result = getLastShutdownServers()
+
+      expect(result).toEqual(mockServers)
+      expect(mockStoreInstance.get).toHaveBeenCalledWith(
+        'lastShutdownServers',
+        []
+      )
+    })
+
+    it('should return empty array when no servers in store', () => {
+      mockStoreInstance.get.mockReturnValue([])
+
+      const result = getLastShutdownServers()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('clearShutdownHistory', () => {
+    it('should clear shutdown history in electron store', () => {
+      clearShutdownHistory()
+
+      expect(mockStoreInstance.set).toHaveBeenCalledWith(
+        'lastShutdownServers',
+        []
+      )
+      expect(mockLog.info).toHaveBeenCalledWith('Shutdown history cleared')
+    })
+  })
+
+  describe('polling behavior', () => {
+    it('should log server status during polling', async () => {
+      const runningServer: CoreWorkload[] = [
+        { name: 'server1', status: 'running', port: 3001 },
+      ]
+
+      const stoppingServer: CoreWorkload[] = [
+        { name: 'server1', status: 'stopping', port: 3001 },
+      ]
+
+      const stoppedServer: CoreWorkload[] = [
+        { name: 'server1', status: 'stopped', port: 3001 },
+      ]
+
+      mockGetApiV1BetaWorkloads
+        .mockResolvedValueOnce(createMockWorkloadsResponse(runningServer))
+        .mockResolvedValueOnce(createMockWorkloadsResponse(stoppingServer))
+        .mockResolvedValueOnce(createMockWorkloadsResponse(stoppedServer))
+
+      mockPostApiV1BetaWorkloadsByNameStop.mockResolvedValue(
+        createMockStopResponse()
+      )
+
+      await stopAllServers('', 3000)
+
+      expect(mockLog.info).toHaveBeenCalledWith(
+        'Still waiting for 1 servers to reach final state: server1(stopping)'
+      )
+      expect(mockLog.info).toHaveBeenCalledWith(
+        'All servers have reached final state'
+      )
+    })
+
+    it('should respect polling intervals', async () => {
+      const runningServer: CoreWorkload[] = [
+        { name: 'server1', status: 'running', port: 3001 },
+      ]
+
+      const stoppedServer: CoreWorkload[] = [
+        { name: 'server1', status: 'stopped', port: 3001 },
+      ]
+
+      mockGetApiV1BetaWorkloads
+        .mockResolvedValueOnce(createMockWorkloadsResponse(runningServer))
+        .mockResolvedValueOnce(createMockWorkloadsResponse(runningServer))
+        .mockResolvedValueOnce(createMockWorkloadsResponse(stoppedServer))
+
+      mockPostApiV1BetaWorkloadsByNameStop.mockResolvedValue(
+        createMockStopResponse()
+      )
+
+      await stopAllServers('', 3000)
+
+      // Should call delay between polling attempts (not on first attempt)
+      expect(mockDelay).toHaveBeenCalledWith(2000)
+    })
+  })
+})


### PR DESCRIPTION
This PR enhances the `graceful-exit` functionality by updating the polling logic to properly handle all final server statuses that now we have with the latest API update (stopped, error, unknown, unhealthy) instead of just checking for running servers. Added also some unit tests