### PR TITLE
ci: upgrade toolhive clients within renovate pr

### DIFF
--- a/.github/workflows/renovate-post-upgrade.yml
+++ b/.github/workflows/renovate-post-upgrade.yml
@@ -1,0 +1,63 @@
+name: Renovate Post-Upgrade
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'utils/constants.ts'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  regenerate-artifacts:
+    name: Regenerate THV Binary and API Client
+    runs-on: ubuntu-latest
+    # Only run for Renovate PRs
+    if: github.actor == 'renovate[bot]'
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        with:
+          version: '10.25.0'
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download THV binary
+        run: pnpm run thv
+
+      - name: Generate API Client
+        run: pnpm run generate-client
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add bin/ api/generated/
+          git commit -m "chore: regenerate artifacts for updated toolhive version"
+          git push

--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,7 @@
       "matchDatasources": ["github-releases"],
       "matchPackageNames": ["stacklok/toolhive"],
       "prPriority": 10,
-      "schedule": [],
-      "postUpgradeTasks": {
-        "commands": ["pnpm run thv", "pnpm run generate-client"],
-        "fileFilters": ["bin/**", "api/generated/**"],
-        "executionMode": "update"
-      }
+      "schedule": []
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Added a github action that commit the changes on `pnpm thv && pnpm generate-client` cmds within the renovate PR related toolhive binary upgrade