### PR TITLE
chore(thv): bump to version 0.3.8

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,1 +1,1 @@
-export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.3.7'
+export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.3.8'


### PR DESCRIPTION
As per title, this is just a bump in the version,  no changes to the API in this release