### PR TITLE
fix(playground): adjust storage for settings and clean state

### DIFF
--- a/main/src/chat/settings-storage.ts
+++ b/main/src/chat/settings-storage.ts
@@ -178,6 +178,7 @@ export function saveEnabledMcpTools(
     const enabledMcpTools = chatStore.get('enabledMcpTools')
     const typedTools = isToolsRecord(enabledMcpTools) ? enabledMcpTools : {}
     typedTools[serverName] = toolNames
+    chatStore.set('enabledMcpTools', typedTools)
     return { success: true }
   } catch (error) {
     return {

--- a/renderer/src/features/chat/components/chat-message.tsx
+++ b/renderer/src/features/chat/components/chat-message.tsx
@@ -412,7 +412,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
           {/* Message Content */}
           <div className="space-y-2">
             <div
-              className="bg-primary text-primary-foreground rounded-2xl
+              className="bg-secondary text-secondary-foreground rounded-2xl
                 rounded-br-md px-4 py-3 shadow-sm"
             >
               <div className="break-words">

--- a/renderer/src/features/chat/components/mcp-server-selector.tsx
+++ b/renderer/src/features/chat/components/mcp-server-selector.tsx
@@ -45,17 +45,20 @@ export function McpServerSelector() {
         // First get the server's available tools
         const serverTools =
           await window.electronAPI.chat.getMcpServerTools(serverName)
-
         if (serverTools?.tools && serverTools.tools.length > 0) {
           const allToolNames = serverTools.tools.map((tool) => tool.name)
-          await window.electronAPI.chat.saveEnabledMcpTools(
+          const response = await window.electronAPI.chat.saveEnabledMcpTools(
             serverName,
             allToolNames
           )
-          // Invalidate query to refetch latest state
-          queryClient.invalidateQueries({
-            queryKey: ['chat', 'enabledMcpServers'],
-          })
+          if (response.success) {
+            // Invalidate query to refetch latest state
+            queryClient.invalidateQueries({
+              queryKey: ['chat', 'enabledMcpServers'],
+            })
+          } else {
+            toast.error(`Failed to enable server tools for ${serverName}`)
+          }
         }
       } catch (error) {
         log.error('Failed to enable server tools:', error)

--- a/renderer/src/features/chat/hooks/use-chat-settings.ts
+++ b/renderer/src/features/chat/hooks/use-chat-settings.ts
@@ -80,7 +80,10 @@ export function useChatSettings() {
     useSelectedModel()
   const { data: providerSettings, isLoading: isProviderSettingsLoading } =
     useProviderSettings(selectedModel?.provider || '')
-  const allProvidersWithSettingsQuery = useAllProvidersWithSettings()
+  const {
+    data: allProvidersWithSettings,
+    isLoading: isAllProviderWithSettingsLoading,
+  } = useAllProvidersWithSettings()
 
   // Query for enabled MCP servers (this is what the UI uses)
   const { data: enabledMcpServers = [], isLoading: isMcpServersLoading } =
@@ -107,16 +110,10 @@ export function useChatSettings() {
 
   // Combine the data into a single ChatSettings object
   const settings: ChatSettings = useMemo(() => {
-    // Use the same logic as the UI: only include tools from servers in enabledMcpServers
     const mcpToolNames: string[] = []
 
-    // Get enabled server names (remove 'mcp_' prefix) - same as UI logic
-    const enabledServerNames = enabledMcpServers.map((serverId: string) =>
-      serverId.replace('mcp_', '')
-    )
-
     // Include tools from all servers that are enabled (same as UI)
-    for (const serverName of enabledServerNames) {
+    for (const serverName of enabledMcpServers) {
       const serverTools = enabledMcpTools[serverName] || []
       mcpToolNames.push(...serverTools)
     }
@@ -271,8 +268,8 @@ export function useChatSettings() {
       updateEnabledTools,
       updateProviderSettingsMutation,
       loadPersistedSettings,
-      allProvidersWithSettings: allProvidersWithSettingsQuery.data || [],
-      isLoadingProviders: allProvidersWithSettingsQuery.isLoading,
+      allProvidersWithSettings: allProvidersWithSettings || [],
+      isLoadingProviders: isAllProviderWithSettingsLoading,
       isLoading: combinedIsLoading,
     }),
     [
@@ -281,8 +278,8 @@ export function useChatSettings() {
       updateEnabledTools,
       updateProviderSettingsMutation,
       loadPersistedSettings,
-      allProvidersWithSettingsQuery.data,
-      allProvidersWithSettingsQuery.isLoading,
+      allProvidersWithSettings,
+      isAllProviderWithSettingsLoading,
       combinedIsLoading,
     ]
   )


### PR DESCRIPTION
when we select API keys for the first time, we need to auto-select the model as well, since we no longer always show the selector. there was also an issue saving chatStore for `saveEnabledMcpTools`  the set got removed by mistake.

I also change the background of the user bubble box in the chat, there was a problem when is contained a link

<img width="1039" height="698" alt="Screenshot 2025-09-19 at 12 48 52" src="https://github.com/user-attachments/assets/867119c5-bc11-4dee-9e14-ca41272a358f" />

<img width="1041" height="698" alt="Screenshot 2025-09-19 at 12 49 10" src="https://github.com/user-attachments/assets/d7422d54-29a2-434e-a1f8-44995bb1cf87" />
