### PR TITLE
fix: coveralls gh action

### DIFF
--- a/.github/workflows/_unit-tests.yml
+++ b/.github/workflows/_unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           file: ./coverage/lcov.info
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: false


### PR DESCRIPTION
Remove unneeded permission and avoid comment on PR with report, we have it in the jobs it is enough