### PR TITLE
chore(renovate): add to hey-api bump client gen command

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,14 @@
       "matchPackageNames": ["stacklok/toolhive"],
       "prPriority": 10,
       "schedule": []
+    },
+    {
+      "matchPackageNames": ["@hey-api/openapi-ts"],
+      "postUpgradeTasks": {
+        "commands": ["pnpm generate-client"],
+        "fileFilters": ["api/generated/**"],
+        "executionMode": "branch"
+      }
     }
   ],
   "customManagers": [


### PR DESCRIPTION
As per title, when we bump hey-api we need to run generate-client command 