### PR TITLE
fix: update docs links to correct anchors

### DIFF
--- a/renderer/src/features/mcp-servers/components/remote-mcp/dialog-form-remote-mcp.tsx
+++ b/renderer/src/features/mcp-servers/components/remote-mcp/dialog-form-remote-mcp.tsx
@@ -351,7 +351,7 @@ export function DialogFormRemoteMcp({
                         rel="noopener noreferrer"
                         className="flex cursor-pointer items-center gap-1
                           underline"
-                        href="https://docs.stacklok.com/toolhive/guides-ui/run-mcp-servers#custom-mcp-server"
+                        href="https://docs.stacklok.com/toolhive/guides-ui/run-mcp-servers?custom-type=custom_remote#install-a-custom-mcp-server"
                         target="_blank"
                       >
                         documentation <ExternalLinkIcon size={12} />

--- a/renderer/src/features/registry-servers/components/dialog-form-remote-registry-mcp.tsx
+++ b/renderer/src/features/registry-servers/components/dialog-form-remote-registry-mcp.tsx
@@ -294,7 +294,7 @@ export function DialogFormRemoteRegistryMcp({
                         rel="noopener noreferrer"
                         className="flex cursor-pointer items-center gap-1
                           underline"
-                        href="https://docs.stacklok.com/toolhive/guides-ui/run-mcp-servers#configure-server"
+                        href="https://docs.stacklok.com/toolhive/guides-ui/run-mcp-servers?server-type=remote#configure-the-server"
                         target="_blank"
                       >
                         documentation <ExternalLinkIcon size={12} />

--- a/renderer/src/routes/(registry)/registry.tsx
+++ b/renderer/src/routes/(registry)/registry.tsx
@@ -36,7 +36,7 @@ export function Registry() {
           actions={[
             <Button asChild key="docs">
               <a
-                href="https://docs.stacklok.com/toolhive/guides-cli/registry#use-a-remote-registry"
+                href="https://docs.stacklok.com/toolhive/guides-ui/registry#registry-settings"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
We can direct link to the right tab in the new remote MCP docs pages.

Also corrects the destination for the custom registry error text.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>