### PR TITLE
fix: rely on status api avoiding refetch workloads api

### DIFF
--- a/renderer/src/features/mcp-servers/hooks/use-mutation-update-workload.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-mutation-update-workload.ts
@@ -17,7 +17,7 @@ export const useMutationUpdateWorkload = () => {
       const previousServersList = queryClient.getQueryData(queryKey)
 
       queryClient.setQueryData(queryKey, (old: V1WorkloadListResponse) => {
-        const newWorkloads = old.workloads?.map((server) =>
+        const newWorkloads = old?.workloads?.map((server) =>
           server.name === path.name ? { ...server, status: 'updating' } : server
         )
         return {
@@ -32,11 +32,14 @@ export const useMutationUpdateWorkload = () => {
         queryClient.setQueryData(context?.queryKey, context.previousServersList)
       }
     },
-    onSettled: (_data, _error, variables) => {
-      const queryKey = getApiV1BetaWorkloadsQueryKey({
-        query: { all: true, group: variables.body.group },
-      })
-      queryClient.refetchQueries({ queryKey })
+    onSettled: (_data, _error, variables, cachedResult) => {
+      // Only refetch workloads without cached data, as servers may be temporarily unavailable during restart.
+      if (!cachedResult?.previousServersList) {
+        const queryKey = getApiV1BetaWorkloadsQueryKey({
+          query: { all: true, group: variables.body.group },
+        })
+        queryClient.refetchQueries({ queryKey })
+      }
     },
   })
 


### PR DESCRIPTION
For MCP that needs more time to be stopped/deleted/re-created with new configuration (remote mcp with oauth is a good use case) we cannot leverage the workload list api after edit an mcp cause a server may be temporarily unavailable during restart.
We can rely on status api and fetch workloads after polling status is completed.

**Issue**

https://github.com/user-attachments/assets/17c08f88-453c-4cbd-a017-e76054c238a1



**Fix**

https://github.com/user-attachments/assets/be5e2d07-ce57-488a-ba7d-31e0b738cfd9

