### PR TITLE
build: revert arm64 for windows

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -53,8 +53,6 @@ jobs:
           - os: ubuntu-latest
             arch: x64
           - os: windows-latest
-            arch: arm64
-          - os: windows-latest
             arch: x64
           - os: macos-15-intel
             arch: x64

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -137,9 +137,6 @@ jobs:
             arch: x64
             platform: linux
           - os: windows-latest
-            arch: arm64
-            platform: win32
-          - os: windows-latest
             arch: x64
             platform: win32
           - os: macos-15-intel


### PR DESCRIPTION
sorry in the end the assert where still x64, I just get confuse in the output, let's remove it for the moment