### PR TITLE
fix(docs): update download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ setup, no security headaches, no runtime hassles.
 ## Getting started
 
 To get started with ToolHive, download the latest release from
-[the website](https://toolhive.dev/download.html) and follow the
+[the website](https://toolhive.dev/download/) and follow the
 [quickstart guide](https://docs.stacklok.com/toolhive/tutorials/quickstart-ui).
 
 ---


### PR DESCRIPTION
Download page path has changed slightly with the updated website.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>