### PR TITLE
chore: patched tar vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prettier-plugin-classnames": "^0.8.0",
     "prettier-plugin-merge": "^0.8.0",
     "prettier-plugin-tailwindcss": "^0.7.0",
-    "tar": "^7.4.3",
+    "tar": "^7.5.2",
     "ts-node": "^10.9.2",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,8 +331,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0(prettier@3.6.2)
       tar:
-        specifier: ^7.4.3
-        version: 7.5.1
+        specifier: ^7.5.2
+        version: 7.5.2
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.13.5)(@types/node@22.18.11)(typescript@5.9.3)
@@ -6958,8 +6958,8 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
 
-  tar@7.5.1:
-    resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
+  tar@7.5.2:
+    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
 
   temp@0.9.4:
@@ -15459,7 +15459,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.5.1:
+  tar@7.5.2:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
We have npm audit failing because of tar vuln - https://github.com/stacklok/toolhive-studio/actions/runs/18951211024/job/54116053339?pr=1211
