### PR TITLE
fix: prevent default event avoiding close dialog on click

### DIFF
--- a/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/items/edit-configuration-menu-item.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/items/edit-configuration-menu-item.tsx
@@ -12,7 +12,8 @@ export function EditConfigurationMenuItem({
 }: EditConfigurationMenuItemProps) {
   const [isRunWithCommandOpen, setIsRunWithCommandOpen] = useState(false)
 
-  const handleEdit = () => {
+  const handleEdit = (e: React.MouseEvent) => {
+    e.preventDefault()
     setIsRunWithCommandOpen(true)
   }
 


### PR DESCRIPTION
We need to prevent default event actions triggered by the click on edit configuration

**BEFORE**

https://github.com/user-attachments/assets/50b3dfdc-b7cc-47bd-ac65-11a19bb6d542



**AFTER**

https://github.com/user-attachments/assets/47d900ff-0344-4963-b186-7ee4b8371420

