### PR TITLE
feat(feature-flag): Add new page and starting logic for customize tools 

### DIFF
--- a/main/src/feature-flags.ts
+++ b/main/src/feature-flags.ts
@@ -21,6 +21,10 @@ const featureFlagOptions: Record<FeatureFlagKey, FeatureFlagOptions> = {
     isDisabled: false,
     defaultValue: false,
   },
+  [featureFlagKeys.CUSTOMIZE_TOOLS]: {
+    isDisabled: false,
+    defaultValue: false,
+  },
 }
 
 // Create a dedicated store for feature flags

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -63,6 +63,7 @@ import {
   getToolhiveMcpInfo,
   type ChatRequest,
 } from './chat'
+import { getWorkloadAvailableTools } from './utils/mcp-tools'
 
 let tray: Tray | null = null
 let isQuitting = false
@@ -837,3 +838,8 @@ ipcMain.handle(
     saveEnabledMcpTools(serverName, enabledTools)
 )
 ipcMain.handle('chat:get-toolhive-mcp-info', () => getToolhiveMcpInfo())
+
+// Workload tools discovery handler
+ipcMain.handle('utils:get-workload-available-tools', async (_, workload) =>
+  getWorkloadAvailableTools(workload)
+)

--- a/main/src/utils/mcp-tools.ts
+++ b/main/src/utils/mcp-tools.ts
@@ -1,0 +1,133 @@
+import {
+  experimental_createMCPClient as createMCPClient,
+  type experimental_MCPClientConfig as MCPClientConfig,
+  type Tool,
+} from 'ai'
+import { Experimental_StdioMCPTransport as StdioMCPTransport } from 'ai/mcp-stdio'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { CoreWorkload } from '@api/types.gen'
+import log from '../logger'
+
+// Interface for MCP tool definition from client
+export interface McpToolDefinition {
+  description?: string
+  inputSchema?: Tool['inputSchema']
+}
+
+// Type guard to check if an object is a valid MCP tool definition
+export function isMcpToolDefinition(obj: Tool): obj is McpToolDefinition {
+  if (!obj || typeof obj !== 'object' || obj === null) return false
+
+  const tool = obj
+
+  // Description should be string if present
+  if (
+    'description' in tool &&
+    tool.description !== undefined &&
+    typeof tool.description !== 'string'
+  )
+    return false
+
+  // InputSchema should be object if present
+  if ('inputSchema' in tool && tool.inputSchema !== undefined) {
+    if (typeof tool.inputSchema !== 'object' || tool.inputSchema === null)
+      return false
+
+    const inputSchema = tool.inputSchema as Record<string, unknown>
+    if ('properties' in inputSchema && inputSchema.properties !== undefined) {
+      if (
+        typeof inputSchema.properties !== 'object' ||
+        inputSchema.properties === null ||
+        Array.isArray(inputSchema.properties)
+      ) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+// Create transport configuration based on workload type
+export function createTransport(
+  workload: CoreWorkload,
+  serverName: string,
+  port: number
+): MCPClientConfig {
+  const transportConfigs = {
+    stdio: () => ({
+      name: serverName,
+      transport: new StdioMCPTransport({
+        command: 'node',
+        args: [],
+      }),
+    }),
+    'streamable-http': () => {
+      const url = new URL(workload.url || `http://localhost:${port}/mcp`)
+      return {
+        name: serverName,
+        transport: new StreamableHTTPClientTransport(url),
+      }
+    },
+    sse: () => ({
+      name: serverName,
+      transport: {
+        type: 'sse' as const,
+        url: `${workload.url || `http://localhost:${port}/sse#${serverName}`}`,
+      },
+    }),
+    default: () => ({
+      name: serverName,
+      transport: {
+        type: 'sse' as const,
+        url: `${workload.url || `http://localhost:${port}/sse#${serverName}`}`,
+      },
+    }),
+  }
+
+  // Check if transport_type is stdio but URL suggests SSE
+  let transportType = workload.transport_type as keyof typeof transportConfigs
+
+  if (transportType === 'stdio' && workload.url) {
+    // If URL contains /sse or #, use SSE transport instead
+    if (workload.url.includes('/sse') || workload.url.includes('#')) {
+      // Override stdio to SSE based on URL pattern
+      transportType = 'sse'
+    }
+  }
+
+  const configBuilder =
+    transportConfigs[transportType] || transportConfigs.default
+  return configBuilder()
+}
+
+// Get available tools from a workload
+export async function getWorkloadAvailableTools(workload: CoreWorkload) {
+  if (!workload.name) return null
+
+  try {
+    // Try to create an MCP client and discover tools
+    const config = createTransport(workload, workload.name, workload.port!)
+    if (config) {
+      const mcpClient = await createMCPClient(config)
+      const rawTools = await mcpClient.tools<'automatic'>()
+
+      // Filter and validate tools using type guard, creating serializable copies
+      const serverMcpTools = Object.entries(rawTools)
+        .filter(([, defTool]) => isMcpToolDefinition(defTool))
+        .reduce<Record<string, McpToolDefinition>>((prev, [name, def]) => {
+          if (!def || !name) return prev
+          prev[name] = {
+            description: def.description ?? '',
+            inputSchema: def.inputSchema ?? undefined,
+          }
+          return prev
+        }, {})
+      await mcpClient.close()
+      return serverMcpTools
+    }
+  } catch (error) {
+    log.error(`Failed to discover tools for ${workload.name}:`, error)
+    return {}
+  }
+}

--- a/preload/src/preload.ts
+++ b/preload/src/preload.ts
@@ -161,6 +161,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getToolhiveMcpInfo: () => ipcRenderer.invoke('chat:get-toolhive-mcp-info'),
   },
 
+  // Utility functions
+  utils: {
+    getWorkloadAvailableTools: (workload: unknown) =>
+      ipcRenderer.invoke('utils:get-workload-available-tools', workload),
+  },
+
   // IPC event listeners for streaming
   on: (channel: string, listener: (...args: unknown[]) => void) => {
     ipcRenderer.on(channel, (_, ...args) => listener(...args))
@@ -304,6 +310,20 @@ export interface ElectronAPI {
       toolCount: number
       tools: Array<{ name: string; description: string }>
     } | null>
+  }
+  utils: {
+    getWorkloadAvailableTools: (workload: unknown) => Promise<
+      | Record<
+          string,
+          {
+            description?: string
+            inputSchema?: {
+              properties?: Record<string, unknown>
+            }
+          }
+        >
+      | undefined
+    >
   }
 
   // IPC event listeners for streaming

--- a/renderer/src/features/mcp-servers/components/card-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuSeparator,
 } from '@/common/components/ui/dropdown-menu'
 import { Button } from '@/common/components/ui/button'
-import { MoreVertical, Trash2, Github, Text, Copy } from 'lucide-react'
+import { MoreVertical, Trash2, Github, Text, Copy, Edit3 } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Input } from '@/common/components/ui/input'
@@ -25,6 +25,8 @@ import { useConfirm } from '@/common/hooks/use-confirm'
 import { useDeleteServer } from '../hooks/use-delete-server'
 import { useQuery } from '@tanstack/react-query'
 import { useSearch } from '@tanstack/react-router'
