### PR TITLE
fix: make logs page "Back" button group-aware

### DIFF
--- a/renderer/src/common/components/link-view-transition.tsx
+++ b/renderer/src/common/components/link-view-transition.tsx
@@ -22,13 +22,10 @@ function getViewTransition(
   from: string,
   to: string
 ): ViewTransitionOptions | boolean {
-  // Match route by checking if path starts with route prefix (for dynamic segments)
   const matchRoute = (path: string): Route | null => {
     for (const route of ORDERED_ROUTES) {
       if (path === route) return route
 
-      // For patterns like /group/$groupName, match /group/* paths
-      // For patterns like /logs/$groupName/$serverName, match /logs/*/* paths
       const parts = route.split('/')
       const pathParts = path.split('/')
 
@@ -71,11 +68,9 @@ export const LinkViewTransition = forwardRef<
     typeof props.to === 'string' ? props.to : String(props.to)
   )
 
-  // Cast is necessary because Link's generic types don't properly infer through forwardRef
-  type LinkProps = Parameters<typeof Link>[0]
   return (
     <Link
-      {...(props as unknown as LinkProps)}
+      {...(props as unknown as Parameters<typeof Link>[0])}
       ref={ref}
       viewTransition={viewTransition}
     />

--- a/renderer/src/common/components/link-view-transition.tsx
+++ b/renderer/src/common/components/link-view-transition.tsx
@@ -1,6 +1,6 @@
 import type { FileRouteTypes } from '@/route-tree.gen'
 import { Link, useRouterState } from '@tanstack/react-router'
-import { forwardRef, type ComponentProps } from 'react'
+import { forwardRef } from 'react'
 
 type Route = FileRouteTypes['fullPaths']
 const ORDERED_ROUTES: Route[] = [
@@ -37,14 +37,22 @@ function getViewTransition(
 
 export const LinkViewTransition = forwardRef<
   HTMLAnchorElement,
-  Omit<ComponentProps<typeof Link>, 'viewTransition'>
+  Record<string, unknown> & { to: string }
 >((props, ref) => {
   const location = useRouterState({ select: (s) => s.location })
 
   const viewTransition = getViewTransition(
     location.pathname,
-    props.to as string
+    typeof props.to === 'string' ? props.to : String(props.to)
   )
 
-  return <Link {...props} ref={ref} viewTransition={viewTransition} />
+  // Cast is necessary because Link's generic types don't properly infer through forwardRef
+  type LinkProps = Parameters<typeof Link>[0]
+  return (
+    <Link
+      {...(props as unknown as LinkProps)}
+      ref={ref}
+      viewTransition={viewTransition}
+    />
+  )
 })

--- a/renderer/src/common/components/link-view-transition.tsx
+++ b/renderer/src/common/components/link-view-transition.tsx
@@ -1,6 +1,6 @@
 import type { FileRouteTypes } from '@/route-tree.gen'
 import { Link, useRouterState } from '@tanstack/react-router'
-import { forwardRef } from 'react'
+import { forwardRef, type ComponentProps } from 'react'
 
 type Route = FileRouteTypes['fullPaths']
 const ORDERED_ROUTES: Route[] = [
@@ -59,14 +59,14 @@ function getViewTransition(
 
 export const LinkViewTransition = forwardRef<
   HTMLAnchorElement,
-  Record<string, unknown> & { to: string }
+  Omit<ComponentProps<typeof Link>, 'viewTransition' | 'params'> & {
+    params?: Record<string, unknown>
+  }
 >((props, ref) => {
   const routeId = useRouterState({ select: (s) => s.location.pathname })
 
-  const viewTransition = getViewTransition(
-    routeId,
-    typeof props.to === 'string' ? props.to : String(props.to)
-  )
+  const toPath = typeof props.to === 'string' ? props.to : String(props.to)
+  const viewTransition = getViewTransition(routeId, toPath)
 
   return (
     <Link

--- a/renderer/src/features/mcp-servers/components/__tests__/card-mcp-server.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/card-mcp-server.test.tsx
@@ -33,6 +33,7 @@ function createCardMcpServerTestRouter() {
         statusContext={undefined}
         url="http://localhost:8080"
         transport="http"
+        groupName="default"
       />
     ),
   })

--- a/renderer/src/features/mcp-servers/components/__tests__/card-mcp-server.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/card-mcp-server.test.tsx
@@ -33,7 +33,7 @@ function createCardMcpServerTestRouter() {
         statusContext={undefined}
         url="http://localhost:8080"
         transport="http"
-        groupName="default"
+        group="default"
       />
     ),
   })
@@ -81,7 +81,7 @@ it('navigates to logs page when logs menu item is clicked', async () => {
   await user.click(logsMenuItem)
 
   await waitFor(() => {
-    expect(router.state.location.pathname).toBe('/logs/postgres-db')
+    expect(router.state.location.pathname).toBe('/logs/default/postgres-db')
   })
 })
 

--- a/renderer/src/features/mcp-servers/components/card-mcp-server/index.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/index.tsx
@@ -91,6 +91,7 @@ export function CardMcpServer({
   url,
   remote,
   transport,
+  groupName,
 }: {
   name: string
   status: CoreWorkload['status']
@@ -98,6 +99,7 @@ export function CardMcpServer({
   remote?: CoreWorkload['remote']
   url: string
   transport: CoreWorkload['transport_type']
+  groupName: string
 }) {
   const nameRef = useRef<HTMLElement | null>(null)
   const search = useSearch({
@@ -186,6 +188,7 @@ export function CardMcpServer({
               url={url}
               status={status}
               remote={!!remote}
+              groupName={groupName}
             />
           </div>
         </div>

--- a/renderer/src/features/mcp-servers/components/card-mcp-server/index.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/index.tsx
@@ -91,7 +91,7 @@ export function CardMcpServer({
   url,
   remote,
   transport,
-  groupName,
+  group,
 }: {
   name: string
   status: CoreWorkload['status']
@@ -99,7 +99,7 @@ export function CardMcpServer({
   remote?: CoreWorkload['remote']
   url: string
   transport: CoreWorkload['transport_type']
-  groupName: string
+  group?: CoreWorkload['group']
 }) {
   const nameRef = useRef<HTMLElement | null>(null)
   const search = useSearch({
@@ -188,7 +188,7 @@ export function CardMcpServer({
               url={url}
               status={status}
               remote={!!remote}
-              groupName={groupName}
+              group={group}
             />
           </div>
         </div>

--- a/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/index.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/index.tsx
@@ -22,6 +22,7 @@ interface ServerActionsDropdownProps {
   url: string
   status: string | undefined
   remote: boolean
+  groupName: string
 }
 
 export function ServerActionsDropdown({
@@ -29,6 +30,7 @@ export function ServerActionsDropdown({
   url,
   status,
   remote,
+  groupName,
 }: ServerActionsDropdownProps) {
   const isCustomizeToolsEnabled = useFeatureFlag(
     featureFlagKeys.CUSTOMIZE_TOOLS
@@ -69,7 +71,7 @@ export function ServerActionsDropdown({
         {repositoryUrl && (
           <GithubRepositoryMenuItem repositoryUrl={repositoryUrl} />
         )}
-        <LogsMenuItem serverName={name} remote={remote} />
+        <LogsMenuItem serverName={name} remote={remote} groupName={groupName} />
         {isCustomizeToolsEnabled && (
           <CustomizeToolsMenuItem serverName={name} status={status} />
         )}

--- a/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/index.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/index.tsx
@@ -22,7 +22,7 @@ interface ServerActionsDropdownProps {
   url: string
   status: string | undefined
   remote: boolean
-  groupName: string
+  group?: string
 }
 
 export function ServerActionsDropdown({
@@ -30,7 +30,7 @@ export function ServerActionsDropdown({
   url,
   status,
   remote,
-  groupName,
+  group,
 }: ServerActionsDropdownProps) {
   const isCustomizeToolsEnabled = useFeatureFlag(
     featureFlagKeys.CUSTOMIZE_TOOLS
@@ -71,7 +71,7 @@ export function ServerActionsDropdown({
         {repositoryUrl && (
           <GithubRepositoryMenuItem repositoryUrl={repositoryUrl} />
         )}
-        <LogsMenuItem serverName={name} remote={remote} groupName={groupName} />
+        <LogsMenuItem serverName={name} remote={remote} group={group} />
         {isCustomizeToolsEnabled && (
           <CustomizeToolsMenuItem serverName={name} status={status} />
         )}

--- a/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/items/logs-menu-item.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/items/logs-menu-item.tsx
@@ -5,16 +5,17 @@ import { DropdownMenuItem } from '@/common/components/ui/dropdown-menu'
 interface LogsMenuItemProps {
   serverName: string
   remote: boolean
+  groupName: string
 }
 
-export function LogsMenuItem({ serverName, remote }: LogsMenuItemProps) {
+export function LogsMenuItem({ serverName, remote, groupName }: LogsMenuItemProps) {
   return (
     <DropdownMenuItem
       asChild
       className="flex cursor-pointer items-center"
       disabled={remote}
     >
-      <Link to="/logs/$serverName" params={{ serverName }}>
+      <Link to="/logs/$groupName/$serverName" params={{ serverName, groupName }}>
         <Text className="mr-2 h-4 w-4" />
         Logs
       </Link>

--- a/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/items/logs-menu-item.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/items/logs-menu-item.tsx
@@ -5,17 +5,22 @@ import { DropdownMenuItem } from '@/common/components/ui/dropdown-menu'
 interface LogsMenuItemProps {
   serverName: string
   remote: boolean
-  groupName: string
+  group?: string
 }
 
-export function LogsMenuItem({ serverName, remote, groupName }: LogsMenuItemProps) {
+export function LogsMenuItem({ serverName, remote, group }: LogsMenuItemProps) {
+  const groupName = group ?? 'default'
+
   return (
     <DropdownMenuItem
       asChild
       className="flex cursor-pointer items-center"
       disabled={remote}
     >
-      <Link to="/logs/$groupName/$serverName" params={{ serverName, groupName }}>
+      <Link
+        to="/logs/$groupName/$serverName"
+        params={{ serverName, groupName }}
+      >
         <Text className="mr-2 h-4 w-4" />
         Logs
       </Link>

--- a/renderer/src/features/mcp-servers/components/grid-cards-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/grid-cards-mcp-server.tsx
@@ -5,8 +5,10 @@ import { InputSearch } from '@/common/components/ui/input-search'
 
 export function GridCardsMcpServers({
   mcpServers,
+  groupName,
 }: {
   mcpServers: CoreWorkload[]
+  groupName: string
 }) {
   const [filters, setFilters] = useState({
     text: '',
@@ -59,6 +61,7 @@ export function GridCardsMcpServers({
               statusContext={mcpServer.status_context}
               url={mcpServer.url ?? ''}
               transport={mcpServer.transport_type}
+              groupName={groupName}
             />
           ) : null
         )}

--- a/renderer/src/features/mcp-servers/components/grid-cards-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/grid-cards-mcp-server.tsx
@@ -5,10 +5,8 @@ import { InputSearch } from '@/common/components/ui/input-search'
 
 export function GridCardsMcpServers({
   mcpServers,
-  groupName,
 }: {
   mcpServers: CoreWorkload[]
-  groupName: string
 }) {
   const [filters, setFilters] = useState({
     text: '',
@@ -61,7 +59,7 @@ export function GridCardsMcpServers({
               statusContext={mcpServer.status_context}
               url={mcpServer.url ?? ''}
               transport={mcpServer.transport_type}
-              groupName={groupName}
+              group={mcpServer.group}
             />
           ) : null
         )}

--- a/renderer/src/features/mcp-servers/sub-pages/logs-page/index.tsx
+++ b/renderer/src/features/mcp-servers/sub-pages/logs-page/index.tsx
@@ -11,7 +11,9 @@ import { InputSearch } from '@/common/components/ui/input-search'
 import { highlight } from './search'
 
 export function LogsPage() {
-  const { serverName } = useParams({ from: '/logs/$serverName' })
+  const { serverName, groupName } = useParams({
+    from: '/logs/$groupName/$serverName',
+  })
   const [search, setSearch] = useState('')
 
   const { data: logs, refetch } = useSuspenseQuery(
@@ -32,7 +34,10 @@ export function LogsPage() {
   return (
     <div className="flex max-h-full w-full flex-1 flex-col">
       <div className="mb-2">
-        <LinkViewTransition to="/group/default">
+        <LinkViewTransition
+          to="/group/$groupName"
+          params={{ groupName } as any}
+        >
           <Button
             variant="ghost"
             aria-label="Back"

--- a/renderer/src/features/mcp-servers/sub-pages/logs-page/index.tsx
+++ b/renderer/src/features/mcp-servers/sub-pages/logs-page/index.tsx
@@ -34,10 +34,7 @@ export function LogsPage() {
   return (
     <div className="flex max-h-full w-full flex-1 flex-col">
       <div className="mb-2">
-        <LinkViewTransition
-          to="/group/$groupName"
-          params={{ groupName } as any}
-        >
+        <LinkViewTransition to="/group/$groupName" params={{ groupName }}>
           <Button
             variant="ghost"
             aria-label="Back"

--- a/renderer/src/route-tree.gen.ts
+++ b/renderer/src/route-tree.gen.ts
@@ -13,10 +13,10 @@ import { Route as ShutdownRouteImport } from "./routes/shutdown"
 import { Route as SettingsRouteImport } from "./routes/settings"
 import { Route as SecretsRouteImport } from "./routes/secrets"
 import { Route as PlaygroundRouteImport } from "./routes/playground"
-import { Route as LogsServerNameRouteImport } from "./routes/logs.$serverName"
 import { Route as GroupGroupNameRouteImport } from "./routes/group.$groupName"
 import { Route as CustomizeToolsServerNameRouteImport } from "./routes/customize-tools.$serverName"
 import { Route as registryRegistryRouteImport } from "./routes/(registry)/registry"
+import { Route as LogsGroupNameServerNameRouteImport } from "./routes/logs.$groupName.$serverName"
 import { Route as registryRegistryNameRouteImport } from "./routes/(registry)/registry_.$name"
 
 const ShutdownRoute = ShutdownRouteImport.update({
@@ -39,11 +39,6 @@ const PlaygroundRoute = PlaygroundRouteImport.update({
   path: "/playground",
   getParentRoute: () => rootRouteImport,
 } as any)
-const LogsServerNameRoute = LogsServerNameRouteImport.update({
-  id: "/logs/$serverName",
-  path: "/logs/$serverName",
-  getParentRoute: () => rootRouteImport,
-} as any)
 const GroupGroupNameRoute = GroupGroupNameRouteImport.update({
   id: "/group/$groupName",
   path: "/group/$groupName",
@@ -60,6 +55,11 @@ const registryRegistryRoute = registryRegistryRouteImport.update({
   path: "/registry",
   getParentRoute: () => rootRouteImport,
 } as any)
+const LogsGroupNameServerNameRoute = LogsGroupNameServerNameRouteImport.update({
+  id: "/logs/$groupName/$serverName",
+  path: "/logs/$groupName/$serverName",
+  getParentRoute: () => rootRouteImport,
+} as any)
 const registryRegistryNameRoute = registryRegistryNameRouteImport.update({
   id: "/(registry)/registry_/$name",
   path: "/registry/$name",
@@ -74,8 +74,8 @@ export interface FileRoutesByFullPath {
   "/registry": typeof registryRegistryRoute
   "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/group/$groupName": typeof GroupGroupNameRoute
-  "/logs/$serverName": typeof LogsServerNameRoute
   "/registry/$name": typeof registryRegistryNameRoute
+  "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
 }
 export interface FileRoutesByTo {
   "/playground": typeof PlaygroundRoute
@@ -85,8 +85,8 @@ export interface FileRoutesByTo {
   "/registry": typeof registryRegistryRoute
   "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/group/$groupName": typeof GroupGroupNameRoute
-  "/logs/$serverName": typeof LogsServerNameRoute
   "/registry/$name": typeof registryRegistryNameRoute
+  "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -97,8 +97,8 @@ export interface FileRoutesById {
   "/(registry)/registry": typeof registryRegistryRoute
   "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/group/$groupName": typeof GroupGroupNameRoute
-  "/logs/$serverName": typeof LogsServerNameRoute
   "/(registry)/registry_/$name": typeof registryRegistryNameRoute
+  "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -110,8 +110,8 @@ export interface FileRouteTypes {
     | "/registry"
     | "/customize-tools/$serverName"
     | "/group/$groupName"
-    | "/logs/$serverName"
     | "/registry/$name"
+    | "/logs/$groupName/$serverName"
   fileRoutesByTo: FileRoutesByTo
   to:
     | "/playground"
@@ -121,8 +121,8 @@ export interface FileRouteTypes {
     | "/registry"
     | "/customize-tools/$serverName"
     | "/group/$groupName"
-    | "/logs/$serverName"
     | "/registry/$name"
+    | "/logs/$groupName/$serverName"
   id:
     | "__root__"
     | "/playground"
@@ -132,8 +132,8 @@ export interface FileRouteTypes {
     | "/(registry)/registry"
     | "/customize-tools/$serverName"
     | "/group/$groupName"
-    | "/logs/$serverName"
     | "/(registry)/registry_/$name"
+    | "/logs/$groupName/$serverName"
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -144,8 +144,8 @@ export interface RootRouteChildren {
   registryRegistryRoute: typeof registryRegistryRoute
   CustomizeToolsServerNameRoute: typeof CustomizeToolsServerNameRoute
   GroupGroupNameRoute: typeof GroupGroupNameRoute
-  LogsServerNameRoute: typeof LogsServerNameRoute
   registryRegistryNameRoute: typeof registryRegistryNameRoute
+  LogsGroupNameServerNameRoute: typeof LogsGroupNameServerNameRoute
 }
 
 declare module "@tanstack/react-router" {
@@ -178,13 +178,6 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof PlaygroundRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/logs/$serverName": {
-      id: "/logs/$serverName"
-      path: "/logs/$serverName"
-      fullPath: "/logs/$serverName"
-      preLoaderRoute: typeof LogsServerNameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     "/group/$groupName": {
       id: "/group/$groupName"
       path: "/group/$groupName"
@@ -206,6 +199,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof registryRegistryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/logs/$groupName/$serverName": {
+      id: "/logs/$groupName/$serverName"
+      path: "/logs/$groupName/$serverName"
+      fullPath: "/logs/$groupName/$serverName"
+      preLoaderRoute: typeof LogsGroupNameServerNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     "/(registry)/registry_/$name": {
       id: "/(registry)/registry_/$name"
       path: "/registry/$name"
@@ -224,8 +224,8 @@ const rootRouteChildren: RootRouteChildren = {
   registryRegistryRoute: registryRegistryRoute,
   CustomizeToolsServerNameRoute: CustomizeToolsServerNameRoute,
   GroupGroupNameRoute: GroupGroupNameRoute,
-  LogsServerNameRoute: LogsServerNameRoute,
   registryRegistryNameRoute: registryRegistryNameRoute,
+  LogsGroupNameServerNameRoute: LogsGroupNameServerNameRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/renderer/src/routes/__tests__/logs.$serverName.test.tsx
+++ b/renderer/src/routes/__tests__/logs.$serverName.test.tsx
@@ -12,18 +12,30 @@ describe('Logs Route', () => {
   })
 
   const testCases = [
-    { serverName: 'postgres-db', description: 'simple server name' },
+    {
+      serverName: 'postgres-db',
+      groupName: 'default',
+      description: 'simple server name',
+    },
     {
       serverName: 'vscode-server',
+      groupName: 'production',
       description: 'server name with hyphens',
     },
-    { serverName: 'github', description: 'server name with numbers' },
+    {
+      serverName: 'github',
+      groupName: 'research',
+      description: 'server name with numbers',
+    },
   ]
 
-  testCases.forEach(({ serverName, description }) => {
+  testCases.forEach(({ serverName, groupName, description }) => {
     it(`displays server name as header for ${description}`, async () => {
-      const router = createTestRouter(LogsPage, '/logs/$serverName')
-      router.navigate({ to: '/logs/$serverName', params: { serverName } })
+      const router = createTestRouter(LogsPage, '/logs/$groupName/$serverName')
+      router.navigate({
+        to: '/logs/$groupName/$serverName',
+        params: { serverName, groupName },
+      })
       renderRoute(router)
 
       await waitFor(() => {
@@ -31,9 +43,12 @@ describe('Logs Route', () => {
       })
     })
 
-    it(`has a back button that navigates to root route for ${description}`, async () => {
-      const router = createTestRouter(LogsPage, '/logs/$serverName')
-      router.navigate({ to: '/logs/$serverName', params: { serverName } })
+    it(`has a back button that navigates to correct group for ${description}`, async () => {
+      const router = createTestRouter(LogsPage, '/logs/$groupName/$serverName')
+      router.navigate({
+        to: '/logs/$groupName/$serverName',
+        params: { serverName, groupName },
+      })
       renderRoute(router)
 
       await waitFor(() => {
@@ -42,18 +57,21 @@ describe('Logs Route', () => {
 
       const backButton = screen.getByRole('button', { name: /back/i })
       expect(backButton).toBeVisible()
-      expect(backButton.closest('a')).toHaveAttribute('href', '/group/default')
+      expect(backButton.closest('a')).toHaveAttribute('href', `/group/${groupName}`)
 
       await userEvent.click(backButton)
 
       await waitFor(() => {
-        expect(router.state.location.pathname).toBe('/group/default')
+        expect(router.state.location.pathname).toBe(`/group/${groupName}`)
       })
     })
 
     it(`filters logs when searching for ${description}`, async () => {
-      const router = createTestRouter(LogsPage, '/logs/$serverName')
-      router.navigate({ to: '/logs/$serverName', params: { serverName } })
+      const router = createTestRouter(LogsPage, '/logs/$groupName/$serverName')
+      router.navigate({
+        to: '/logs/$groupName/$serverName',
+        params: { serverName, groupName },
+      })
       renderRoute(router)
 
       await waitFor(() => {
@@ -85,8 +103,12 @@ describe('Logs Route', () => {
 
   it('handles empty logs response gracefully', async () => {
     const serverName = 'empty-logs-server'
-    const router = createTestRouter(LogsPage, '/logs/$serverName')
-    router.navigate({ to: '/logs/$serverName', params: { serverName } })
+    const groupName = 'default'
+    const router = createTestRouter(LogsPage, '/logs/$groupName/$serverName')
+    router.navigate({
+      to: '/logs/$groupName/$serverName',
+      params: { serverName, groupName },
+    })
     renderRoute(router)
 
     await waitFor(() => {
@@ -98,8 +120,12 @@ describe('Logs Route', () => {
 
   it('refreshes logs when refresh button is clicked', async () => {
     const serverName = 'postgres-db'
-    const router = createTestRouter(LogsPage, '/logs/$serverName')
-    router.navigate({ to: '/logs/$serverName', params: { serverName } })
+    const groupName = 'default'
+    const router = createTestRouter(LogsPage, '/logs/$groupName/$serverName')
+    router.navigate({
+      to: '/logs/$groupName/$serverName',
+      params: { serverName, groupName },
+    })
     renderRoute(router)
 
     await waitFor(() => {

--- a/renderer/src/routes/__tests__/logs.$serverName.test.tsx
+++ b/renderer/src/routes/__tests__/logs.$serverName.test.tsx
@@ -57,7 +57,10 @@ describe('Logs Route', () => {
 
       const backButton = screen.getByRole('button', { name: /back/i })
       expect(backButton).toBeVisible()
-      expect(backButton.closest('a')).toHaveAttribute('href', `/group/${groupName}`)
+      expect(backButton.closest('a')).toHaveAttribute(
+        'href',
+        `/group/${groupName}`
+      )
 
       await userEvent.click(backButton)
 

--- a/renderer/src/routes/group.$groupName.tsx
+++ b/renderer/src/routes/group.$groupName.tsx
@@ -120,7 +120,7 @@ function GroupRoute() {
             </div>
           </EmptyState>
         ) : (
-          <GridCardsMcpServers mcpServers={filteredWorkloads} />
+          <GridCardsMcpServers mcpServers={filteredWorkloads} groupName={groupName} />
         )}
       </div>
     </div>

--- a/renderer/src/routes/group.$groupName.tsx
+++ b/renderer/src/routes/group.$groupName.tsx
@@ -120,7 +120,7 @@ function GroupRoute() {
             </div>
           </EmptyState>
         ) : (
-          <GridCardsMcpServers mcpServers={filteredWorkloads} groupName={groupName} />
+          <GridCardsMcpServers mcpServers={filteredWorkloads} />
         )}
       </div>
     </div>

--- a/renderer/src/routes/logs.$groupName.$serverName.tsx
+++ b/renderer/src/routes/logs.$groupName.$serverName.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { LogsPage } from '@/features/mcp-servers/sub-pages/logs-page'
 import { getApiV1BetaWorkloadsByNameLogsOptions } from '@api/@tanstack/react-query.gen'
 
-export const Route = createFileRoute('/logs/$serverName')({
+export const Route = createFileRoute('/logs/$groupName/$serverName')({
   loader: async ({ context: { queryClient }, params }) =>
     queryClient.ensureQueryData(
       getApiV1BetaWorkloadsByNameLogsOptions({


### PR DESCRIPTION
related to #904 

This PR just replaces the hardcoded `default~ group in the back button in the logs page with the appropriate group name.

The only change visible to the user is that the back button leads to the appropriate group now. 



https://github.com/user-attachments/assets/404e2807-c453-41ad-b9ca-891dc1df7a3d

