### PR TITLE
feat(toolhive-manager): add sentry on thv process exit

### DIFF
--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -30,6 +30,12 @@ vi.mock('../system-tray')
 vi.mock('../logger')
 vi.mock('@sentry/electron/main', () => ({
   captureMessage: vi.fn(),
+  withScope: vi.fn((callback) => {
+    const mockScope = {
+      addBreadcrumb: vi.fn(),
+    }
+    callback(mockScope)
+  }),
 }))
 
 const mockSpawn = vi.mocked(spawn)
@@ -201,7 +207,7 @@ describe('toolhive-manager', () => {
       )
       expect(mockCaptureMessage).toHaveBeenCalledWith(
         `Failed to start ToolHive: ${JSON.stringify(testError)}`,
-        'error'
+        'fatal'
       )
       expect(mockUpdateTrayStatus).toHaveBeenCalledWith(mockTray, false)
     })

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -238,10 +238,10 @@ describe('toolhive-manager', () => {
 
       const startPromise = startToolhive(mockTray)
 
+      // Advancing the timer actually allows the promise to resolve
       await vi.advanceTimersByTimeAsync(50)
       await startPromise
 
-      // Clear previous calls
       mockCaptureMessage.mockClear()
 
       mockProcess.emit('exit', 1)
@@ -260,7 +260,6 @@ describe('toolhive-manager', () => {
       await vi.advanceTimersByTimeAsync(50)
       await startPromise
 
-      // Clear previous calls
       mockCaptureMessage.mockClear()
 
       mockProcess.emit('exit', 0)
@@ -276,7 +275,6 @@ describe('toolhive-manager', () => {
       await vi.advanceTimersByTimeAsync(50)
       await startPromise
 
-      // Clear previous calls
       mockCaptureMessage.mockClear()
 
       // Create a new mock process for the restart

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -11,10 +11,12 @@ import {
   getToolhiveMcpPort,
   isToolhiveRunning,
   stopToolhive,
+  restartToolhive,
 } from '../toolhive-manager'
 import { updateTrayStatus } from '../system-tray'
 import log from '../logger'
 import * as Sentry from '@sentry/electron/main'
+import { getQuittingState } from '../app-state'
 
 // Mock dependencies
 vi.mock('node:child_process')
@@ -28,6 +30,9 @@ vi.mock('electron', () => ({
 }))
 vi.mock('../system-tray')
 vi.mock('../logger')
+vi.mock('../app-state', () => ({
+  getQuittingState: vi.fn().mockReturnValue(false),
+}))
 vi.mock('@sentry/electron/main', () => ({
   captureMessage: vi.fn(),
   withScope: vi.fn((callback) => {
@@ -45,6 +50,7 @@ const mockApp = vi.mocked(app)
 const mockUpdateTrayStatus = vi.mocked(updateTrayStatus)
 const mockLog = vi.mocked(log)
 const mockCaptureMessage = vi.mocked(Sentry.captureMessage)
+const mockGetQuittingState = vi.mocked(getQuittingState)
 
 // Mock process for testing
 class MockProcess extends EventEmitter {
@@ -225,6 +231,74 @@ describe('toolhive-manager', () => {
       )
       expect(mockUpdateTrayStatus).toHaveBeenCalledWith(mockTray, false)
       expect(isToolhiveRunning()).toBe(false)
+    })
+
+    it('captures Sentry message when process exits unexpectedly', async () => {
+      mockGetQuittingState.mockReturnValue(false)
+
+      const startPromise = startToolhive(mockTray)
+
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
+
+      // Clear previous calls
+      mockCaptureMessage.mockClear()
+
+      mockProcess.emit('exit', 1)
+
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        'ToolHive process exited with code: 1',
+        'fatal'
+      )
+    })
+
+    it('does not capture Sentry message when app is quitting', async () => {
+      mockGetQuittingState.mockReturnValue(true)
+
+      const startPromise = startToolhive(mockTray)
+
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
+
+      // Clear previous calls
+      mockCaptureMessage.mockClear()
+
+      mockProcess.emit('exit', 0)
+
+      expect(mockCaptureMessage).not.toHaveBeenCalled()
+    })
+
+    it('does not capture Sentry message when process exits during restart', async () => {
+      mockGetQuittingState.mockReturnValue(false)
+
+      // Start initial process
+      const startPromise = startToolhive(mockTray)
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
+
+      // Clear previous calls
+      mockCaptureMessage.mockClear()
+
+      // Create a new mock process for the restart
+      const newMockProcess = new MockProcess()
+      mockSpawn.mockReturnValue(
+        newMockProcess as unknown as ReturnType<typeof spawn>
+      )
+
+      // Start restart (this sets isRestarting = true)
+      const restartPromise = restartToolhive(mockTray)
+
+      // Let the original process exit during restart
+      mockProcess.emit('exit', 0)
+
+      await vi.advanceTimersByTimeAsync(50)
+      await restartPromise
+
+      // Advance time to complete restart timeout
+      await vi.advanceTimersByTimeAsync(5000)
+
+      // Should not have called Sentry because isRestarting was true
+      expect(mockCaptureMessage).not.toHaveBeenCalled()
     })
 
     it('assigns different ports to main and MCP services', async () => {

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -105,7 +105,7 @@ async function findFreePort(
 }
 
 export async function startToolhive(tray?: Tray): Promise<void> {
-  Sentry.withScope(async (scope) => {
+  Sentry.withScope<Promise<void>>(async (scope) => {
     if (!existsSync(binPath)) {
       log.error(`ToolHive binary not found at: ${binPath}`)
       return

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -150,13 +150,16 @@ export async function startToolhive(tray?: Tray): Promise<void> {
       log.info(`[ToolHive] Capturing stderr enabled`)
       toolhiveProcess.stderr.on('data', (data) => {
         const output = data.toString().trim()
-        if (output) {
-          scope.addBreadcrumb({
-            category: 'debug',
-            message: `[ToolHive stderr] ${output}`,
-            level: 'log',
-          })
+        if (!output) return
+        if (output.includes('A new version of ToolHive is available')) {
+          return
         }
+        log.error(`[ToolHive stderr] ${output}`)
+        scope.addBreadcrumb({
+          category: 'debug',
+          message: `[ToolHive stderr] ${output}`,
+          level: 'log',
+        })
       })
     }
 

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -7,6 +7,7 @@ import type { Tray } from 'electron'
 import { updateTrayStatus } from './system-tray'
 import log from './logger'
 import * as Sentry from '@sentry/electron/main'
+import { getQuittingState } from './app-state'
 
 const binName = process.platform === 'win32' ? 'thv.exe' : 'thv'
 const binPath = app.isPackaged
@@ -104,65 +105,81 @@ async function findFreePort(
 }
 
 export async function startToolhive(tray?: Tray): Promise<void> {
-  if (!existsSync(binPath)) {
-    log.error(`ToolHive binary not found at: ${binPath}`)
-    return
-  }
-
-  log.info(`APP USER DATA: ${app.getPath('userData')}`)
-  toolhivePort = await findFreePort(50000, 50100)
-  toolhiveMcpPort = await findFreePort()
-  log.info(
-    `Starting ToolHive from: ${binPath} on port ${toolhivePort}, MCP on port ${toolhiveMcpPort}`
-  )
-
-  toolhiveProcess = spawn(
-    binPath,
-    [
-      'serve',
-      '--openapi',
-      '--experimental-mcp',
-      '--experimental-mcp-host=127.0.0.1',
-      `--experimental-mcp-port=${toolhiveMcpPort}`,
-      '--host=127.0.0.1',
-      `--port=${toolhivePort}`,
-    ],
-    {
-      stdio: ['ignore', 'ignore', 'pipe'],
-      detached: false,
+  Sentry.withScope(async (scope) => {
+    if (!existsSync(binPath)) {
+      log.error(`ToolHive binary not found at: ${binPath}`)
+      return
     }
-  )
 
-  log.info(`[startToolhive] Process spawned with PID: ${toolhiveProcess.pid}`)
+    toolhivePort = await findFreePort(50000, 50100)
+    toolhiveMcpPort = await findFreePort()
+    log.info(
+      `Starting ToolHive from: ${binPath} on port ${toolhivePort}, MCP on port ${toolhiveMcpPort}`
+    )
 
-  if (tray) {
-    updateTrayStatus(tray, !!toolhiveProcess)
-  }
+    toolhiveProcess = spawn(
+      binPath,
+      [
+        'serve',
+        '--openapi',
+        '--experimental-mcp',
+        '--experimental-mcp-host=127.0.0.1',
+        `--experimental-mcp-port=${toolhiveMcpPort}`,
+        '--host=127.0.0.1',
+        `--port=${toolhivePort}`,
+      ],
+      {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        detached: false,
+      }
+    )
 
-  // Capture and log stderr
-  if (toolhiveProcess.stderr) {
-    log.info(`[ToolHive] Capturing stderr enabled`)
-    toolhiveProcess.stderr.on('data', (data) => {
-      const output = data.toString().trim()
-      if (output) {
-        log.error(`[ToolHive stderr] ${output}`)
+    log.info(`[startToolhive] Process spawned with PID: ${toolhiveProcess.pid}`)
+
+    scope.addBreadcrumb({
+      category: 'debug',
+      message: `Starting ToolHive from: ${binPath} on port ${toolhivePort}, MCP on port ${toolhiveMcpPort}, PID: ${toolhiveProcess.pid}`,
+    })
+
+    if (tray) {
+      updateTrayStatus(tray, !!toolhiveProcess)
+    }
+
+    // Capture and log stderr
+    if (toolhiveProcess.stderr) {
+      log.info(`[ToolHive] Capturing stderr enabled`)
+      toolhiveProcess.stderr.on('data', (data) => {
+        const output = data.toString().trim()
+        if (output) {
+          scope.addBreadcrumb({
+            category: 'debug',
+            message: `[ToolHive stderr] ${output}`,
+            level: 'log',
+          })
+        }
+      })
+    }
+
+    toolhiveProcess.on('error', (error) => {
+      log.error('Failed to start ToolHive: ', error)
+      Sentry.captureMessage(
+        `Failed to start ToolHive: ${JSON.stringify(error)}`,
+        'fatal'
+      )
+      if (tray) updateTrayStatus(tray, false)
+    })
+
+    toolhiveProcess.on('exit', (code) => {
+      log.warn(`ToolHive process exited with code: ${code}`)
+      toolhiveProcess = undefined
+      if (tray) updateTrayStatus(tray, false)
+      if (!isRestarting && !getQuittingState()) {
+        Sentry.captureMessage(
+          `ToolHive process exited with code: ${code}`,
+          'fatal'
+        )
       }
     })
-  }
-
-  toolhiveProcess.on('error', (error) => {
-    log.error('Failed to start ToolHive: ', error)
-    Sentry.captureMessage(
-      `Failed to start ToolHive: ${JSON.stringify(error)}`,
-      'error'
-    )
-    if (tray) updateTrayStatus(tray, false)
-  })
-
-  toolhiveProcess.on('exit', (code) => {
-    log.warn(`ToolHive process exited with code: ${code}`)
-    toolhiveProcess = undefined
-    if (tray) updateTrayStatus(tray, false)
   })
 }
 
@@ -189,7 +206,7 @@ export async function restartToolhive(tray?: Tray): Promise<void> {
     log.error('Failed to restart ToolHive: ', error)
     Sentry.captureMessage(
       `Failed to restart ToolHive: ${JSON.stringify(error)}`,
-      'error'
+      'fatal'
     )
   } finally {
     // avoid another restart until process is stabilized


### PR DESCRIPTION
## Changes
- **Wrap ToolHive startup in Sentry scope** for better crash context and debugging
- **Add process exit crash reporting** with conditional logic to avoid noise:
  - Report crashes when ToolHive exits unexpectedly (`fatal` severity)
  - Skip reporting during normal app shutdown or restart operations
- **Enhanced debugging context** with breadcrumbs for process lifecycle and stderr output

### Implementation Details
- Uses `Sentry.withScope()` to capture startup context and process metadata
- Captures stderr output as breadcrumbs for better crash diagnosis
- Conditional reporting based on `isRestarting` flag and app quitting state
