### PR TITLE
feat(window): change default size to 1280x800

### DIFF
--- a/main/src/main-window.ts
+++ b/main/src/main-window.ts
@@ -9,8 +9,8 @@ import { pollWindowReady } from './util'
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined
 declare const MAIN_WINDOW_VITE_NAME: string
 
-const DEFAULT_WINDOW_WIDTH = 1040
-const DEFAULT_WINDOW_HEIGHT = 700
+const DEFAULT_WINDOW_WIDTH = 1280
+const DEFAULT_WINDOW_HEIGHT = 800
 const TRAFFIC_LIGHT_POSITION = { x: 21, y: 24 }
 
 interface WindowOptions {


### PR DESCRIPTION
As per title, I think we need to expand our default window width and height

<img width="1279" height="797" alt="Screenshot 2025-10-03 at 10 11 38" src="https://github.com/user-attachments/assets/790c25aa-d8b7-4193-b058-8fba69424efa" />

