### PR TITLE
fix(playground): remove double close button on modal image preview

### DIFF
--- a/renderer/src/features/chat/components/image-modal.tsx
+++ b/renderer/src/features/chat/components/image-modal.tsx
@@ -25,6 +25,7 @@ export function ImageModal({
       <DialogContent
         aria-describedby="image-modal-description"
         className="max-h-[90vh] max-w-4xl p-2"
+        showCloseButton={false}
       >
         <DialogTitle className="sr-only">{fileName}</DialogTitle>
         <DialogDescription aria-describedby={`ImageModal for ${fileName}`} />


### PR DESCRIPTION
As per title

before:
<img width="1279" height="801" alt="Screenshot 2025-10-06 at 14 14 22" src="https://github.com/user-attachments/assets/32eb6f3a-315d-48ff-8d50-28ad7f3831aa" />

after:
<img width="1287" height="798" alt="Screenshot 2025-10-06 at 14 14 10" src="https://github.com/user-attachments/assets/afc21e43-359b-421c-ae61-c5b533bd8f68" />
