### PR TITLE
fix(cli-validation): avoid to redirect if we have symlink-missing

### DIFF
--- a/renderer/src/routes/__root.tsx
+++ b/renderer/src/routes/__root.tsx
@@ -123,7 +123,15 @@ export const Route = createRootRouteWithContext<{
     if (!isCliOrShutdownRoute) {
       const validationResult =
         await window.electronAPI.cliAlignment.getValidationResult()
-      if (validationResult && validationResult.status !== 'valid') {
+      const actionableStatuses = [
+        'external-cli-found',
+        'symlink-broken',
+        'symlink-tampered',
+      ]
+      if (
+        validationResult &&
+        actionableStatuses.includes(validationResult.status)
+      ) {
         log.info(
           `[beforeLoad] CLI validation issue: ${validationResult.status}, redirecting to /cli-issue`
         )


### PR DESCRIPTION
Fix dangling symlink detection by using `lstatSync` instead of `existsSync` (which follows symlinks and misses broken ones) and skip redirecting to the CLI issue page for auto-fixable statuses that have no user-actionable UI