### PR TITLE
chore: handle renovate post-upgrade

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,8 @@
   "timezone": "Europe/London",
   "schedule": ["after 01:00 and before 07:00 every weekday"],
   "allowedPostUpgradeCommands": [
-    "^pnpm run thv",
-    "^pnpm run generate-client"
+    "/^pnpm run thv$/",
+    "/^pnpm run generate-client$/"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Looking to the PR https://github.com/stacklok/toolhive-studio/pull/1258 it seems renovate needs to have those custom scripts in the `allowedPostUpgradeCommands` 