### PR TITLE
fix(top-nav): remove gap and add spacing to divide

### DIFF
--- a/renderer/src/common/components/layout/top-nav/index.tsx
+++ b/renderer/src/common/components/layout/top-nav/index.tsx
@@ -117,7 +117,7 @@ function TopNavLinks() {
               hover:text-foreground focus:text-foreground
               data-[status=active]:text-foreground
               data-[status=active]:before:bg-foreground
-              focus-visible:ring-ring/50 relative py-2 pr-0 pl-3 text-sm
+              focus-visible:ring-ring/50 relative px-3 py-2 text-sm
               transition-all outline-none hover:bg-transparent
               focus:bg-transparent focus-visible:ring-[3px]
               focus-visible:outline-1 data-[status=active]:bg-transparent
@@ -173,9 +173,9 @@ export function TopNav(props: HTMLProps<HTMLElement>) {
   return (
     <TopNavContainer {...props}>
       <QuitConfirmationListener />
-      <div className="flex h-10 items-center gap-4">
+      <div className="flex h-10 items-center">
         <TopNavLinks />
-        <Separator orientation="vertical" />
+        <Separator orientation="vertical" className="mr-4 ml-2" />
         <div className="flex items-center gap-2">
           <LinkViewTransition to="/settings" className="app-region-no-drag">
             <SettingsIcon className="text-muted-foreground size-4" />


### PR DESCRIPTION
In the previous PR I tried to fix the spacing by tweaking the last menu item, but it wasn’t correct when selected.

I removed the gap from the container and applied the spacing directly on the separator instead

before:
<img width="997" height="736" alt="Screenshot 2025-10-01 at 18 44 25" src="https://github.com/user-attachments/assets/c836b567-5201-466c-bec2-45463edd0378" />

after:
<img width="997" height="733" alt="Screenshot 2025-10-01 at 18 44 08" src="https://github.com/user-attachments/assets/eb8417cd-db80-4ed1-845b-79147663d22b" />
