### PR TITLE
chore: upgrade thv to v0.3.3

### DIFF
--- a/api/generated/types.gen.ts
+++ b/api/generated/types.gen.ts
@@ -664,6 +664,10 @@ export type RunnerRunConfig = {
    */
   debug?: boolean
   /**
+   * EnvFileDir is the directory path to load environment files from
+   */
+  env_file_dir?: string
+  /**
    * EnvVars are the parsed environment variables as key-value pairs
    */
   env_vars?: {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -738,6 +738,10 @@
             "description": "Debug indicates whether debug mode is enabled",
             "type": "boolean"
           },
+          "env_file_dir": {
+            "description": "EnvFileDir is the directory path to load environment files from",
+            "type": "string"
+          },
           "env_vars": {
             "additionalProperties": { "type": "string" },
             "description": "EnvVars are the parsed environment variables as key-value pairs",

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,1 +1,1 @@
-export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.3.1'
+export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.3.3'


### PR DESCRIPTION
The secrets provider issue is fixed


**custom mcp**
https://github.com/user-attachments/assets/e6375587-3b79-4cae-96bc-5362f717723d

**registry mcp**
https://github.com/user-attachments/assets/b3257b87-296d-4c23-9f7f-313caa01baea

