### PR TITLE
feat: add instace_id to sentry tracking

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -46,7 +46,7 @@ import {
   getToolhiveMcpPort,
 } from './toolhive-manager'
 import log from './logger'
-import { getAppVersion, isOfficialReleaseBuild } from './util'
+import { getAppVersion, getInstanceId, isOfficialReleaseBuild } from './util'
 import { delay } from '../../utils/delay'
 import {
   initAutoUpdate,
@@ -487,6 +487,11 @@ ipcMain.handle('sentry.opt-out', (): boolean => {
 ipcMain.handle('sentry.opt-in', (): boolean => {
   store.set('isTelemetryEnabled', true)
   return true
+})
+
+ipcMain.handle('get-instance-id', async () => {
+  const instanceId = await getInstanceId()
+  return instanceId
 })
 
 // Log file operations

--- a/main/src/util.ts
+++ b/main/src/util.ts
@@ -1,4 +1,6 @@
 import { app, BrowserWindow } from 'electron'
+import { existsSync, readFile } from 'node:fs'
+import path from 'node:path'
 import log from './logger'
 import { delay } from '../../utils/delay'
 
@@ -27,5 +29,31 @@ export function isOfficialReleaseBuild(): boolean {
   } catch {
     log.error('Failed to get app version')
     return false
+  }
+}
+
+export async function getInstanceId() {
+  try {
+    const userDataPath = app.getPath('userData')
+    const updatesFilePath = path.join(userDataPath, 'updates.json')
+    if (!existsSync(updatesFilePath)) {
+      log.warn(`Updates file does not exist: ${updatesFilePath}`)
+      return
+    }
+
+    const content = await new Promise<string>((resolve, reject) => {
+      readFile(updatesFilePath, 'utf8', (err, data) => {
+        if (err) reject(err)
+        else resolve(data)
+      })
+    })
+
+    const updatesData = JSON.parse(content)
+    const instanceId = updatesData?.instance_id
+    log.info(`Retrieved instance_id: ${instanceId}`)
+    return instanceId
+  } catch (error) {
+    log.error('Failed to retrieve instance_id:', error)
+    return
   }
 }

--- a/preload/src/preload.ts
+++ b/preload/src/preload.ts
@@ -26,6 +26,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   isOfficialReleaseBuild: () => ipcRenderer.invoke('is-official-release-build'),
   getTelemetryHeaders: () => ipcRenderer.invoke('telemetry-headers'),
 
+  getInstanceId: () => ipcRenderer.invoke('get-instance-id'),
+
   // ToolHive port
   getToolhivePort: () => ipcRenderer.invoke('get-toolhive-port'),
   getToolhiveMcpPort: () => ipcRenderer.invoke('get-toolhive-mcp-port'),
@@ -248,6 +250,7 @@ export interface ElectronAPI {
     optIn: () => Promise<boolean>
     optOut: () => Promise<boolean>
   }
+  getInstanceId: () => Promise<string>
   getMainLogContent: () => Promise<string>
   isMac: boolean
   isWindows: boolean

--- a/renderer/src/common/lib/analytics.ts
+++ b/renderer/src/common/lib/analytics.ts
@@ -1,6 +1,8 @@
 import * as Sentry from '@sentry/electron/renderer'
 
-export function trackEvent(eventName: string, data = {}) {
+const instanceId = await window.electronAPI.getInstanceId()
+
+export async function trackEvent(eventName: string, data = {}) {
   Sentry.startSpan(
     {
       name: eventName,
@@ -13,6 +15,7 @@ export function trackEvent(eventName: string, data = {}) {
         'screen.aspect_ratio': (window.innerWidth / window.innerHeight).toFixed(
           2
         ),
+        'custom.user_id': instanceId,
         ...data,
         timestamp: new Date().toISOString(),
       },
@@ -21,7 +24,7 @@ export function trackEvent(eventName: string, data = {}) {
   )
 }
 
-export function trackPageView(pageName: string, data = {}) {
+export async function trackPageView(pageName: string, data = {}) {
   Sentry.startSpan(
     {
       name: `Page: ${pageName}`,
@@ -30,6 +33,7 @@ export function trackPageView(pageName: string, data = {}) {
         'analytics.source': 'tracking',
         'analytics.type': 'page_view',
         'page.name': pageName,
+        'custom.user_id': instanceId,
         'action.type': 'navigation',
         'screen.width': window.innerWidth,
         'screen.height': window.innerHeight,


### PR DESCRIPTION
In order to track the instance_id, we can pass it to sentry traces using `custom.user_id` attr