### PR TITLE
feat(feature-flag): implement editing with custom server form

### DIFF
--- a/main/src/feature-flags.ts
+++ b/main/src/feature-flags.ts
@@ -25,6 +25,10 @@ const featureFlagOptions: Record<FeatureFlagKey, FeatureFlagOptions> = {
     isDisabled: false,
     defaultValue: false,
   },
+  [featureFlagKeys.EDIT_WORKLOAD]: {
+    isDisabled: false,
+    defaultValue: false,
+  },
 }
 
 // Create a dedicated store for feature flags

--- a/renderer/src/features/mcp-servers/components/__tests__/card-mcp-server.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/card-mcp-server.test.tsx
@@ -12,6 +12,7 @@ const router = createTestRouter(() => (
     statusContext={undefined}
     url=""
     transport="http"
+    onEdit={() => {}}
   />
 ))
 

--- a/renderer/src/features/mcp-servers/components/__tests__/dialog-form-run-mcp-command.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/dialog-form-run-mcp-command.test.tsx
@@ -144,7 +144,11 @@ describe('DialogFormRunMcpServerWithCommand', () => {
             type: 'docker_image',
             envVars: [],
             secrets: [],
-            cmd_arguments: undefined,
+            cmd_arguments: [],
+            networkIsolation: false,
+            allowedHosts: [],
+            allowedPorts: [],
+            target_port: 0,
           }),
         },
         expect.any(Object)
