### PR TITLE
fix: improve top alignment on the groups sidebar

### DIFF
--- a/renderer/src/features/mcp-servers/components/mcp-servers-sidebar.tsx
+++ b/renderer/src/features/mcp-servers/components/mcp-servers-sidebar.tsx
@@ -9,7 +9,7 @@ export function McpServersSidebar(): ReactElement {
     <aside
       className="border-input bg-muted/50 text-sidebar-foreground w-sidebar
         fixed top-16 bottom-0 left-0 z-0 flex h-full flex-col items-start gap-3
-        border-r px-4 pt-10 pb-4"
+        border-r px-4 pt-4 pb-4"
     >
       <div className="flex flex-col gap-3">
         {isGroupsEnabled ? <GroupsManager /> : null}


### PR DESCRIPTION
<img width="1600" height="640" alt="screenshot-2025-10-13_12-25-56" src="https://github.com/user-attachments/assets/9f138ddd-d0e2-41bd-bb9b-07d625a48a98" />


context https://stacklok.slack.com/archives/C072SGY78TS/p1760091576027869 