### PR TITLE
fix(playground): use providers instead of API Keys

### DIFF
--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -243,7 +243,7 @@ export function ChatInterface() {
                           onClick={() => setIsSettingsOpen(true)}
                           className="mt-6"
                         >
-                          <Plus /> Configure your API Keys
+                          <Plus /> Configure your providers
                         </Button>
                       </>
                     )}


### PR DESCRIPTION
As per title, very simple change

<img width="1280" height="794" alt="Screenshot 2025-11-06 at 14 12 36" src="https://github.com/user-attachments/assets/94500e84-7580-4048-9322-d2aaa85d1bf9" />
