### PR TITLE
fix: check on isMaximized, warning tooltip, unreliable isToolhiveRunning and change log severity for thv stderr

### DIFF
--- a/main/src/main-window.ts
+++ b/main/src/main-window.ts
@@ -308,7 +308,10 @@ export function toggleMaximizeMainWindow(): void {
  */
 export function isMainWindowMaximized(): boolean {
   try {
-    return mainWindow?.isMaximized() ?? false
+    if (!isMainWindowValid()) {
+      return false
+    }
+    return mainWindow!.isMaximized()
   } catch (error) {
     log.error('Failed to check if window is maximized:', error)
     return false

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -154,7 +154,7 @@ export async function startToolhive(tray?: Tray): Promise<void> {
         if (output.includes('A new version of ToolHive is available')) {
           return
         }
-        log.error(`[ToolHive stderr] ${output}`)
+        log.info(`[ToolHive stderr] ${output}`)
         scope.addBreadcrumb({
           category: 'debug',
           message: `[ToolHive stderr] ${output}`,

--- a/renderer/src/common/components/ui/tooltip.tsx
+++ b/renderer/src/common/components/ui/tooltip.tsx
@@ -35,12 +35,19 @@ function Tooltip({ onlyWhenTruncated = false, ...props }: TooltipProps) {
     [onlyWhenTruncated]
   )
 
-  const effectiveOpen = onlyWhenTruncated
-    ? // if not truncated, force closed; otherwise respect consumer control
-      isTruncated
-      ? props.open
-      : false
-    : props.open
+  const effectiveOpen = React.useMemo(() => {
+    if (!onlyWhenTruncated) {
+      return props.open
+    }
+
+    // When onlyWhenTruncated is enabled, only show tooltip if text is truncated
+    if (!isTruncated) {
+      return false
+    }
+
+    // Text is truncated, respect consumer control or default to false
+    return props.open ?? false
+  }, [onlyWhenTruncated, isTruncated, props.open])
 
   return (
     <TooltipProvider>

--- a/renderer/src/routes/__root.tsx
+++ b/renderer/src/routes/__root.tsx
@@ -100,6 +100,7 @@ export const Route = createRootRouteWithContext<{
       },
       retry: 3,
       retryDelay: 300,
+      staleTime: 0,
     })
     try {
       await queryClient.ensureQueryData({


### PR DESCRIPTION
## Batch Fixes

**Fixes multiple UI and stability issues:**

- **Fix Electron window destroyed error** - Add validation before calling `isMaximized` on destroyed windows
- **Fix tooltip controlled/uncontrolled warning** - Ensure consistent state management in tooltip component  
- **Fix ToolHive status polling** - Add `staleTime: 0` for accurate running state checks
- **Improve logging** - Change ToolHive stderr from error to info level

**Impact:** Resolves Sentry error reports and React warnings, improving app stability.