### PR TITLE
fix(playground): search tools icon adjustment

### DIFF
--- a/renderer/src/features/chat/components/mcp-tools-modal.tsx
+++ b/renderer/src/features/chat/components/mcp-tools-modal.tsx
@@ -187,7 +187,7 @@ export function McpToolsModal({
         </DialogHeader>
 
         <div className="flex min-h-0 flex-1 flex-col space-y-4">
-          <div className="relative mb-0 pr-2">
+          <div className="relative mb-2 flex items-center pr-2">
             <Search
               className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4
                 -translate-y-1/2"
@@ -196,7 +196,7 @@ export function McpToolsModal({
               placeholder="Search tools..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="mb-2 pl-9"
+              className="pl-9"
             />
           </div>
 


### PR DESCRIPTION
Before:
<img width="1175" height="894" alt="Screenshot 2025-10-01 at 11 53 52" src="https://github.com/user-attachments/assets/953d8c3d-c091-4cdc-9fa4-288ad2279556" />


After:
<img width="1180" height="889" alt="Screenshot 2025-10-01 at 11 53 32" src="https://github.com/user-attachments/assets/db8e486d-3edf-4705-84e1-7f1b6cc49a8d" />
