### PR TITLE
fix(flatpak): support rootless podman socket

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -170,6 +170,7 @@ const config: ForgeConfig = {
           '--socket=session-bus',
           '--filesystem=/run/docker.sock',
           '--filesystem=/run/podman/podman.sock',
+          '--filesystem=xdg-run/podman/podman.sock',
         ],
         icon: './icons/icon.png',
         files: [],


### PR DESCRIPTION
This change allows flatpak installs on systems that use rootless podman to work as expected. The placeholder `xdg-run` is supported by flatpak, and will be replaced by the users run director. For example, in a typical case it will resolve to `/run/user/1000/podman/podman.sock`.

For more information on the template variable you can see the [docs](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-run).

> --filesystem=FILESYSTEM
> 
>    .... FILESYSTEM can be one of: home, host, host-os, host-etc, xdg-desktop, xdg-documents, xdg-download, xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run, xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir. ....