### PR TITLE
fix(menu): add padding right 0 on the last menu item

### DIFF
--- a/renderer/src/common/components/layout/top-nav/index.tsx
+++ b/renderer/src/common/components/layout/top-nav/index.tsx
@@ -113,7 +113,7 @@ function TopNavLinks() {
               hover:text-foreground focus:text-foreground
               data-[status=active]:text-foreground
               data-[status=active]:before:bg-foreground
-              focus-visible:ring-ring/50 relative px-3 py-2 text-sm
+              focus-visible:ring-ring/50 relative py-2 pr-0 pl-3 text-sm
               transition-all outline-none hover:bg-transparent
               focus:bg-transparent focus-visible:ring-[3px]
               focus-visible:outline-1 data-[status=active]:bg-transparent


### PR DESCRIPTION
This is trying to adjust the uneven margins on the menu 

before:
<img width="180" height="85" alt="Screenshot 2025-09-30 at 15 27 55" src="https://github.com/user-attachments/assets/ac9e75b8-9f43-4d9a-9f63-dab62e33898e" />


after:
<img width="159" height="71" alt="Screenshot 2025-09-30 at 15 27 20" src="https://github.com/user-attachments/assets/3fd197f6-5f5d-4a6e-96a5-da01861184dd" />
