### PR TITLE
style(playground): remove some override for code tag

### DIFF
--- a/renderer/src/features/chat/components/chat-message.tsx
+++ b/renderer/src/features/chat/components/chat-message.tsx
@@ -417,10 +417,9 @@ export function ChatMessage({ message }: ChatMessageProps) {
             >
               <div className="break-words">
                 <Streamdown
-                  className="prose prose-sm [&_code]:bg-primary-foreground/20
-                    max-w-none [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5
-                    [&_code]:font-mono [&_code]:text-sm [&_em]:italic [&_p]:mb-0
-                    [&_p:last-child]:mb-0 [&_strong]:font-bold"
+                  className="prose prose-sm max-w-none [&_code]:text-sm
+                    [&_em]:italic [&_p]:mb-0 [&_p:last-child]:mb-0
+                    [&_pre]:text-xs [&_strong]:font-bold"
                   remarkPlugins={[remarkGfm, remarkMath]}
                   allowedImagePrefixes={['data:']}
                   defaultOrigin="https://localhost"
@@ -589,7 +588,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
               return (
                 <div>
                   <Streamdown
-                    className="prose prose-sm text-foreground/80 [&_h1]:text-foreground/85 [&_h2]:text-foreground/80 [&_h3]:text-foreground/75 [&_table]:border-border [&_th]:border-border [&_th]:bg-muted/50 [&_th]:text-foreground/75 [&_td]:border-border [&_code]:bg-muted/70 [&_code]:text-foreground/85 [&_pre]:bg-muted/50 [&_a]:text-primary [&_strong]:text-foreground/90 [&_em]:text-foreground/75 [&_blockquote]:border-muted-foreground/30 max-w-none [&_a:hover]:underline [&_blockquote]:mb-3 [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:italic [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs [&_em]:italic [&_h1]:mt-3 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h1:first-child]:mt-0 [&_h2]:mt-3 [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2:first-child]:mt-0 [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_h3:first-child]:mt-0 [&_li]:ml-2 [&_li]:text-sm [&_ol]:mb-2 [&_ol]:list-inside [&_ol]:list-decimal [&_ol]:space-y-0.5 [&_p]:mb-2 [&_p]:leading-relaxed [&_p:last-child]:mb-0 [&_pre]:mb-3 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:p-3 [&_pre]:text-xs [&_strong]:font-medium [&_table]:mb-4 [&_table]:min-w-full [&_table]:rounded-md [&_table]:border [&_td]:border [&_td]:px-3 [&_td]:py-2 [&_td]:text-xs [&_th]:border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-xs [&_th]:font-medium [&_ul]:mb-2 [&_ul]:list-inside [&_ul]:list-disc [&_ul]:space-y-0.5"
+                    className="prose prose-sm text-foreground/80 [&_h1]:text-foreground/85 [&_h2]:text-foreground/80 [&_h3]:text-foreground/75 [&_table]:border-border [&_th]:border-border [&_th]:bg-muted/50 [&_th]:text-foreground/75 [&_td]:border-border [&_a]:text-primary [&_strong]:text-foreground/90 [&_em]:text-foreground/75 [&_blockquote]:border-muted-foreground/30 max-w-none [&_a:hover]:underline [&_blockquote]:mb-3 [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:italic [&_code]:text-xs [&_em]:italic [&_h1]:mt-3 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h1:first-child]:mt-0 [&_h2]:mt-3 [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2:first-child]:mt-0 [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_h3:first-child]:mt-0 [&_li]:ml-2 [&_li]:text-sm [&_ol]:mb-2 [&_ol]:list-inside [&_ol]:list-decimal [&_ol]:space-y-0.5 [&_p]:mb-2 [&_p]:leading-relaxed [&_p:last-child]:mb-0 [&_pre]:text-xs [&_strong]:font-medium [&_table]:mb-4 [&_table]:min-w-full [&_table]:rounded-md [&_table]:border [&_td]:border [&_td]:px-3 [&_td]:py-2 [&_td]:text-xs [&_th]:border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-xs [&_th]:font-medium [&_ul]:mb-2 [&_ul]:list-inside [&_ul]:list-disc [&_ul]:space-y-0.5"
                     remarkPlugins={[remarkGfm, remarkMath]}
                     allowedImagePrefixes={['data:']}
                     defaultOrigin="https://localhost"


### PR DESCRIPTION
just a minor style fix that I notice when I upgraded streamdown

before:
<img width="1041" height="1630" alt="Screenshot 2025-08-29 at 17 36 29" src="https://github.com/user-attachments/assets/e2ce221b-1925-431e-bacb-259396b2cb3e" />


after:
<img width="1044" height="1626" alt="Screenshot 2025-08-29 at 17 36 11" src="https://github.com/user-attachments/assets/a638eeca-3e3c-492d-8204-d70ea6e164c8" />
