### PR TITLE
ci: remove window code signin in normal build

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -41,16 +41,6 @@ jobs:
           apple-issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
           apple-key-id: ${{ secrets.APPLE_KEY_ID }}
 
-      - name: Setup Windows code signing
-        uses: ./.github/actions/setup-windows-codesign
-        if: runner.os == 'Windows'
-        with:
-          sm-host: ${{ secrets.SM_HOST }}
-          sm-api-key: ${{ secrets.SM_API_KEY }}
-          sm-client-cert-file-b64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
-          sm-client-cert-password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-          sm-code-signing-cert-sha1-hash: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
-
       - name: Install Flatpak tool-chain (Linux only)
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
as per title, we don't need the signature in PR, remove it