### PR TITLE
feat(playground): add missing margin bottom on tool selection modal

### DIFF
--- a/renderer/src/features/chat/components/mcp-tools-modal.tsx
+++ b/renderer/src/features/chat/components/mcp-tools-modal.tsx
@@ -196,7 +196,7 @@ export function McpToolsModal({
               placeholder="Search tools..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9"
+              className="mb-2 pl-9"
             />
           </div>
 


### PR DESCRIPTION
As per the title, I forgot to reapply the bottom margin. Initially, I wanted to add a gradient to fade out the content, but I didn’t have time to get a good result. For now, I’ve added the margin back when there’s a scroll.

<img width="1158" height="805" alt="Screenshot 2025-09-30 at 14 54 44" src="https://github.com/user-attachments/assets/4529e82d-c1a4-41d2-abf0-f7ad0a195d78" />
