### PR TITLE
fix: validate callback_port range value

### DIFF
--- a/renderer/src/common/lib/workloads/remote/__tests__/form-schema-remote-mcp.test.ts
+++ b/renderer/src/common/lib/workloads/remote/__tests__/form-schema-remote-mcp.test.ts
@@ -158,7 +158,7 @@ describe('getFormSchemaRemoteMcp', () => {
       const errors = result.error?.issues.map((issue) => issue.message)
       expect(errors).toContain('Authorize URL is required for OAuth 2.0')
       expect(errors).toContain('Token URL is required for OAuth2')
-      expect(errors).toContain('Client ID is required for OAuth 2.0 ')
+      expect(errors).toContain('Client ID is required for OAuth 2.0')
     })
   })
 

--- a/renderer/src/common/lib/workloads/remote/__tests__/form-schema-remote-mcp.test.ts
+++ b/renderer/src/common/lib/workloads/remote/__tests__/form-schema-remote-mcp.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from 'vitest'
+import { getFormSchemaRemoteMcp } from '../form-schema-remote-mcp'
+
+describe('getFormSchemaRemoteMcp', () => {
+  const baseValidInput = {
+    name: 'test-remote-server',
+    url: 'https://api.example.com/mcp',
+    transport: 'streamable-http' as const,
+    auth_type: 'none' as const,
+    oauth_config: {
+      authorize_url: '',
+      callback_port: 8080,
+      client_id: '',
+      client_secret: undefined,
+      issuer: '',
+      oauth_params: {},
+      scopes: '',
+      skip_browser: false,
+      token_url: '',
+      use_pkce: true,
+    },
+    envVars: [],
+    secrets: [],
+  }
+
+  describe('auth_type: "none"', () => {
+    const noneAuthInput = {
+      ...baseValidInput,
+      auth_type: 'none' as const,
+    }
+
+    it('passes with valid callback_port', () => {
+      const input = {
+        ...noneAuthInput,
+        oauth_config: {
+          ...noneAuthInput.oauth_config,
+          callback_port: 50051,
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success, `${result.error}`).toBe(true)
+    })
+
+    it('fails when callback_port is not defined (required)', () => {
+      const input = {
+        ...noneAuthInput,
+        oauth_config: {
+          ...noneAuthInput.oauth_config,
+          callback_port: undefined,
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const portError = result.error?.issues.find((issue) =>
+        issue.path.includes('callback_port')
+      )
+      expect(portError?.message).toBe('Callback port is required')
+    })
+
+    it('fails when callback_port is below 1024', () => {
+      const input = {
+        ...noneAuthInput,
+        oauth_config: {
+          ...noneAuthInput.oauth_config,
+          callback_port: 1023,
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const portError = result.error?.issues.find((issue) =>
+        issue.path.includes('callback_port')
+      )
+      expect(portError?.message).toBe('Port must be between 1024 and 65535')
+    })
+
+    it('fails when callback_port is above 65535', () => {
+      const input = {
+        ...noneAuthInput,
+        oauth_config: {
+          ...noneAuthInput.oauth_config,
+          callback_port: 65536,
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const portError = result.error?.issues.find((issue) =>
+        issue.path.includes('callback_port')
+      )
+      expect(portError?.message).toBe('Port must be between 1024 and 65535')
+    })
+  })
+
+  describe('auth_type: "oauth2"', () => {
+    const oauth2Input = {
+      ...baseValidInput,
+      auth_type: 'oauth2' as const,
+      oauth_config: {
+        ...baseValidInput.oauth_config,
+        authorize_url: 'https://auth.example.com/oauth/authorize',
+        token_url: 'https://auth.example.com/oauth/token',
+        client_id: 'test-client-id',
+      },
+    }
+
+    it('passes with all required fields and valid callback_port', () => {
+      const input = {
+        ...oauth2Input,
+        oauth_config: {
+          ...oauth2Input.oauth_config,
+          callback_port: 8080,
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success, `${result.error}`).toBe(true)
+    })
+
+    it('passes without callback_port (optional for oauth2)', () => {
+      const result = getFormSchemaRemoteMcp([]).safeParse(oauth2Input)
+      expect(result.success, `${result.error}`).toBe(true)
+    })
+
+    it('fails with invalid callback_port range', () => {
+      const input = {
+        ...oauth2Input,
+        oauth_config: {
+          ...oauth2Input.oauth_config,
+          callback_port: 1023,
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const portError = result.error?.issues.find((issue) =>
+        issue.path.includes('callback_port')
+      )
+      expect(portError?.message).toBe('Port must be between 1024 and 65535')
+    })
+
+    it('fails when required oauth2 fields are missing', () => {
+      const input = {
+        ...baseValidInput,
+        auth_type: 'oauth2' as const,
+        oauth_config: {
+          ...baseValidInput.oauth_config,
+          authorize_url: '',
+          token_url: '',
+          client_id: '',
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const errors = result.error?.issues.map((issue) => issue.message)
+      expect(errors).toContain('Authorize URL is required for OAuth 2.0')
+      expect(errors).toContain('Token URL is required for OAuth2')
+      expect(errors).toContain('Client ID is required for OAuth 2.0 ')
+    })
+  })
+
+  describe('auth_type: "oidc"', () => {
+    const oidcInput = {
+      ...baseValidInput,
+      auth_type: 'oidc' as const,
+      oauth_config: {
+        ...baseValidInput.oauth_config,
+        issuer: 'https://auth.example.com/',
+        client_id: 'test-client-id',
+      },
+    }
+
+    it('passes with all required fields and valid callback_port', () => {
+      const input = {
+        ...oidcInput,
+        oauth_config: {
+          ...oidcInput.oauth_config,
+          callback_port: 8080,
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success, `${result.error}`).toBe(true)
+    })
+
+    it('passes without callback_port (optional for oidc)', () => {
+      const result = getFormSchemaRemoteMcp([]).safeParse(oidcInput)
+      expect(result.success, `${result.error}`).toBe(true)
+    })
+
+    it('fails with invalid callback_port range', () => {
+      const input = {
+        ...oidcInput,
+        oauth_config: {
+          ...oidcInput.oauth_config,
+          callback_port: 65536,
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const portError = result.error?.issues.find((issue) =>
+        issue.path.includes('callback_port')
+      )
+      expect(portError?.message).toBe('Port must be between 1024 and 65535')
+    })
+
+    it('fails when required oidc fields are missing', () => {
+      const input = {
+        ...baseValidInput,
+        auth_type: 'oidc' as const,
+        oauth_config: {
+          ...baseValidInput.oauth_config,
+          issuer: '',
+          client_id: '',
+        },
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const errors = result.error?.issues.map((issue) => issue.message)
+      expect(errors).toContain('Issuer URL is required for OIDC')
+      expect(errors).toContain('Client ID is required for OIDC')
+    })
+  })
+
+  describe('base field validation', () => {
+    it('passes with all valid required fields', () => {
+      const result = getFormSchemaRemoteMcp([]).safeParse(baseValidInput)
+      expect(result.success, `${result.error}`).toBe(true)
+      expect(result.data).toMatchObject({
+        name: 'test-remote-server',
+        url: 'https://api.example.com/mcp',
+        transport: 'streamable-http',
+        auth_type: 'none',
+      })
+    })
+
+    it('fails when name is empty', () => {
+      const input = {
+        ...baseValidInput,
+        name: '',
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const nameError = result.error?.issues.find((issue) =>
+        issue.path.includes('name')
+      )
+      expect(nameError?.message).toBe('Name is required')
+    })
+
+    it('fails when url is empty', () => {
+      const input = {
+        ...baseValidInput,
+        url: '',
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const urlError = result.error?.issues.find((issue) =>
+        issue.path.includes('url')
+      )
+      expect(urlError?.message).toBe('The MCP server URL is required')
+    })
+
+    it('fails when name contains invalid characters', () => {
+      const input = {
+        ...baseValidInput,
+        name: 'invalid name with spaces!',
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const nameError = result.error?.issues.find((issue) =>
+        issue.path.includes('name')
+      )
+      expect(nameError?.message).toContain('Invalid server name')
+    })
+
+    it('fails when name is already in use', () => {
+      const existingWorkloads = [{ name: 'test-remote-server' }] as Array<{
+        name: string
+      }>
+
+      const result =
+        getFormSchemaRemoteMcp(existingWorkloads).safeParse(baseValidInput)
+      expect(result.success).toBe(false)
+      const nameError = result.error?.issues.find((issue) =>
+        issue.path.includes('name')
+      )
+      expect(nameError?.message).toBe('This name is already in use')
+    })
+
+    it('passes with valid transport types', () => {
+      const input = {
+        ...baseValidInput,
+        transport: 'sse' as const,
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success, `${result.error}`).toBe(true)
+    })
+  })
+
+  describe('environment variables and secrets', () => {
+    it('passes with valid environment variables and secrets', () => {
+      const input = {
+        ...baseValidInput,
+        envVars: [{ name: 'API_KEY', value: 'test-key' }],
+        secrets: [
+          {
+            name: 'SECRET_TOKEN',
+            value: { secret: 'secret-value', isFromStore: false },
+          },
+        ],
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success, `${result.error}`).toBe(true)
+    })
+
+    it('fails with invalid environment variable name', () => {
+      const input = {
+        ...baseValidInput,
+        envVars: [{ name: '', value: 'test-key' }],
+      }
+
+      const result = getFormSchemaRemoteMcp([]).safeParse(input)
+      expect(result.success).toBe(false)
+      const envVarError = result.error?.issues.find((issue) =>
+        issue.path.includes('envVars')
+      )
+      expect(envVarError?.message).toBe('Name is required')
+    })
+  })
+})

--- a/renderer/src/common/lib/workloads/remote/form-schema-remote-mcp.ts
+++ b/renderer/src/common/lib/workloads/remote/form-schema-remote-mcp.ts
@@ -16,7 +16,7 @@ const OAUTH_VALIDATION_RULES = {
     },
     {
       field: 'client_id',
-      message: 'Client ID is required for OAuth 2.0 ',
+      message: 'Client ID is required for OAuth 2.0',
       path: ['oauth_config', 'client_id'],
     },
   ],

--- a/renderer/src/features/mcp-servers/components/local-mcp/dialog-form-local-mcp.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/dialog-form-local-mcp.tsx
@@ -168,6 +168,7 @@ export function DialogFormLocalMcp({
           onSuccess: () => {
             checkServerStatus({ serverName: data.name, groupName, isEditing })
             closeDialog()
+            form.reset()
           },
           onSettled: (_, error) => {
             setIsSubmitting(false)

--- a/renderer/src/features/mcp-servers/components/remote-mcp/dialog-form-remote-mcp.tsx
+++ b/renderer/src/features/mcp-servers/components/remote-mcp/dialog-form-remote-mcp.tsx
@@ -153,6 +153,7 @@ export function DialogFormRemoteMcp({
           onSuccess: () => {
             checkServerStatus({ serverName: data.name, groupName, isEditing })
             closeDialog()
+            form.reset()
           },
           onSettled: (_, error) => {
             setIsSubmitting(false)

--- a/renderer/src/features/mcp-servers/components/remote-mcp/form-fields-auth.tsx
+++ b/renderer/src/features/mcp-servers/components/remote-mcp/form-fields-auth.tsx
@@ -172,9 +172,10 @@ export function FormFieldsAuth({
                 data-1p-ignore
                 placeholder="e.g. 50051"
                 value={field.value || ''}
-                onChange={(e) => {
+                onChange={async (e) => {
                   const value = e.target.value
                   field.onChange(value === '' ? '' : parseInt(value, 10))
+                  await form.trigger()
                 }}
                 name={field.name}
               />

--- a/renderer/src/features/registry-servers/components/dialog-form-remote-registry-mcp.tsx
+++ b/renderer/src/features/registry-servers/components/dialog-form-remote-registry-mcp.tsx
@@ -135,6 +135,7 @@ export function DialogFormRemoteRegistryMcp({
         onSuccess: () => {
           checkServerStatus({ serverName: data.name, groupName: 'default' })
           closeDialog()
+          form.reset()
         },
         onSettled: (_, error) => {
           setIsSubmitting(false)


### PR DESCRIPTION
Fix `callback_port` for remote mcp `Port must be between 1024 and 65535`.
The validation should be applied to all auth_type, but only for `auth_type: none`, that means dynbamic client registration, the field is mandatory.
Added a unit test for remote validation schema and reset form value after success form submitted.

https://github.com/user-attachments/assets/2ac1dbf6-8f5f-4a30-96b3-4dd96781e02b