+import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
+import { featureFlagKeys } from '../../../../../utils/feature-flags'
 import { getApiV1BetaRegistryByNameServersByServerName } from '@api/sdk.gen'
 import { useEffect, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -34,6 +36,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/common/components/ui/tooltip'
+import { cn } from '@/common/lib/utils'
 
 type CardContentMcpServerProps = {
   status: CoreWorkload['status']
@@ -114,6 +117,9 @@ export function CardMcpServer({
   const { mutateAsync: deleteServer, isPending: isDeletePending } =
     useDeleteServer({ name })
   const nameRef = useRef<HTMLElement | null>(null)
+  const isCustomizeToolsEnabled = useFeatureFlag(
+    featureFlagKeys.CUSTOMIZE_TOOLS
+  )
 
   const { data: serverDetails } = useQuery({
     queryKey: ['serverDetails', name],
@@ -285,6 +291,24 @@ export function CardMcpServer({
                   Logs
                 </Link>
               </DropdownMenuItem>
+              {isCustomizeToolsEnabled && (
+                <DropdownMenuItem
+                  asChild
+                  className="flex cursor-pointer items-center"
+                >
+                  <Link
+                    disabled={status !== 'running'}
+                    className={cn(
+                      status !== 'running' && 'pointer-events-none opacity-50'
+                    )}
+                    to="/customize-tools/$serverName"
+                    params={{ serverName: name }}
+                  >
+                    <Edit3 className="mr-2 h-4 w-4" />
+                    Customize Tools
+                  </Link>
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={handleRemove}
                 disabled={isDeletePending}

--- a/renderer/src/features/mcp-servers/components/customize-tools-table.tsx
+++ b/renderer/src/features/mcp-servers/components/customize-tools-table.tsx
@@ -1,0 +1,134 @@
+import { Button } from '@/common/components/ui/button'
+import { Switch } from '@/common/components/ui/switch'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/common/components/ui/table'
+import { useState, useEffect } from 'react'
+
+// Simple skeleton component if not available in UI library
+function Skeleton({ className }: { className?: string }) {
+  return <div className={`bg-muted animate-pulse rounded ${className}`} />
+}
+
+interface Tool {
+  name: string
+  description?: string
+}
+
+interface CustomizeToolsTableProps {
+  tools: Tool[]
+  isLoading?: boolean
+  onApply?: (enabledTools: Record<string, boolean>) => void
+  onCancel?: () => void
+}
+
+export function CustomizeToolsTable({
+  tools,
+  isLoading = true,
+  onApply,
+  onCancel,
+}: CustomizeToolsTableProps) {
+  // State to track which tools are enabled
+  const [enabledTools, setEnabledTools] = useState<Record<string, boolean>>({})
+
+  // Initialize enabled tools when tools data is available
+  useEffect(() => {
+    if (tools && tools.length > 0) {
+      const initialState = tools.reduce(
+        (acc, tool) => ({ ...acc, [tool.name]: true }),
+        {}
+      )
+      setEnabledTools(initialState)
+    }
+  }, [tools])
+
+  const handleToolToggle = (toolName: string, enabled: boolean) => {
+    setEnabledTools((prev) => ({
+      ...prev,
+      [toolName]: enabled,
+    }))
+  }
+
+  const handleApply = () => {
+    onApply?.(enabledTools)
+  }
+
+  const handleCancel = () => {
+    onCancel?.()
+  }
+
+  if (!isLoading && tools.length === 0) {
+    return <div>No tools available</div>
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="overflow-hidden rounded-md border">
+        <Table>
+          <TableHeader className="bg-muted/50">
+            <TableRow className="border-border border-b">
+              <TableHead className="text-muted-foreground w-[60px] text-xs"></TableHead>
+              <TableHead className="text-muted-foreground text-xs">
+                Tool
+              </TableHead>
+              <TableHead className="text-muted-foreground text-xs">
+                Description
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading
+              ? Array.from({ length: 10 }).map((_, index) => (
+                  <TableRow key={`skeleton-${index}`}>
+                    <TableCell className="w-[60px] px-2 py-4">
+                      <Skeleton className="h-5 w-8 rounded" />
+                    </TableCell>
+                    <TableCell className="px-2 py-4">
+                      <Skeleton className="h-4 w-24" />
+                    </TableCell>
+                    <TableCell className="px-2 py-4">
+                      <Skeleton className="h-4 w-full max-w-md" />
+                    </TableCell>
+                  </TableRow>
+                ))
+              : tools.map((tool) => (
+                  <TableRow key={tool.name}>
+                    <TableCell className="w-[60px] px-2 py-4">
+                      <Switch
+                        checked={enabledTools[tool.name] ?? true}
+                        onCheckedChange={(checked) =>
+                          handleToolToggle(tool.name, checked)
+                        }
+                      />
+                    </TableCell>
+                    <TableCell className="px-2 py-4">
+                      <span className="font-medium">{tool.name}</span>
+                    </TableCell>
+                    <TableCell
+                      className="text-muted-foreground px-2 py-4 break-words
+                        whitespace-normal"
+                    >
+                      {tool.description || ''}
+                    </TableCell>
+                  </TableRow>
+                ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <Button variant="default" onClick={handleApply} disabled={isLoading}>
+          Apply
+        </Button>
+        <Button variant="outline" onClick={handleCancel} disabled={isLoading}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/renderer/src/features/mcp-servers/hooks/use-update-server.tsx
+++ b/renderer/src/features/mcp-servers/hooks/use-update-server.tsx
@@ -1,0 +1,100 @@
+import {
+  postApiV1BetaWorkloadsByNameEditMutation,
+  getApiV1BetaWorkloadsByNameStatusOptions,
+  getApiV1BetaWorkloadsQueryKey,
+} from '@api/@tanstack/react-query.gen'
+import { pollServerStatus } from '@/common/lib/polling'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useRef } from 'react'
+
+import { type V1UpdateRequest } from '@api/types.gen'
+import { toast } from 'sonner'
+import { Button } from '@/common/components/ui/button'
+import { Link } from '@tanstack/react-router'
+import { restartClientNotification } from '../lib/restart-client-notification'
+import { trackEvent } from '@/common/lib/analytics'
+
+type UpdateServerCheck = () => Promise<unknown> | unknown
+
+export function useUpdateServer(serverName: string) {
+  const toastIdRef = useRef(new Date(Date.now()).toISOString())
+  const queryClient = useQueryClient()
+
+  const { mutateAsync: updateWorkload } = useMutation({
+    ...postApiV1BetaWorkloadsByNameEditMutation(),
+  })
+
+  const handleSettled = useCallback<UpdateServerCheck>(async () => {
+    toast.loading(`Updating "${serverName}"...`, {
+      duration: 30_000,
+      id: toastIdRef.current,
+    })
+
+    const isServerReady = await pollServerStatus(
+      () =>
+        queryClient.fetchQuery(
+          getApiV1BetaWorkloadsByNameStatusOptions({
+            path: { name: serverName },
+          })
+        ),
+      'running'
+    )
+
+    if (isServerReady) {
+      await queryClient.invalidateQueries({
+        queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+      })
+
+      toast.success(`"${serverName}" updated successfully.`, {
+        id: toastIdRef.current,
+        duration: 5_000,
+        action: (
+          <Button asChild>
+            <Link
+              to="/"
+              search={{ newServerName: serverName }}
+              onClick={() => toast.dismiss(toastIdRef.current)}
+              viewTransition={{ types: ['slide-left'] }}
+              className="ml-auto"
+            >
+              View
+            </Link>
+          </Button>
+        ),
+      })
+    } else {
+      toast.warning(
+        `Server "${serverName}" was updated but may still be restarting. Check the servers list to monitor its status.`,
+        {
+          id: toastIdRef.current,
+          duration: 5_000,
+        }
+      )
+    }
+  }, [queryClient, serverName])
+
+  const { mutate: updateServerMutation } = useMutation({
+    mutationFn: async ({
+      updateRequest,
+    }: {
+      updateRequest: V1UpdateRequest
+    }) => {
+      await updateWorkload({
+        path: { name: serverName },
+        body: updateRequest,
+      })
+      await restartClientNotification({
+        queryClient,
+      })
+      trackEvent(`Workload ${serverName} updated`, {
+        workload: serverName,
+        'route.pathname': '/customize-tools',
+      })
+    },
+  })
+
+  return {
+    updateServerMutation,
+    checkServerStatus: handleSettled,
+  }
+}

--- a/renderer/src/features/mcp-servers/sub-pages/customize-tools/page.tsx
+++ b/renderer/src/features/mcp-servers/sub-pages/customize-tools/page.tsx
@@ -1,0 +1,137 @@
+import { LinkViewTransition } from '@/common/components/link-view-transition'
+import { Button } from '@/common/components/ui/button'
+import { CustomizeToolsTable } from '@/features/mcp-servers/components/customize-tools-table'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { useParams } from '@tanstack/react-router'
+import { ChevronLeft } from 'lucide-react'
+import { useUpdateServer } from '@/features/mcp-servers/hooks/use-update-server'
+import { toast } from 'sonner'
+import type { V1UpdateRequest } from '@api/types.gen'
+import { getApiV1BetaWorkloads } from '@api/sdk.gen'
+
+export function CustomizeToolsPage() {
+  const { serverName } = useParams({ from: '/customize-tools/$serverName' })
+
+  const { data: workload, isLoading: isWorkloadLoading } = useSuspenseQuery({
+    queryKey: ['workload', serverName],
+    queryFn: async () => {
+      const { data } = await getApiV1BetaWorkloads({
+        query: {
+          all: true,
+        },
+      })
+      // TODO: GET single server do not return the correct port?
+      return data?.workloads?.find((item) => item.name === serverName) ?? null
+    },
+  })
+
+  const { data: serverTools, isLoading } = useQuery({
+    queryKey: ['workload-available-tools', serverName, workload?.name],
+    queryFn: async () => {
+      if (!workload) return null
+      const results =
+        await window.electronAPI.utils.getWorkloadAvailableTools(workload)
+      // for showing the loading state
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      return results
+    },
+    enabled:
+      !!serverName && !isWorkloadLoading && workload?.status === 'running',
+    refetchOnWindowFocus: true,
+    staleTime: 0,
+  })
+
+  const { updateServerMutation, checkServerStatus } =
+    useUpdateServer(serverName)
+
+  const handleApply = async (enabledTools: Record<string, boolean>) => {
+    if (!serverTools) {
+      toast.error('Server data not loaded')
+      return
+    }
+
+    try {
+      // Step 1: Save enabled tools using temporary API
+      const enabledToolNames = Object.entries(enabledTools)
+        .filter(([, enabled]) => enabled)
+        .map(([toolName]) => toolName)
+
+      const toolsSaveResult = await window.electronAPI.chat.saveEnabledMcpTools(
+        serverName,
+        enabledToolNames
+      )
+
+      if (!toolsSaveResult.success) {
+        throw new Error(toolsSaveResult.error || 'Failed to save tool settings')
+      }
+
+      // Step 2: Update server with just the tools
+      const updateRequest: V1UpdateRequest = {
+        tools: enabledToolNames,
+      }
+
+      updateServerMutation(
+        { updateRequest },
+        {
+          onSuccess: () => {
+            checkServerStatus()
+            toast.success('Server tools updated successfully')
+          },
+          onError: (error) => {
+            toast.error(
+              `Failed to update server: ${typeof error === 'string' ? error : error.message}`
+            )
+          },
+        }
+      )
+    } catch (error) {
+      toast.error(
+        `Failed to apply changes: ${error instanceof Error ? error.message : 'Unknown error'}`
+      )
+    }
+  }
+
+  const handleCancel = () => {
+    // Navigate back or reset - for now just go back
+    window.history.back()
+  }
+
+  return (
+    <div className="">
+      <div className="mb-2">
+        <LinkViewTransition to="/">
+          <Button
+            variant="ghost"
+            aria-label="Back"
+            className="text-muted-foreground"
+          >
+            <ChevronLeft className="size-5" />
+            Back
+          </Button>
+        </LinkViewTransition>
+      </div>
+      <div className="mb-5 flex flex-col gap-5">
+        <h1 className="m-0 mb-0 p-0 text-3xl font-bold">
+          Customize Tools for {serverName}
+        </h1>
+        {workload?.status !== 'running' ? (
+          <div>Server is not running</div>
+        ) : (
+          <CustomizeToolsTable
+            tools={
+              serverTools
+                ? Object.entries(serverTools).map(([name, toolDef]) => ({
+                    name,
+                    description: toolDef.description,
+                  }))
+                : []
+            }
+            isLoading={isWorkloadLoading || isLoading}
+            onApply={handleApply}
+            onCancel={handleCancel}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/renderer/src/features/secrets/components/secrets-table.tsx
+++ b/renderer/src/features/secrets/components/secrets-table.tsx
@@ -40,7 +40,7 @@ export function SecretsTable({
       />
       <div className="overflow-hidden rounded-md border">
         <Table className="">
-          <TableHeader>
+          <TableHeader className="bg-muted/50">
             <TableRow>
               <TableHead
                 className="text-muted-foreground flex items-center px-5 text-xs"

--- a/renderer/src/route-tree.gen.ts
+++ b/renderer/src/route-tree.gen.ts
@@ -16,6 +16,7 @@ import { Route as PlaygroundRouteImport } from "./routes/playground"
 import { Route as ClientsRouteImport } from "./routes/clients"
 import { Route as IndexRouteImport } from "./routes/index"
 import { Route as LogsServerNameRouteImport } from "./routes/logs.$serverName"
+import { Route as CustomizeToolsServerNameRouteImport } from "./routes/customize-tools.$serverName"
 import { Route as registryRegistryRouteImport } from "./routes/(registry)/registry"
 import { Route as registryRegistryNameRouteImport } from "./routes/(registry)/registry_.$name"
 
@@ -54,6 +55,12 @@ const LogsServerNameRoute = LogsServerNameRouteImport.update({
   path: "/logs/$serverName",
   getParentRoute: () => rootRouteImport,
 } as any)
+const CustomizeToolsServerNameRoute =
+  CustomizeToolsServerNameRouteImport.update({
+    id: "/customize-tools/$serverName",
+    path: "/customize-tools/$serverName",
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const registryRegistryRoute = registryRegistryRouteImport.update({
   id: "/(registry)/registry",
   path: "/registry",
@@ -73,6 +80,7 @@ export interface FileRoutesByFullPath {
   "/settings": typeof SettingsRoute
   "/shutdown": typeof ShutdownRoute
   "/registry": typeof registryRegistryRoute
+  "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/logs/$serverName": typeof LogsServerNameRoute
   "/registry/$name": typeof registryRegistryNameRoute
 }
@@ -84,6 +92,7 @@ export interface FileRoutesByTo {
   "/settings": typeof SettingsRoute
   "/shutdown": typeof ShutdownRoute
   "/registry": typeof registryRegistryRoute
+  "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/logs/$serverName": typeof LogsServerNameRoute
   "/registry/$name": typeof registryRegistryNameRoute
 }
@@ -96,6 +105,7 @@ export interface FileRoutesById {
   "/settings": typeof SettingsRoute
   "/shutdown": typeof ShutdownRoute
   "/(registry)/registry": typeof registryRegistryRoute
+  "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/logs/$serverName": typeof LogsServerNameRoute
   "/(registry)/registry_/$name": typeof registryRegistryNameRoute
 }
@@ -109,6 +119,7 @@ export interface FileRouteTypes {
     | "/settings"
     | "/shutdown"
     | "/registry"
+    | "/customize-tools/$serverName"
     | "/logs/$serverName"
     | "/registry/$name"
   fileRoutesByTo: FileRoutesByTo
@@ -120,6 +131,7 @@ export interface FileRouteTypes {
     | "/settings"
     | "/shutdown"
     | "/registry"
+    | "/customize-tools/$serverName"
     | "/logs/$serverName"
     | "/registry/$name"
   id:
@@ -131,6 +143,7 @@ export interface FileRouteTypes {
     | "/settings"
     | "/shutdown"
     | "/(registry)/registry"
+    | "/customize-tools/$serverName"
     | "/logs/$serverName"
     | "/(registry)/registry_/$name"
   fileRoutesById: FileRoutesById
@@ -143,6 +156,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   ShutdownRoute: typeof ShutdownRoute
   registryRegistryRoute: typeof registryRegistryRoute
+  CustomizeToolsServerNameRoute: typeof CustomizeToolsServerNameRoute
   LogsServerNameRoute: typeof LogsServerNameRoute
   registryRegistryNameRoute: typeof registryRegistryNameRoute
 }
@@ -198,6 +212,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof LogsServerNameRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/customize-tools/$serverName": {
+      id: "/customize-tools/$serverName"
+      path: "/customize-tools/$serverName"
+      fullPath: "/customize-tools/$serverName"
+      preLoaderRoute: typeof CustomizeToolsServerNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     "/(registry)/registry": {
       id: "/(registry)/registry"
       path: "/registry"
@@ -223,6 +244,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   ShutdownRoute: ShutdownRoute,
   registryRegistryRoute: registryRegistryRoute,
+  CustomizeToolsServerNameRoute: CustomizeToolsServerNameRoute,
   LogsServerNameRoute: LogsServerNameRoute,
   registryRegistryNameRoute: registryRegistryNameRoute,
 }

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -1,4 +1,5 @@
 export const featureFlagKeys = {
   PLAYGROUND: 'playground',
   GROUPS: 'groups',
+  CUSTOMIZE_TOOLS: 'customize_tools',
 } as const


### PR DESCRIPTION
as per title, I just opened this under a feature flag, this is still WIP, it introduces:

- dedicated page for customizing tools
- dedicated IPC function to retrieve the tools (temporary), reusing the logic we had in the playground while waiting for the dedicated endpoint from thv
- components for showing the tool list
- hook for the update (not working at the moment)
- feature flag (customize_tools)


With the flag enable:

https://github.com/user-attachments/assets/f122689f-a68a-480d-b03e-171dfd263b55



