### PR TITLE
test: fail tests when accidentally sending sentry events

### DIFF
--- a/renderer/src/common/hooks/__tests__/use-cleanup-meta-optimizer.test.ts
+++ b/renderer/src/common/hooks/__tests__/use-cleanup-meta-optimizer.test.ts
@@ -15,9 +15,8 @@ vi.mock('../use-feature-flag')
 vi.mock('@/features/mcp-servers/hooks/use-mutation-delete-group')
 
 const { useFeatureFlag } = await import('../use-feature-flag')
-const { useMutationDeleteGroup } = await import(
-  '@/features/mcp-servers/hooks/use-mutation-delete-group'
-)
+const { useMutationDeleteGroup } =
+  await import('@/features/mcp-servers/hooks/use-mutation-delete-group')
 
 function createWrapper() {
   const queryClient = new QueryClient({

--- a/renderer/src/features/clients/components/__tests__/manage-clients-button.test.tsx
+++ b/renderer/src/features/clients/components/__tests__/manage-clients-button.test.tsx
@@ -13,9 +13,8 @@ vi.mock('@/common/hooks/use-feature-flag')
 vi.mock('@/features/meta-mcp/hooks/use-mcp-optimizer-clients')
 
 const { useFeatureFlag } = await import('@/common/hooks/use-feature-flag')
-const { useMcpOptimizerClients } = await import(
-  '@/features/meta-mcp/hooks/use-mcp-optimizer-clients'
-)
+const { useMcpOptimizerClients } =
+  await import('@/features/meta-mcp/hooks/use-mcp-optimizer-clients')
 
 // Use the shared request recorder from mocks/node.ts for consistency
 

--- a/renderer/src/features/mcp-servers/types/tool-override.ts
+++ b/renderer/src/features/mcp-servers/types/tool-override.ts
@@ -13,8 +13,10 @@ export interface Tool {
   originalDescription?: string
 }
 
-export interface ToolWithMetadata
-  extends Omit<Tool, 'description' | 'isInitialEnabled'> {
+export interface ToolWithMetadata extends Omit<
+  Tool,
+  'description' | 'isInitialEnabled'
+> {
   description: string
   isInitialEnabled: boolean
   originalName?: string


### PR DESCRIPTION
This code makes sure that it is not possible to generate sentry events form end-to-end tests. 

We are already not sending sentry events in end-to-end tests unless the end-to-end tests are run against production builds, so this problem was already rare and unlikely.

This PR just adds a final warning: if you accidentally run the tests and send Sentry events, you will get tests failures with an error explaining this. Under normal circumstances, the events will still be associated with your local user ID, so will still be filtered out anyway.

Running end-to-end tests against production builds remains possible as long as you build it with an empty Sentry DSN