### PR TITLE
fix: make disabled group dot visible in dark mode

### DIFF
--- a/renderer/src/features/mcp-servers/components/groups-manager/group.tsx
+++ b/renderer/src/features/mcp-servers/components/groups-manager/group.tsx
@@ -23,8 +23,9 @@ export function Group(props: {
       <div className="flex min-w-0 items-center gap-2">
         <span
           aria-hidden
-          className={`inline-block size-[7px] rounded-full
-            ${isEnabled ? 'bg-green-600' : 'bg-zinc-900/20'}`}
+          className={`inline-block size-[7px] shrink-0 rounded-full ${
+            isEnabled ? 'bg-green-600' : 'bg-zinc-900/20 dark:bg-zinc-200/50'
+          }`}
         />
         <span className="truncate">{name}</span>
       </div>

--- a/renderer/src/index.css
+++ b/renderer/src/index.css
@@ -5,7 +5,8 @@
 
 @source '../../node_modules/streamdown/dist/index.js';
 
-@custom-variant dark (&: is(.dark *));
+/* Ensure Tailwind's `dark:` variant targets when any ancestor has `.dark` */
+@custom-variant dark (.dark &);
 
 @theme inline {
   --font-sans: 'Inter Variable', sans-serif;


### PR DESCRIPTION
related to https://github.com/stacklok/toolhive-studio/issues/904


see also: https://stacklok.slack.com/archives/C091GRYAG49/p1758275229195199?thread_ts=1758210348.300909&cid=C091GRYAG49 


#### Before: 

<img width="266" height="209" alt="Screenshot_select-area_20250919131901" src="https://github.com/user-attachments/assets/f45bc518-b888-468a-9f2d-ab16b424bcfb" />


#### After:

<img width="269" height="211" alt="Screenshot_select-area_20250919140649" src="https://github.com/user-attachments/assets/b4aea4d5-57fe-4ad8-b1b3-546b6b8acb3a" />
