### PR TITLE
fix: fix group handling when editing local mpcs

### DIFF
--- a/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-local-server.test.tsx
+++ b/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-local-server.test.tsx
@@ -602,7 +602,7 @@ describe('prepareUpdateWorkloadData', () => {
       transport: 'sse',
       target_port: 3000,
       type: 'docker_image',
-      group: 'default',
+      group: 'production',
       image: 'ghcr.io/test/updated-server',
       cmd_arguments: ['--verbose'],
       envVars: [
@@ -625,6 +625,7 @@ describe('prepareUpdateWorkloadData', () => {
     expect(result).toEqual({
       image: 'ghcr.io/test/updated-server',
       transport: 'sse',
+      group: 'production',
       target_port: 3000,
       cmd_arguments: ['--verbose'],
       env_vars: { DEBUG: 'true', LOG_LEVEL: 'info' },

--- a/renderer/src/features/mcp-servers/lib/orchestrate-run-local-server.tsx
+++ b/renderer/src/features/mcp-servers/lib/orchestrate-run-local-server.tsx
@@ -241,6 +241,7 @@ export function prepareUpdateWorkloadData(
   return {
     image,
     transport: data.transport,
+    group: data.group,
     target_port: data.target_port,
     cmd_arguments: data.cmd_arguments || [],
     env_vars: mapEnvVars(data.envVars),


### PR DESCRIPTION
this fixes the bug where the group was not saved correctly + includes test changes that fail without the fix (prove the fix was implemented)

now after manual testing, I can see that this feature works properly both for local and remote servers:


https://github.com/user-attachments/assets/36f70858-f435-4552-83ad-cd74d33bf6b1

