### PR TITLE
fix: bring back the logic of mcp utils

### DIFF
--- a/main/src/utils/mcp-tools.ts
+++ b/main/src/utils/mcp-tools.ts
@@ -13,7 +13,7 @@ export interface McpToolDefinition {
   inputSchema: Tool['inputSchema']
 }
 
-export function isMcpToolDefinition(obj: Tool): obj is McpToolDefinition {
+export function isMcpToolDefinition(obj: unknown): obj is McpToolDefinition {
   if (!obj || typeof obj !== 'object' || obj === null) return false
 
   const tool = obj
@@ -113,8 +113,8 @@ export async function getWorkloadAvailableTools(
         .reduce<Record<string, McpToolDefinition>>((prev, [name, def]) => {
           if (!def || !name) return prev
           prev[name] = {
-            description: def.description ?? '',
-            inputSchema: def.inputSchema ?? undefined,
+            description: def.description,
+            inputSchema: def.inputSchema,
           }
           return prev
         }, {})


### PR DESCRIPTION
In the [bump of the libs](https://github.com/stacklok/toolhive-studio/pull/1240/files) I touched this file but was not correct, I just revert the type and logic as before.

This fix the retrival of tools for tool override.