### PR TITLE
fix: redirect to home

### DIFF
--- a/renderer/src/common/components/not-found.tsx
+++ b/renderer/src/common/components/not-found.tsx
@@ -20,7 +20,7 @@ export function NotFound() {
             The page you're looking for doesn't exist or has been moved.
           </p>
           <Button asChild className="w-full">
-            <LinkViewTransition to="/">
+            <LinkViewTransition to="/group/default">
               <Home className="mr-2 size-4" />
               Go to Installed
             </LinkViewTransition>

--- a/renderer/src/features/mcp-servers/sub-pages/customize-tools/page.tsx
+++ b/renderer/src/features/mcp-servers/sub-pages/customize-tools/page.tsx
@@ -100,7 +100,7 @@ export function CustomizeToolsPage() {
   return (
     <div className="">
       <div className="mb-2">
-        <LinkViewTransition to="/">
+        <LinkViewTransition to="/group/default">
           <Button
             variant="ghost"
             aria-label="Back"

--- a/renderer/src/features/mcp-servers/sub-pages/logs-page/index.tsx
+++ b/renderer/src/features/mcp-servers/sub-pages/logs-page/index.tsx
@@ -32,7 +32,7 @@ export function LogsPage() {
   return (
     <div className="flex max-h-full w-full flex-1 flex-col">
       <div className="mb-2">
-        <LinkViewTransition to="/">
+        <LinkViewTransition to="/group/default">
           <Button
             variant="ghost"
             aria-label="Back"

--- a/renderer/src/routes/__tests__/logs.$serverName.test.tsx
+++ b/renderer/src/routes/__tests__/logs.$serverName.test.tsx
@@ -42,12 +42,12 @@ describe('Logs Route', () => {
 
       const backButton = screen.getByRole('button', { name: /back/i })
       expect(backButton).toBeVisible()
-      expect(backButton.closest('a')).toHaveAttribute('href', '/')
+      expect(backButton.closest('a')).toHaveAttribute('href', '/group/default')
 
       await userEvent.click(backButton)
 
       await waitFor(() => {
-        expect(router.state.location.pathname).toBe('/')
+        expect(router.state.location.pathname).toBe('/group/default')
       })
     })
 


### PR DESCRIPTION
After removed the index route we didn't replaced all the redirect in the app, we have 3 occurrences:
- logs
- 404 component
- edit tools
____

**MCP Logs**
**Before**

https://github.com/user-attachments/assets/f3cc7e4b-2148-4e83-b5cc-1fe49d58db88

**After**

https://github.com/user-attachments/assets/42e58a0d-72b8-49e2-8f84-0d793e649537

