### PR TITLE
feat: use the new status endpoint for polling

### DIFF
--- a/renderer/src/common/hooks/use-toast-mutation.ts
+++ b/renderer/src/common/hooks/use-toast-mutation.ts
@@ -64,6 +64,8 @@ export function useToastMutation<
         },
         ...(toastId ? { id: toastId } : {}),
       })
+
+      return promise
     },
     [errorMsg, loadingMsg, originalMutateAsync, successMsg, toastId]
   )

--- a/renderer/src/common/mocks/handlers.ts
+++ b/renderer/src/common/mocks/handlers.ts
@@ -101,6 +101,17 @@ export const handlers = [
     }
   ),
 
+  http.get(mswEndpoint('/api/v1beta/workloads/:name/status'), ({ params }) => {
+    const { name } = params
+
+    const server = getWorkloadByName(name as string)
+    if (!server) {
+      return HttpResponse.json({ error: 'Server not found' }, { status: 404 })
+    }
+
+    return HttpResponse.json({ status: server.status })
+  }),
+
   // Batch restart endpoint
   http.post(
     mswEndpoint('/api/v1beta/workloads/restart'),

--- a/renderer/src/features/mcp-servers/hooks/use-delete-server.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-delete-server.ts
@@ -1,7 +1,7 @@
 import type { V1WorkloadListResponse, CoreWorkload } from '@api/types.gen'
 import {
   deleteApiV1BetaWorkloadsByNameMutation,
-  getApiV1BetaWorkloadsByNameOptions,
+  getApiV1BetaWorkloadsByNameStatusOptions,
   getApiV1BetaWorkloadsQueryKey,
 } from '@api/@tanstack/react-query.gen'
 import { useToastMutation } from '@/common/hooks/use-toast-mutation'
@@ -43,7 +43,7 @@ export function useDeleteServer({ name }: { name: string }) {
     onSuccess: async () => {
       await pollServerDelete(() =>
         queryClient.fetchQuery(
-          getApiV1BetaWorkloadsByNameOptions({
+          getApiV1BetaWorkloadsByNameStatusOptions({
             path: { name },
           })
         )

--- a/renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts
@@ -2,7 +2,7 @@ import type { V1WorkloadListResponse, CoreWorkload } from '@api/types.gen'
 import {
   postApiV1BetaWorkloadsByNameRestartMutation,
   getApiV1BetaWorkloadsQueryKey,
-  getApiV1BetaWorkloadsByNameOptions,
+  getApiV1BetaWorkloadsByNameStatusOptions,
   postApiV1BetaWorkloadsRestartMutation,
 } from '@api/@tanstack/react-query.gen'
 import { useToastMutation } from '@/common/hooks/use-toast-mutation'
@@ -94,7 +94,7 @@ export function useMutationRestartServerAtStartup() {
           const servers = await Promise.all(
             names.map((name) =>
               queryClient.fetchQuery(
-                getApiV1BetaWorkloadsByNameOptions({ path: { name } })
+                getApiV1BetaWorkloadsByNameStatusOptions({ path: { name } })
               )
             )
           )

--- a/renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts
@@ -91,14 +91,18 @@ export function useMutationRestartServerAtStartup() {
       // Poll until all servers are running
       await pollBatchServerStatus(
         async (names) => {
-          const servers = await Promise.all(
+          const statusResponses = await Promise.all(
             names.map((name) =>
               queryClient.fetchQuery(
                 getApiV1BetaWorkloadsByNameStatusOptions({ path: { name } })
               )
             )
           )
-          return servers
+          // Convert status responses to CoreWorkload-like objects for polling
+          return statusResponses.map((response, index) => ({
+            name: names[index],
+            status: response.status || 'unknown',
+          })) as CoreWorkload[]
         },
         serverNames,
         'running'

--- a/renderer/src/features/mcp-servers/hooks/use-mutation-stop-server.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-mutation-stop-server.ts
@@ -2,7 +2,7 @@ import type { CoreWorkload, V1WorkloadListResponse } from '@api/types.gen'
 import {
   postApiV1BetaWorkloadsByNameStopMutation,
   getApiV1BetaWorkloadsQueryKey,
-  getApiV1BetaWorkloadsByNameOptions,
+  getApiV1BetaWorkloadsByNameStatusOptions,
 } from '@api/@tanstack/react-query.gen'
 import { useToastMutation } from '@/common/hooks/use-toast-mutation'
 import { pollBatchServerStatus } from '@/common/lib/polling'
@@ -52,7 +52,7 @@ export function useMutationStopServerList({ name }: { name: string }) {
           const servers = await Promise.all(
             names.map((name) =>
               queryClient.fetchQuery(
-                getApiV1BetaWorkloadsByNameOptions({ path: { name } })
+                getApiV1BetaWorkloadsByNameStatusOptions({ path: { name } })
               )
             )
           )

--- a/renderer/src/features/mcp-servers/hooks/use-mutation-stop-server.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-mutation-stop-server.ts
@@ -49,14 +49,18 @@ export function useMutationStopServerList({ name }: { name: string }) {
       // Poll until server stopped
       await pollBatchServerStatus(
         async (names) => {
-          const servers = await Promise.all(
+          const statusResponses = await Promise.all(
             names.map((name) =>
               queryClient.fetchQuery(
                 getApiV1BetaWorkloadsByNameStatusOptions({ path: { name } })
               )
             )
           )
-          return servers
+          // Convert status responses to CoreWorkload-like objects for polling
+          return statusResponses.map((response, index) => ({
+            name: names[index],
+            status: response.status || 'unknown',
+          })) as CoreWorkload[]
         },
         [name],
         'stopped'

--- a/renderer/src/features/mcp-servers/hooks/use-run-custom-server.tsx
+++ b/renderer/src/features/mcp-servers/hooks/use-run-custom-server.tsx
@@ -1,6 +1,6 @@
 import {
   postApiV1BetaWorkloadsMutation,
-  getApiV1BetaWorkloadsByNameOptions,
+  getApiV1BetaWorkloadsByNameStatusOptions,
   postApiV1BetaSecretsDefaultKeysMutation,
   getApiV1BetaWorkloadsQueryKey,
 } from '@api/@tanstack/react-query.gen'
@@ -62,7 +62,7 @@ export function useRunCustomServer({
       const isServerReady = await pollServerStatus(
         () =>
           queryClient.fetchQuery(
-            getApiV1BetaWorkloadsByNameOptions({
+            getApiV1BetaWorkloadsByNameStatusOptions({
               path: { name: formData.name },
             })
           ),

--- a/renderer/src/features/registry-servers/hooks/use-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/hooks/use-run-from-registry.tsx
@@ -7,7 +7,7 @@ import {
 import { getApiV1BetaSecretsDefaultKeys, type Options } from '@api/sdk.gen'
 import {
   postApiV1BetaWorkloadsMutation,
-  getApiV1BetaWorkloadsByNameOptions,
+  getApiV1BetaWorkloadsByNameStatusOptions,
   postApiV1BetaSecretsDefaultKeysMutation,
   getApiV1BetaWorkloadsQueryKey,
 } from '@api/@tanstack/react-query.gen'
@@ -71,7 +71,7 @@ export function useRunFromRegistry({
       const isServerReady = await pollServerStatus(
         () =>
           queryClient.fetchQuery(
-            getApiV1BetaWorkloadsByNameOptions({
+            getApiV1BetaWorkloadsByNameStatusOptions({
               path: { name: formData.serverName },
             })
           ),


### PR DESCRIPTION
as per title, status is no longer returned for the GET single workload, we now have this new endpoint that just checks that