### PR TITLE
ci(release): add prerelease tag validation

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -14,25 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate prerelease tag
+        if: ${{ github.event.release.prerelease == true }}
         shell: bash
-        env:
-          IS_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          echo "Tag: $TAG"
-          echo "GitHub prerelease flag: $IS_PRERELEASE"
-          
-          # First check: is this marked as a prerelease in GitHub?
-          if [[ "$IS_PRERELEASE" == "true" ]]; then
-            # Second check: validate the tag uses allowed identifiers (alpha, beta, rc)
-            if [[ ! "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)(\.[0-9]+)?$ ]]; then
-              echo "::error::Invalid prerelease tag '$TAG'. Allowed identifiers: alpha, beta, rc"
-              exit 1
-            fi
-            echo "Valid prerelease: flag=true, tag=$TAG"
-          else
-            echo "Stable release: flag=false, tag=$TAG"
+          if [[ ! "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)(\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid prerelease tag '$TAG'. Allowed identifiers: alpha, beta, rc"
+            exit 1
           fi
+          echo "Valid prerelease tag: $TAG"
 
   security:
     name: Security Checks


### PR DESCRIPTION
## Summary

- Add `validate-prerelease` job to the release workflow that validates prerelease tags before building
- Only allow prerelease identifiers: `alpha`, `beta`, `rc` (e.g., `v1.0.0-alpha`, `v1.0.0-beta.1`, `v1.0.0-rc.2`)
- Block builds for invalid prerelease tags (e.g., `v1.0.0-test`, `v1.0.0-dev`)

## Flow

```mermaid
flowchart TD
    A[Release Published] --> B{Is Prerelease?}
    B -->|No| C[Proceed with Build]
    B -->|Yes| D{Valid Identifier?}
    D -->|alpha/beta/rc| C
    D -->|Other| E[Block Build with Error]
```

## Examples

| Tag | Result |
|-----|--------|
| `v1.0.0` | Allowed (stable release) |
| `v1.0.0-alpha` | Allowed |
| `v1.0.0-beta.1` | Allowed |
| `v1.0.0-rc.2` | Allowed |
| `v1.0.0-test` | Blocked |
| `v1.0.0-dev` | Blocked |

