### PR TITLE
build: change base folder on s3 publish

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -12,6 +12,7 @@ import { ensureThv } from './utils/fetch-thv'
 import MakerTarGz from './utils/forge-makers/MakerTarGz'
 import MakerDMGWithArch from './utils/forge-makers/MakerDMGWithArch'
 import { isPrerelease } from './utils/pre-release'
+import packageJson from './package.json'
 
 function isValidPlatform(platform: string): platform is NodeJS.Platform {
   return ['win32', 'darwin', 'linux'].includes(platform)
@@ -103,6 +104,7 @@ const config: ForgeConfig = {
       name: '@electron-forge/publisher-s3',
       config: {
         bucket: 'toolhive-studio-releases',
+        folder: `${isPrerelease() ? 'pre-release' : 'stable'}/${packageJson.version}`,
         public: true,
       },
     },


### PR DESCRIPTION
Uploading to s3 with a better folder structure:

- Stable release: stable/1.2.3/darwin/x64/ToolHive.dmg
- Pre-release: pre-release/1.2.3-beta.1/darwin/x64/ToolHive.dmg