### PR TITLE
feat(playground): persist thread on storage and adjust tools

### DIFF
--- a/main/src/chat/index.ts
+++ b/main/src/chat/index.ts
@@ -1,7 +1,9 @@
 // Export all chat-related functionality
 export * from './types'
 export * from './providers'
-export * from './storage'
+export * from './settings-storage'
+export * from './threads-storage'
+export * from './thread-integration'
 export * from './mcp-tools'
 export * from './streaming'
 export * from './stream-utils'

--- a/main/src/chat/settings-storage.ts
+++ b/main/src/chat/settings-storage.ts
@@ -8,17 +8,17 @@ import { getHeaders } from '../headers'
 import { getTearingDownState } from '../app-state'
 
 // Chat store types
-export interface ChatSettingsProvider {
+interface ChatSettingsProvider {
   apiKey: string
   enabledTools: string[]
 }
 
-export interface ChatSettingsSelectedModel {
+interface ChatSettingsSelectedModel {
   provider: string
   model: string
 }
 
-export interface ChatSettings {
+interface ChatSettings {
   providers: Record<string, ChatSettingsProvider>
   selectedModel: ChatSettingsSelectedModel
   enabledMcpTools: Record<string, string[]> // serverName -> [toolName1, toolName2]

--- a/main/src/chat/settings-storage.ts
+++ b/main/src/chat/settings-storage.ts
@@ -1,5 +1,28 @@
 import Store from 'electron-store'
 import log from '../logger'
+import { getToolhivePort } from '../toolhive-manager'
+import { createClient } from '@api/client'
+import { getApiV1BetaWorkloads } from '@api/sdk.gen'
+import type { CoreWorkload } from '@api/types.gen'
+import { getHeaders } from '../headers'
+import { getTearingDownState } from '../app-state'
+
+// Chat store types
+export interface ChatSettingsProvider {
+  apiKey: string
+  enabledTools: string[]
+}
+
+export interface ChatSettingsSelectedModel {
+  provider: string
+  model: string
+}
+
+export interface ChatSettings {
+  providers: Record<string, ChatSettingsProvider>
+  selectedModel: ChatSettingsSelectedModel
+  enabledMcpTools: Record<string, string[]> // serverName -> [toolName1, toolName2]
+}
 
 // Type guard functions
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -10,9 +33,7 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string')
 }
 
-function isProvidersRecord(
-  value: unknown
-): value is Record<string, ChatSettings> {
+function isProvidersRecord(value: unknown): value is ChatSettings['providers'] {
   if (!isRecord(value)) return false
   return Object.values(value).every(
     (item) =>
@@ -22,14 +43,14 @@ function isProvidersRecord(
   )
 }
 
-function isToolsRecord(value: unknown): value is Record<string, string[]> {
+function isToolsRecord(
+  value: unknown
+): value is ChatSettings['enabledMcpTools'] {
   if (!isRecord(value)) return false
   return Object.values(value).every((item) => isStringArray(item))
 }
 
-function isSelectedModel(
-  value: unknown
-): value is { provider: string; model: string } {
+function isSelectedModel(value: unknown): value is ChatSettingsSelectedModel {
   return (
     isRecord(value) &&
     typeof value.provider === 'string' &&
@@ -38,34 +59,21 @@ function isSelectedModel(
 }
 
 // Create a secure store for chat settings (API keys and model selection)
-const chatStore = new Store({
+const chatStore = new Store<ChatSettings>({
   name: 'chat-settings',
   encryptionKey: 'toolhive-chat-encryption-key', // Basic encryption for API keys
   defaults: {
-    providers: {} as Record<
-      string,
-      {
-        apiKey: string
-        enabledTools: string[]
-      }
-    >,
+    providers: {},
     selectedModel: {
       provider: '',
       model: '',
     },
-    // Individual tool enablement per server (single source of truth)
-    enabledMcpTools: {} as Record<string, string[]>, // serverName -> [toolName1, toolName2]
+    enabledMcpTools: {},
   },
 })
 
-// Chat settings interface
-interface ChatSettings {
-  apiKey: string
-  enabledTools: string[]
-}
-
 // Get chat settings for a provider
-export function getChatSettings(providerId: string): ChatSettings {
+export function getChatSettings(providerId: string): ChatSettingsProvider {
   try {
     const providers = chatStore.get('providers')
     if (isProvidersRecord(providers)) {
@@ -81,7 +89,7 @@ export function getChatSettings(providerId: string): ChatSettings {
 // Save chat settings for a provider
 export function saveChatSettings(
   providerId: string,
-  settings: ChatSettings
+  settings: ChatSettingsProvider
 ): { success: boolean; error?: string } {
   try {
     const providers = chatStore.get('providers')
@@ -126,7 +134,7 @@ export function clearChatSettings(providerId?: string): {
 }
 
 // Get selected model
-export function getSelectedModel(): { provider: string; model: string } {
+export function getSelectedModel(): ChatSettingsSelectedModel {
   try {
     const selectedModel = chatStore.get('selectedModel')
     if (
@@ -159,20 +167,6 @@ export function saveSelectedModel(
   }
 }
 
-// Get enabled MCP tools for a specific server
-// function getEnabledMcpToolsForServer(serverName: string): string[] {
-//   try {
-//     const enabledMcpTools = chatStore.get('enabledMcpTools')
-//     if (isToolsRecord(enabledMcpTools)) {
-//       return enabledMcpTools[serverName] || []
-//     }
-//     return []
-//   } catch (error) {
-//     log.error('Failed to get enabled MCP tools:', error)
-//     return []
-//   }
-// }
-
 // Save enabled MCP tools for a server
 export function saveEnabledMcpTools(
   serverName: string,
@@ -193,14 +187,77 @@ export function saveEnabledMcpTools(
   }
 }
 
-// Get all enabled MCP tools (global)
-export function getEnabledMcpTools(): Record<string, string[]> {
+// Get all enabled MCP tools (global) - filters out tools from stopped servers
+export async function getEnabledMcpTools(): Promise<
+  ChatSettings['enabledMcpTools']
+> {
   try {
     const enabledMcpTools = chatStore.get('enabledMcpTools')
-    if (isToolsRecord(enabledMcpTools)) {
+    if (!isToolsRecord(enabledMcpTools)) {
+      return {}
+    }
+
+    // Skip validation during shutdown to prevent interrupting teardown
+    if (getTearingDownState()) {
+      log.debug('Skipping MCP tools validation during teardown')
       return enabledMcpTools
     }
-    return {}
+
+    // Get running servers to filter out tools from stopped servers
+    const port = getToolhivePort()
+
+    if (!port) {
+      // If ToolHive is not running, return stored tools without validation
+      return enabledMcpTools
+    }
+
+    try {
+      const client = createClient({
+        baseUrl: `http://localhost:${port}`,
+        headers: getHeaders(),
+      })
+
+      const { data } = await getApiV1BetaWorkloads({
+        client,
+        query: { all: true },
+      })
+
+      const runningServerNames = (data?.workloads || [])
+        .filter((w: CoreWorkload) => w.status === 'running')
+        .map((w: CoreWorkload) => w.name)
+
+      // Filter enabled tools to only include tools from running servers
+      const filteredTools: ChatSettings['enabledMcpTools'] = {}
+      const serversToRemove: string[] = []
+
+      for (const [serverName, tools] of Object.entries(enabledMcpTools)) {
+        if (runningServerNames.includes(serverName)) {
+          filteredTools[serverName] = tools
+        } else if (tools.length > 0) {
+          // Only log if server actually had tools to clean up
+          log.info(`Cleaning up tools for stopped server: ${serverName}`)
+          serversToRemove.push(serverName)
+        }
+      }
+
+      // Remove stopped servers from storage in one operation
+      if (serversToRemove.length > 0) {
+        const updatedTools = { ...enabledMcpTools }
+        for (const serverName of serversToRemove) {
+          delete updatedTools[serverName]
+        }
+        chatStore.set('enabledMcpTools', updatedTools)
+      }
+
+      return filteredTools
+    } catch (apiError) {
+      log.warn(
+        'Failed to check running servers during shutdown, returning stored tools:',
+        apiError
+      )
+      // During shutdown, just return stored tools without validation
+      return enabledMcpTools
+    }
   } catch (error) {
     log.error('Failed to get all enabled MCP tools:', error)
     return {}
@@ -208,9 +265,9 @@ export function getEnabledMcpTools(): Record<string, string[]> {
 }
 
 // Get enabled MCP servers from tools (get servers that have enabled tools)
-export function getEnabledMcpServersFromTools(): string[] {
+export async function getEnabledMcpServersFromTools(): Promise<string[]> {
   try {
-    const allEnabledTools = getEnabledMcpTools()
+    const allEnabledTools = await getEnabledMcpTools()
     const enabledServerNames = Object.keys(allEnabledTools).filter(
       (serverName) => {
         const tools = allEnabledTools[serverName]

--- a/main/src/chat/thread-integration.ts
+++ b/main/src/chat/thread-integration.ts
@@ -1,0 +1,222 @@
+import type { UIMessage } from 'ai'
+import type { LanguageModelV2Usage } from '@ai-sdk/provider'
+import {
+  createThread,
+  getThread,
+  addMessageToThread,
+  setActiveThreadId,
+  generateMessageId,
+  type ChatSettingsThread,
+} from './threads-storage'
+
+/**
+ * Create a new chat thread with an optional initial user message
+ */
+export function createChatThread(title?: string): {
+  success: boolean
+  threadId?: string
+  error?: string
+} {
+  try {
+    return createThread(title)
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+/**
+ * Get messages from a thread in AI SDK format for use with the transport
+ * Validates messages against current tool schemas
+ */
+export async function getThreadMessagesForTransport(
+  threadId: string
+): Promise<ChatSettingsThread['messages']> {
+  const thread = getThread(threadId)
+  if (!thread) {
+    return []
+  }
+
+  if (!thread.messages || thread.messages.length === 0) {
+    return []
+  }
+
+  // Return stored messages directly
+  return thread.messages
+}
+
+/**
+ * Add a new message to an existing thread
+ */
+export function addMessageToExistingThread(
+  threadId: string,
+  role: 'user' | 'assistant' | 'system',
+  text: string,
+  metadata?: {
+    model?: string
+    totalUsage?: LanguageModelV2Usage
+    responseTime?: number
+    finishReason?: string
+  }
+): { success: boolean; messageId?: string; error?: string } {
+  try {
+    const messageId = generateMessageId()
+    const message: UIMessage<{
+      createdAt?: number
+      model?: string
+      totalUsage?: LanguageModelV2Usage
+      responseTime?: number
+      finishReason?: string
+    }> = {
+      id: messageId,
+      role,
+      parts: [{ type: 'text', text }],
+      metadata: {
+        createdAt: Date.now(),
+        ...metadata,
+      },
+    }
+
+    const result = addMessageToThread(threadId, message)
+    return result.success
+      ? { success: true, messageId }
+      : { success: false, error: result.error }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+/**
+ * Get thread info with message count and last activity
+ */
+export function getThreadInfo(threadId: string): {
+  thread: ChatSettingsThread | null
+  messageCount: number
+  lastActivity: Date | null
+  hasUserMessages: boolean
+  hasAssistantMessages: boolean
+} {
+  const thread = getThread(threadId)
+
+  if (!thread) {
+    return {
+      thread: null,
+      messageCount: 0,
+      lastActivity: null,
+      hasUserMessages: false,
+      hasAssistantMessages: false,
+    }
+  }
+
+  const messageCount = thread.messages.length
+  const lastActivity = new Date(thread.lastEditTimestamp)
+  const hasUserMessages = thread.messages.some(
+    (msg: unknown) =>
+      typeof msg === 'object' &&
+      msg !== null &&
+      'role' in msg &&
+      msg.role === 'user'
+  )
+  const hasAssistantMessages = thread.messages.some(
+    (msg: unknown) =>
+      typeof msg === 'object' &&
+      msg !== null &&
+      'role' in msg &&
+      msg.role === 'assistant'
+  )
+
+  return {
+    thread,
+    messageCount,
+    lastActivity,
+    hasUserMessages,
+    hasAssistantMessages,
+  }
+}
+
+/**
+ * Create or get a thread for a chat session
+ * If threadId is provided and exists, return that thread
+ * Otherwise create a new thread
+ */
+export function ensureThreadExists(
+  threadId?: string,
+  title?: string
+): { success: boolean; threadId?: string; error?: string; isNew?: boolean } {
+  try {
+    // If threadId provided, check if it exists
+    if (threadId) {
+      const existingThread = getThread(threadId)
+      if (existingThread) {
+        setActiveThreadId(threadId)
+        return { success: true, threadId, isNew: false }
+      }
+    }
+
+    // Create new thread
+    const result = createThread(title)
+    if (result.success && result.threadId) {
+      return { success: true, threadId: result.threadId, isNew: true }
+    }
+
+    return { success: false, error: result.error }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+/**
+ * Helper to generate a thread title from the first user message
+ */
+export function generateThreadTitle(messages: unknown[]): string {
+  const firstUserMessage = messages.find(
+    (msg: unknown) =>
+      typeof msg === 'object' &&
+      msg !== null &&
+      'role' in msg &&
+      msg.role === 'user'
+  )
+
+  if (
+    !firstUserMessage ||
+    typeof firstUserMessage !== 'object' ||
+    !('parts' in firstUserMessage)
+  ) {
+    return `Chat ${new Date().toLocaleDateString()}`
+  }
+
+  const parts = firstUserMessage.parts
+  if (!Array.isArray(parts)) {
+    return `Chat ${new Date().toLocaleDateString()}`
+  }
+
+  const textPart = parts.find(
+    (part: unknown) =>
+      typeof part === 'object' &&
+      part !== null &&
+      'type' in part &&
+      part.type === 'text' &&
+      'text' in part
+  )
+
+  if (
+    !textPart ||
+    typeof textPart !== 'object' ||
+    !('text' in textPart) ||
+    typeof textPart.text !== 'string'
+  ) {
+    return `Chat ${new Date().toLocaleDateString()}`
+  }
+
+  // Take first 50 characters and add ellipsis if longer
+  const title = textPart.text.trim()
+  return title.length > 50 ? `${title.substring(0, 50)}...` : title
+}

--- a/main/src/chat/threads-storage.ts
+++ b/main/src/chat/threads-storage.ts
@@ -2,44 +2,12 @@ import Store from 'electron-store'
 import log from '../logger'
 import type { LanguageModelV2Usage } from '@ai-sdk/provider'
 import type { UIMessage } from 'ai'
-
-// Chat thread types following ChatSettings naming convention
-export interface ChatSettingsMessageMetadata {
-  createdAt?: number
-  model?: string
-  totalUsage?: LanguageModelV2Usage
-  responseTime?: number
-  finishReason?: string
-}
-
-export interface ChatSettingsMessagePart {
-  type: 'text' | 'image' | 'tool-call' | 'tool-result' | 'step-start'
-  text?: string
-  image?: string | Uint8Array | URL
-  toolCallId?: string
-  toolName?: string
-  args?: Record<string, unknown>
-  result?: unknown
-  isError?: boolean
-}
-
-export interface ChatSettingsMessage {
-  id: string
-  role: 'system' | 'user' | 'assistant' | 'tool'
-  parts: ChatSettingsMessagePart[]
-  metadata?: ChatSettingsMessageMetadata
-}
+import type { ChatUIMessage } from './types'
 
 export interface ChatSettingsThread {
   id: string
   title?: string
-  messages: UIMessage<{
-    createdAt?: number
-    model?: string
-    totalUsage?: LanguageModelV2Usage
-    responseTime?: number
-    finishReason?: string
-  }>[]
+  messages: ChatUIMessage[]
   lastEditTimestamp: number
   createdAt: number
 }

--- a/main/src/chat/threads-storage.ts
+++ b/main/src/chat/threads-storage.ts
@@ -17,7 +17,6 @@ export interface ChatSettingsThreads {
   activeThreadId?: string
 }
 
-// Type guard functions
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -28,7 +27,6 @@ function isUIMessage(value: unknown): boolean {
   if (typeof value.role !== 'string') return false
   if (!Array.isArray(value.parts)) return false
 
-  // Basic validation for UIMessage structure
   return true
 }
 
@@ -49,7 +47,6 @@ function isThreadsRecord(
   return Object.values(value).every((thread) => isThread(thread))
 }
 
-// Create a secure store for chat threads
 const threadsStore = new Store<ChatSettingsThreads>({
   name: 'chat-threads',
   encryptionKey: 'toolhive-threads-encryption-key',
@@ -62,11 +59,6 @@ const threadsStore = new Store<ChatSettingsThreads>({
 // Generate a unique thread ID
 function generateThreadId(): string {
   return `thread_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
-}
-
-// Generate a unique message ID
-export function generateMessageId(): string {
-  return `msg_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
 }
 
 // Create a new thread

--- a/main/src/chat/threads-storage.ts
+++ b/main/src/chat/threads-storage.ts
@@ -12,7 +12,7 @@ export interface ChatSettingsThread {
   createdAt: number
 }
 
-export interface ChatSettingsThreads {
+interface ChatSettingsThreads {
   threads: Record<string, ChatSettingsThread>
   activeThreadId?: string
 }

--- a/main/src/chat/threads-storage.ts
+++ b/main/src/chat/threads-storage.ts
@@ -56,12 +56,10 @@ const threadsStore = new Store<ChatSettingsThreads>({
   },
 })
 
-// Generate a unique thread ID
 function generateThreadId(): string {
   return `thread_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
 }
 
-// Create a new thread
 export function createThread(
   title?: string,
   initialMessages: ChatSettingsThread['messages'] = []
@@ -95,7 +93,6 @@ export function createThread(
   }
 }
 
-// Get a thread by ID
 export function getThread(threadId: string): ChatSettingsThread | null {
   try {
     const threads = threadsStore.get('threads')
@@ -109,7 +106,6 @@ export function getThread(threadId: string): ChatSettingsThread | null {
   }
 }
 
-// Get all threads
 export function getAllThreads(): ChatSettingsThread[] {
   try {
     const threads = threadsStore.get('threads')
@@ -125,7 +121,6 @@ export function getAllThreads(): ChatSettingsThread[] {
   }
 }
 
-// Update a thread
 export function updateThread(
   threadId: string,
   updates: Partial<Omit<ChatSettingsThread, 'id' | 'createdAt'>>
@@ -157,7 +152,6 @@ export function updateThread(
   }
 }
 
-// Add a message to a thread
 export function addMessageToThread(
   threadId: string,
   message: UIMessage<{
@@ -197,7 +191,6 @@ export function addMessageToThread(
   }
 }
 
-// Update messages in a thread (replace all messages)
 export function updateThreadMessages(
   threadId: string,
   messages: ChatSettingsThread['messages']
@@ -233,7 +226,6 @@ export function updateThreadMessages(
   }
 }
 
-// Delete a thread
 export function deleteThread(threadId: string): {
   success: boolean
   error?: string
@@ -265,7 +257,6 @@ export function deleteThread(threadId: string): {
   }
 }
 
-// Get active thread ID
 export function getActiveThreadId(): string | undefined {
   try {
     return threadsStore.get('activeThreadId')
@@ -275,7 +266,6 @@ export function getActiveThreadId(): string | undefined {
   }
 }
 
-// Set active thread ID
 export function setActiveThreadId(threadId: string | undefined): {
   success: boolean
   error?: string
@@ -300,7 +290,6 @@ export function setActiveThreadId(threadId: string | undefined): {
   }
 }
 
-// Clear all threads
 export function clearAllThreads(): { success: boolean; error?: string } {
   try {
     threadsStore.set('threads', {})
@@ -315,7 +304,6 @@ export function clearAllThreads(): { success: boolean; error?: string } {
   }
 }
 
-// Get thread count
 export function getThreadCount(): number {
   try {
     const threads = threadsStore.get('threads')

--- a/main/src/chat/threads-storage.ts
+++ b/main/src/chat/threads-storage.ts
@@ -1,0 +1,370 @@
+import Store from 'electron-store'
+import log from '../logger'
+import type { LanguageModelV2Usage } from '@ai-sdk/provider'
+import type { UIMessage } from 'ai'
+
+// Chat thread types following ChatSettings naming convention
+export interface ChatSettingsMessageMetadata {
+  createdAt?: number
+  model?: string
+  totalUsage?: LanguageModelV2Usage
+  responseTime?: number
+  finishReason?: string
+}
+
+export interface ChatSettingsMessagePart {
+  type: 'text' | 'image' | 'tool-call' | 'tool-result' | 'step-start'
+  text?: string
+  image?: string | Uint8Array | URL
+  toolCallId?: string
+  toolName?: string
+  args?: Record<string, unknown>
+  result?: unknown
+  isError?: boolean
+}
+
+export interface ChatSettingsMessage {
+  id: string
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  parts: ChatSettingsMessagePart[]
+  metadata?: ChatSettingsMessageMetadata
+}
+
+export interface ChatSettingsThread {
+  id: string
+  title?: string
+  messages: UIMessage<{
+    createdAt?: number
+    model?: string
+    totalUsage?: LanguageModelV2Usage
+    responseTime?: number
+    finishReason?: string
+  }>[]
+  lastEditTimestamp: number
+  createdAt: number
+}
+
+export interface ChatSettingsThreads {
+  threads: Record<string, ChatSettingsThread>
+  activeThreadId?: string
+}
+
+// Type guard functions
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isUIMessage(value: unknown): boolean {
+  if (!isRecord(value)) return false
+  if (typeof value.id !== 'string') return false
+  if (typeof value.role !== 'string') return false
+  if (!Array.isArray(value.parts)) return false
+
+  // Basic validation for UIMessage structure
+  return true
+}
+
+function isThread(value: unknown): value is ChatSettingsThread {
+  if (!isRecord(value)) return false
+  if (typeof value.id !== 'string') return false
+  if (typeof value.lastEditTimestamp !== 'number') return false
+  if (typeof value.createdAt !== 'number') return false
+  if (!Array.isArray(value.messages)) return false
+
+  return value.messages.every((msg) => isUIMessage(msg))
+}
+
+function isThreadsRecord(
+  value: unknown
+): value is ChatSettingsThreads['threads'] {
+  if (!isRecord(value)) return false
+  return Object.values(value).every((thread) => isThread(thread))
+}
+
+// Create a secure store for chat threads
+const threadsStore = new Store<ChatSettingsThreads>({
+  name: 'chat-threads',
+  encryptionKey: 'toolhive-threads-encryption-key',
+  defaults: {
+    threads: {},
+    activeThreadId: undefined,
+  },
+})
+
+// Generate a unique thread ID
+function generateThreadId(): string {
+  return `thread_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
+}
+
+// Generate a unique message ID
+export function generateMessageId(): string {
+  return `msg_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
+}
+
+// Create a new thread
+export function createThread(
+  title?: string,
+  initialMessages: ChatSettingsThread['messages'] = []
+): { success: boolean; threadId?: string; error?: string } {
+  try {
+    const threadId = generateThreadId()
+    const now = Date.now()
+
+    const newThread: ChatSettingsThread = {
+      id: threadId,
+      title,
+      messages: initialMessages,
+      lastEditTimestamp: now,
+      createdAt: now,
+    }
+
+    const threads = threadsStore.get('threads')
+    const typedThreads = isThreadsRecord(threads) ? threads : {}
+    typedThreads[threadId] = newThread
+
+    threadsStore.set('threads', typedThreads)
+    threadsStore.set('activeThreadId', threadId)
+
+    return { success: true, threadId }
+  } catch (error) {
+    log.error('[THREADS] Failed to create thread:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+// Get a thread by ID
+export function getThread(threadId: string): ChatSettingsThread | null {
+  try {
+    const threads = threadsStore.get('threads')
+    if (isThreadsRecord(threads)) {
+      return threads[threadId] || null
+    }
+    return null
+  } catch (error) {
+    log.error(`[THREADS] Failed to get thread ${threadId}:`, error)
+    return null
+  }
+}
+
+// Get all threads
+export function getAllThreads(): ChatSettingsThread[] {
+  try {
+    const threads = threadsStore.get('threads')
+    if (isThreadsRecord(threads)) {
+      return Object.values(threads).sort(
+        (a, b) => b.lastEditTimestamp - a.lastEditTimestamp
+      )
+    }
+    return threads
+  } catch (error) {
+    log.error('[THREADS] Failed to get all threads:', error)
+    return []
+  }
+}
+
+// Update a thread
+export function updateThread(
+  threadId: string,
+  updates: Partial<Omit<ChatSettingsThread, 'id' | 'createdAt'>>
+): { success: boolean; error?: string } {
+  try {
+    const threads = threadsStore.get('threads')
+    const typedThreads = isThreadsRecord(threads) ? threads : {}
+
+    if (!typedThreads[threadId]) {
+      return { success: false, error: 'Thread not found' }
+    }
+
+    const updatedThread: ChatSettingsThread = {
+      ...typedThreads[threadId],
+      ...updates,
+      lastEditTimestamp: Date.now(),
+    }
+
+    typedThreads[threadId] = updatedThread
+    threadsStore.set('threads', typedThreads)
+
+    return { success: true }
+  } catch (error) {
+    log.error(`[THREADS] Failed to update thread ${threadId}:`, error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+// Add a message to a thread
+export function addMessageToThread(
+  threadId: string,
+  message: UIMessage<{
+    createdAt?: number
+    model?: string
+    totalUsage?: LanguageModelV2Usage
+    responseTime?: number
+    finishReason?: string
+  }>
+): { success: boolean; error?: string } {
+  try {
+    const threads = threadsStore.get('threads')
+    const typedThreads = isThreadsRecord(threads) ? threads : {}
+
+    if (!typedThreads[threadId]) {
+      return { success: false, error: 'Thread not found' }
+    }
+
+    const updatedMessages = [...typedThreads[threadId].messages, message]
+
+    const updatedThread: ChatSettingsThread = {
+      ...typedThreads[threadId],
+      messages: updatedMessages,
+      lastEditTimestamp: Date.now(),
+    }
+
+    typedThreads[threadId] = updatedThread
+    threadsStore.set('threads', typedThreads)
+
+    return { success: true }
+  } catch (error) {
+    log.error(`[THREADS] Failed to add message to thread ${threadId}:`, error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+// Update messages in a thread (replace all messages)
+export function updateThreadMessages(
+  threadId: string,
+  messages: ChatSettingsThread['messages']
+): { success: boolean; error?: string } {
+  try {
+    const threads = threadsStore.get('threads')
+    const typedThreads = isThreadsRecord(threads) ? threads : {}
+
+    if (!typedThreads[threadId]) {
+      log.info('Thread not found')
+      return { success: false, error: 'Thread not found' }
+    }
+
+    const updatedThread: ChatSettingsThread = {
+      ...typedThreads[threadId],
+      messages,
+      lastEditTimestamp: Date.now(),
+    }
+
+    typedThreads[threadId] = updatedThread
+    threadsStore.set('threads', typedThreads)
+
+    return { success: true }
+  } catch (error) {
+    log.error(
+      `[THREADS] Failed to update messages in thread ${threadId}:`,
+      error
+    )
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+// Delete a thread
+export function deleteThread(threadId: string): {
+  success: boolean
+  error?: string
+} {
+  try {
+    const threads = threadsStore.get('threads')
+    const typedThreads = isThreadsRecord(threads) ? threads : {}
+
+    if (!typedThreads[threadId]) {
+      return { success: false, error: 'Thread not found' }
+    }
+
+    delete typedThreads[threadId]
+    threadsStore.set('threads', typedThreads)
+
+    // If this was the active thread, clear the active thread
+    const activeThreadId = threadsStore.get('activeThreadId')
+    if (activeThreadId === threadId) {
+      threadsStore.set('activeThreadId', undefined)
+    }
+
+    return { success: true }
+  } catch (error) {
+    log.error(`[THREADS] Failed to delete thread ${threadId}:`, error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+// Get active thread ID
+export function getActiveThreadId(): string | undefined {
+  try {
+    return threadsStore.get('activeThreadId')
+  } catch (error) {
+    log.error('[THREADS] Failed to get active thread ID:', error)
+    return undefined
+  }
+}
+
+// Set active thread ID
+export function setActiveThreadId(threadId: string | undefined): {
+  success: boolean
+  error?: string
+} {
+  try {
+    if (threadId) {
+      // Verify thread exists
+      const thread = getThread(threadId)
+      if (!thread) {
+        return { success: false, error: 'Thread not found' }
+      }
+    }
+
+    threadsStore.set('activeThreadId', threadId)
+    return { success: true }
+  } catch (error) {
+    log.error('[THREADS] Failed to set active thread ID:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+// Clear all threads
+export function clearAllThreads(): { success: boolean; error?: string } {
+  try {
+    threadsStore.set('threads', {})
+    threadsStore.set('activeThreadId', undefined)
+    return { success: true }
+  } catch (error) {
+    log.error('[THREADS] Failed to clear all threads:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+// Get thread count
+export function getThreadCount(): number {
+  try {
+    const threads = threadsStore.get('threads')
+    if (isThreadsRecord(threads)) {
+      return Object.keys(threads).length
+    }
+    return 0
+  } catch (error) {
+    log.error('[THREADS] Failed to get thread count:', error)
+    return 0
+  }
+}

--- a/main/src/chat/types.ts
+++ b/main/src/chat/types.ts
@@ -1,13 +1,22 @@
+import type { LanguageModelV2Usage } from '@ai-sdk/provider'
+import type { UIMessage } from 'ai'
+
+// Define message metadata schema for type safety
+interface MessageMetadata {
+  createdAt?: number
+  model?: string
+  totalUsage?: LanguageModelV2Usage
+  responseTime?: number
+  finishReason?: string
+}
+
+// Create a typed UIMessage with our metadata
+export type ChatUIMessage = UIMessage<MessageMetadata>
+
 // Chat request interface
 export interface ChatRequest {
-  messages: Array<{
-    id: string
-    role: 'user' | 'assistant'
-    parts: Array<{
-      type: string
-      text?: string
-    }>
-  }>
+  chatId: string
+  messages: ChatUIMessage[]
   provider: string
   model: string
   apiKey: string

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -63,8 +63,29 @@ import {
   discoverToolSupportedModels,
   fetchOpenRouterModels,
   getToolhiveMcpInfo,
+  // Thread storage functions
+  createThread,
+  getThread,
+  getAllThreads,
+  updateThread,
+  deleteThread,
+  clearAllThreads,
+  getThreadCount,
+  addMessageToThread,
+  updateThreadMessages,
+  getActiveThreadId,
+  setActiveThreadId,
+  // Thread integration functions
+  createChatThread,
+  getThreadMessagesForTransport,
+  addMessageToExistingThread,
+  getThreadInfo,
+  ensureThreadExists,
   type ChatRequest,
+  type ChatSettingsThread,
+  handleChatStreamRealtime,
 } from './chat'
+import type { LanguageModelV2Usage } from '@ai-sdk/provider'
 import { getWorkloadAvailableTools } from './utils/mcp-tools'
 import {
   getQuittingState,
@@ -74,6 +95,7 @@ import {
   setTray,
   getTray,
 } from './app-state'
+import type { UIMessage } from 'ai'
 
 const store = new Store<{
   isTelemetryEnabled: boolean
@@ -619,7 +641,6 @@ ipcMain.handle('chat:get-providers', async () => {
 // Chat streaming endpoint - uses real-time IPC events
 ipcMain.handle('chat:stream', async (event, request: ChatRequest) => {
   const streamId = `stream-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
-  const { handleChatStreamRealtime } = await import('./chat')
 
   // Start streaming (non-blocking)
   handleChatStreamRealtime(request, streamId, event.sender)
@@ -666,6 +687,108 @@ ipcMain.handle(
     saveEnabledMcpTools(serverName, enabledTools)
 )
 ipcMain.handle('chat:get-toolhive-mcp-info', () => getToolhiveMcpInfo())
+
+// ────────────────────────────────────────────────────────────────────────────
+//  Chat Threads Storage IPC handlers
+// ────────────────────────────────────────────────────────────────────────────
+
+// Thread management
+ipcMain.handle(
+  'chat:create-thread',
+  (
+    _,
+    title?: string,
+    initialMessages?: UIMessage<{
+      createdAt?: number
+      model?: string
+      totalUsage?: LanguageModelV2Usage
+      responseTime?: number
+      finishReason?: string
+    }>[]
+  ) => createThread(title, initialMessages)
+)
+ipcMain.handle('chat:get-thread', (_, threadId: string) => getThread(threadId))
+ipcMain.handle('chat:get-all-threads', () => getAllThreads())
+ipcMain.handle(
+  'chat:update-thread',
+  (
+    _,
+    threadId: string,
+    updates: Partial<Omit<ChatSettingsThread, 'id' | 'createdAt'>>
+  ) => updateThread(threadId, updates)
+)
+ipcMain.handle('chat:delete-thread', (_, threadId: string) =>
+  deleteThread(threadId)
+)
+ipcMain.handle('chat:clear-all-threads', () => clearAllThreads())
+ipcMain.handle('chat:get-thread-count', () => getThreadCount())
+
+// Message management
+ipcMain.handle(
+  'chat:add-message-to-thread',
+  (
+    _,
+    threadId: string,
+    message: UIMessage<{
+      createdAt?: number
+      model?: string
+      totalUsage?: LanguageModelV2Usage
+      responseTime?: number
+      finishReason?: string
+    }>
+  ) => addMessageToThread(threadId, message)
+)
+ipcMain.handle(
+  'chat:update-thread-messages',
+  (
+    _,
+    threadId: string,
+    messages: UIMessage<{
+      createdAt?: number
+      model?: string
+      totalUsage?: LanguageModelV2Usage
+      responseTime?: number
+      finishReason?: string
+    }>[]
+  ) => updateThreadMessages(threadId, messages)
+)
+
+// Active thread management
+ipcMain.handle('chat:get-active-thread-id', () => getActiveThreadId())
+ipcMain.handle('chat:set-active-thread-id', (_, threadId?: string) =>
+  setActiveThreadId(threadId)
+)
+
+// High-level thread integration
+ipcMain.handle('chat:create-chat-thread', (_, title?: string) =>
+  createChatThread(title)
+)
+ipcMain.handle(
+  'chat:get-thread-messages-for-transport',
+  (_, threadId: string) => getThreadMessagesForTransport(threadId)
+)
+ipcMain.handle(
+  'chat:add-message-to-existing-thread',
+  (
+    _,
+    threadId: string,
+    role: 'user' | 'assistant' | 'system',
+    text: string,
+    metadata?: {
+      model?: string
+      totalUsage?: LanguageModelV2Usage
+      responseTime?: number
+      finishReason?: string
+    }
+  ) => addMessageToExistingThread(threadId, role, text, metadata)
+)
+ipcMain.handle('chat:get-thread-info', (_, threadId: string) =>
+  getThreadInfo(threadId)
+)
+ipcMain.handle(
+  'chat:ensure-thread-exists',
+  (_, threadId?: string, title?: string) => ensureThreadExists(threadId, title)
+)
 
 // Workload tools discovery handler
 ipcMain.handle('utils:get-workload-available-tools', async (_, workload) =>

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -78,7 +78,6 @@ import {
   // Thread integration functions
   createChatThread,
   getThreadMessagesForTransport,
-  addMessageToExistingThread,
   getThreadInfo,
   ensureThreadExists,
   type ChatRequest,
@@ -766,21 +765,6 @@ ipcMain.handle('chat:create-chat-thread', (_, title?: string) =>
 ipcMain.handle(
   'chat:get-thread-messages-for-transport',
   (_, threadId: string) => getThreadMessagesForTransport(threadId)
-)
-ipcMain.handle(
-  'chat:add-message-to-existing-thread',
-  (
-    _,
-    threadId: string,
-    role: 'user' | 'assistant' | 'system',
-    text: string,
-    metadata?: {
-      model?: string
-      totalUsage?: LanguageModelV2Usage
-      responseTime?: number
-      finishReason?: string
-    }
-  ) => addMessageToExistingThread(threadId, role, text, metadata)
 )
 ipcMain.handle('chat:get-thread-info', (_, threadId: string) =>
   getThreadInfo(threadId)

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@tanstack/react-query-devtools": "^5.80.5",
     "@tanstack/react-router": "^1.120.11",
     "@tanstack/react-router-devtools": "^1.120.11",
-    "ai": "^5.0.40",
+    "ai": "^5.0.44",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 1.17.5
       '@openrouter/ai-sdk-provider':
         specifier: ^1.1.2
-        version: 1.2.0(ai@5.0.40(zod@4.1.5))(zod@4.1.5)
+        version: 1.2.0(ai@5.0.44(zod@4.1.5))(zod@4.1.5)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.2
         version: 1.3.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -111,8 +111,8 @@ importers:
         specifier: ^1.120.11
         version: 1.131.36(@tanstack/react-router@1.131.36(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@tanstack/router-core@1.131.36)(csstype@3.1.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(solid-js@1.9.9)(tiny-invariant@1.3.3)
       ai:
-        specifier: ^5.0.40
-        version: 5.0.40(zod@4.1.5)
+        specifier: ^5.0.44
+        version: 5.0.44(zod@4.1.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -363,6 +363,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  '@ai-sdk/gateway@1.0.23':
+    resolution: {integrity: sha512-ynV7WxpRK2zWLGkdOtrU2hW22mBVkEYVS3iMg1+ZGmAYSgzCqzC74bfOJZ2GU1UdcrFWUsFI9qAYjsPkd+AebA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/google@2.0.13':
     resolution: {integrity: sha512-5WauM+IrqbllWT4uXZVrfTnPCSKTtkHGNsD2CYD0JgGfeIOpa285UYCYUi0Z4RtcovwnZitvQABq465FfeLwzA==}
     engines: {node: '>=18'}
@@ -383,6 +389,12 @@ packages:
 
   '@ai-sdk/provider-utils@3.0.8':
     resolution: {integrity: sha512-cDj1iigu7MW2tgAQeBzOiLhjHOUM9vENsgh4oAVitek0d//WdgfPCsKO3euP7m7LyO/j9a1vr/So+BGNdpFXYw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider-utils@3.0.9':
+    resolution: {integrity: sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -3035,6 +3047,12 @@ packages:
 
   ai@5.0.40:
     resolution: {integrity: sha512-AEKVjVQjnzomEz39f1axnCLtmNRU/BrP12Ou6ztinGhv5u1VxrrRk5qbXugVI0ijeaVwxKQ/SWs0dicUC0qLEA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
+  ai@5.0.44:
+    resolution: {integrity: sha512-l/rdoM4LcRpsRBVvZQBwSU73oNoFGlWj+PcH86QRzxDGJgZqgGItWO0QcKjBNcLDmUjGN1VYd/8J0TAXHJleRQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -7311,6 +7329,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
       zod: 4.1.5
 
+  '@ai-sdk/gateway@1.0.23(zod@4.1.5)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.5)
+      zod: 4.1.5
+
   '@ai-sdk/google@2.0.13(zod@4.1.5)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -7330,6 +7354,13 @@ snapshots:
       zod: 4.1.5
 
   '@ai-sdk/provider-utils@3.0.8(zod@4.1.5)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.1.5
+
+  '@ai-sdk/provider-utils@3.0.9(zod@4.1.5)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
@@ -8556,9 +8587,9 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openrouter/ai-sdk-provider@1.2.0(ai@5.0.40(zod@4.1.5))(zod@4.1.5)':
+  '@openrouter/ai-sdk-provider@1.2.0(ai@5.0.44(zod@4.1.5))(zod@4.1.5)':
     dependencies:
-      ai: 5.0.40(zod@4.1.5)
+      ai: 5.0.44(zod@4.1.5)
       zod: 4.1.5
 
   '@opentelemetry/api-logs@0.57.2':
@@ -10389,6 +10420,14 @@ snapshots:
       '@ai-sdk/gateway': 1.0.21(zod@4.1.5)
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.1.5
+
+  ai@5.0.44(zod@4.1.5):
+    dependencies:
+      '@ai-sdk/gateway': 1.0.23(zod@4.1.5)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.9(zod@4.1.5)
       '@opentelemetry/api': 1.9.0
       zod: 4.1.5
 

--- a/preload/src/preload.ts
+++ b/preload/src/preload.ts
@@ -3,10 +3,10 @@
 
 import { contextBridge, ipcRenderer } from 'electron'
 import type { CoreWorkload } from '../../api/generated/types.gen'
+import type { ChatUIMessage } from '../../main/src/chat/types'
 import { TOOLHIVE_VERSION } from '../../utils/constants'
 import type { UIMessage } from 'ai'
 import type { LanguageModelV2Usage } from '@ai-sdk/provider'
-import type { ChatUIMessage } from '@/features/chat/types'
 
 // Expose auto-launch functionality to renderer
 contextBridge.exposeInMainWorld('electronAPI', {

--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -10,6 +10,7 @@ import { ModelSelector } from './model-selector'
 import { ErrorAlert } from './error-alert'
 
 import { useChatStreaming } from '../hooks/use-chat-streaming'
+import { useConfirm } from '@/common/hooks/use-confirm'
 
 function ChatInterfaceContent() {
   const {
@@ -24,6 +25,7 @@ function ChatInterfaceContent() {
     updateSettings,
     isPersistentLoading,
   } = useChatStreaming()
+  const confirm = useConfirm()
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
@@ -45,6 +47,19 @@ function ChatInterfaceContent() {
   const hasProviderAndModel = settings.provider && settings.model
   const hasMessages = messages.length > 0
 
+  const onClearMessages = useCallback(async () => {
+    const confirmed = await confirm(
+      'Are you sure you want to delete all messages?',
+      {
+        title: 'Clear messages',
+        buttons: { yes: 'Delete', no: 'Cancel' },
+        isDestructive: true,
+      }
+    )
+    if (!confirmed) return
+    clearMessages()
+  }, [clearMessages, confirm])
+
   return (
     <div className="bg-background flex h-full flex-col">
       {/* Model Selection Bar */}
@@ -62,7 +77,7 @@ function ChatInterfaceContent() {
             />
             {hasMessages && (
               <Button
-                onClick={clearMessages}
+                onClick={onClearMessages}
                 variant="ghost"
                 size="sm"
                 className="text-muted-foreground hover:text-foreground"

--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -22,6 +22,7 @@ function ChatInterfaceContent() {
     cancelRequest,
     loadPersistedSettings,
     updateSettings,
+    isPersistentLoading,
   } = useChatStreaming()
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -76,7 +77,29 @@ function ChatInterfaceContent() {
 
       {/* Messages Area */}
       <div className="flex-1 overflow-hidden">
-        {hasMessages ? (
+        {isPersistentLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="flex items-center space-x-3">
+              <div className="flex space-x-1">
+                <div
+                  className="bg-muted-foreground h-2 w-2 animate-bounce
+                    rounded-full [animation-delay:-0.3s]"
+                ></div>
+                <div
+                  className="bg-muted-foreground h-2 w-2 animate-bounce
+                    rounded-full [animation-delay:-0.15s]"
+                ></div>
+                <div
+                  className="bg-muted-foreground h-2 w-2 animate-bounce
+                    rounded-full"
+                ></div>
+              </div>
+              <span className="text-muted-foreground text-sm">
+                Loading chat history...
+              </span>
+            </div>
+          </div>
+        ) : hasMessages ? (
           <div className="h-full overflow-y-auto scroll-smooth">
             <div className="container mx-auto py-8">
               <div className="space-y-8 pr-2">

--- a/renderer/src/features/chat/components/mcp-server-badge.tsx
+++ b/renderer/src/features/chat/components/mcp-server-badge.tsx
@@ -19,14 +19,14 @@ export function McpServerBadge({
   const { data: enabledMcpTools } = useQuery({
     queryKey: ['enabled-mcp-tools'],
     queryFn: () => window.electronAPI.chat.getEnabledMcpTools(),
-    refetchInterval: 2000, // Refresh every 2 seconds to keep counts updated
+    refetchInterval: 5000, // Refresh every 5 seconds
   })
 
   // Fetch server tools data to get total count
   const { data: serverTools } = useQuery({
     queryKey: ['mcp-server-tools', serverName],
     queryFn: () => window.electronAPI.chat.getMcpServerTools(serverName),
-    refetchInterval: 5000, // Refresh every 5 seconds
+    refetchInterval: 7000, // Refresh every 7 seconds
     staleTime: 0,
     refetchOnMount: true,
   })

--- a/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -42,6 +42,16 @@ vi.mock('../../transport/electron-ipc-chat-transport', () => ({
   })),
 }))
 
+vi.mock('../use-thread-management', () => ({
+  useThreadManagement: vi.fn(() => ({
+    currentThreadId: 'toolhive-chat',
+    isLoading: false,
+    error: null,
+    loadMessages: vi.fn().mockResolvedValue([]),
+    clearMessages: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
 // Get references to the mocked functions after mocking
 
 // Mock electron API chat methods
@@ -52,6 +62,11 @@ const mockChatAPI = {
   saveSelectedModel: vi.fn(),
   saveSettings: vi.fn(),
   clearSettings: vi.fn(),
+  getAllThreads: vi.fn(),
+  setActiveThreadId: vi.fn(),
+  createChatThread: vi.fn(),
+  getThreadMessagesForTransport: vi.fn(),
+  updateThreadMessages: vi.fn(),
 }
 
 // Extend the existing window.electronAPI with chat methods
@@ -109,6 +124,14 @@ describe('useChatStreaming', () => {
     mockChatAPI.saveSelectedModel.mockResolvedValue({ success: true })
     mockChatAPI.saveSettings.mockResolvedValue({ success: true })
     mockChatAPI.clearSettings.mockResolvedValue({ success: true })
+    mockChatAPI.getAllThreads.mockResolvedValue([])
+    mockChatAPI.setActiveThreadId.mockResolvedValue({ success: true })
+    mockChatAPI.createChatThread.mockResolvedValue({
+      success: true,
+      threadId: 'toolhive-chat',
+    })
+    mockChatAPI.getThreadMessagesForTransport.mockResolvedValue([])
+    mockChatAPI.updateThreadMessages.mockResolvedValue({ success: true })
 
     // Reset mockUseChat state to default values
     mockUseChat.messages = []

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -90,8 +90,8 @@ export function useChatStreaming() {
   const clearMessages = useCallback(async () => {
     try {
       // Clear both UI state and persistent storage
-      setMessages([])
       await clearThreadMessages()
+      setMessages([])
       setPersistentError(null)
     } catch (err) {
       const errorMessage =

--- a/renderer/src/features/chat/hooks/use-thread-management.ts
+++ b/renderer/src/features/chat/hooks/use-thread-management.ts
@@ -1,0 +1,96 @@
+import { useState, useEffect, useCallback } from 'react'
+import log from 'electron-log/renderer'
+import type { ChatUIMessage } from '../types'
+
+export function useThreadManagement() {
+  const [currentThreadId, setCurrentThreadId] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Get the current thread ID (most recent or create new) Temporary until we have threads
+  useEffect(() => {
+    async function getCurrentThread() {
+      try {
+        setIsLoading(true)
+        setError(null)
+
+        const allThreads = await window.electronAPI.chat.getAllThreads()
+
+        if (allThreads && allThreads.length > 0) {
+          // Find the thread with the latest lastEditTimestamp
+          const mostRecentThread = allThreads.reduce((latest, current) => {
+            return current.lastEditTimestamp > latest.lastEditTimestamp
+              ? current
+              : latest
+          })
+
+          setCurrentThreadId(mostRecentThread.id)
+          window.electronAPI.chat.setActiveThreadId(mostRecentThread.id)
+        } else {
+          // Create new thread only if none exist
+          const result = await window.electronAPI.chat.createChatThread('Chat')
+          if (result.success && result.threadId) {
+            setCurrentThreadId(result.threadId)
+          } else {
+            log.error(`[THREAD] Failed to create thread: ${result.threadId}`)
+            throw new Error(result.error || 'Failed to create thread')
+          }
+        }
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : 'Failed to get current thread'
+        setError(errorMessage)
+        log.error('Failed to get current thread:', err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    getCurrentThread()
+  }, [])
+
+  // Load messages from the current thread
+  const loadMessages = useCallback(async (): Promise<ChatUIMessage[]> => {
+    if (!currentThreadId) {
+      return []
+    }
+
+    try {
+      const messages =
+        await window.electronAPI.chat.getThreadMessagesForTransport(
+          currentThreadId
+        )
+      return messages || []
+    } catch (err) {
+      log.error('Failed to load messages:', err)
+      return []
+    }
+  }, [currentThreadId])
+
+  // Clear messages in the current thread
+  const clearMessages = useCallback(async () => {
+    if (!currentThreadId) return
+
+    try {
+      const result = await window.electronAPI.chat.updateThreadMessages(
+        currentThreadId,
+        []
+      )
+      if (!result.success) {
+        console.error('Failed to clear thread:', result.error)
+        throw new Error(result.error || 'Failed to clear thread')
+      }
+    } catch (err) {
+      log.error('Failed to clear thread messages:', err)
+      throw err
+    }
+  }, [currentThreadId])
+
+  return {
+    currentThreadId,
+    isLoading,
+    error,
+    loadMessages,
+    clearMessages,
+  }
+}

--- a/renderer/src/features/chat/transport/__tests__/electron-ipc-chat-transport.test.ts
+++ b/renderer/src/features/chat/transport/__tests__/electron-ipc-chat-transport.test.ts
@@ -231,6 +231,7 @@ describe('Electron IPC Chat Transport', () => {
       const stream = await transport.sendMessages(defaultOptions)
 
       expect(mockElectronAPI.chat.stream).toHaveBeenCalledWith({
+        chatId: 'test-chat',
         messages: [
           {
             id: 'msg-1',

--- a/renderer/src/features/chat/transport/electron-ipc-chat-transport.ts
+++ b/renderer/src/features/chat/transport/electron-ipc-chat-transport.ts
@@ -69,14 +69,8 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
     }
 
     const backendRequest = {
-      messages: options.messages.map((msg) => ({
-        id: msg.id,
-        role: msg.role,
-        parts: msg.parts.map((part) => ({
-          type: part.type,
-          text: part.type === 'text' ? part.text : '',
-        })),
-      })),
+      chatId: options.chatId,
+      messages: options.messages,
       provider: settings.provider,
       model: settings.model,
       apiKey: settings.apiKey,


### PR DESCRIPTION
This is the first implementation for handling persistent threads, we will save the playground chat in the file system, it's a little bit verbose on IPC side but I will clean up in the next PR

I also adjusted the connection of the MCP tools for the remote ones


https://github.com/user-attachments/assets/c3c2e99d-b777-4e71-a0b7-f81033f27154



