### PR TITLE
feat(playground): adjust tool discovery for remote mcp

### DIFF
--- a/renderer/src/features/chat/components/mcp-server-selector.tsx
+++ b/renderer/src/features/chat/components/mcp-server-selector.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getApiV1BetaWorkloadsOptions } from '@api/@tanstack/react-query.gen'
 import type { CoreWorkload } from '@api/types.gen'
+import { toast } from 'sonner'
+import log from 'electron-log/renderer'
 import { Button } from '@/common/components/ui/button'
 import {
   DropdownMenu,
@@ -97,7 +99,8 @@ export function McpServerSelector({
           })
         }
       } catch (error) {
-        console.error('Failed to enable server tools:', error)
+        log.error('Failed to enable server tools:', error)
+        toast.error(`Failed to detect tools for ${serverName}`)
       }
     }
   }


### PR DESCRIPTION
in this PR I’m adjusting the utility function that creates the configuration object for discovering the tools of a running MCP server.

previously, we were filtering workloads by checking if tool_type was mcp. in the case of remote servers, this caused an issue , clicking on a remote server in the playground wouldn’t allow adding tools.

I removed the filtering and simplified the utility to always use the proxy as the MCP URL.

I also removed the various try/catch blocks that were suppressing connection errors, so now errors bubble up to the UI and trigger a toast if something goes wrong.

tested it with notion MCP remote server

https://github.com/user-attachments/assets/c1bb86d7-490b-4437-a9d9-4e1cfbe38308

