### PR TITLE
feat: add remote mcp components

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -30,6 +30,7 @@ export default {
     'renderer/src/features/mcp-servers/hooks/use-mutation-restart-server.ts',
     'renderer/src/features/mcp-servers/hooks/use-mutation-stop-server.ts',
     'renderer/src/features/mcp-servers/lib/form-schema-remote-mcp.ts',
+    'renderer/src/features/mcp-servers/components/remote-mcp/dialog-form-remote-mcp.tsx',
     'renderer/src/common/lib/utils.ts',
     'main/src/vite-env.d.ts',
   ],

--- a/renderer/src/features/mcp-servers/components/remote-mcp/__tests__/dialog-form-remote-mcp.test.tsx
+++ b/renderer/src/features/mcp-servers/components/remote-mcp/__tests__/dialog-form-remote-mcp.test.tsx
@@ -1,0 +1,362 @@
+import { render, waitFor, screen, act } from '@testing-library/react'
+import { it, expect, vi, describe, beforeEach } from 'vitest'
+import { DialogFormRemoteMcp } from '../dialog-form-remote-mcp'
+import userEvent from '@testing-library/user-event'
+import { Dialog } from '@/common/components/ui/dialog'
+import { server as mswServer } from '@/common/mocks/node'
+import { http, HttpResponse } from 'msw'
+import { mswEndpoint } from '@/common/mocks/msw-endpoint'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useRunRemoteServer } from '../../../hooks/use-run-remote-server'
+
+// Mock the hook
+vi.mock('../../../hooks/use-run-remote-server', () => ({
+  useRunRemoteServer: vi.fn(),
+}))
+
+const mockUseRunRemoteServer = vi.mocked(useRunRemoteServer)
+
+window.HTMLElement.prototype.hasPointerCapture = vi.fn()
+window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+const renderWithProviders = (component: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: 0,
+        staleTime: 0,
+      },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
+  )
+}
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <Dialog open>{children}</Dialog>
+)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+
+  // Setup MSW with default secrets
+  mswServer.use(
+    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
+      return HttpResponse.json({
+        keys: [
+          { key: 'SECRET_FROM_STORE' },
+          { key: 'GITHUB_TOKEN' },
+          { key: 'API_KEY' },
+        ],
+      })
+    }),
+    // Mock empty workloads by default
+    http.get(mswEndpoint('/api/v1beta/workloads'), () => {
+      return HttpResponse.json({ workloads: [] })
+    })
+  )
+
+  // Default mock implementation
+  mockUseRunRemoteServer.mockReturnValue({
+    installServerMutation: vi.fn(),
+    checkServerStatus: vi.fn(),
+    isErrorSecrets: false,
+    isPendingSecrets: false,
+  })
+})
+
+describe('DialogFormRemoteMcp', () => {
+  it('handles secrets correctly - both inline and from store', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunRemoteServer.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    renderWithProviders(
+      <Wrapper>
+        <DialogFormRemoteMcp isOpen closeDialog={vi.fn()} />
+      </Wrapper>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Fill basic fields
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /server name/i }),
+      'secret-server'
+    )
+    await userEvent.click(screen.getByLabelText('Transport'))
+    await userEvent.click(
+      screen.getByRole('option', { name: /streamable http/i })
+    )
+
+    // Add inline secret
+    await userEvent.click(screen.getByRole('button', { name: 'Add secret' }))
+    await userEvent.type(screen.getByLabelText('Secret key'), 'API_TOKEN')
+    await userEvent.type(screen.getByLabelText('Secret value'), 'secret-value')
+
+    // Add secret from store
+    await userEvent.click(screen.getByRole('button', { name: 'Add secret' }))
+    await userEvent.type(
+      screen.getAllByLabelText('Secret key')[1] as HTMLElement,
+      'GITHUB_TOKEN'
+    )
+    await userEvent.click(
+      screen.getAllByLabelText('Use a secret from the store')[1] as HTMLElement
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('dialog', { name: 'Secrets store' })
+      ).toBeVisible()
+    })
+
+    await userEvent.click(
+      screen.getByRole('option', { name: 'SECRET_FROM_STORE' })
+    )
+
+    await userEvent.type(
+      screen.getByRole('textbox', {
+        name: /server url/i,
+      }),
+      'https://api.example.com/mcp'
+    )
+    await userEvent.type(screen.getByLabelText('Callback port'), '8888')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install server' })
+    )
+
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalledWith(
+        {
+          data: expect.objectContaining({
+            secrets: [
+              {
+                name: 'API_TOKEN',
+                value: {
+                  isFromStore: false,
+                  secret: 'secret-value',
+                },
+              },
+              {
+                name: 'GITHUB_TOKEN',
+                value: {
+                  isFromStore: true,
+                  secret: 'SECRET_FROM_STORE',
+                },
+              },
+            ],
+          }),
+        },
+        expect.any(Object)
+      )
+    })
+  })
+
+  it('validates required fields and shows errors', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunRemoteServer.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    renderWithProviders(
+      <Wrapper>
+        <DialogFormRemoteMcp isOpen closeDialog={vi.fn()} />
+      </Wrapper>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Try to submit without filling required fields
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install server' })
+    )
+
+    await waitFor(() => {
+      expect(mockInstallServerMutation).not.toHaveBeenCalled()
+    })
+
+    // Check that validation errors are shown
+    await waitFor(() => {
+      expect(
+        screen.getByRole('textbox', {
+          name: /server name/i,
+        })
+      ).toHaveAttribute('aria-invalid', 'true')
+      expect(
+        screen.getByRole('textbox', {
+          name: /server url/i,
+        })
+      ).toHaveAttribute('aria-invalid', 'true')
+      expect(screen.getByLabelText('Callback port')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      )
+    })
+  })
+
+  it('shows loading state when submitting', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunRemoteServer.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    renderWithProviders(
+      <Wrapper>
+        <DialogFormRemoteMcp isOpen closeDialog={vi.fn()} />
+      </Wrapper>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Fill required fields
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /server name/i }),
+      'test-server'
+    )
+    await userEvent.click(screen.getByLabelText('Transport'))
+    await userEvent.click(
+      screen.getByRole('option', {
+        name: /streamable http/i,
+      })
+    )
+    await userEvent.type(
+      screen.getByRole('textbox', {
+        name: /server url/i,
+      }),
+      'https://api.example.com/mcp'
+    )
+    await userEvent.type(screen.getByLabelText('Callback port'), '8888')
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install server' })
+    )
+
+    // The loading state should be shown
+    await waitFor(() => {
+      expect(
+        screen.getByText(/installing server|creating secrets/i)
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('submit remote mcp', async () => {
+    const mockInstallServerMutation = vi.fn()
+    const mockCheckServerStatus = vi.fn()
+    const mockOnOpenChange = vi.fn()
+
+    mockUseRunRemoteServer.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: mockCheckServerStatus,
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    renderWithProviders(
+      <Wrapper>
+        <DialogFormRemoteMcp isOpen closeDialog={mockOnOpenChange} />
+      </Wrapper>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+    // Fill required fields
+    await userEvent.type(
+      screen.getByRole('textbox', {
+        name: /name/i,
+      }),
+      'test-remote-server'
+    )
+
+    await userEvent.type(
+      screen.getByRole('textbox', {
+        name: /url/i,
+      }),
+      'https://api.example.com/mcp'
+    )
+
+    expect(screen.getByLabelText('Authorization method')).toBeVisible()
+
+    await userEvent.type(screen.getByLabelText('Callback port'), '8888')
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install server' })
+    )
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            envVars: [],
+            url: 'https://api.example.com/mcp',
+            auth_type: 'none',
+            name: 'test-remote-server',
+            oauth_config: {
+              authorize_url: '',
+              callback_port: 8888,
+              client_id: '',
+              client_secret: '',
+              issuer: '',
+              oauth_params: {},
+              scopes: [],
+              skip_browser: false,
+              token_url: '',
+              use_pkce: true,
+            },
+            secrets: [],
+            transport: 'streamable-http',
+          }),
+        }),
+        expect.any(Object)
+      )
+    })
+
+    // Simulate successful submission
+    const onSuccessCallback =
+      mockInstallServerMutation.mock.calls[0]?.[1]?.onSuccess
+
+    await act(async () => {
+      onSuccessCallback?.()
+    })
+
+    await waitFor(() => {
+      expect(mockCheckServerStatus).toHaveBeenCalled()
+      expect(mockOnOpenChange).toHaveBeenCalled()
+    })
+  })
+
+  it('can cancel and close dialog', async () => {
+    const mockOnOpenChange = vi.fn()
+
+    renderWithProviders(
+      <Wrapper>
+        <DialogFormRemoteMcp isOpen closeDialog={mockOnOpenChange} />
+      </Wrapper>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(mockOnOpenChange).toHaveBeenCalled()
+  })
+})

