### PR TITLE
feat: remove groups and override feature flags

### DIFF
--- a/main/src/feature-flags/flags.ts
+++ b/main/src/feature-flags/flags.ts
@@ -7,16 +7,6 @@ import type { FeatureFlagKey, FeatureFlagOptions } from './types'
 const FLAG_STORE_PREFIX = 'feature_flag_'
 
 const featureFlagOptions: Record<FeatureFlagKey, FeatureFlagOptions> = {
-  [featureFlagKeys.CUSTOMIZE_TOOLS]: {
-    isDisabled: false,
-    defaultValue: false,
-    isExperimental: false,
-  },
-  [featureFlagKeys.GROUPS_IN_REGISTRY]: {
-    isDisabled: false,
-    defaultValue: false,
-    isExperimental: false,
-  },
   [featureFlagKeys.META_OPTIMIZER]: {
     isDisabled: false,
     defaultValue: false,

--- a/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/index.tsx
+++ b/renderer/src/features/mcp-servers/components/card-mcp-server/server-actions/index.tsx
@@ -6,8 +6,6 @@ import {
   DropdownMenuContent,
   DropdownMenuSeparator,
 } from '@/common/components/ui/dropdown-menu'
-import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
-import { featureFlagKeys } from '../../../../../../../utils/feature-flags'
 import { useServerDetails } from '../../../hooks/use-server-details'
 import { ServerUrl } from './items/server-url'
 import { EditConfigurationMenuItem } from './items/edit-configuration-menu-item'
@@ -32,10 +30,6 @@ export function ServerActionsDropdown({
   remote,
   group,
 }: ServerActionsDropdownProps) {
-  const isCustomizeToolsEnabled = useFeatureFlag(
-    featureFlagKeys.CUSTOMIZE_TOOLS
-  )
-
   const { data: serverDetails } = useServerDetails(name)
 
   const repositoryUrl = serverDetails?.server?.repository_url
@@ -68,9 +62,7 @@ export function ServerActionsDropdown({
           <GithubRepositoryMenuItem repositoryUrl={repositoryUrl} />
         )}
         <LogsMenuItem serverName={name} remote={remote} group={group} />
-        {isCustomizeToolsEnabled && (
-          <CustomizeToolsMenuItem serverName={name} status={status} />
-        )}
+        <CustomizeToolsMenuItem serverName={name} status={status} />
         <RemoveServerMenuItem serverName={name} group={group} />
         <DropdownMenuSeparator />
         <AddServerToGroupMenuItem serverName={name} />

--- a/renderer/src/routes/(registry)/registry.tsx
+++ b/renderer/src/routes/(registry)/registry.tsx
@@ -9,8 +9,6 @@ import { EmptyState } from '@/common/components/empty-state'
 import { ExternalLinkIcon } from 'lucide-react'
 import { Button } from '@/common/components/ui/button'
 import { IllustrationNoConnection } from '@/common/components/illustrations/illustration-no-connection'
-import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
-import { featureFlagKeys } from '../../../../utils/feature-flags'
 import {
   DEPRECATED_MCP_OPTIMIZER_REGISTRY_SERVER_NAME,
   MCP_OPTIMIZER_REGISTRY_SERVER_NAME,
@@ -40,10 +38,6 @@ export const Route = createFileRoute('/(registry)/registry')({
 })
 
 export function Registry() {
-  const isGroupsInRegistryEnabled = useFeatureFlag(
-    featureFlagKeys.GROUPS_IN_REGISTRY
-  )
-
   const { data: serversData } = useSuspenseQuery(
     getApiV1BetaRegistryByNameServersOptions({
       path: { name: DEFAULT_REGISTRY_NAME },
@@ -59,9 +53,7 @@ export function Registry() {
   const { servers: serversList = [], remote_servers: remoteServersList = [] } =
     serversData || {}
 
-  const groups = isGroupsInRegistryEnabled
-    ? registryData?.registry?.groups || []
-    : []
+  const groups = registryData?.registry?.groups || []
 
   const servers = [...serversList, ...remoteServersList].filter(
     (server) => !SKIP_META_MCP.includes(server.name ?? '')

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -1,5 +1,3 @@
 export const featureFlagKeys = {
-  CUSTOMIZE_TOOLS: 'customize_tools',
-  GROUPS_IN_REGISTRY: 'groups_in_registry',
   META_OPTIMIZER: 'meta_optimizer',
 } as const


### PR DESCRIPTION
Remove feature flags for:
- group catalog 
- tools override

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `CUSTOMIZE_TOOLS` and `GROUPS_IN_REGISTRY` feature flags and always enables their UI/behavior; retains only `META_OPTIMIZER` flag.
> 
> - **Feature Flags**:
>   - Remove `CUSTOMIZE_TOOLS` and `GROUPS_IN_REGISTRY` from `utils/feature-flags` and `main/src/feature-flags/flags.ts` options.
>   - Keep only `META_OPTIMIZER` flag.
> - **Renderer UI**:
>   - In `server-actions/index.tsx`, drop `useFeatureFlag` usage and always render `CustomizeToolsMenuItem`.
>   - In `routes/(registry)/registry.tsx`, remove flag gating and always use `registry.registry.groups` for `groups`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c84fe265c72749eb945cf02c18d90032b5a414f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->