### PR TITLE
fix: replace browser with hash history

### DIFF
--- a/renderer/src/renderer.tsx
+++ b/renderer/src/renderer.tsx
@@ -112,8 +112,6 @@ if (!window.electronAPI || !window.electronAPI.getToolhivePort) {
     router.navigate({ to: '/shutdown' })
   })
 
-  await router.load()
-
   const rootElement = document.getElementById('root')!
   const root = ReactDOM.createRoot(rootElement)
 


### PR DESCRIPTION
## Fix: 404 error on first app load

<img width="2736" height="1696" alt="Screenshot 2025-11-03 at 14 56 46" src="https://github.com/user-attachments/assets/f0482143-c6a8-4dce-9abc-c022adec440f" />

### Problem
The app showed a 404 "Page Not Found" error on first load in production builds, working only after clicked on go to installed button.

### Root Cause
TanStack Router's default browser history doesn't work with Electron's `file://` protocol when loading local files via `loadFile()`.

### Solution
1. **Use Hash History**: Switch from browser history to `createHashHistory()` which supports `file://` URLs
2. **Proper initialization order**: Configure API client before creating the router to prevent race conditions

### Changes
- Added `createHashHistory()` to router configuration
- Moved router creation inside async initialization function after API client setup
- Routes and navigation code remain unchanged (hash conversion is automatic)

Hash routing is the [recommended approach](https://tanstack.com/router/v1/docs/framework/react/guide/history-types) for environments without a server, including Electron apps loading local files.