### PR TITLE
feat(customize-tools-page): add empty state for server not running

### DIFF
--- a/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/items/customize-tools-menu-item.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/items/customize-tools-menu-item.tsx
@@ -1,31 +1,23 @@
 import { Edit3 } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { DropdownMenuItem } from '@/common/components/ui/dropdown-menu'
-import { cn } from '@/common/lib/utils'
 import { useIsServerFromRegistry } from '@/features/mcp-servers/hooks/use-is-server-from-registry'
 
 interface CustomizeToolsMenuItemProps {
   serverName: string
-  status: string | undefined
+  status?: string | undefined
 }
 
 export function CustomizeToolsMenuItem({
   serverName,
-  status,
 }: CustomizeToolsMenuItemProps) {
   const { isFromRegistry } = useIsServerFromRegistry(serverName)
-  const isRunning = status === 'running'
 
   if (!isFromRegistry) return null
 
   return (
     <DropdownMenuItem asChild className="flex cursor-pointer items-center">
-      <Link
-        disabled={!isRunning}
-        className={cn(!isRunning && 'pointer-events-none opacity-50')}
-        to="/customize-tools/$serverName"
-        params={{ serverName }}
-      >
+      <Link to="/customize-tools/$serverName" params={{ serverName }}>
         <Edit3 className="mr-2 h-4 w-4" />
         Customize Tools
       </Link>


### PR DESCRIPTION
As per title, with this change, we want to acces to the page even if the server is not running and show an Empty State, whit the CTA that let you decide to start the server.


https://github.com/user-attachments/assets/69c34384-6fc9-48b7-86c3-c74e084d0df2

