### PR TITLE
chore(api): regenerate clients after upgrade

### DIFF
--- a/api/generated/@tanstack/react-query.gen.ts
+++ b/api/generated/@tanstack/react-query.gen.ts
@@ -178,6 +178,7 @@ export const getApiOpenapiJsonQueryKey = (
 
 /**
  * Get OpenAPI specification
+ *
  * Returns the OpenAPI specification for the API
  */
 export const getApiOpenapiJsonOptions = (
@@ -203,6 +204,7 @@ export const getApiV1BetaClientsQueryKey = (
 
 /**
  * List all clients
+ *
  * List all registered clients in ToolHive
  */
 export const getApiV1BetaClientsOptions = (
@@ -224,6 +226,7 @@ export const getApiV1BetaClientsOptions = (
 
 /**
  * Register a new client
+ *
  * Register a new client with ToolHive
  */
 export const postApiV1BetaClientsMutation = (
@@ -252,6 +255,7 @@ export const postApiV1BetaClientsMutation = (
 
 /**
  * Register multiple clients
+ *
  * Register multiple clients with ToolHive
  */
 export const postApiV1BetaClientsRegisterMutation = (
@@ -280,6 +284,7 @@ export const postApiV1BetaClientsRegisterMutation = (
 
 /**
  * Unregister multiple clients
+ *
  * Unregister multiple clients from ToolHive
  */
 export const postApiV1BetaClientsUnregisterMutation = (
@@ -308,6 +313,7 @@ export const postApiV1BetaClientsUnregisterMutation = (
 
 /**
  * Unregister a client
+ *
  * Unregister a client from ToolHive
  */
 export const deleteApiV1BetaClientsByNameMutation = (
@@ -336,6 +342,7 @@ export const deleteApiV1BetaClientsByNameMutation = (
 
 /**
  * Unregister a client from a specific group
+ *
  * Unregister a client from a specific group in ToolHive
  */
 export const deleteApiV1BetaClientsByNameGroupsByGroupMutation = (
@@ -368,6 +375,7 @@ export const getApiV1BetaDiscoveryClientsQueryKey = (
 
 /**
  * List all clients status
+ *
  * List all clients compatible with ToolHive and their status
  */
 export const getApiV1BetaDiscoveryClientsOptions = (
@@ -393,6 +401,7 @@ export const getApiV1BetaGroupsQueryKey = (
 
 /**
  * List all groups
+ *
  * Get a list of all groups
  */
 export const getApiV1BetaGroupsOptions = (
@@ -414,6 +423,7 @@ export const getApiV1BetaGroupsOptions = (
 
 /**
  * Create a new group
+ *
  * Create a new group with the specified name
  */
 export const postApiV1BetaGroupsMutation = (
@@ -442,6 +452,7 @@ export const postApiV1BetaGroupsMutation = (
 
 /**
  * Delete a group
+ *
  * Delete a group by name.
  */
 export const deleteApiV1BetaGroupsByNameMutation = (
@@ -474,6 +485,7 @@ export const getApiV1BetaGroupsByNameQueryKey = (
 
 /**
  * Get group details
+ *
  * Get details of a specific group
  */
 export const getApiV1BetaGroupsByNameOptions = (
@@ -499,6 +511,7 @@ export const getApiV1BetaRegistryQueryKey = (
 
 /**
  * List registries
+ *
  * Get a list of the current registries
  */
 export const getApiV1BetaRegistryOptions = (
@@ -520,6 +533,7 @@ export const getApiV1BetaRegistryOptions = (
 
 /**
  * Add a registry
+ *
  * Add a new registry
  */
 export const postApiV1BetaRegistryMutation = (
@@ -548,6 +562,7 @@ export const postApiV1BetaRegistryMutation = (
 
 /**
  * Remove a registry
+ *
  * Remove a specific registry
  */
 export const deleteApiV1BetaRegistryByNameMutation = (
@@ -580,6 +595,7 @@ export const getApiV1BetaRegistryByNameQueryKey = (
 
 /**
  * Get a registry
+ *
  * Get details of a specific registry
  */
 export const getApiV1BetaRegistryByNameOptions = (
@@ -601,6 +617,7 @@ export const getApiV1BetaRegistryByNameOptions = (
 
 /**
  * Update registry configuration
+ *
  * Update registry URL or local path for the default registry
  */
 export const putApiV1BetaRegistryByNameMutation = (
@@ -633,6 +650,7 @@ export const getApiV1BetaRegistryByNameServersQueryKey = (
 
 /**
  * List servers in a registry
+ *
  * Get a list of servers in a specific registry
  */
 export const getApiV1BetaRegistryByNameServersOptions = (
@@ -658,6 +676,7 @@ export const getApiV1BetaRegistryByNameServersByServerNameQueryKey = (
 
 /**
  * Get a server from a registry
+ *
  * Get details of a specific server in a registry
  */
 export const getApiV1BetaRegistryByNameServersByServerNameOptions = (
@@ -679,6 +698,7 @@ export const getApiV1BetaRegistryByNameServersByServerNameOptions = (
 
 /**
  * Setup or reconfigure secrets provider
+ *
  * Setup the secrets provider with the specified type and configuration.
  */
 export const postApiV1BetaSecretsMutation = (
@@ -711,6 +731,7 @@ export const getApiV1BetaSecretsDefaultQueryKey = (
 
 /**
  * Get secrets provider details
+ *
  * Get details of the default secrets provider
  */
 export const getApiV1BetaSecretsDefaultOptions = (
@@ -736,6 +757,7 @@ export const getApiV1BetaSecretsDefaultKeysQueryKey = (
 
 /**
  * List secrets
+ *
  * Get a list of all secret keys from the default provider
  */
 export const getApiV1BetaSecretsDefaultKeysOptions = (
@@ -757,6 +779,7 @@ export const getApiV1BetaSecretsDefaultKeysOptions = (
 
 /**
  * Create a new secret
+ *
  * Create a new secret in the default provider (encrypted provider only)
  */
 export const postApiV1BetaSecretsDefaultKeysMutation = (
@@ -785,6 +808,7 @@ export const postApiV1BetaSecretsDefaultKeysMutation = (
 
 /**
  * Delete a secret
+ *
  * Delete a secret from the default provider (encrypted provider only)
  */
 export const deleteApiV1BetaSecretsDefaultKeysByKeyMutation = (
@@ -813,6 +837,7 @@ export const deleteApiV1BetaSecretsDefaultKeysByKeyMutation = (
 
 /**
  * Update a secret
+ *
  * Update an existing secret in the default provider (encrypted provider only)
  */
 export const putApiV1BetaSecretsDefaultKeysByKeyMutation = (
@@ -845,6 +870,7 @@ export const getApiV1BetaVersionQueryKey = (
 
 /**
  * Get server version
+ *
  * Returns the current version of the server
  */
 export const getApiV1BetaVersionOptions = (
@@ -870,6 +896,7 @@ export const getApiV1BetaWorkloadsQueryKey = (
 
 /**
  * List all workloads
+ *
  * Get a list of all running workloads, optionally filtered by group
  */
 export const getApiV1BetaWorkloadsOptions = (
@@ -891,6 +918,7 @@ export const getApiV1BetaWorkloadsOptions = (
 
 /**
  * Create a new workload
+ *
  * Create and start a new workload
  */
 export const postApiV1BetaWorkloadsMutation = (
@@ -919,6 +947,7 @@ export const postApiV1BetaWorkloadsMutation = (
 
 /**
  * Delete workloads in bulk
+ *
  * Delete multiple workloads by name or by group
  */
 export const postApiV1BetaWorkloadsDeleteMutation = (
@@ -947,6 +976,7 @@ export const postApiV1BetaWorkloadsDeleteMutation = (
 
 /**
  * Restart workloads in bulk
+ *
  * Restart multiple workloads by name or by group
  */
 export const postApiV1BetaWorkloadsRestartMutation = (
@@ -975,6 +1005,7 @@ export const postApiV1BetaWorkloadsRestartMutation = (
 
 /**
  * Stop workloads in bulk
+ *
  * Stop multiple workloads by name or by group
  */
 export const postApiV1BetaWorkloadsStopMutation = (
@@ -1003,6 +1034,7 @@ export const postApiV1BetaWorkloadsStopMutation = (
 
 /**
  * Delete a workload
+ *
  * Delete a workload
  */
 export const deleteApiV1BetaWorkloadsByNameMutation = (
@@ -1035,6 +1067,7 @@ export const getApiV1BetaWorkloadsByNameQueryKey = (
 
 /**
  * Get workload details
+ *
  * Get details of a specific workload
  */
 export const getApiV1BetaWorkloadsByNameOptions = (
@@ -1056,6 +1089,7 @@ export const getApiV1BetaWorkloadsByNameOptions = (
 
 /**
  * Update workload
+ *
  * Update an existing workload configuration
  */
 export const postApiV1BetaWorkloadsByNameEditMutation = (
@@ -1088,6 +1122,7 @@ export const getApiV1BetaWorkloadsByNameExportQueryKey = (
 
 /**
  * Export workload configuration
+ *
  * Export a workload's run configuration as JSON
  */
 export const getApiV1BetaWorkloadsByNameExportOptions = (
@@ -1113,6 +1148,7 @@ export const getApiV1BetaWorkloadsByNameLogsQueryKey = (
 
 /**
  * Get logs for a specific workload
+ *
  * Retrieve at most 100 lines of logs for a specific workload by name.
  */
 export const getApiV1BetaWorkloadsByNameLogsOptions = (
@@ -1134,6 +1170,7 @@ export const getApiV1BetaWorkloadsByNameLogsOptions = (
 
 /**
  * Restart a workload
+ *
  * Restart a running workload
  */
 export const postApiV1BetaWorkloadsByNameRestartMutation = (
@@ -1166,6 +1203,7 @@ export const getApiV1BetaWorkloadsByNameStatusQueryKey = (
 
 /**
  * Get workload status
+ *
  * Get the current status of a specific workload
  */
 export const getApiV1BetaWorkloadsByNameStatusOptions = (
@@ -1187,6 +1225,7 @@ export const getApiV1BetaWorkloadsByNameStatusOptions = (
 
 /**
  * Stop a workload
+ *
  * Stop a running workload
  */
 export const postApiV1BetaWorkloadsByNameStopMutation = (
@@ -1218,6 +1257,7 @@ export const getHealthQueryKey = (options?: Options<GetHealthData>) =>
 
 /**
  * Health check
+ *
  * Check if the API is healthy
  */
 export const getHealthOptions = (options?: Options<GetHealthData>) => {

--- a/api/generated/sdk.gen.ts
+++ b/api/generated/sdk.gen.ts
@@ -137,6 +137,7 @@ export type Options<
 
 /**
  * Get OpenAPI specification
+ *
  * Returns the OpenAPI specification for the API
  */
 export const getApiOpenapiJson = <ThrowOnError extends boolean = false>(
@@ -154,6 +155,7 @@ export const getApiOpenapiJson = <ThrowOnError extends boolean = false>(
 
 /**
  * List all clients
+ *
  * List all registered clients in ToolHive
  */
 export const getApiV1BetaClients = <ThrowOnError extends boolean = false>(
@@ -171,6 +173,7 @@ export const getApiV1BetaClients = <ThrowOnError extends boolean = false>(
 
 /**
  * Register a new client
+ *
  * Register a new client with ToolHive
  */
 export const postApiV1BetaClients = <ThrowOnError extends boolean = false>(
@@ -192,6 +195,7 @@ export const postApiV1BetaClients = <ThrowOnError extends boolean = false>(
 
 /**
  * Register multiple clients
+ *
  * Register multiple clients with ToolHive
  */
 export const postApiV1BetaClientsRegister = <
@@ -215,6 +219,7 @@ export const postApiV1BetaClientsRegister = <
 
 /**
  * Unregister multiple clients
+ *
  * Unregister multiple clients from ToolHive
  */
 export const postApiV1BetaClientsUnregister = <
@@ -238,6 +243,7 @@ export const postApiV1BetaClientsUnregister = <
 
 /**
  * Unregister a client
+ *
  * Unregister a client from ToolHive
  */
 export const deleteApiV1BetaClientsByName = <
@@ -257,6 +263,7 @@ export const deleteApiV1BetaClientsByName = <
 
 /**
  * Unregister a client from a specific group
+ *
  * Unregister a client from a specific group in ToolHive
  */
 export const deleteApiV1BetaClientsByNameGroupsByGroup = <
@@ -276,6 +283,7 @@ export const deleteApiV1BetaClientsByNameGroupsByGroup = <
 
 /**
  * List all clients status
+ *
  * List all clients compatible with ToolHive and their status
  */
 export const getApiV1BetaDiscoveryClients = <
@@ -295,6 +303,7 @@ export const getApiV1BetaDiscoveryClients = <
 
 /**
  * List all groups
+ *
  * Get a list of all groups
  */
 export const getApiV1BetaGroups = <ThrowOnError extends boolean = false>(
@@ -312,6 +321,7 @@ export const getApiV1BetaGroups = <ThrowOnError extends boolean = false>(
 
 /**
  * Create a new group
+ *
  * Create a new group with the specified name
  */
 export const postApiV1BetaGroups = <ThrowOnError extends boolean = false>(
@@ -333,6 +343,7 @@ export const postApiV1BetaGroups = <ThrowOnError extends boolean = false>(
 
 /**
  * Delete a group
+ *
  * Delete a group by name.
  */
 export const deleteApiV1BetaGroupsByName = <
@@ -352,6 +363,7 @@ export const deleteApiV1BetaGroupsByName = <
 
 /**
  * Get group details
+ *
  * Get details of a specific group
  */
 export const getApiV1BetaGroupsByName = <ThrowOnError extends boolean = false>(
@@ -369,6 +381,7 @@ export const getApiV1BetaGroupsByName = <ThrowOnError extends boolean = false>(
 
 /**
  * List registries
+ *
  * Get a list of the current registries
  */
 export const getApiV1BetaRegistry = <ThrowOnError extends boolean = false>(
@@ -386,6 +399,7 @@ export const getApiV1BetaRegistry = <ThrowOnError extends boolean = false>(
 
 /**
  * Add a registry
+ *
  * Add a new registry
  */
 export const postApiV1BetaRegistry = <ThrowOnError extends boolean = false>(
@@ -407,6 +421,7 @@ export const postApiV1BetaRegistry = <ThrowOnError extends boolean = false>(
 
 /**
  * Remove a registry
+ *
  * Remove a specific registry
  */
 export const deleteApiV1BetaRegistryByName = <
@@ -426,6 +441,7 @@ export const deleteApiV1BetaRegistryByName = <
 
 /**
  * Get a registry
+ *
  * Get details of a specific registry
  */
 export const getApiV1BetaRegistryByName = <
@@ -445,6 +461,7 @@ export const getApiV1BetaRegistryByName = <
 
 /**
  * Update registry configuration
+ *
  * Update registry URL or local path for the default registry
  */
 export const putApiV1BetaRegistryByName = <
@@ -468,6 +485,7 @@ export const putApiV1BetaRegistryByName = <
 
 /**
  * List servers in a registry
+ *
  * Get a list of servers in a specific registry
  */
 export const getApiV1BetaRegistryByNameServers = <
@@ -487,6 +505,7 @@ export const getApiV1BetaRegistryByNameServers = <
 
 /**
  * Get a server from a registry
+ *
  * Get details of a specific server in a registry
  */
 export const getApiV1BetaRegistryByNameServersByServerName = <
@@ -509,6 +528,7 @@ export const getApiV1BetaRegistryByNameServersByServerName = <
 
 /**
  * Setup or reconfigure secrets provider
+ *
  * Setup the secrets provider with the specified type and configuration.
  */
 export const postApiV1BetaSecrets = <ThrowOnError extends boolean = false>(
@@ -530,6 +550,7 @@ export const postApiV1BetaSecrets = <ThrowOnError extends boolean = false>(
 
 /**
  * Get secrets provider details
+ *
  * Get details of the default secrets provider
  */
 export const getApiV1BetaSecretsDefault = <
@@ -549,6 +570,7 @@ export const getApiV1BetaSecretsDefault = <
 
 /**
  * List secrets
+ *
  * Get a list of all secret keys from the default provider
  */
 export const getApiV1BetaSecretsDefaultKeys = <
@@ -568,6 +590,7 @@ export const getApiV1BetaSecretsDefaultKeys = <
 
 /**
  * Create a new secret
+ *
  * Create a new secret in the default provider (encrypted provider only)
  */
 export const postApiV1BetaSecretsDefaultKeys = <
@@ -591,6 +614,7 @@ export const postApiV1BetaSecretsDefaultKeys = <
 
 /**
  * Delete a secret
+ *
  * Delete a secret from the default provider (encrypted provider only)
  */
 export const deleteApiV1BetaSecretsDefaultKeysByKey = <
@@ -610,6 +634,7 @@ export const deleteApiV1BetaSecretsDefaultKeysByKey = <
 
 /**
  * Update a secret
+ *
  * Update an existing secret in the default provider (encrypted provider only)
  */
 export const putApiV1BetaSecretsDefaultKeysByKey = <
@@ -633,6 +658,7 @@ export const putApiV1BetaSecretsDefaultKeysByKey = <
 
 /**
  * Get server version
+ *
  * Returns the current version of the server
  */
 export const getApiV1BetaVersion = <ThrowOnError extends boolean = false>(
@@ -650,6 +676,7 @@ export const getApiV1BetaVersion = <ThrowOnError extends boolean = false>(
 
 /**
  * List all workloads
+ *
  * Get a list of all running workloads, optionally filtered by group
  */
 export const getApiV1BetaWorkloads = <ThrowOnError extends boolean = false>(
@@ -667,6 +694,7 @@ export const getApiV1BetaWorkloads = <ThrowOnError extends boolean = false>(
 
 /**
  * Create a new workload
+ *
  * Create and start a new workload
  */
 export const postApiV1BetaWorkloads = <ThrowOnError extends boolean = false>(
@@ -688,6 +716,7 @@ export const postApiV1BetaWorkloads = <ThrowOnError extends boolean = false>(
 
 /**
  * Delete workloads in bulk
+ *
  * Delete multiple workloads by name or by group
  */
 export const postApiV1BetaWorkloadsDelete = <
@@ -711,6 +740,7 @@ export const postApiV1BetaWorkloadsDelete = <
 
 /**
  * Restart workloads in bulk
+ *
  * Restart multiple workloads by name or by group
  */
 export const postApiV1BetaWorkloadsRestart = <
@@ -734,6 +764,7 @@ export const postApiV1BetaWorkloadsRestart = <
 
 /**
  * Stop workloads in bulk
+ *
  * Stop multiple workloads by name or by group
  */
 export const postApiV1BetaWorkloadsStop = <
@@ -757,6 +788,7 @@ export const postApiV1BetaWorkloadsStop = <
 
 /**
  * Delete a workload
+ *
  * Delete a workload
  */
 export const deleteApiV1BetaWorkloadsByName = <
@@ -776,6 +808,7 @@ export const deleteApiV1BetaWorkloadsByName = <
 
 /**
  * Get workload details
+ *
  * Get details of a specific workload
  */
 export const getApiV1BetaWorkloadsByName = <
@@ -795,6 +828,7 @@ export const getApiV1BetaWorkloadsByName = <
 
 /**
  * Update workload
+ *
  * Update an existing workload configuration
  */
 export const postApiV1BetaWorkloadsByNameEdit = <
@@ -818,6 +852,7 @@ export const postApiV1BetaWorkloadsByNameEdit = <
 
 /**
  * Export workload configuration
+ *
  * Export a workload's run configuration as JSON
  */
 export const getApiV1BetaWorkloadsByNameExport = <
@@ -837,6 +872,7 @@ export const getApiV1BetaWorkloadsByNameExport = <
 
 /**
  * Get logs for a specific workload
+ *
  * Retrieve at most 100 lines of logs for a specific workload by name.
  */
 export const getApiV1BetaWorkloadsByNameLogs = <
@@ -856,6 +892,7 @@ export const getApiV1BetaWorkloadsByNameLogs = <
 
 /**
  * Restart a workload
+ *
  * Restart a running workload
  */
 export const postApiV1BetaWorkloadsByNameRestart = <
@@ -875,6 +912,7 @@ export const postApiV1BetaWorkloadsByNameRestart = <
 
 /**
  * Get workload status
+ *
  * Get the current status of a specific workload
  */
 export const getApiV1BetaWorkloadsByNameStatus = <
@@ -894,6 +932,7 @@ export const getApiV1BetaWorkloadsByNameStatus = <
 
 /**
  * Stop a workload
+ *
  * Stop a running workload
  */
 export const postApiV1BetaWorkloadsByNameStop = <
@@ -913,6 +952,7 @@ export const postApiV1BetaWorkloadsByNameStop = <
 
 /**
  * Health check
+ *
  * Check if the API is healthy
  */
 export const getHealth = <ThrowOnError extends boolean = false>(


### PR DESCRIPTION
I had an older version of the branch when I tested the upgrade locally.  
The output of the generated clients API included an extra `*` in the comments.

For consistency, it’s better to have the latest generated version, even if it doesn’t impact the logic.