### PR TITLE
fix(cli-validation): update CLI binary on Windows when app version changes

### DIFF
--- a/main/src/cli/validation.ts
+++ b/main/src/cli/validation.ts
@@ -165,32 +165,40 @@ export async function handleValidationResult(
 
             const bundledPath = getBundledCliPath()
             const cliPath = getDesktopCliPath(platform)
-            let newChecksum = marker.cli_checksum
 
             // On Windows, we need to recopy the CLI since it's a copy not a symlink
             if (platform === 'win32') {
               log.info('Recopying CLI on Windows after app update...')
               const symlinkResult = createSymlink(platform)
               if (symlinkResult.success) {
-                newChecksum = symlinkResult.checksum
                 span.setAttribute('cli.windows_recopy', true)
+                const cliInfo = await getCliInfo(cliPath)
+                createMarkerForDesktopInstall(
+                  cliInfo.version ?? 'unknown',
+                  undefined,
+                  symlinkResult.checksum,
+                  platform
+                )
               } else {
+                // Don't update marker on failure - next launch will retry
                 log.error(
                   `Failed to recopy CLI on Windows: ${symlinkResult.error}`
                 )
-                span.setAttribute(
-                  'cli.windows_recopy_error',
-                  symlinkResult.error ?? 'unknown'
-                )
+                span.setAttributes({
+                  'cli.windows_recopy': false,
+                  'cli.windows_recopy_error': symlinkResult.error ?? 'unknown',
+                })
               }
+            } else {
+              // macOS/Linux: symlink auto-updates, just update marker
+              const cliInfo = await getCliInfo(cliPath)
+              createMarkerForDesktopInstall(
+                cliInfo.version ?? 'unknown',
+                bundledPath,
+                marker.cli_checksum,
+                platform
+              )
             }
-
-            const cliInfo = await getCliInfo(cliPath)
-            createMarkerForDesktopInstall(
-              cliInfo.version ?? 'unknown',
-              platform === 'win32' ? undefined : bundledPath,
-              newChecksum
-            )
           }
 
           span.setAttributes({ 'cli.output_status': 'valid' })


### PR DESCRIPTION
On Windows, the CLI is copied (not symlinked) to `%LocalAppData%\ToolHive\bin\thv.exe`
When the app updated, the old CLI copy remained in place instead of being replaced with the new version.
This PR recopies the bundled CLI executable when a desktop version change is detected on Windows.