### PR TITLE
fix: use correct query key to invalidate add group

### DIFF
--- a/renderer/src/features/mcp-servers/hooks/use-mutation-create-group.ts
+++ b/renderer/src/features/mcp-servers/hooks/use-mutation-create-group.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { postApiV1BetaGroups } from '@api/sdk.gen'
+import { getApiV1BetaGroupsQueryKey } from '@api/@tanstack/react-query.gen'
 import type { PostApiV1BetaGroupsData } from '@api/types.gen'
 import { useToastMutation } from '@/common/hooks/use-toast-mutation'
 import { trackEvent } from '@/common/lib/analytics'
@@ -23,7 +24,7 @@ export function useMutationCreateGroup() {
       trackEvent('Group created', {
         existing_groups_count: existingGroupsCount,
       })
-      queryClient.invalidateQueries({ queryKey: ['api', 'v1beta', 'groups'] })
+      queryClient.invalidateQueries({ queryKey: getApiV1BetaGroupsQueryKey() })
     },
     successMsg: (variables) =>
       `Group "${variables.body.name}" created successfully`,


### PR DESCRIPTION
When adding a new group the sidebar was not refreshing to show the group being added. This fix provides the correct query key to invalidate.

Fixes #1133