### PR TITLE
chore: trigger mirror-to-gh-pages action after release completed

### DIFF
--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -23,7 +23,12 @@ jobs:
       - name: Get release info
         id: release
         run: |
-          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            # Get the latest release tag when triggered by workflow_run
+            TAG=$(gh api "repos/${{ github.repository }}/releases/latest" | jq -r '.tag_name')
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
           # Get release metadata


### PR DESCRIPTION
Based on [Running a workflow based on the conclusion of another workflow](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow) we can run `mirror-to-gh-pages` action after the release gh action is completed and assets generated