### PR TITLE
feat: add file picker for custom local registry

### DIFF
--- a/renderer/src/common/components/settings/registry/registry-source-field.tsx
+++ b/renderer/src/common/components/settings/registry/registry-source-field.tsx
@@ -70,6 +70,7 @@ export function RegistrySourceField({
                 />
               ) : (
                 <FilePickerInput
+                  mode="file"
                   placeholder={'/path/to/registry.json'}
                   name={field.name}
                   value={field.value ?? ''}

--- a/renderer/src/common/components/ui/file-picker-input.tsx
+++ b/renderer/src/common/components/ui/file-picker-input.tsx
@@ -10,9 +10,30 @@ import { Input } from './input'
 
 function FilePicker({
   onPick,
+  mode = 'file-or-folder',
 }: {
   onPick: (args: { pickedPath: string | null }) => void
+  mode?: 'file' | 'file-or-folder'
 }) {
+  if (mode === 'file') {
+    return (
+      <Button
+        variant="adornment"
+        aria-label="Select path"
+        onClick={async () => {
+          try {
+            const filePath = await window.electronAPI.selectFile()
+            onPick({ pickedPath: filePath })
+          } catch (err) {
+            console.error('Failed to open file picker', err)
+          }
+        }}
+      >
+        <FolderOpen className="size-4" />
+      </Button>
+    )
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -60,9 +81,11 @@ function FilePicker({
 
 function FilePickerInput({
   onChange,
+  mode = 'file-or-folder',
   ...props
 }: Omit<React.ComponentProps<'input'>, 'type' | 'onChange'> & {
   onChange: (props: { newValue: string }) => void
+  mode?: 'file' | 'file-or-folder'
 }) {
   return (
     <Input
@@ -70,6 +93,7 @@ function FilePickerInput({
       type="text"
       adornment={
         <FilePicker
+          mode={mode}
           onPick={({ pickedPath }) => {
             if (pickedPath) {
               onChange({ newValue: pickedPath })


### PR DESCRIPTION
this is a quality of life improvement that would make it easier to use and test the "groups in registry" feature (does not fix, but related to https://github.com/stacklok/toolhive-studio/issues/860)

fixes https://github.com/stacklok/toolhive-studio/issues/1057 

## Before


https://github.com/user-attachments/assets/8ab2633b-b318-4778-8f79-7243339c8eef


## After


https://github.com/user-attachments/assets/b463b28b-a6a3-4200-a727-6ed867c6dabb

