### PR TITLE
ci: update macOS-13 intel in the github actions

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             arch: arm64
     env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
+      NODE_OPTIONS: '--max_old_space_size=4096'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -37,7 +37,7 @@ jobs:
           - os: macos-latest
             arch: arm64
     env:
-      NODE_OPTIONS: "--max_old_space_size=4096"
+      NODE_OPTIONS: '--max_old_space_size=4096'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6


### PR DESCRIPTION
GitHub Actions is starting the deprecation process for macOS 13 and macOS 13 arm64

Detail [here](https://github.com/actions/runner-images/issues/13046)

<img width="1377" height="270" alt="Screenshot 2025-12-10 at 14 39 05" src="https://github.com/user-attachments/assets/0cc91dd9-1632-4394-8238-6b5037017c9b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update GitHub Actions matrices to use `macos-15-intel` instead of `macos-13` for x64 macOS builds in both build and release workflows.
> 
> - **CI/Workflows**:
>   - Update macOS x64 runner in build matrices:
>     - `macos-13` -> `macos-15-intel` in `/.github/workflows/_build-matrix.yml` and `/.github/workflows/on-release.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00d90d22b2722168dfb17780d0907c566b2d185b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->