### PR TITLE
fix(optimizer): hide advance if no group is selected

### DIFF
--- a/renderer/src/routes/__tests__/mcp-optimizer.test.tsx
+++ b/renderer/src/routes/__tests__/mcp-optimizer.test.tsx
@@ -46,6 +46,19 @@ it('renders the MCP Optimizer page title', async () => {
 })
 
 it('renders the Advanced dropdown menu button', async () => {
+  server.use(
+    http.get(mswEndpoint('/api/v1beta/workloads/:name'), ({ params }) => {
+      if (params.name === META_MCP_SERVER_NAME) {
+        return HttpResponse.json({
+          name: META_MCP_SERVER_NAME,
+          group: MCP_OPTIMIZER_GROUP_NAME,
+          env_vars: { ALLOWED_GROUPS: 'default' },
+        })
+      }
+      return HttpResponse.json(null, { status: 404 })
+    })
+  )
+
   renderRoute(router)
 
   await waitFor(() => {
@@ -365,6 +378,19 @@ it('refetches the selected group when navigating back to the page', async () => 
 })
 
 it('clicking Meta-MCP logs in Advanced menu navigates to logs page', async () => {
+  server.use(
+    http.get(mswEndpoint('/api/v1beta/workloads/:name'), ({ params }) => {
+      if (params.name === META_MCP_SERVER_NAME) {
+        return HttpResponse.json({
+          name: META_MCP_SERVER_NAME,
+          group: MCP_OPTIMIZER_GROUP_NAME,
+          env_vars: { ALLOWED_GROUPS: 'default' },
+        })
+      }
+      return HttpResponse.json(null, { status: 404 })
+    })
+  )
+
   const user = userEvent.setup()
   renderRoute(router)
 

--- a/renderer/src/routes/mcp-optimizer.tsx
+++ b/renderer/src/routes/mcp-optimizer.tsx
@@ -41,7 +41,7 @@ function McpOptimizerContent() {
       <McpServersSidebar />
       <div className={'ml-sidebar min-w-0 flex-1'}>
         <TitlePage title="MCP Optimizer">
-          <>
+          {optimizedGroupName ? (
             <div className="flex gap-2 lg:ml-auto">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -66,19 +66,17 @@ function McpOptimizerContent() {
                       MCP Optimizer logs
                     </LinkViewTransition>
                   </DropdownMenuItem>
-                  {optimizedGroupName ? (
-                    <DropdownMenuItem
-                      className="flex cursor-pointer items-center"
-                      onClick={handleCustomizeConfiguration}
-                    >
-                      <Edit3 className="mr-2 h-4 w-4" />
-                      Customize MCP Optimizer configuration
-                    </DropdownMenuItem>
-                  ) : null}
+                  <DropdownMenuItem
+                    className="flex cursor-pointer items-center"
+                    onClick={handleCustomizeConfiguration}
+                  >
+                    <Edit3 className="mr-2 h-4 w-4" />
+                    Customize MCP Optimizer configuration
+                  </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
-          </>
+          ) : null}
         </TitlePage>
         <div className="p-6">
           <div className="mx-auto max-w-2xl">


### PR DESCRIPTION
This hides the dropdown menu if no group is selected, meaning the MCP optimizer isn’t running.

<img width="1276" height="796" alt="Screenshot 2025-10-24 at 20 17 50" src="https://github.com/user-attachments/assets/bd999fbd-a4cc-4685-8559-de8604ec2d07" />