--- a/renderer/src/features/mcp-servers/components/remote-mcp/dialog-form-remote-mcp.tsx
+++ b/renderer/src/features/mcp-servers/components/remote-mcp/dialog-form-remote-mcp.tsx
@@ -1,0 +1,409 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/common/components/ui/dialog'
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+  Form,
+} from '@/common/components/ui/form'
+import { Input } from '@/common/components/ui/input'
+import { TooltipInfoIcon } from '@/common/components/ui/tooltip-info-icon'
+import { zodV4Resolver } from '@/common/lib/zod-v4-resolver'
+import { useForm } from 'react-hook-form'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/common/components/ui/select'
+import { Button } from '@/common/components/ui/button'
+import {
+  getFormSchemaRemoteMcp,
+  type FormSchemaRemoteMcp,
+} from '../../lib/form-schema-remote-mcp'
+import { FormFieldsArrayCustomSecrets } from '../form-fields-array-custom-secrets'
+import { FormFieldsArrayCustomEnvVars } from '../form-fields-array-custom-env-vars'
+import { FormFieldsAuth } from './form-fields-auth'
+import { useRunRemoteServer } from '../../hooks/use-run-remote-server'
+import log from 'electron-log/renderer'
+import { useState } from 'react'
+import { useUpdateServer } from '../../hooks/use-update-remote-server'
+import {
+  getApiV1BetaSecretsDefaultKeysOptions,
+  getApiV1BetaWorkloadsByNameOptions,
+  getApiV1BetaWorkloadsOptions,
+} from '@api/@tanstack/react-query.gen'
+import { useQuery } from '@tanstack/react-query'
+import { convertCreateRequestToFormData } from '../../lib/orchestrate-run-remote-server'
+import { LoadingStateAlert } from '@/common/components/secrets/loading-state-alert'
+import { AlertErrorFormSubmission } from '@/common/components/workloads/alert-error-form-submission'
+
+const DEFAULT_FORM_VALUES: FormSchemaRemoteMcp = {
+  name: '',
+  transport: 'streamable-http',
+  auth_type: 'none',
+  oauth_config: {
+    authorize_url: '',
+    callback_port: undefined,
+    client_id: '',
+    client_secret: '',
+    issuer: '',
+    oauth_params: {},
+    scopes: [],
+    skip_browser: false,
+    token_url: '',
+    use_pkce: true,
+  },
+  envVars: [],
+  secrets: [],
+  url: '',
+}
+
+export function DialogFormRemoteMcp({
+  closeDialog,
+  isOpen,
+  serverToEdit,
+}: {
+  closeDialog: () => void
+  serverToEdit?: string | null
+  isOpen: boolean
+}) {
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [loadingSecrets, setLoadingSecrets] = useState<{
+    text: string
+    completedCount: number
+    secretsCount: number
+  } | null>(null)
+
+  const handleSecrets = (completedCount: number, secretsCount: number) => {
+    setLoadingSecrets((prev) => ({
+      ...prev,
+      text: `Encrypting secrets (${completedCount} of ${secretsCount})...`,
+      completedCount,
+      secretsCount,
+    }))
+  }
+
+  const {
+    installServerMutation,
+    checkServerStatus,
+    isErrorSecrets,
+    isPendingSecrets,
+  } = useRunRemoteServer({
+    onSecretSuccess: handleSecrets,
+    onSecretError: (error, variables) => {
+      log.error('onSecretError', error, variables)
+    },
+  })
+
+  const { updateServerMutation, checkServerStatus: checkUpdateServerStatus } =
+    useUpdateServer(serverToEdit || '', {
+      onSecretSuccess: handleSecrets,
+      onSecretError: (error, variables) => {
+        log.error('onSecretError during update', error, variables)
+      },
+    })
+
+  const { data } = useQuery({
+    ...getApiV1BetaWorkloadsOptions({ query: { all: true } }),
+    retry: false,
+  })
+
+  const { data: availableSecrets } = useQuery({
+    ...getApiV1BetaSecretsDefaultKeysOptions(),
+    enabled: !!serverToEdit,
+    retry: false,
+  })
+
+  const { data: existingServerData, isLoading: isLoadingServer } = useQuery({
+    ...getApiV1BetaWorkloadsByNameOptions({
+      path: { name: serverToEdit || '' },
+    }),
+    enabled: !!serverToEdit,
+    retry: false,
+  })
+
+  const workloads = data?.workloads ?? []
+  const existingServer = existingServerData
+  const isEditing = !!existingServer && !!serverToEdit
+  const editingFormData =
+    isEditing &&
+    convertCreateRequestToFormData(existingServer, availableSecrets)
+
+  const form = useForm<FormSchemaRemoteMcp>({
+    resolver: zodV4Resolver(
+      getFormSchemaRemoteMcp(workloads, serverToEdit || undefined)
+    ),
+    defaultValues: DEFAULT_FORM_VALUES,
+    reValidateMode: 'onChange',
+    mode: 'onChange',
+    ...(editingFormData ? { values: editingFormData } : {}),
+  })
+
+  const onSubmitForm = (data: FormSchemaRemoteMcp) => {
+    setIsSubmitting(true)
+    if (error) {
+      setError(null)
+    }
+    if (isEditing) {
+      updateServerMutation(
+        { data },
+        {
+          onSuccess: () => {
+            checkUpdateServerStatus()
+            closeDialog()
+          },
+          onSettled: (_, error) => {
+            setIsSubmitting(false)
+            setLoadingSecrets(null)
+            if (!error) {
+              form.reset()
+            }
+          },
+          onError: (error) => {
+            setError(typeof error === 'string' ? error : error.message)
+          },
+        }
+      )
+    } else {
+      installServerMutation(
+        { data },
+        {
+          onSuccess: () => {
+            checkServerStatus(data)
+            closeDialog()
+          },
+          onSettled: (_, error) => {
+            setIsSubmitting(false)
+            if (!error) {
+              form.reset()
+            }
+          },
+          onError: (error) => {
+            setError(typeof error === 'string' ? error : error.message)
+          },
+        }
+      )
+    }
+  }
+
+  const authType = form.watch('auth_type')
+
+  return (
+    <Dialog open={isOpen} onOpenChange={closeDialog}>
+      <DialogContent
+        className="p-0 sm:max-w-2xl"
+        onCloseAutoFocus={() => {
+          closeDialog()
+        }}
+        onInteractOutside={(e) => {
+          // Prevent closing the dialog when clicking outside
+          e.preventDefault()
+        }}
+      >
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmitForm)}>
+            <DialogHeader className="mb-4 p-6">
+              <DialogTitle>Add a remote MCP server</DialogTitle>
+              <DialogDescription className="sr-only">
+                Set up the environment variables and name for this MCP server
+                installation.
+              </DialogDescription>
+            </DialogHeader>
+            {(isSubmitting || (isEditing && isLoadingServer)) && (
+              <LoadingStateAlert
+                isPendingSecrets={isPendingSecrets}
+                loadingSecrets={
+                  isLoadingServer
+                    ? {
+                        text: `Loading server "${serverToEdit}"...`,
+                        completedCount: 0,
+                        secretsCount: 0,
+                      }
+                    : loadingSecrets
+                }
+              />
+            )}
+            {!isSubmitting && !(isEditing && isLoadingServer) && (
+              <div
+                className="relative max-h-[65dvh] space-y-4 overflow-y-auto
+                  px-6"
+              >
+                {error && (
+                  <AlertErrorFormSubmission
+                    error={error}
+                    isErrorSecrets={isErrorSecrets}
+                    onDismiss={() => setError(null)}
+                  />
+                )}
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-center gap-1">
+                        <FormLabel>Server name</FormLabel>
+                        <TooltipInfoIcon>
+                          The human-readable name you will use to identify this
+                          server.
+                        </TooltipInfoIcon>
+                      </div>
+                      <FormControl>
+                        <Input
+                          autoCorrect="off"
+                          autoComplete="off"
+                          autoFocus
+                          data-1p-ignore
+                          placeholder="e.g. my-awesome-server"
+                          defaultValue={field.value}
+                          onChange={(e) => field.onChange(e.target.value)}
+                          name={field.name}
+                          disabled={isEditing}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="url"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-center gap-1">
+                        <FormLabel>Server URL</FormLabel>
+                        <TooltipInfoIcon>
+                          The URL of the MCP server.
+                        </TooltipInfoIcon>
+                      </div>
+                      <FormControl>
+                        <Input
+                          autoCorrect="off"
+                          autoComplete="off"
+                          autoFocus
+                          data-1p-ignore
+                          placeholder="e.g. https://example.com/mcp"
+                          defaultValue={field.value}
+                          onChange={(e) => field.onChange(e.target.value)}
+                          name={field.name}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="transport"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-center gap-1">
+                        <FormLabel htmlFor={field.name}>Transport</FormLabel>
+                        <TooltipInfoIcon>
+                          The transport mechanism the MCP server uses to
+                          communicate with clients.
+                        </TooltipInfoIcon>
+                      </div>
+                      <FormControl>
+                        <Select
+                          onValueChange={(value) => field.onChange(value)}
+                          value={field.value}
+                          name={field.name}
+                        >
+                          <SelectTrigger id={field.name} className="w-full">
+                            <SelectValue placeholder="e.g. SSE, Streamable HTTP" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="sse">SSE</SelectItem>
+                            <SelectItem value="streamable-http">
+                              Streamable HTTP
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="auth_type"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-center gap-1">
+                        <FormLabel htmlFor={field.name}>
+                          Authorization method
+                        </FormLabel>
+                        <TooltipInfoIcon>
+                          The authorization method the MCP server uses to
+                          authenticate clients.
+                        </TooltipInfoIcon>
+                      </div>
+                      <FormControl>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value || ''}
+                          name={field.name}
+                        >
+                          <SelectTrigger id={field.name} className="w-full">
+                            <SelectValue placeholder="Select authorization method" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="none">None</SelectItem>
+                            <SelectItem value="oauth2">OAuth2</SelectItem>
+                            <SelectItem value="oidc">OIDC</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormFieldsAuth authType={authType} form={form} />
+
+                {(authType === undefined || authType === 'none') && (
+                  <>
+                    <FormFieldsArrayCustomSecrets form={form} />
+                    <FormFieldsArrayCustomEnvVars form={form} />
+                  </>
+                )}
+              </div>
+            )}
+
+            <DialogFooter className="p-6">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isSubmitting || (isEditing && isLoadingServer)}
+                onClick={() => {
+                  closeDialog()
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={isSubmitting || (isEditing && isLoadingServer)}
+                type="submit"
+              >
+                {isEditing ? 'Update server' : 'Install server'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/renderer/src/features/mcp-servers/components/remote-mcp/form-fields-auth.tsx
+++ b/renderer/src/features/mcp-servers/components/remote-mcp/form-fields-auth.tsx
@@ -1,0 +1,322 @@
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/common/components/ui/form'
+import { Input } from '@/common/components/ui/input'
+import { TooltipInfoIcon } from '@/common/components/ui/tooltip-info-icon'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/common/components/ui/select'
+import { type FormSchemaRemoteMcp } from '../../lib/form-schema-remote-mcp'
+import { type UseFormReturn } from 'react-hook-form'
+
+export function FormFieldsAuth({
+  authType,
+  form,
+}: {
+  authType: string | undefined
+  form: UseFormReturn<FormSchemaRemoteMcp>
+}) {
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="oauth_config.callback_port"
+        render={({ field }) => (
+          <FormItem>
+            <div className="flex items-center gap-1">
+              <FormLabel htmlFor={field.name}>Callback port</FormLabel>
+              <TooltipInfoIcon className="max-w-72">
+                Callback port to expose from the container. If not specified,
+                ToolHive will automatically assign a random port.
+              </TooltipInfoIcon>
+            </div>
+            <FormControl>
+              <Input
+                id={field.name}
+                autoCorrect="off"
+                autoComplete="off"
+                autoFocus
+                type="number"
+                data-1p-ignore
+                placeholder="e.g. 50051"
+                defaultValue={field.value}
+                onChange={(e) => field.onChange(parseInt(e.target.value, 10))}
+                name={field.name}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {authType === 'oidc' && (
+        <>
+          <FormField
+            control={form.control}
+            name="oauth_config.issuer"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel>Issuer URL</FormLabel>
+                  <TooltipInfoIcon>The URL of the OIDC issuer.</TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Input
+                    autoCorrect="off"
+                    autoComplete="off"
+                    autoFocus
+                    data-1p-ignore
+                    placeholder="e.g. https://auth.example.com/"
+                    defaultValue={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    name={field.name}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="oauth_config.client_id"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel>Client ID</FormLabel>
+                  <TooltipInfoIcon>
+                    The client ID of the OIDC issuer.
+                  </TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Input
+                    autoCorrect="off"
+                    autoComplete="off"
+                    autoFocus
+                    data-1p-ignore
+                    placeholder="e.g. 00000000-0000-0000-0000-000000000000"
+                    defaultValue={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    name={field.name}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="oauth_config.client_secret"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel>Client Secret</FormLabel>
+                  <TooltipInfoIcon>
+                    The client secret of the OIDC issuer.
+                  </TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Input
+                    autoCorrect="off"
+                    autoComplete="off"
+                    autoFocus
+                    data-1p-ignore
+                    placeholder="e.g. secret"
+                    defaultValue={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    name={field.name}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="oauth_config.use_pkce"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel htmlFor={field.name}>PKCE</FormLabel>
+                  <TooltipInfoIcon>
+                    Whether to use PKCE for the OAuth flow.
+                  </TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Select
+                    onValueChange={(value) => field.onChange(value === 'true')}
+                    value={field.value ? 'true' : 'false'}
+                    name={field.name}
+                  >
+                    <SelectTrigger id={field.name} className="w-full">
+                      <SelectValue placeholder="Select PKCE" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="true">True</SelectItem>
+                      <SelectItem value="false">False</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </>
+      )}
+
+      {authType === 'oauth2' && (
+        <>
+          <FormField
+            control={form.control}
+            name="oauth_config.authorize_url"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel>Authorize URL</FormLabel>
+                  <TooltipInfoIcon>
+                    The URL of the OAuth authorize endpoint.
+                  </TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Input
+                    autoCorrect="off"
+                    autoComplete="off"
+                    autoFocus
+                    data-1p-ignore
+                    placeholder="e.g. https://auth.example.com/oauth/authorize"
+                    defaultValue={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    name={field.name}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="oauth_config.token_url"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel>Token URL</FormLabel>
+                  <TooltipInfoIcon>
+                    The URL of the OAuth token endpoint.
+                  </TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Input
+                    autoCorrect="off"
+                    autoComplete="off"
+                    autoFocus
+                    data-1p-ignore
+                    placeholder="e.g. https://auth.example.com/oauth/token"
+                    defaultValue={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    name={field.name}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="oauth_config.client_id"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel>Client ID</FormLabel>
+                  <TooltipInfoIcon>
+                    The client ID of the OIDC issuer.
+                  </TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Input
+                    autoCorrect="off"
+                    autoComplete="off"
+                    autoFocus
+                    data-1p-ignore
+                    placeholder="e.g. 00000000-0000-0000-0000-000000000000"
+                    defaultValue={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    name={field.name}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="oauth_config.client_secret"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel>Client Secret</FormLabel>
+                  <TooltipInfoIcon>
+                    The client secret of the OIDC issuer.
+                  </TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Input
+                    autoCorrect="off"
+                    autoComplete="off"
+                    autoFocus
+                    data-1p-ignore
+                    placeholder="e.g. secret"
+                    defaultValue={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    name={field.name}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="oauth_config.scopes"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormLabel>Scopes</FormLabel>
+                  <TooltipInfoIcon>
+                    The scopes of the OAuth flow.
+                  </TooltipInfoIcon>
+                </div>
+                <FormControl>
+                  <Input
+                    autoCorrect="off"
+                    autoComplete="off"
+                    autoFocus
+                    data-1p-ignore
+                    placeholder="e.g. users, administrators"
+                    defaultValue={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    name={field.name}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </>
+      )}
+    </>
+  )
+}

--- a/renderer/src/features/mcp-servers/components/remote-mcp/form-fields-auth.tsx
+++ b/renderer/src/features/mcp-servers/components/remote-mcp/form-fields-auth.tsx
@@ -240,7 +240,7 @@ export function FormFieldsAuth({
                 <div className="flex items-center gap-1">
                   <FormLabel>Client ID</FormLabel>
                   <TooltipInfoIcon>
-                    The client ID of the OIDC issuer.
+                    The client ID of the OAuth provider
                   </TooltipInfoIcon>
                 </div>
                 <FormControl>
@@ -268,7 +268,7 @@ export function FormFieldsAuth({
                 <div className="flex items-center gap-1">
                   <FormLabel>Client Secret</FormLabel>
                   <TooltipInfoIcon>
-                    The client secret of the OIDC issuer.
+                    The client secret of the OAuth issuer.
                   </TooltipInfoIcon>
                 </div>
                 <FormControl>

--- a/renderer/src/features/mcp-servers/hooks/use-run-remote-server.tsx
+++ b/renderer/src/features/mcp-servers/hooks/use-run-remote-server.tsx
@@ -1,0 +1,193 @@
+import {
+  postApiV1BetaWorkloadsMutation,
+  getApiV1BetaWorkloadsByNameStatusOptions,
+  postApiV1BetaSecretsDefaultKeysMutation,
+  getApiV1BetaWorkloadsQueryKey,
+} from '@api/@tanstack/react-query.gen'
+import { pollServerStatus } from '@/common/lib/polling'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useRef } from 'react'
+
+import type { FormSchemaRemoteMcp } from '../lib/form-schema-remote-mcp'
+import {
+  groupSecrets,
+  prepareCreateWorkloadData,
+  saveSecrets,
+} from '../lib/orchestrate-run-remote-server'
+import {
+  type PostApiV1BetaSecretsDefaultKeysData,
+  type SecretsSecretParameter,
+  type V1CreateRequest,
+} from '@api/types.gen'
+import type { Options } from '@api/client'
+import { getApiV1BetaSecretsDefaultKeys } from '@api/sdk.gen'
+import { prepareSecretsWithoutNamingCollision } from '@/common/lib/secrets/prepare-secrets-without-naming-collision'
+import { toast } from 'sonner'
+import { Button } from '@/common/components/ui/button'
+import { Link } from '@tanstack/react-router'
+import { restartClientNotification } from '../lib/restart-client-notification'
+import { trackEvent } from '@/common/lib/analytics'
+
+type InstallServerCheck = (
+  data: FormSchemaRemoteMcp
+) => Promise<unknown> | unknown
+
+export function useRunRemoteServer({
+  onSecretSuccess,
+  onSecretError,
+}: {
+  onSecretSuccess: (completedCount: number, secretsCount: number) => void
+  onSecretError: (
+    error: string,
+    variables: Options<PostApiV1BetaSecretsDefaultKeysData>
+  ) => void
+}) {
+  const toastIdRef = useRef(new Date(Date.now()).toISOString())
+  const queryClient = useQueryClient()
+
+  const { mutateAsync: saveSecret } = useMutation({
+    ...postApiV1BetaSecretsDefaultKeysMutation(),
+  })
+  const { mutateAsync: createWorkload } = useMutation({
+    ...postApiV1BetaWorkloadsMutation(),
+  })
+
+  const handleSettled = useCallback<InstallServerCheck>(
+    async (formData) => {
+      toast.loading(`Starting "${formData.name}"...`, {
+        duration: 30_000,
+        id: toastIdRef.current,
+      })
+
+      const isServerReady = await pollServerStatus(
+        () =>
+          queryClient.fetchQuery(
+            getApiV1BetaWorkloadsByNameStatusOptions({
+              path: { name: formData.name },
+            })
+          ),
+        'running'
+      )
+
+      if (isServerReady) {
+        await queryClient.invalidateQueries({
+          queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+        })
+
+        toast.success(`"${formData.name}" started successfully.`, {
+          id: toastIdRef.current,
+          duration: 5_000, // slightly longer than default
+          action: (
+            <Button asChild>
+              <Link
+                to="/group/$groupName"
+                params={{ groupName: 'default' }}
+                search={{ newServerName: formData.name }}
+                onClick={() => toast.dismiss(toastIdRef.current)}
+                viewTransition={{ types: ['slide-left'] }}
+                className="ml-auto"
+              >
+                View
+              </Link>
+            </Button>
+          ),
+        })
+      } else {
+        toast.warning(
+          `Server "${formData.name}" was created but may still be starting up. Check the servers list to monitor its status.`,
+          {
+            id: toastIdRef.current,
+            duration: 5_000,
+          }
+        )
+      }
+    },
+    [queryClient]
+  )
+
+  const {
+    mutateAsync: handleSecrets,
+    isPending: isPendingSecrets,
+    isError: isErrorSecrets,
+  } = useMutation({
+    mutationFn: async (data: FormSchemaRemoteMcp) => {
+      let newlyCreatedSecrets: SecretsSecretParameter[] = []
+
+      // Step 1: Group secrets into new and existing
+      // We need to know which secrets are new (not from the registry) and which are
+      // existing (already stored). This helps us handle the encryption and storage
+      // of secrets correctly.
+      const { existingSecrets, newSecrets } = groupSecrets(data.secrets)
+
+      // Step 2: Fetch existing secrets & handle naming collisions
+      // We need an up-to-date list of secrets so we can handle any existing keys
+      // safely & correctly. This is done with a manual fetch call to avoid freshness issues /
+      // side-effects from the `useQuery` hook.
+      // In the event of a naming collision, we will append an incrementing number
+      // to the secret name, e.g. `MY_API_TOKEN` -> `MY_API_TOKEN_2`
+      const { data: fetchedSecrets } = await getApiV1BetaSecretsDefaultKeys({
+        throwOnError: true,
+      })
+      const preparedNewSecrets = prepareSecretsWithoutNamingCollision(
+        newSecrets,
+        fetchedSecrets
+      )
+
+      // Step 3: Encrypt secrets
+      // If there are secrets with values, create them in the secret store first.
+      // We need the data returned by the API to pass along with the "run workload" request.
+      if (preparedNewSecrets.length > 0) {
+        newlyCreatedSecrets = await saveSecrets(
+          preparedNewSecrets,
+          saveSecret,
+          onSecretSuccess,
+          onSecretError
+        )
+      }
+
+      return {
+        newlyCreatedSecrets,
+        existingSecrets,
+      }
+    },
+  })
+
+  const { mutate: installServerMutation } = useMutation({
+    mutationFn: async ({ data }: { data: FormSchemaRemoteMcp }) => {
+      const { newlyCreatedSecrets, existingSecrets } = await handleSecrets(data)
+      // Step 4: Create the MCP server workload
+      // Prepare the request data and send it to the API
+      // We pass the encrypted secrets along with the request.
+      const secretsForRequest: SecretsSecretParameter[] = [
+        ...newlyCreatedSecrets,
+        ...existingSecrets.map((secret) => ({
+          name: secret.value.secret,
+          target: secret.name,
+        })),
+      ]
+
+      const createRequest: V1CreateRequest = prepareCreateWorkloadData(
+        data,
+        secretsForRequest
+      )
+
+      await createWorkload({
+        body: createRequest,
+      })
+      await restartClientNotification({
+        queryClient,
+      })
+      trackEvent(`Workload remote ${data.name} started`, {
+        workload: data.name,
+        'route.pathname': '/',
+      })
+    },
+  })
+
+  return {
+    installServerMutation,
+    checkServerStatus: handleSettled,
+    isPendingSecrets,
+    isErrorSecrets,
+  }
+}

--- a/renderer/src/features/mcp-servers/hooks/use-update-remote-server.tsx
+++ b/renderer/src/features/mcp-servers/hooks/use-update-remote-server.tsx
@@ -1,0 +1,158 @@
+import {
+  postApiV1BetaWorkloadsByNameEditMutation,
+  getApiV1BetaWorkloadsByNameStatusOptions,
+  getApiV1BetaWorkloadsQueryKey,
+  postApiV1BetaSecretsDefaultKeysMutation,
+} from '@api/@tanstack/react-query.gen'
+import { getApiV1BetaSecretsDefaultKeys } from '@api/sdk.gen'
+import { pollServerStatus } from '@/common/lib/polling'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useRef } from 'react'
+import {
+  type PostApiV1BetaSecretsDefaultKeysData,
+  type SecretsSecretParameter,
+} from '@api/types.gen'
+import type { Options } from '@api/client'
+import type { FormSchemaRemoteMcp } from '../lib/form-schema-remote-mcp'
+import { prepareSecretsWithoutNamingCollision } from '@/common/lib/secrets/prepare-secrets-without-naming-collision'
+import { toast } from 'sonner'
+import { Button } from '@/common/components/ui/button'
+import { Link } from '@tanstack/react-router'
+import { restartClientNotification } from '../lib/restart-client-notification'
+import { trackEvent } from '@/common/lib/analytics'
+import {
+  getDefinedSecrets,
+  groupSecrets,
+  prepareUpdateWorkloadData,
+  saveSecrets,
+} from '../lib/orchestrate-run-remote-server'
+
+type UpdateServerCheck = () => Promise<unknown> | unknown
+
+export function useUpdateServer(
+  serverName: string,
+  options?: {
+    onSecretSuccess?: (completedCount: number, secretsCount: number) => void
+    onSecretError?: (
+      error: string,
+      variables: Options<PostApiV1BetaSecretsDefaultKeysData>
+    ) => void
+  }
+) {
+  const toastIdRef = useRef(new Date(Date.now()).toISOString())
+  const queryClient = useQueryClient()
+
+  const { mutateAsync: updateWorkload } = useMutation({
+    ...postApiV1BetaWorkloadsByNameEditMutation(),
+  })
+
+  const { mutateAsync: saveSecret } = useMutation({
+    ...postApiV1BetaSecretsDefaultKeysMutation(),
+  })
+
+  const handleSettled = useCallback<UpdateServerCheck>(async () => {
+    toast.loading(`Updating "${serverName}"...`, {
+      duration: 30_000,
+      id: toastIdRef.current,
+    })
+
+    const isServerReady = await pollServerStatus(
+      () =>
+        queryClient.fetchQuery(
+          getApiV1BetaWorkloadsByNameStatusOptions({
+            path: { name: serverName },
+          })
+        ),
+      'running'
+    )
+
+    if (isServerReady) {
+      await queryClient.invalidateQueries({
+        queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+      })
+
+      toast.success(`"${serverName}" updated successfully.`, {
+        id: toastIdRef.current,
+        duration: 5_000,
+        action: (
+          <Button asChild>
+            <Link
+              to="/group/$groupName"
+              params={{ groupName: 'default' }}
+              search={{ newServerName: serverName }}
+              onClick={() => toast.dismiss(toastIdRef.current)}
+              viewTransition={{ types: ['slide-left'] }}
+              className="ml-auto"
+            >
+              View
+            </Link>
+          </Button>
+        ),
+      })
+    } else {
+      toast.warning(
+        `Server "${serverName}" was updated but may still be restarting. Check the servers list to monitor its status.`,
+        {
+          id: toastIdRef.current,
+          duration: 5_000,
+        }
+      )
+    }
+  }, [queryClient, serverName])
+
+  const { mutate: updateServerMutation } = useMutation({
+    mutationFn: async ({ data }: { data: FormSchemaRemoteMcp }) => {
+      let newlyCreatedSecrets: SecretsSecretParameter[] = []
+
+      // Step 1: Group secrets into new and existing
+      const definedSecrets = getDefinedSecrets(data.secrets)
+      const { existingSecrets, newSecrets } = groupSecrets(definedSecrets)
+
+      // Step 2: Fetch existing secrets & handle naming collisions
+      const { data: fetchedSecrets } = await getApiV1BetaSecretsDefaultKeys({
+        throwOnError: true,
+      })
+      const preparedNewSecrets = prepareSecretsWithoutNamingCollision(
+        newSecrets,
+        fetchedSecrets
+      )
+
+      // Step 3: Encrypt secrets
+      if (preparedNewSecrets.length > 0) {
+        newlyCreatedSecrets = await saveSecrets(
+          preparedNewSecrets,
+          saveSecret,
+          options?.onSecretSuccess || (() => {}),
+          options?.onSecretError || (() => {})
+        )
+      }
+
+      // Step 4: Update the workload with all secrets
+      const allSecrets = [
+        ...newlyCreatedSecrets,
+        ...existingSecrets.map((secret) => ({
+          name: secret.value.secret,
+          target: secret.name,
+        })),
+      ]
+      const updateRequest = prepareUpdateWorkloadData(data, allSecrets)
+
+      await updateWorkload({
+        path: { name: serverName },
+        body: updateRequest,
+      })
+      await restartClientNotification({
+        queryClient,
+      })
+      trackEvent(`Workload ${serverName} updated`, {
+        workload: serverName,
+        'route.pathname': '/customize-tools',
+      })
+    },
+  })
+
+  return {
+    updateServerMutation,
+    checkServerStatus: handleSettled,
+  }
+}

--- a/renderer/src/features/mcp-servers/lib/orchestrate-run-remote-server.tsx
+++ b/renderer/src/features/mcp-servers/lib/orchestrate-run-remote-server.tsx
@@ -1,0 +1,250 @@
+import { type UseMutateAsyncFunction } from '@tanstack/react-query'
+import {
+  type PostApiV1BetaSecretsDefaultKeysData,
+  type SecretsSecretParameter,
+  type V1CreateRequest,
+  type V1CreateSecretResponse,
+  type V1ListSecretsResponse,
+  type V1UpdateRequest,
+} from '@api/types.gen'
+import type { Options } from '@api/client'
+import type { FormSchemaRemoteMcp } from './form-schema-remote-mcp'
+import type { DefinedSecret, PreparedSecret } from '@/common/types/secrets'
+import { mapEnvVars, omit } from '@/common/lib/utils'
+
+type SaveSecretFn = UseMutateAsyncFunction<
+  V1CreateSecretResponse,
+  string,
+  Options<PostApiV1BetaSecretsDefaultKeysData>,
+  unknown
+>
+
+/**
+ * Takes all of the secrets from the form and saves them serially to the
+ * secret store. Accepts a `toastId`, which it uses to provide feedback on the
+ * progress of the operation.
+ * // NOTE: We add a short, arbitrary delay to allow the `toast` message that
+ * displays progress to show up-to-date progress.
+ */
+export async function saveSecrets(
+  secrets: PreparedSecret[],
+  saveSecret: SaveSecretFn,
+  onSecretSuccess: (completedCount: number, secretsCount: number) => void,
+  onSecretError: (
+    error: string,
+    variables: Options<PostApiV1BetaSecretsDefaultKeysData>
+  ) => void
+): Promise<SecretsSecretParameter[]> {
+  const secretsCount: number = secrets.length
+  let completedCount: number = 0
+  const createdSecrets: SecretsSecretParameter[] = []
+
+  for (const { secretStoreKey, target, value } of secrets) {
+    const { key: createdKey } = await saveSecret(
+      {
+        body: { key: secretStoreKey, value },
+      },
+      {
+        onError: (error, variables) => {
+          onSecretError(error, variables)
+        },
+        onSuccess: () => {
+          completedCount++
+          onSecretSuccess(completedCount, secretsCount)
+        },
+      }
+    )
+
+    if (!createdKey) {
+      throw new Error(`Failed to create secret for key "${secretStoreKey}"`)
+    }
+
+    // The arbitrary delay a UX/UI affordance to allow the user to see the progress
+    // of the operation. This is not strictly necessary, but it helps to avoid
+    // confusion when many secrets are being created in quick succession.
+    // The delay is between 100 and 500ms
+    await new Promise((resolve) =>
+      setTimeout(
+        resolve,
+        process.env.NODE_ENV === 'test'
+          ? 0
+          : Math.floor(Math.random() * 401) + 100
+      )
+    )
+    createdSecrets.push({
+      /** The name of the secret in the secret store */
+      name: createdKey,
+      /** The property in the MCP server's config that we are mapping the secret to */
+      target: target,
+    })
+  }
+
+  return createdSecrets
+}
+
+/**
+ * Combines the registry server definition, the form fields, and the newly
+ * created secrets from the secret store into a single request object.
+ */
+export function prepareCreateWorkloadData(
+  data: FormSchemaRemoteMcp,
+  secrets: SecretsSecretParameter[] = []
+): V1CreateRequest {
+  const { oauth_config, envVars, ...rest } = data
+  // Transform client_secret from string to SecretsSecretParameter if it exists
+  const transformedOAuthConfig = oauth_config
+    ? {
+        ...oauth_config,
+        client_secret: oauth_config.client_secret
+          ? ({
+              name: 'oauth_client_secret',
+              target: 'client_secret',
+            } as SecretsSecretParameter)
+          : undefined,
+      }
+    : oauth_config
+
+  const request = {
+    ...rest,
+    oauth_config: transformedOAuthConfig,
+    env_vars: mapEnvVars(envVars),
+    secrets,
+  }
+
+  return request
+}
+
+/**
+ * A utility function to filter out secrets that are not defined.
+ */
+export function getDefinedSecrets(
+  secrets: FormSchemaRemoteMcp['secrets']
+): DefinedSecret[] {
+  return secrets.reduce<DefinedSecret[]>((acc, { name, value }) => {
+    if (name && value.secret) {
+      acc.push({
+        name,
+        value: {
+          secret: value.secret,
+          isFromStore: value.isFromStore ?? false,
+        },
+      })
+    }
+    return acc
+  }, [])
+}
+
+/**
+ * Transforms form data into an update request object
+ */
+export function prepareUpdateWorkloadData(
+  data: FormSchemaRemoteMcp,
+  secrets: SecretsSecretParameter[] = []
+): V1UpdateRequest {
+  const { oauth_config, envVars, ...rest } = data
+
+  // Transform client_secret from string to SecretsSecretParameter if it exists
+  const transformedOAuthConfig = oauth_config
+    ? {
+        ...oauth_config,
+        client_secret: oauth_config.client_secret
+          ? ({
+              name: 'oauth_client_secret',
+              target: 'client_secret',
+            } as SecretsSecretParameter)
+          : undefined,
+      }
+    : oauth_config
+
+  return {
+    ...omit(rest, 'auth_type'),
+    oauth_config: transformedOAuthConfig,
+    env_vars: mapEnvVars(envVars),
+    secrets,
+  }
+}
+
+/**
+ * Groups secrets into two categories: new secrets (not from the registry) and
+ * existing secrets (from the registry). We need this separation to know which
+ * secrets need to be encrypted and stored before creating the server workload.
+ */
+export function groupSecrets(secrets: DefinedSecret[]): {
+  newSecrets: DefinedSecret[]
+  existingSecrets: DefinedSecret[]
+} {
+  return secrets.reduce<{
+    newSecrets: DefinedSecret[]
+    existingSecrets: DefinedSecret[]
+  }>(
+    (acc, secret) => {
+      if (secret.value.isFromStore) {
+        acc.existingSecrets.push(secret)
+      } else {
+        acc.newSecrets.push(secret)
+      }
+      return acc
+    },
+    { newSecrets: [], existingSecrets: [] }
+  )
+}
+
+const getAuthType = (
+  oauthConfig?: V1CreateRequest['oauth_config']
+): 'oauth2' | 'oidc' | 'none' => {
+  if (!oauthConfig) return 'none'
+  if (oauthConfig.authorize_url) return 'oauth2'
+  if (oauthConfig.issuer) return 'oidc'
+  return 'none'
+}
+
+// The type of the GET is V1CreateRequest
+export function convertCreateRequestToFormData(
+  createRequest: V1CreateRequest,
+  availableSecrets?: V1ListSecretsResponse
+): FormSchemaRemoteMcp {
+  // Convert secrets from API format to form format
+  const availableSecretKeys = new Set(
+    availableSecrets?.keys?.map((key) => key.key).filter(Boolean) || []
+  )
+
+  const secrets = (createRequest.secrets || []).map((secret) => {
+    const secretKey = secret.name || ''
+    const isFromStore = availableSecretKeys.has(secretKey)
+
+    return {
+      name: secret.target || '',
+      value: {
+        secret: secretKey,
+        isFromStore,
+      },
+    }
+  })
+
+  const authType = getAuthType(createRequest.oauth_config)
+
+  const baseFormData: FormSchemaRemoteMcp = {
+    name: createRequest.name || '',
+    url: createRequest.url || '',
+    transport: createRequest.transport as 'sse' | 'streamable-http',
+    oauth_config: {
+      skip_browser: createRequest.oauth_config?.skip_browser ?? false,
+      use_pkce: createRequest.oauth_config?.use_pkce ?? true,
+      authorize_url: createRequest.oauth_config?.authorize_url,
+      callback_port: createRequest.oauth_config?.callback_port,
+      client_id: createRequest.oauth_config?.client_id,
+      client_secret: createRequest.oauth_config?.client_secret?.name,
+      issuer: createRequest.oauth_config?.issuer,
+      oauth_params: createRequest.oauth_config?.oauth_params,
+      scopes: createRequest.oauth_config?.scopes,
+      token_url: createRequest.oauth_config?.token_url,
+    },
+    auth_type: authType,
+    envVars: Object.entries(createRequest.env_vars || {}).map(
+      ([name, value]) => ({ name, value })
+    ),
+    secrets,
+  }
+
+  return baseFormData
+}


### PR DESCRIPTION
No UI changes in this PR.

Created a bunch of remote mcp form components, not rendering in the UI, only defined. Next PR will render the remote mcp form in the wrapper

```
export function WrapperDialogFormMcp({
  serverType,
  closeDialog,
  serverToEdit,
}: {
  serverType: { local: boolean; remote: boolean }
  closeDialog: () => void
  serverToEdit?: string | null
}) {
  return (
    <DialogFormLocalMcp
      isOpen={serverType.local}
      closeDialog={closeDialog}
      serverToEdit={serverToEdit}
    />
  )
}
```

