### PR TITLE
chore: logs potential boostrap error on restart

### DIFF
--- a/renderer/src/routes/__root.tsx
+++ b/renderer/src/routes/__root.tsx
@@ -133,11 +133,9 @@ export const Route = createRootRouteWithContext<{
         tags: {
           component: 'root-route',
           phase: 'beforeLoad',
-          toolhive_running: `${isToolhiveRunning}`,
-          container_engine_available: `${containerEngineStatus.available}`,
         },
         extra: {
-          is_toolhive_running: `${isToolhiveRunning}`,
+          toolhive_running: `${isToolhiveRunning}`,
           toolhive_port: port,
           client_base_url: clientConfig.baseUrl,
           client_configured: `${!!clientConfig.baseUrl}`,


### PR DESCRIPTION
A bunch of time we have this error during an app restarting ( in particular after an app upgrade ). In order to debug it, let's add more logs and see what cause the issue

```
[2025-10-08 15:48:40.900] [error] Error: TypeError: Failed to fetch (localhost:50074)
    at Object.beforeLoad (file:///Users/giuseppe/workspace/toolhive-react/out/ToolHive-darwin-arm64/ToolHive.app/Contents/Resources/app.asar/.vite/renderer/main_window/assets/index-CY_Ujpgk.js:507:58651)
    at async uC (file:///Users/giuseppe/workspace/toolhive-react/out/ToolHive-darwin-arm64/ToolHive.app/Contents/Resources/app.asar/.vite/renderer/main_window/assets/index-CY_Ujpgk.js:54:66510)
    at async file:///Users/giuseppe/workspace/toolhive-react/out/ToolHive-darwin-arm64/ToolHive.app/Contents/Resources/app.asar/.vite/renderer/main_window/assets/index-CY_Ujpgk.js:54:77352
[2025-10-08 15:48:42.262] [info]  Container engines are now available, restarting ToolHive...
```