### PR TITLE
feat(playground): handle errors for prompt input attachments

### DIFF
--- a/renderer/src/common/lib/toast.ts
+++ b/renderer/src/common/lib/toast.ts
@@ -1,0 +1,10 @@
+export const toastVariants = {
+  destructive: {
+    style: {
+      color: 'var(--destructive)',
+      borderColor: 'var(--border)',
+      alignItems: 'flex-start',
+      gap: '12px',
+    },
+  },
+} as const

--- a/renderer/src/common/lib/toast.ts
+++ b/renderer/src/common/lib/toast.ts
@@ -3,8 +3,6 @@ export const toastVariants = {
     style: {
       color: 'var(--destructive)',
       borderColor: 'var(--border)',
-      alignItems: 'flex-start',
-      gap: '12px',
     },
   },
 } as const

--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -29,6 +29,24 @@ import type { ChatSettings } from '../types'
 import { toast } from 'sonner'
 import { toastVariants } from '@/common/lib/toast'
 
+const errorToastConfig = {
+  max_files: {
+    id: 'error_max_files',
+    title: 'You reached the maximum number of files',
+    description: 'You can only upload up to 5 files',
+  },
+  max_file_size: {
+    id: 'error_max_file_size',
+    title: 'File size too large',
+    description: 'The file size must be less than 10MB',
+  },
+  accept: {
+    id: 'error_accept',
+    title: 'File type not supported',
+    description: 'Only images and PDFs are supported',
+  },
+} as const
+
 interface ChatInputProps {
   status: ChatStatus
   settings: ChatSettings
@@ -204,25 +222,11 @@ export function ChatInputPrompt({
           return
         }
 
-        if (er.code === 'max_files') {
-          toast.error('You reached the maximum number of files', {
-            id: 'error_max_files',
-            description: 'You can only upload up to 5 files',
-            duration: 5000,
-            ...toastVariants.destructive,
-          })
-        }
-        if (er.code === 'max_file_size') {
-          toast.error('File size must be less than 10MB', {
-            id: 'error_max_file_size',
-            duration: 5000,
-            ...toastVariants.destructive,
-          })
-        }
-        if (er.code === 'accept') {
-          toast.error('File type not supported', {
-            id: 'error_accept',
-            description: 'Only images and PDFs are supported',
+        const config = errorToastConfig[er.code]
+        if (config) {
+          toast.error(config.title, {
+            id: config.id,
+            description: config.description,
             duration: 5000,
             ...toastVariants.destructive,
           })


### PR DESCRIPTION
as per title, when an error happens while attaching a file, we’ll trigger a toast error with the dedicated message

Example:
<img width="1049" height="694" alt="Screenshot 2025-10-02 at 15 37 06" src="https://github.com/user-attachments/assets/ef403c13-bbe1-4361-ae04-0121321f2bb5" />