@@ -179,7 +183,7 @@ describe('DialogFormRunMcpServerWithCommand', () => {
     // Fill all fields
     await userEvent.type(screen.getByLabelText('Name'), 'npm-server')
     await userEvent.click(screen.getByLabelText('Transport'))
-    await userEvent.click(screen.getByRole('option', { name: 'stdio' }))
+    await userEvent.click(screen.getByRole('option', { name: 'SSE' }))
     await userEvent.type(screen.getByLabelText('Target port'), '8080')
     await userEvent.click(screen.getByLabelText('Protocol'))
     await userEvent.click(screen.getByRole('option', { name: 'npx' }))
@@ -195,7 +199,7 @@ describe('DialogFormRunMcpServerWithCommand', () => {
         {
           data: expect.objectContaining({
             name: 'npm-server',
-            transport: 'stdio',
+            transport: 'sse',
             target_port: 8080,
             protocol: 'npx',
             package_name: '@test/package',

--- a/renderer/src/features/mcp-servers/components/card-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server.tsx
@@ -12,7 +12,15 @@ import {
   DropdownMenuSeparator,
 } from '@/common/components/ui/dropdown-menu'
 import { Button } from '@/common/components/ui/button'
-import { MoreVertical, Trash2, Github, Text, Copy, Edit3 } from 'lucide-react'
+import {
+  MoreVertical,
+  Trash2,
+  Github,
+  Text,
+  Copy,
+  Edit3,
+  Settings,
+} from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import { Input } from '@/common/components/ui/input'
@@ -106,12 +114,14 @@ export function CardMcpServer({
   statusContext,
   url,
   transport,
+  onEdit,
 }: {
   name: string
   status: CoreWorkload['status']
   statusContext: CoreWorkload['status_context']
   url: string
   transport: CoreWorkload['transport_type']
+  onEdit: (serverName: string) => void
 }) {
   const confirm = useConfirm()
   const { mutateAsync: deleteServer, isPending: isDeletePending } =
@@ -120,6 +130,7 @@ export function CardMcpServer({
   const isCustomizeToolsEnabled = useFeatureFlag(
     featureFlagKeys.CUSTOMIZE_TOOLS
   )
+  const isEditWorkloadEnabled = useFeatureFlag(featureFlagKeys.EDIT_WORKLOAD)
 
   const { data: serverDetails } = useQuery({
     queryKey: ['serverDetails', name],
@@ -269,6 +280,17 @@ export function CardMcpServer({
                 </Button>
               </div>
               <DropdownMenuSeparator />
+              {isEditWorkloadEnabled && (
+                <DropdownMenuItem
+                  asChild
+                  className="flex cursor-pointer items-center"
+                >
+                  <a className="self-start" onClick={() => onEdit(name)}>
+                    <Settings className="mr-2 h-4 w-4" />
+                    Edit configuration
+                  </a>
+                </DropdownMenuItem>
+              )}
               {repositoryUrl && (
                 <DropdownMenuItem asChild>
                   <a

--- a/renderer/src/features/mcp-servers/components/dialog-form-run-mcp-command.tsx
+++ b/renderer/src/features/mcp-servers/components/dialog-form-run-mcp-command.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { useQuery } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
@@ -8,7 +8,13 @@ import {
   type FormSchemaRunMcpCommand,
 } from '../lib/form-schema-run-mcp-server-with-command'
 import { FormFieldsRunMcpCommand } from './form-fields-run-mcp-command'
-import { getApiV1BetaWorkloadsOptions } from '@api/@tanstack/react-query.gen'
+import {
+  getApiV1BetaWorkloadsOptions,
+  getApiV1BetaWorkloadsByNameOptions,
+  getApiV1BetaSecretsDefaultKeysOptions,
+} from '@api/@tanstack/react-query.gen'
+import { convertCreateRequestToFormData } from '../lib/orchestrate-run-custom-server'
+import { useUpdateServer } from '../hooks/use-update-server'
 import {
   Dialog,
   DialogContent,
@@ -54,12 +60,28 @@ const FIELD_TAB_MAP = {
   volumes: 'configuration',
 } satisfies FieldTabMapping<Tab, Field>
 
+const DEFAULT_FORM_VALUES: Partial<FormSchemaRunMcpCommand> = {
+  type: 'docker_image',
+  name: '',
+  transport: 'stdio',
+  target_port: 0,
+  networkIsolation: false,
+  allowedHosts: [],
+  allowedPorts: [],
+  volumes: [{ host: '', container: '', accessMode: 'rw' as const }],
+  envVars: [],
+  secrets: [],
+  cmd_arguments: [],
+}
+
 export function DialogFormRunMcpServerWithCommand({
   isOpen,
   onOpenChange,
+  serverToEdit,
 }: {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
+  serverToEdit?: string | null
 }) {
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -74,45 +96,81 @@ export function DialogFormRunMcpServerWithCommand({
       defaultTab: 'configuration',
     })
 
+  const handleSecrets = (completedCount: number, secretsCount: number) => {
+    setLoadingSecrets((prev) => ({
+      ...prev,
+      text: `Encrypting secrets (${completedCount} of ${secretsCount})...`,
+      completedCount,
+      secretsCount,
+    }))
+  }
+
   const {
     installServerMutation,
     checkServerStatus,
     isErrorSecrets,
     isPendingSecrets,
   } = useRunCustomServer({
-    onSecretSuccess: (completedCount, secretsCount) => {
-      setLoadingSecrets((prev) => ({
-        ...prev,
-        text: `Encrypting secrets (${completedCount} of ${secretsCount})...`,
-        completedCount,
-        secretsCount,
-      }))
-    },
+    onSecretSuccess: handleSecrets,
     onSecretError: (error, variables) => {
       log.error('onSecretError', error, variables)
     },
   })
 
+  const { updateServerMutation, checkServerStatus: checkUpdateServerStatus } =
+    useUpdateServer(serverToEdit || '', {
+      onSecretSuccess: handleSecrets,
+      onSecretError: (error, variables) => {
+        log.error('onSecretError during update', error, variables)
+      },
+    })
+
+  // Fetch all workloads for validation (to check for duplicate names)
   const { data } = useQuery({
     ...getApiV1BetaWorkloadsOptions({ query: { all: true } }),
+    retry: false,
+  })
+
+  const { data: availableSecrets } = useQuery({
+    ...getApiV1BetaSecretsDefaultKeysOptions(),
+    enabled: !!serverToEdit,
+    retry: false,
+  })
+
+  const { data: existingServerData, isLoading: isLoadingServer } = useQuery({
+    ...getApiV1BetaWorkloadsByNameOptions({
+      path: { name: serverToEdit || '' },
+    }),
+    enabled: !!serverToEdit,
+    retry: false,
   })
 
   const workloads = data?.workloads ?? []
+  const existingServer = existingServerData
+  const isEditing = !!existingServer && !!serverToEdit
 
   const form = useForm<FormSchemaRunMcpCommand>({
-    resolver: zodV4Resolver(getFormSchemaRunMcpCommand(workloads)),
-    defaultValues: {
-      type: 'docker_image',
-      image: '',
-      target_port: undefined,
-      networkIsolation: false,
-      allowedHosts: [],
-      allowedPorts: [],
-      volumes: [{ host: '', container: '', accessMode: 'rw' }],
-    },
+    resolver: zodV4Resolver(
+      getFormSchemaRunMcpCommand(workloads, serverToEdit || undefined)
+    ),
+    defaultValues: DEFAULT_FORM_VALUES,
     reValidateMode: 'onChange',
     mode: 'onChange',
   })
+
+  // Reset form with workload data when editing
+  useEffect(() => {
+    if (isEditing && existingServer) {
+      const formData = convertCreateRequestToFormData(
+        existingServer,
+        availableSecrets
+      )
+
+      form.reset(formData)
+    } else if (!isEditing) {
+      form.reset(DEFAULT_FORM_VALUES)
+    }
+  }, [isEditing, existingServer, availableSecrets, serverToEdit, form])
 
   const onSubmitForm = (data: FormSchemaRunMcpCommand) => {
     setIsSubmitting(true)
@@ -120,30 +178,53 @@ export function DialogFormRunMcpServerWithCommand({
       setError(null)
     }
 
-    installServerMutation(
-      { data },
-      {
-        onSuccess: () => {
-          checkServerStatus(data)
-          onOpenChange(false)
-        },
-        onSettled: (_, error) => {
-          setIsSubmitting(false)
-          if (!error) {
-            form.reset()
-          }
-        },
-        onError: (error) => {
-          setError(typeof error === 'string' ? error : error.message)
-        },
-      }
-    )
+    if (isEditing) {
+      updateServerMutation(
+        { data },
+        {
+          onSuccess: () => {
+            checkUpdateServerStatus()
+            onOpenChange(false)
+          },
+          onSettled: (_, error) => {
+            setIsSubmitting(false)
+            setLoadingSecrets(null)
+            if (!error) {
+              form.reset()
+            }
+          },
+          onError: (error) => {
+            setError(typeof error === 'string' ? error : error.message)
+          },
+        }
+      )
+    } else {
+      // Handle create case
+      installServerMutation(
+        { data },
+        {
+          onSuccess: () => {
+            checkServerStatus(data)
+            onOpenChange(false)
+          },
+          onSettled: (_, error) => {
+            setIsSubmitting(false)
+            if (!error) {
+              form.reset()
+            }
+          },
+          onError: (error) => {
+            setError(typeof error === 'string' ? error : error.message)
+          },
+        }
+      )
+    }
   }
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className="p-0 sm:max-w-2xl"
+        className="flex max-h-[95dvh] flex-col p-0 sm:max-w-2xl"
         onCloseAutoFocus={() => {
           form.reset()
           resetTab()
@@ -156,24 +237,38 @@ export function DialogFormRunMcpServerWithCommand({
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmitForm, activateTabWithError)}
+            className="flex min-h-0 flex-1 flex-col"
           >
-            <DialogHeader className="mb-4 p-6">
-              <DialogTitle>Custom MCP server</DialogTitle>
+            <DialogHeader className="mb-4 flex-shrink-0 p-6">
+              <DialogTitle>
+                {isEditing
+                  ? `Edit ${serverToEdit} MCP server`
+                  : 'Custom MCP server'}
+              </DialogTitle>
               <DialogDescription>
-                ToolHive allows you to securely run a custom MCP server from a
-                Docker image or a package manager command.
+                {isEditing
+                  ? 'Update the configuration for your MCP server.'
+                  : 'ToolHive allows you to securely run a custom MCP server from a Docker image or a package manager command.'}
               </DialogDescription>
             </DialogHeader>
-            {isSubmitting && (
+            {(isSubmitting || (isEditing && isLoadingServer)) && (
               <LoadingStateAlert
                 isPendingSecrets={isPendingSecrets}
-                loadingSecrets={loadingSecrets}
+                loadingSecrets={
+                  isLoadingServer
+                    ? {
+                        text: `Loading server "${serverToEdit}"...`,
+                        completedCount: 0,
+                        secretsCount: 0,
+                      }
+                    : loadingSecrets
+                }
               />
             )}
-            {!isSubmitting && (
-              <>
+            {!isSubmitting && !(isEditing && isLoadingServer) && (
+              <div className="flex flex-1 flex-col overflow-hidden">
                 <Tabs
-                  className="mb-6 w-full px-6"
+                  className="mb-6 w-full flex-shrink-0 px-6"
                   value={activeTab}
                   onValueChange={(value: string) => setActiveTab(value as Tab)}
                 >
@@ -187,10 +282,7 @@ export function DialogFormRunMcpServerWithCommand({
                   </TabsList>
                 </Tabs>
                 {activeTab === 'configuration' && (
-                  <div
-                    className="relative max-h-[65dvh] space-y-4 overflow-y-auto
-                      px-6"
-                  >
+                  <div className="flex-1 space-y-4 overflow-y-auto px-6">
                     {error && (
                       <AlertErrorFormSubmission
                         error={error}
@@ -198,7 +290,10 @@ export function DialogFormRunMcpServerWithCommand({
                         onDismiss={() => setError(null)}
                       />
                     )}
-                    <FormFieldsRunMcpCommand form={form} />
+                    <FormFieldsRunMcpCommand
+                      form={form}
+                      isEditing={isEditing}
+                    />
                     <FormFieldsArrayCustomSecrets form={form} />
                     <FormFieldsArrayCustomEnvVars form={form} />
                     <FormFieldsArrayVolumes<FormSchemaRunMcpCommand>
@@ -207,16 +302,18 @@ export function DialogFormRunMcpServerWithCommand({
                   </div>
                 )}
                 {activeTab === 'network-isolation' && (
-                  <NetworkIsolationTabContent form={form} />
+                  <div className="flex-1 overflow-y-auto">
+                    <NetworkIsolationTabContent form={form} />
+                  </div>
                 )}
-              </>
+              </div>
             )}
 
-            <DialogFooter className="p-6">
+            <DialogFooter className="flex-shrink-0 p-6">
               <Button
                 type="button"
                 variant="outline"
-                disabled={isSubmitting}
+                disabled={isSubmitting || (isEditing && isLoadingServer)}
                 onClick={() => {
                   onOpenChange(false)
                   setActiveTab('configuration')
@@ -224,8 +321,11 @@ export function DialogFormRunMcpServerWithCommand({
               >
                 Cancel
               </Button>
-              <Button disabled={isSubmitting} type="submit">
-                Install server
+              <Button
+                disabled={isSubmitting || (isEditing && isLoadingServer)}
+                type="submit"
+              >
+                {isEditing ? 'Update server' : 'Install server'}
               </Button>
             </DialogFooter>
           </form>

--- a/renderer/src/features/mcp-servers/components/form-fields-array-custom-secrets.tsx
+++ b/renderer/src/features/mcp-servers/components/form-fields-array-custom-secrets.tsx
@@ -5,6 +5,7 @@ import {
   type ArrayPath,
   type ControllerRenderProps,
 } from 'react-hook-form'
+import type { ChangeEventHandler } from 'react'
 
 import type { FormSchemaRunMcpCommand } from '../lib/form-schema-run-mcp-server-with-command'
 import { FormControl, FormField, FormItem } from '@/common/components/ui/form'
@@ -42,7 +43,17 @@ export function FormFieldsArrayCustomSecrets({
             ]}
             form={form}
           >
-            {({ inputProps, setInputRef, idx }) => (
+            {({
+              inputProps,
+              setInputRef,
+              idx,
+            }: {
+              inputProps: { id: string; onChange: ChangeEventHandler }
+              setInputRef: (
+                idx: number
+              ) => (el: HTMLInputElement | null) => void
+              idx: number
+            }) => (
               <FormField
                 control={form.control}
                 name={`secrets.${idx}` as Path<FormSchemaRunMcpCommand>}

--- a/renderer/src/features/mcp-servers/components/form-fields-run-mcp-command.tsx
+++ b/renderer/src/features/mcp-servers/components/form-fields-run-mcp-command.tsx
@@ -22,11 +22,14 @@ import { CommandArgumentsField } from '@/common/components/workload-cmd-arg/comm
 
 export function FormFieldsRunMcpCommand({
   form,
+  isEditing = false,
 }: {
   form: UseFormReturn<FormSchemaRunMcpCommand>
+  isEditing?: boolean
 }) {
   const typeValue = form.watch('type')
   const protocolValue = form.watch('protocol') ?? 'npx'
+  const transportValue = form.watch('transport')
 
   return (
     <>
@@ -82,6 +85,7 @@ export function FormFieldsRunMcpCommand({
                 defaultValue={field.value}
                 onChange={(e) => field.onChange(e.target.value)}
                 name={field.name}
+                disabled={isEditing}
               />
             </FormControl>
             <FormMessage />
@@ -103,8 +107,14 @@ export function FormFieldsRunMcpCommand({
             </div>
             <FormControl>
               <Select
-                onValueChange={field.onChange}
-                defaultValue={field.value}
+                onValueChange={(value) => {
+                  field.onChange(value)
+                  // Automatically set target_port to 0 for stdio transport
+                  if (value === 'stdio') {
+                    form.setValue('target_port', 0)
+                  }
+                }}
+                value={field.value}
                 name={field.name}
               >
                 <SelectTrigger id={field.name} className="w-full">
@@ -124,36 +134,39 @@ export function FormFieldsRunMcpCommand({
         )}
       />
 
-      <FormField
-        control={form.control}
-        name="target_port"
-        render={({ field }) => (
-          <FormItem>
-            <div className="flex items-center gap-1">
-              <FormLabel htmlFor={field.name}>Target port</FormLabel>
-              <TooltipInfoIcon className="max-w-72">
-                Target port to expose from the container. If not specified,
-                ToolHive will automatically assign a random port.
-              </TooltipInfoIcon>
-            </div>
-            <FormControl>
-              <Input
-                id={field.name}
-                autoCorrect="off"
-                autoComplete="off"
-                autoFocus
-                type="number"
-                data-1p-ignore
-                placeholder="e.g. 50051"
-                defaultValue={field.value}
-                onChange={(e) => field.onChange(parseInt(e.target.value, 10))}
-                name={field.name}
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      {/* Only show target_port for non-stdio transports */}
+      {transportValue !== 'stdio' && (
+        <FormField
+          control={form.control}
+          name="target_port"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center gap-1">
+                <FormLabel htmlFor={field.name}>Target port</FormLabel>
+                <TooltipInfoIcon className="max-w-72">
+                  Target port to expose from the container. If not specified,
+                  ToolHive will automatically assign a random port.
+                </TooltipInfoIcon>
+              </div>
+              <FormControl>
+                <Input
+                  id={field.name}
+                  autoCorrect="off"
+                  autoComplete="off"
+                  autoFocus
+                  type="number"
+                  data-1p-ignore
+                  placeholder="e.g. 50051"
+                  defaultValue={field.value}
+                  onChange={(e) => field.onChange(parseInt(e.target.value, 10))}
+                  name={field.name}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      )}
 
       {typeValue === 'docker_image' ? (
         <FormField

--- a/renderer/src/features/mcp-servers/components/grid-cards-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/grid-cards-mcp-server.tsx
@@ -2,12 +2,15 @@ import type { CoreWorkload } from '@api/types.gen'
 import { CardMcpServer } from './card-mcp-server'
 import { useMemo, useState } from 'react'
 import { InputSearch } from '@/common/components/ui/input-search'
+import { DialogFormRunMcpServerWithCommand } from './dialog-form-run-mcp-command'
 
 export function GridCardsMcpServers({
   mcpServers,
 }: {
   mcpServers: CoreWorkload[]
 }) {
+  const [isRunWithCommandOpen, setIsRunWithCommandOpen] = useState(false)
+  const [serverToEdit, setServerToEdit] = useState<string | null>(null)
   const [filters, setFilters] = useState({
     text: '',
     state: 'all',
@@ -56,6 +59,10 @@ export function GridCardsMcpServers({
               statusContext={mcpServer.status_context}
               url={mcpServer.url ?? ''}
               transport={mcpServer.transport_type}
+              onEdit={(serverName) => {
+                setServerToEdit(serverName)
+                setIsRunWithCommandOpen(true)
+              }}
             />
           ) : null
         )}
@@ -69,6 +76,12 @@ export function GridCardsMcpServers({
             </p>
           </div>
         )}
+
+      <DialogFormRunMcpServerWithCommand
+        isOpen={isRunWithCommandOpen}
+        onOpenChange={setIsRunWithCommandOpen}
+        serverToEdit={serverToEdit}
+      />
     </div>
   )
 }

--- a/renderer/src/features/mcp-servers/hooks/use-run-custom-server.tsx
+++ b/renderer/src/features/mcp-servers/hooks/use-run-custom-server.tsx
@@ -159,7 +159,10 @@ export function useRunCustomServer({
       // We pass the encrypted secrets along with the request.
       const secretsForRequest: SecretsSecretParameter[] = [
         ...newlyCreatedSecrets,
-        ...existingSecrets,
+        ...existingSecrets.map((secret) => ({
+          name: secret.value.secret,
+          target: secret.name,
+        })),
       ]
 
       const createRequest: V1CreateRequest = prepareCreateWorkloadData(

--- a/renderer/src/features/mcp-servers/hooks/use-run-custom-server.tsx
+++ b/renderer/src/features/mcp-servers/hooks/use-run-custom-server.tsx
@@ -159,10 +159,7 @@ export function useRunCustomServer({
       // We pass the encrypted secrets along with the request.
       const secretsForRequest: SecretsSecretParameter[] = [
         ...newlyCreatedSecrets,
-        ...existingSecrets.map((secret) => ({
-          name: secret.value.secret,
-          target: secret.name,
-        })),
+        ...existingSecrets,
       ]
 
       const createRequest: V1CreateRequest = prepareCreateWorkloadData(

--- a/renderer/src/features/mcp-servers/hooks/use-update-server.tsx
+++ b/renderer/src/features/mcp-servers/hooks/use-update-server.tsx
@@ -2,12 +2,26 @@ import {
   postApiV1BetaWorkloadsByNameEditMutation,
   getApiV1BetaWorkloadsByNameStatusOptions,
   getApiV1BetaWorkloadsQueryKey,
+  postApiV1BetaSecretsDefaultKeysMutation,
 } from '@api/@tanstack/react-query.gen'
+import { getApiV1BetaSecretsDefaultKeys } from '@api/sdk.gen'
 import { pollServerStatus } from '@/common/lib/polling'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useRef } from 'react'
 
-import { type V1UpdateRequest } from '@api/types.gen'
+import {
+  type PostApiV1BetaSecretsDefaultKeysData,
+  type SecretsSecretParameter,
+} from '@api/types.gen'
+import type { Options } from '@api/client'
+import type { FormSchemaRunMcpCommand } from '../lib/form-schema-run-mcp-server-with-command'
+import {
+  prepareUpdateWorkloadData,
+  saveSecrets,
+  groupSecrets,
+  getDefinedSecrets,
+} from '../lib/orchestrate-run-custom-server'
+import { prepareSecretsWithoutNamingCollision } from '@/common/lib/secrets/prepare-secrets-without-naming-collision'
 import { toast } from 'sonner'
 import { Button } from '@/common/components/ui/button'
 import { Link } from '@tanstack/react-router'
@@ -16,12 +30,25 @@ import { trackEvent } from '@/common/lib/analytics'
 
 type UpdateServerCheck = () => Promise<unknown> | unknown
 
-export function useUpdateServer(serverName: string) {
+export function useUpdateServer(
+  serverName: string,
+  options?: {
+    onSecretSuccess?: (completedCount: number, secretsCount: number) => void
+    onSecretError?: (
+      error: string,
+      variables: Options<PostApiV1BetaSecretsDefaultKeysData>
+    ) => void
+  }
+) {
   const toastIdRef = useRef(new Date(Date.now()).toISOString())
   const queryClient = useQueryClient()
 
   const { mutateAsync: updateWorkload } = useMutation({
     ...postApiV1BetaWorkloadsByNameEditMutation(),
+  })
+
+  const { mutateAsync: saveSecret } = useMutation({
+    ...postApiV1BetaSecretsDefaultKeysMutation(),
   })
 
   const handleSettled = useCallback<UpdateServerCheck>(async () => {
@@ -74,11 +101,36 @@ export function useUpdateServer(serverName: string) {
   }, [queryClient, serverName])
 
   const { mutate: updateServerMutation } = useMutation({
-    mutationFn: async ({
-      updateRequest,
-    }: {
-      updateRequest: V1UpdateRequest
-    }) => {
+    mutationFn: async ({ data }: { data: FormSchemaRunMcpCommand }) => {
+      let newlyCreatedSecrets: SecretsSecretParameter[] = []
+
+      // Step 1: Group secrets into new and existing
+      const definedSecrets = getDefinedSecrets(data.secrets)
+      const { existingSecrets, newSecrets } = groupSecrets(definedSecrets)
+
+      // Step 2: Fetch existing secrets & handle naming collisions
+      const { data: fetchedSecrets } = await getApiV1BetaSecretsDefaultKeys({
+        throwOnError: true,
+      })
+      const preparedNewSecrets = prepareSecretsWithoutNamingCollision(
+        newSecrets,
+        fetchedSecrets
+      )
+
+      // Step 3: Encrypt secrets
+      if (preparedNewSecrets.length > 0) {
+        newlyCreatedSecrets = await saveSecrets(
+          preparedNewSecrets,
+          saveSecret,
+          options?.onSecretSuccess || (() => {}),
+          options?.onSecretError || (() => {})
+        )
+      }
+
+      // Step 4: Update the workload with all secrets
+      const allSecrets = [...newlyCreatedSecrets, ...existingSecrets]
+      const updateRequest = prepareUpdateWorkloadData(data, allSecrets)
+
       await updateWorkload({
         path: { name: serverName },
         body: updateRequest,

--- a/renderer/src/features/mcp-servers/hooks/use-update-server.tsx
+++ b/renderer/src/features/mcp-servers/hooks/use-update-server.tsx
@@ -128,7 +128,13 @@ export function useUpdateServer(
       }
 
       // Step 4: Update the workload with all secrets
-      const allSecrets = [...newlyCreatedSecrets, ...existingSecrets]
+      const allSecrets = [
+        ...newlyCreatedSecrets,
+        ...existingSecrets.map((secret) => ({
+          name: secret.value.secret,
+          target: secret.name,
+        })),
+      ]
       const updateRequest = prepareUpdateWorkloadData(data, allSecrets)
 
       await updateWorkload({

--- a/renderer/src/features/mcp-servers/lib/__tests__/form-schema-run-mcp-server-with-command.test.ts
+++ b/renderer/src/features/mcp-servers/lib/__tests__/form-schema-run-mcp-server-with-command.test.ts
@@ -1,5 +1,6 @@
 import { it, expect } from 'vitest'
 import { getFormSchemaRunMcpCommand } from '../form-schema-run-mcp-server-with-command'
+import z from 'zod/v4'
 
 it('passes with valid docker image', () => {
   const validInput = {
@@ -169,10 +170,10 @@ it('fails when name is empty', () => {
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        name: ['Name is required'],
+      properties: expect.objectContaining({
+        name: { errors: ['Name is required'] },
       }),
     })
   )
@@ -200,10 +201,10 @@ it('fails when name is not unique', () => {
   const result = getFormSchemaRunMcpCommand([{ name: 'foo-bar' }]).safeParse(
     invalidInput
   )
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        name: ['This name is already in use'],
+      properties: expect.objectContaining({
+        name: { errors: ['This name is already in use'] },
       }),
     })
   )
@@ -229,12 +230,14 @@ it('fails when name contains invalid characters', () => {
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        name: [
-          'Invalid server name: it can only contain alphanumeric characters, dots, hyphens, and underscores.',
-        ],
+      properties: expect.objectContaining({
+        name: {
+          errors: [
+            'Invalid server name: it can only contain alphanumeric characters, dots, hyphens, and underscores.',
+          ],
+        },
       }),
     })
   )
@@ -275,13 +278,20 @@ it('fails when transport is empty', () => {
         },
       },
     ],
+    networkIsolation: false,
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        transport: ['Please select either SSE, stdio, or streamable-http.'],
+      properties: expect.objectContaining({
+        transport: {
+          errors: [
+            'Invalid input: expected "sse"',
+            'Invalid input: expected "stdio"',
+            'Invalid input: expected "streamable-http"',
+          ],
+        },
       }),
     })
   )
@@ -304,13 +314,20 @@ it('fails when transport is invalid', () => {
         },
       },
     ],
+    networkIsolation: false,
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        transport: ['Please select either SSE, stdio, or streamable-http.'],
+      properties: expect.objectContaining({
+        transport: {
+          errors: [
+            'Invalid input: expected "sse"',
+            'Invalid input: expected "stdio"',
+            'Invalid input: expected "streamable-http"',
+          ],
+        },
       }),
     })
   )
@@ -336,10 +353,10 @@ it('fails when type is empty', () => {
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        type: ['Invalid input'],
+      properties: expect.objectContaining({
+        type: { errors: ['Invalid input'] },
       }),
     })
   )
@@ -365,10 +382,10 @@ it('fails when type is invalid', () => {
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        type: ['Invalid input'],
+      properties: expect.objectContaining({
+        type: { errors: ['Invalid input'] },
       }),
     })
   )
@@ -382,12 +399,28 @@ it('fails when envVars is missing name', () => {
     image: 'ghcr.io/github/github-mcp-server',
     cmd_arguments: ['-y', '--oauth-setup'],
     envVars: [{ value: 'some-value' }], // Missing name
+    secrets: [],
+    networkIsolation: false,
   }
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        envVars: ['Invalid input: expected string, received undefined'],
+      properties: expect.objectContaining({
+        envVars: {
+          errors: [],
+          items: [
+            {
+              errors: [],
+              properties: {
+                name: {
+                  errors: [
+                    'Invalid input: expected string, received undefined',
+                  ],
+                },
+              },
+            },
+          ],
+        },
       }),
     })
   )
@@ -402,12 +435,27 @@ it('fails when envVars is missing value', () => {
     cmd_arguments: ['-y', '--oauth-setup'],
     envVars: [{ name: 'SOME_KEY' }], // Missing value
     secrets: [],
+    networkIsolation: false,
   }
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        envVars: ['Invalid input: expected string, received undefined'],
+      properties: expect.objectContaining({
+        envVars: {
+          errors: [],
+          items: [
+            {
+              errors: [],
+              properties: {
+                value: {
+                  errors: [
+                    'Invalid input: expected string, received undefined',
+                  ],
+                },
+              },
+            },
+          ],
+        },
       }),
     })
   )
@@ -423,10 +471,12 @@ it('fails when secrets is missing', () => {
     envVars: [{ name: 'GITHUB_ORG', value: 'stacklok' }],
   }
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        secrets: ['Invalid input: expected array, received undefined'],
+      properties: expect.objectContaining({
+        secrets: {
+          errors: ['Invalid input: expected array, received undefined'],
+        },
       }),
     })
   )
@@ -441,12 +491,27 @@ it('fails when secrets is missing key', () => {
     cmd_arguments: ['-y', '--oauth-setup'],
     envVars: [{ name: 'GITHUB_ORG', value: 'stacklok' }],
     secrets: [{ value: { secret: 'foo-bar', isFromStore: false } }],
+    networkIsolation: false,
   }
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        secrets: ['Invalid input: expected string, received undefined'],
+      properties: expect.objectContaining({
+        secrets: {
+          errors: [],
+          items: [
+            {
+              errors: [],
+              properties: {
+                name: {
+                  errors: [
+                    'Invalid input: expected string, received undefined',
+                  ],
+                },
+              },
+            },
+          ],
+        },
       }),
     })
   )
@@ -461,12 +526,27 @@ it('fails when secrets is missing value', () => {
     cmd_arguments: ['-y', '--oauth-setup'],
     envVars: [{ name: 'GITHUB_ORG', value: 'stacklok' }],
     secrets: [{ name: 'GITHUB_PERSONAL_ACCESS_TOKEN' }], // Missing value
+    networkIsolation: false,
   }
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        secrets: ['Invalid input: expected object, received undefined'],
+      properties: expect.objectContaining({
+        secrets: {
+          errors: [],
+          items: [
+            {
+              errors: [],
+              properties: {
+                value: {
+                  errors: [
+                    'Invalid input: expected object, received undefined',
+                  ],
+                },
+              },
+            },
+          ],
+        },
       }),
     })
   )
@@ -488,12 +568,32 @@ it('fails when secrets is missing inner secret value', () => {
         },
       },
     ],
+    networkIsolation: false,
   }
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        secrets: ['Invalid input: expected string, received undefined'],
+      properties: expect.objectContaining({
+        secrets: {
+          errors: [],
+          items: [
+            {
+              errors: [],
+              properties: {
+                value: {
+                  errors: [],
+                  properties: {
+                    secret: {
+                      errors: [
+                        'Invalid input: expected string, received undefined',
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
       }),
     })
   )
@@ -515,12 +615,32 @@ it('fails when secrets is missing `isFromStore`', () => {
         },
       },
     ],
+    networkIsolation: false,
   }
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        secrets: ['Invalid input: expected boolean, received undefined'],
+      properties: expect.objectContaining({
+        secrets: {
+          errors: [],
+          items: [
+            {
+              errors: [],
+              properties: {
+                value: {
+                  errors: [],
+                  properties: {
+                    isFromStore: {
+                      errors: [
+                        'Invalid input: expected boolean, received undefined',
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
       }),
     })
   )
@@ -546,10 +666,10 @@ it('docker > fails when image is empty', () => {
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        image: ['Docker image is required'],
+      properties: expect.objectContaining({
+        image: { errors: ['Docker image is required'] },
       }),
     })
   )
@@ -573,13 +693,20 @@ it('package_manager > fails when protocol is empty', () => {
         },
       },
     ],
+    networkIsolation: false,
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        protocol: ['Please select either npx, uvx, or go.'],
+      properties: expect.objectContaining({
+        protocol: {
+          errors: [
+            'Invalid input: expected "npx"',
+            'Invalid input: expected "uvx"',
+            'Invalid input: expected "go"',
+          ],
+        },
       }),
     })
   )
@@ -603,13 +730,20 @@ it('package_manager > fails when protocol is invalid', () => {
         },
       },
     ],
+    networkIsolation: false,
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        protocol: ['Please select either npx, uvx, or go.'],
+      properties: expect.objectContaining({
+        protocol: {
+          errors: [
+            'Invalid input: expected "npx"',
+            'Invalid input: expected "uvx"',
+            'Invalid input: expected "go"',
+          ],
+        },
       }),
     })
   )
@@ -636,11 +770,104 @@ it('package_manager > fails when package_name is empty', () => {
   }
 
   const result = getFormSchemaRunMcpCommand([]).safeParse(invalidInput)
-  expect(result.error?.flatten(), `${result.error}`).toStrictEqual(
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
     expect.objectContaining({
-      fieldErrors: expect.objectContaining({
-        package_name: ['Package name is required'],
+      properties: expect.objectContaining({
+        package_name: { errors: ['Package name is required'] },
       }),
     })
   )
+})
+
+it('passes when name matches editingServerName even if name already exists', () => {
+  const existingWorkloads = [
+    { name: 'existing-server' },
+    { name: 'another-server' },
+  ]
+
+  const validInput = {
+    name: 'existing-server', // This name already exists but matches editingServerName
+    transport: 'stdio',
+    type: 'docker_image',
+    image: 'ghcr.io/test/server',
+    cmd_arguments: [],
+    envVars: [],
+    secrets: [],
+    networkIsolation: false,
+    allowedHosts: [],
+    allowedPorts: [],
+  }
+
+  // Test with editingServerName set to the same name
+  const result = getFormSchemaRunMcpCommand(
+    existingWorkloads,
+    'existing-server'
+  ).safeParse(validInput)
+
+  expect(result.success, `${result.error}`).toBe(true)
+  expect(result.data?.name).toBe('existing-server')
+})
+
+it('fails when name matches different existing server name even with editingServerName set', () => {
+  const existingWorkloads = [
+    { name: 'existing-server' },
+    { name: 'another-server' },
+    { name: 'third-server' },
+  ]
+
+  const invalidInput = {
+    name: 'another-server', // This name exists but doesn't match editingServerName
+    transport: 'stdio',
+    type: 'docker_image',
+    image: 'ghcr.io/test/server',
+    cmd_arguments: [],
+    envVars: [],
+    secrets: [],
+    networkIsolation: false,
+    allowedHosts: [],
+    allowedPorts: [],
+  }
+
+  // Test with editingServerName set to a different name
+  const result = getFormSchemaRunMcpCommand(
+    existingWorkloads,
+    'third-server'
+  ).safeParse(invalidInput)
+
+  expect(z.treeifyError(result.error!), `${result.error}`).toStrictEqual(
+    expect.objectContaining({
+      properties: expect.objectContaining({
+        name: { errors: ['This name is already in use'] },
+      }),
+    })
+  )
+})
+
+it('passes when name is unique even with editingServerName set', () => {
+  const existingWorkloads = [
+    { name: 'existing-server' },
+    { name: 'another-server' },
+  ]
+
+  const validInput = {
+    name: 'brand-new-server', // This name is completely new
+    transport: 'stdio',
+    type: 'docker_image',
+    image: 'ghcr.io/test/server',
+    cmd_arguments: [],
+    envVars: [],
+    secrets: [],
+    networkIsolation: false,
+    allowedHosts: [],
+    allowedPorts: [],
+  }
+
+  // Test with editingServerName set
+  const result = getFormSchemaRunMcpCommand(
+    existingWorkloads,
+    'existing-server'
+  ).safeParse(validInput)
+
+  expect(result.success, `${result.error}`).toBe(true)
+  expect(result.data?.name).toBe('brand-new-server')
 })

--- a/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
+++ b/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
@@ -77,8 +77,9 @@ describe('groupSecrets', () => {
 
     expect(result.newSecrets[0]?.name).toBe('NEW_SECRET')
     expect(result.newSecrets[1]?.name).toBe('ANOTHER_NEW_SECRET')
-    expect(result.existingSecrets[0]?.name).toBe('existing-key')
-    expect(result.existingSecrets[0]?.target).toBe('EXISTING_SECRET')
+    expect(result.existingSecrets[0]?.name).toBe('EXISTING_SECRET')
+    expect(result.existingSecrets[0]?.value.secret).toBe('existing-key')
+    expect(result.existingSecrets[0]?.value.isFromStore).toBe(true)
   })
 
   it('handles empty secrets array', () => {
@@ -122,10 +123,12 @@ describe('groupSecrets', () => {
 
     expect(result.newSecrets).toHaveLength(0)
     expect(result.existingSecrets).toHaveLength(2)
-    expect(result.existingSecrets[0]?.name).toBe('key1')
-    expect(result.existingSecrets[0]?.target).toBe('SECRET1')
-    expect(result.existingSecrets[1]?.name).toBe('key2')
-    expect(result.existingSecrets[1]?.target).toBe('SECRET2')
+    expect(result.existingSecrets[0]?.name).toBe('SECRET1')
+    expect(result.existingSecrets[0]?.value.secret).toBe('key1')
+    expect(result.existingSecrets[0]?.value.isFromStore).toBe(true)
+    expect(result.existingSecrets[1]?.name).toBe('SECRET2')
+    expect(result.existingSecrets[1]?.value.secret).toBe('key2')
+    expect(result.existingSecrets[1]?.value.isFromStore).toBe(true)
   })
 })
 

--- a/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
+++ b/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-custom-server.test.tsx
@@ -4,9 +4,18 @@ import {
   saveSecrets,
   prepareCreateWorkloadData,
   groupSecrets,
+  convertWorkloadToFormData,
+  getDefinedSecrets,
+  convertCreateRequestToFormData,
+  prepareUpdateWorkloadData,
 } from '../orchestrate-run-custom-server'
 import type { DefinedSecret, PreparedSecret } from '@/common/types/secrets'
-import type { SecretsSecretParameter } from '@api/types.gen'
+import type {
+  SecretsSecretParameter,
+  CoreWorkload,
+  V1CreateRequest,
+  V1ListSecretsResponse,
+} from '@api/types.gen'
 
 vi.mock('sonner', async () => {
   const original = await vi.importActual<typeof import('sonner')>('sonner')
@@ -68,7 +77,8 @@ describe('groupSecrets', () => {
 
     expect(result.newSecrets[0]?.name).toBe('NEW_SECRET')
     expect(result.newSecrets[1]?.name).toBe('ANOTHER_NEW_SECRET')
-    expect(result.existingSecrets[0]?.name).toBe('EXISTING_SECRET')
+    expect(result.existingSecrets[0]?.name).toBe('existing-key')
+    expect(result.existingSecrets[0]?.target).toBe('EXISTING_SECRET')
   })
 
   it('handles empty secrets array', () => {
@@ -112,6 +122,10 @@ describe('groupSecrets', () => {
 
     expect(result.newSecrets).toHaveLength(0)
     expect(result.existingSecrets).toHaveLength(2)
+    expect(result.existingSecrets[0]?.name).toBe('key1')
+    expect(result.existingSecrets[0]?.target).toBe('SECRET1')
+    expect(result.existingSecrets[1]?.name).toBe('key2')
+    expect(result.existingSecrets[1]?.target).toBe('SECRET2')
   })
 })
 
@@ -565,5 +579,517 @@ describe('saveSecrets', () => {
       // Restore original NODE_ENV
       process.env.NODE_ENV = originalEnv
     }
+  })
+})
+
+describe('convertWorkloadToFormData', () => {
+  it('converts docker workload to form data', () => {
+    const workload: CoreWorkload = {
+      name: 'docker-server',
+      package: 'ghcr.io/test/server',
+      transport_type: 'stdio',
+    }
+
+    const result = convertWorkloadToFormData(workload)
+
+    expect(result).toEqual({
+      name: 'docker-server',
+      transport: 'stdio',
+      target_port: undefined,
+      cmd_arguments: [],
+      envVars: [],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+      type: 'docker_image',
+      image: 'ghcr.io/test/server',
+    })
+  })
+
+  it('converts package manager workload to form data', () => {
+    const workload: CoreWorkload = {
+      name: 'npm-server',
+      package: 'npx://my-package',
+      transport_type: 'sse',
+      port: 8080,
+    }
+
+    const result = convertWorkloadToFormData(workload)
+
+    expect(result).toEqual({
+      name: 'npm-server',
+      transport: 'sse',
+      target_port: 8080,
+      cmd_arguments: [],
+      envVars: [],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+      type: 'package_manager',
+      protocol: 'npx',
+      package_name: 'my-package',
+    })
+  })
+
+  it('handles uvx protocol', () => {
+    const workload: CoreWorkload = {
+      name: 'python-server',
+      package: 'uvx://python-package',
+      transport_type: 'stdio',
+    }
+
+    const result = convertWorkloadToFormData(workload)
+
+    expect(result.type).toBe('package_manager')
+    if (result.type === 'package_manager') {
+      expect(result.protocol).toBe('uvx')
+      expect(result.package_name).toBe('python-package')
+    }
+  })
+
+  it('handles go protocol', () => {
+    const workload: CoreWorkload = {
+      name: 'go-server',
+      package: 'go://go-package',
+      transport_type: 'stdio',
+    }
+
+    const result = convertWorkloadToFormData(workload)
+
+    expect(result.type).toBe('package_manager')
+    if (result.type === 'package_manager') {
+      expect(result.protocol).toBe('go')
+      expect(result.package_name).toBe('go-package')
+    }
+  })
+
+  it('handles workload with empty package', () => {
+    const workload: CoreWorkload = {
+      name: 'empty-server',
+      package: '',
+      transport_type: 'stdio',
+    }
+
+    const result = convertWorkloadToFormData(workload)
+
+    expect(result.type).toBe('docker_image')
+    if (result.type === 'docker_image') {
+      expect(result.image).toBe('')
+    }
+  })
+
+  it('defaults to stdio transport when not provided', () => {
+    const workload: CoreWorkload = {
+      name: 'default-server',
+      package: 'test-image',
+    }
+
+    const result = convertWorkloadToFormData(workload)
+
+    expect(result.transport).toBe('stdio')
+  })
+})
+
+describe('getDefinedSecrets', () => {
+  it('filters out secrets with empty names', () => {
+    const secrets: FormSchemaRunMcpCommand['secrets'] = [
+      {
+        name: 'VALID_SECRET',
+        value: { secret: 'secret-key', isFromStore: false },
+      },
+      {
+        name: '',
+        value: { secret: 'another-key', isFromStore: true },
+      },
+      {
+        name: 'ANOTHER_VALID',
+        value: { secret: 'third-key', isFromStore: false },
+      },
+    ]
+
+    const result = getDefinedSecrets(secrets)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]?.name).toBe('VALID_SECRET')
+    expect(result[1]?.name).toBe('ANOTHER_VALID')
+  })
+
+  it('filters out secrets with empty secret values', () => {
+    const secrets: FormSchemaRunMcpCommand['secrets'] = [
+      {
+        name: 'VALID_SECRET',
+        value: { secret: 'secret-key', isFromStore: false },
+      },
+      {
+        name: 'INVALID_SECRET',
+        value: { secret: '', isFromStore: false },
+      },
+    ]
+
+    const result = getDefinedSecrets(secrets)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe('VALID_SECRET')
+  })
+
+  it('preserves isFromStore property', () => {
+    const secrets: FormSchemaRunMcpCommand['secrets'] = [
+      {
+        name: 'STORE_SECRET',
+        value: { secret: 'key1', isFromStore: true },
+      },
+      {
+        name: 'NEW_SECRET',
+        value: { secret: 'key2', isFromStore: false },
+      },
+      {
+        name: 'UNDEFINED_STORE',
+        value: { secret: 'key3', isFromStore: false },
+      },
+    ]
+
+    const result = getDefinedSecrets(secrets)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]?.value.isFromStore).toBe(true)
+    expect(result[1]?.value.isFromStore).toBe(false)
+    expect(result[2]?.value.isFromStore).toBe(false) // defaults to false
+  })
+
+  it('returns empty array for empty input', () => {
+    const result = getDefinedSecrets([])
+    expect(result).toEqual([])
+  })
+})
+
+describe('convertCreateRequestToFormData', () => {
+  it('converts docker create request to form data', () => {
+    const createRequest: V1CreateRequest = {
+      name: 'docker-server',
+      image: 'ghcr.io/test/server',
+      transport: 'stdio',
+      cmd_arguments: ['--debug'],
+      env_vars: { DEBUG: 'true', PORT: '8080' },
+      secrets: [{ name: 'secret-key', target: 'API_TOKEN' }],
+    }
+
+    const availableSecrets: V1ListSecretsResponse = {
+      keys: [{ key: 'secret-key' }],
+    }
+
+    const result = convertCreateRequestToFormData(
+      createRequest,
+      availableSecrets
+    )
+
+    expect(result).toEqual({
+      name: 'docker-server',
+      transport: 'stdio',
+      target_port: 0,
+      cmd_arguments: ['--debug'],
+      envVars: [
+        { name: 'DEBUG', value: 'true' },
+        { name: 'PORT', value: '8080' },
+      ],
+      secrets: [
+        {
+          name: 'API_TOKEN',
+          value: { secret: 'secret-key', isFromStore: true },
+        },
+      ],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+      type: 'docker_image',
+      image: 'ghcr.io/test/server',
+    })
+  })
+
+  it('converts package manager create request to form data', () => {
+    const createRequest: V1CreateRequest = {
+      name: 'npm-server',
+      image: 'npx://my-package',
+      transport: 'sse',
+      target_port: 3000,
+    }
+
+    const result = convertCreateRequestToFormData(createRequest)
+
+    expect(result).toEqual({
+      name: 'npm-server',
+      transport: 'sse',
+      target_port: 3000,
+      cmd_arguments: [],
+      envVars: [],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+      type: 'package_manager',
+      protocol: 'npx',
+      package_name: 'my-package',
+    })
+  })
+
+  it('handles invalid transport gracefully', () => {
+    const createRequest: V1CreateRequest = {
+      name: 'test-server',
+      image: 'test-image',
+      transport: 'invalid-transport' as 'stdio',
+    }
+
+    const result = convertCreateRequestToFormData(createRequest)
+
+    expect(result.transport).toBe('stdio') // defaults to stdio
+  })
+
+  it('marks secrets as not from store when not available', () => {
+    const createRequest: V1CreateRequest = {
+      name: 'test-server',
+      image: 'test-image',
+      secrets: [{ name: 'unknown-key', target: 'SECRET' }],
+    }
+
+    const availableSecrets: V1ListSecretsResponse = {
+      keys: [{ key: 'different-key' }],
+    }
+
+    const result = convertCreateRequestToFormData(
+      createRequest,
+      availableSecrets
+    )
+
+    expect(result.secrets[0]?.value.isFromStore).toBe(false)
+  })
+
+  it('converts network isolation settings', () => {
+    const createRequest: V1CreateRequest = {
+      name: 'test-server',
+      image: 'test-image',
+      network_isolation: true,
+      permission_profile: {
+        network: {
+          outbound: {
+            allow_host: ['example.com', 'api.test.com'],
+            allow_port: [80, 443],
+            insecure_allow_all: false,
+          },
+        },
+      },
+    }
+
+    const result = convertCreateRequestToFormData(createRequest)
+
+    expect(result.networkIsolation).toBe(true)
+    expect(result.allowedHosts).toEqual([
+      { value: 'example.com' },
+      { value: 'api.test.com' },
+    ])
+    expect(result.allowedPorts).toEqual([{ value: '80' }, { value: '443' }])
+  })
+
+  it('converts volumes correctly', () => {
+    const createRequest: V1CreateRequest = {
+      name: 'test-server',
+      image: 'test-image',
+      volumes: [
+        '/host/path:/container/path',
+        '/host2:/container2:ro',
+        '/host3:/container3:rw',
+      ],
+    }
+
+    const result = convertCreateRequestToFormData(createRequest)
+
+    expect(result.volumes).toEqual([
+      { host: '/host/path', container: '/container/path', accessMode: 'rw' },
+      { host: '/host2', container: '/container2', accessMode: 'ro' },
+      { host: '/host3', container: '/container3', accessMode: 'rw' },
+    ])
+  })
+
+  it('handles empty or undefined values gracefully', () => {
+    const createRequest: V1CreateRequest = {
+      name: '',
+      image: '',
+    }
+
+    const result = convertCreateRequestToFormData(createRequest)
+
+    expect(result.name).toBe('')
+    expect(result.transport).toBe('stdio')
+    if (result.type === 'docker_image') {
+      expect(result.image).toBe('')
+    }
+    expect(result.cmd_arguments).toEqual([])
+    expect(result.envVars).toEqual([])
+    expect(result.secrets).toEqual([])
+  })
+})
+
+describe('prepareUpdateWorkloadData', () => {
+  it('prepares update data for docker image type', () => {
+    const data: FormSchemaRunMcpCommand = {
+      name: 'updated-server',
+      transport: 'sse',
+      target_port: 3000,
+      type: 'docker_image',
+      image: 'ghcr.io/test/updated-server',
+      cmd_arguments: ['--verbose'],
+      envVars: [
+        { name: 'DEBUG', value: 'true' },
+        { name: 'LOG_LEVEL', value: 'info' },
+      ],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+    }
+
+    const secrets: SecretsSecretParameter[] = [
+      { name: 'api-key', target: 'API_KEY' },
+    ]
+
+    const result = prepareUpdateWorkloadData(data, secrets)
+
+    expect(result).toEqual({
+      image: 'ghcr.io/test/updated-server',
+      transport: 'sse',
+      target_port: 3000,
+      cmd_arguments: ['--verbose'],
+      env_vars: { DEBUG: 'true', LOG_LEVEL: 'info' },
+      secrets: [{ name: 'api-key', target: 'API_KEY' }],
+      network_isolation: false,
+      permission_profile: undefined,
+      volumes: [],
+    })
+  })
+
+  it('prepares update data for package manager type', () => {
+    const data: FormSchemaRunMcpCommand = {
+      name: 'npm-updated',
+      transport: 'stdio',
+      type: 'package_manager',
+      protocol: 'uvx',
+      package_name: 'updated-package',
+      cmd_arguments: [],
+      envVars: [],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+    }
+
+    const result = prepareUpdateWorkloadData(data)
+
+    expect(result.image).toBe('uvx://updated-package')
+    expect(result.transport).toBe('stdio')
+  })
+
+  it('includes network isolation settings when enabled', () => {
+    const data: FormSchemaRunMcpCommand = {
+      name: 'test-server',
+      transport: 'stdio',
+      type: 'docker_image',
+      image: 'test-image',
+      cmd_arguments: [],
+      envVars: [],
+      secrets: [],
+      networkIsolation: true,
+      allowedHosts: [{ value: 'api.example.com' }],
+      allowedPorts: [{ value: '443' }, { value: '80' }],
+      volumes: [],
+    }
+
+    const result = prepareUpdateWorkloadData(data)
+
+    expect(result.network_isolation).toBe(true)
+    expect(result.permission_profile).toEqual({
+      network: {
+        outbound: {
+          allow_host: ['api.example.com'],
+          allow_port: [443, 80],
+          insecure_allow_all: false,
+        },
+      },
+    })
+  })
+
+  it('filters out empty environment variables', () => {
+    const data: FormSchemaRunMcpCommand = {
+      name: 'test-server',
+      transport: 'stdio',
+      type: 'docker_image',
+      image: 'test-image',
+      cmd_arguments: [],
+      envVars: [
+        { name: 'VALID_VAR', value: 'valid-value' },
+        { name: 'EMPTY_VAR', value: '' },
+        { name: 'WHITESPACE_VAR', value: '   ' },
+      ],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+    }
+
+    const result = prepareUpdateWorkloadData(data)
+
+    expect(result.env_vars).toEqual({ VALID_VAR: 'valid-value' })
+  })
+
+  it('handles volumes correctly', () => {
+    const data: FormSchemaRunMcpCommand = {
+      name: 'test-server',
+      transport: 'stdio',
+      type: 'docker_image',
+      image: 'test-image',
+      cmd_arguments: [],
+      envVars: [],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [
+        { host: '/host1', container: '/container1' },
+        { host: '/host2', container: '/container2', accessMode: 'ro' },
+      ],
+    }
+
+    const result = prepareUpdateWorkloadData(data)
+
+    expect(result.volumes).toEqual([
+      '/host1:/container1',
+      '/host2:/container2:ro',
+    ])
+  })
+
+  it('works without secrets parameter', () => {
+    const data: FormSchemaRunMcpCommand = {
+      name: 'test-server',
+      transport: 'stdio',
+      type: 'docker_image',
+      image: 'test-image',
+      cmd_arguments: [],
+      envVars: [],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+    }
+
+    const result = prepareUpdateWorkloadData(data)
+
+    expect(result.secrets).toEqual([])
   })
 })

--- a/renderer/src/features/mcp-servers/lib/form-schema-run-mcp-server-with-command.ts
+++ b/renderer/src/features/mcp-servers/lib/form-schema-run-mcp-server-with-command.ts
@@ -1,7 +1,10 @@
 import type { CoreWorkload } from '@api/types.gen'
 import z from 'zod/v4'
 
-export const getFormSchemaRunMcpCommand = (workloads: CoreWorkload[]) => {
+export const getFormSchemaRunMcpCommand = (
+  workloads: CoreWorkload[],
+  editingServerName?: string
+) => {
   const baseFields = z.object({
     name: z
       .union([z.string(), z.undefined()])
@@ -15,7 +18,10 @@ export const getFormSchemaRunMcpCommand = (workloads: CoreWorkload[]) => {
             'Invalid server name: it can only contain alphanumeric characters, dots, hyphens, and underscores.'
           )
           .refine(
-            (value) => !workloads.some((w) => w.name === value),
+            (value) =>
+              !workloads.some(
+                (w) => w.name === value && value !== editingServerName
+              ),
             'This name is already in use'
           )
       ),

--- a/renderer/src/features/mcp-servers/lib/orchestrate-run-custom-server.tsx
+++ b/renderer/src/features/mcp-servers/lib/orchestrate-run-custom-server.tsx
@@ -234,9 +234,7 @@ export function getDefinedSecrets(
   }, [])
 }
 
-/**
- * Converts a V1CreateRequest (from individual workload endpoint) back to form data for editing
- */
+// The type of the GET is V1CreateRequest
 export function convertCreateRequestToFormData(
   createRequest: V1CreateRequest,
   availableSecrets?: V1ListSecretsResponse
@@ -370,19 +368,15 @@ export function prepareUpdateWorkloadData(
  */
 export function groupSecrets(secrets: DefinedSecret[]): {
   newSecrets: DefinedSecret[]
-  existingSecrets: SecretsSecretParameter[]
+  existingSecrets: DefinedSecret[]
 } {
   return secrets.reduce<{
     newSecrets: DefinedSecret[]
-    existingSecrets: SecretsSecretParameter[]
+    existingSecrets: DefinedSecret[]
   }>(
     (acc, secret) => {
       if (secret.value.isFromStore) {
-        // Convert existing secrets to API format
-        acc.existingSecrets.push({
-          name: secret.value.secret, // secret key name from store
-          target: secret.name, // environment variable name
-        })
+        acc.existingSecrets.push(secret)
       } else {
         acc.newSecrets.push(secret)
       }

--- a/renderer/src/features/mcp-servers/sub-pages/customize-tools/page.tsx
+++ b/renderer/src/features/mcp-servers/sub-pages/customize-tools/page.tsx
@@ -6,7 +6,7 @@ import { useParams } from '@tanstack/react-router'
 import { ChevronLeft } from 'lucide-react'
 import { useUpdateServer } from '@/features/mcp-servers/hooks/use-update-server'
 import { toast } from 'sonner'
-import type { V1UpdateRequest } from '@api/types.gen'
+import { convertWorkloadToFormData } from '@/features/mcp-servers/lib/orchestrate-run-custom-server'
 import { getApiV1BetaWorkloads } from '@api/sdk.gen'
 
 export function CustomizeToolsPage() {
@@ -65,13 +65,14 @@ export function CustomizeToolsPage() {
         throw new Error(toolsSaveResult.error || 'Failed to save tool settings')
       }
 
-      // Step 2: Update server with just the tools
-      const updateRequest: V1UpdateRequest = {
-        tools: enabledToolNames,
+      // Step 2: Update server with existing data
+      if (!workload) {
+        throw new Error('Workload data not available')
       }
 
+      const formData = convertWorkloadToFormData(workload)
       updateServerMutation(
-        { updateRequest },
+        { data: formData },
         {
           onSuccess: () => {
             checkServerStatus()

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -2,4 +2,5 @@ export const featureFlagKeys = {
   PLAYGROUND: 'playground',
   GROUPS: 'groups',
   CUSTOMIZE_TOOLS: 'customize_tools',
+  EDIT_WORKLOAD: 'edit_workload',
 } as const


### PR DESCRIPTION
in this PR:
- added a feature flag for editing
- adjusted the custom server form to be reused for editing
- adjusted the height of the custom form to avoid overflow

the APIs aren’t consistent enough, I’ll do a second step once the fixes are done/released

missing:

- pass the group on editing
- add optimistic updates when fetching the status while polling
- handle errors on GET so the edit form doesn’t break if the workload configuration isn’t available (edge case)