### PR TITLE
fix(network-isolation): skip hosts, ports if network isolation is not enabled

### DIFF
--- a/renderer/src/features/mcp-servers/components/dialog-form-run-mcp-command.tsx
+++ b/renderer/src/features/mcp-servers/components/dialog-form-run-mcp-command.tsx
@@ -103,6 +103,7 @@ export function DialogFormRunMcpServerWithCommand({
     resolver: zodV4Resolver(getFormSchemaRunMcpCommand(workloads)),
     defaultValues: {
       type: 'docker_image',
+      image: '',
       target_port: undefined,
       networkIsolation: false,
       allowedHosts: [],

--- a/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
+++ b/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
@@ -360,6 +360,29 @@ describe('prepareCreateWorkloadData', () => {
     expect(result.network_isolation).toBe(false)
     expect(result.permission_profile).toBeUndefined()
   })
+
+  it('ignores invalid allowedHosts and allowedPorts when network isolation is disabled', () => {
+    const data: FormSchemaRunMcpCommand = {
+      image: 'test-image',
+      name: 'test-server',
+      transport: 'stdio',
+      type: 'docker_image',
+      envVars: [],
+      secrets: [],
+      cmd_arguments: [],
+      networkIsolation: false,
+      allowedHosts: [{ value: 'invalid-host.com' }],
+      allowedPorts: [{ value: '999999' }],
+      volumes: [],
+    }
+
+    const result = prepareCreateWorkloadData(data)
+
+    expect(result.network_isolation).toBe(false)
+    expect(result.permission_profile).toBeUndefined()
+
+    expect(() => prepareCreateWorkloadData(data)).not.toThrow()
+  })
 })
 
 describe('saveSecrets', () => {

--- a/renderer/src/features/mcp-servers/lib/orchestrate-run-custom-server.tsx
+++ b/renderer/src/features/mcp-servers/lib/orchestrate-run-custom-server.tsx
@@ -141,8 +141,14 @@ export function prepareCreateWorkloadData(
     ? {
         network: {
           outbound: {
-            allow_host: allowedHosts.map((host) => host.value),
-            allow_port: allowedPorts.map((port) => parseInt(port.value, 10)),
+            allow_host:
+              allowedHosts
+                ?.map(({ value }) => value)
+                .filter((host) => host.trim() !== '') ?? [],
+            allow_port:
+              allowedPorts
+                ?.map(({ value }) => parseInt(value, 10))
+                .filter((port) => !isNaN(port)) ?? [],
             insecure_allow_all: false,
           } as PermissionsOutboundNetworkPermissions,
         },

--- a/renderer/src/features/registry-servers/lib/get-form-schema-run-from-registry.ts
+++ b/renderer/src/features/registry-servers/lib/get-form-schema-run-from-registry.ts
@@ -64,76 +64,98 @@ export function getFormSchemaRunFromRegistry({
       ? z.string()
       : z.union(envVarNames.map((v) => z.literal(v)))
 
-  return z.object({
-    serverName: z
-      .string()
-      .min(1, 'Server name is required')
-      .refine(
-        (value) => !workloads.some((w) => w.name === value),
-        'This name is already in use'
-      ),
-    cmd_arguments: z.array(z.string()).optional(),
-    secrets: z
-      .object({
-        name: secretNameSchema,
-
-        value: z.object({
-          secret: z.string().optional(), // NOTE: This is optional to allow us to pre-populate the form with empty strings, we refine based on whether it is required by the server later.
-          isFromStore: z.boolean(),
-        }),
-      })
-      .refine((d) => refineSecret(d, secrets), {
-        error: 'This secret is required',
-        path: ['value'],
-      })
-      .array(),
-    envVars: z
-      .object({
-        name: envVarNameSchema,
-        value: z.string().optional(),
-      })
-      .refine((d) => refineEnvVar(d, envVars), {
-        error: 'This environment variable is required',
-        path: ['value'],
-      })
-      .array(),
-    networkIsolation: z.boolean(),
-    allowedHosts: z.array(
-      z.object({
-        value: z.string().refine(
-          (val) => {
-            if (val.trim() === '') return true
-            return /^\.?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(val)
-          },
-          {
-            message: 'Invalid host format',
-          }
+  return z
+    .object({
+      serverName: z
+        .string()
+        .min(1, 'Server name is required')
+        .refine(
+          (value) => !workloads.some((w) => w.name === value),
+          'This name is already in use'
         ),
-      })
-    ),
-    allowedPorts: z.array(
-      z.object({
-        value: z.string().refine(
-          (val) => {
-            const num = parseInt(val, 10)
-            return !isNaN(num) && num >= 1 && num <= 65535
-          },
-          {
-            message: 'Port must be a number between 1 and 65535',
-          }
-        ),
-      })
-    ),
-    volumes: z
-      .array(
-        z.object({
-          host: z.string(),
-          container: z.string(),
-          accessMode: z.enum(['ro', 'rw']).optional(),
+      cmd_arguments: z.array(z.string()).optional(),
+      secrets: z
+        .object({
+          name: secretNameSchema,
+          value: z.object({
+            secret: z.string().optional(),
+            isFromStore: z.boolean(),
+          }),
         })
-      )
-      .optional(),
-  })
+        .refine((d) => refineSecret(d, secrets), {
+          error: 'This secret is required',
+          path: ['value'],
+        })
+        .array(),
+      envVars: z
+        .object({
+          name: envVarNameSchema,
+          value: z.string().optional(),
+        })
+        .refine((d) => refineEnvVar(d, envVars), {
+          error: 'This environment variable is required',
+          path: ['value'],
+        })
+        .array(),
+      networkIsolation: z.boolean(),
+      allowedHosts: z
+        .array(
+          z.object({
+            value: z.string(),
+          })
+        )
+        .optional(),
+      allowedPorts: z
+        .array(
+          z.object({
+            value: z.string(),
+          })
+        )
+        .optional(),
+      volumes: z
+        .array(
+          z.object({
+            host: z.string(),
+            container: z.string(),
+            accessMode: z.enum(['ro', 'rw']).optional(),
+          })
+        )
+        .optional(),
+    })
+    .superRefine((data, ctx) => {
+      // Skip validation if network isolation is disabled
+      if (!data.networkIsolation) {
+        return
+      }
+
+      // Validate allowedHosts only when network isolation is enabled
+      data.allowedHosts?.forEach((host, index) => {
+        if (
+          host.value.trim() !== '' &&
+          !/^\.?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(host.value)
+        ) {
+          ctx.addIssue({
+            code: 'custom',
+            message: 'Invalid host format',
+            path: ['allowedHosts', index, 'value'],
+          })
+        }
+      })
+
+      // Validate allowedPorts only when network isolation is enabled
+      data.allowedPorts?.forEach((port, index) => {
+        if (port.value.trim() !== '') {
+          const num = parseInt(port.value, 10)
+          if (isNaN(num) || num < 1 || num > 65535) {
+            ctx.addIssue({
+              code: 'custom',
+              message: 'Port must be a number between 1 and 65535',
+              path: ['allowedPorts', index, 'value'],
+            })
+          }
+        }
+      })
+    })
 }
 
 export type FormSchemaRunFromRegistry = z.infer<

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
@@ -116,8 +116,14 @@ export function prepareCreateWorkloadData(
     ? {
         network: {
           outbound: {
-            allow_host: allowedHosts.map(({ value }) => value),
-            allow_port: allowedPorts.map(({ value }) => parseInt(value, 10)),
+            allow_host:
+              allowedHosts
+                ?.map(({ value }) => value)
+                .filter((host) => host.trim() !== '') ?? [],
+            allow_port:
+              allowedPorts
+                ?.map(({ value }) => parseInt(value, 10))
+                .filter((port) => !isNaN(port)) ?? [],
             insecure_allow_all: false,
           } as PermissionsOutboundNetworkPermissions,
         },


### PR DESCRIPTION
Currently the validation is always applied also if the network isolation is not enabled, we can skip the network isolation validation in case it is disabled.

Other fix:
- Fix fields format for `allowedHosts` and `allowedPorts` in case of empty values for both registry and custom form
- Fix custom form validation message for docker image, introducing union type 

**Registry form**

https://github.com/user-attachments/assets/13b574bc-93a4-4984-96b5-89857bed183c

**Custom form**

https://github.com/user-attachments/assets/9c8e7ef2-e4cb-4ff9-b032-caf387f9eb70

