### PR TITLE
fix: fix window control colors on Window

### DIFF
--- a/renderer/src/common/components/layout/top-nav/window-controls.tsx
+++ b/renderer/src/common/components/layout/top-nav/window-controls.tsx
@@ -30,12 +30,11 @@ export function WindowControls() {
   }
 
   return (
-    <div className="app-region-no-drag flex items-center gap-0">
+    <div className="app-region-no-drag flex items-center gap-0 text-white">
       <Button
         variant="ghost"
         size="icon"
-        className="hover:bg-accent/50 hover:text-accent-foreground h-8 w-12
-          rounded-none"
+        className="h-8 w-12 rounded-none hover:bg-white/10 hover:text-white"
         onClick={handleMinimize}
       >
         <Minus className="size-4" />
@@ -43,15 +42,14 @@ export function WindowControls() {
       <Button
         variant="ghost"
         size="icon"
-        className="hover:bg-accent/50 hover:text-accent-foreground h-8 w-12
-          rounded-none"
+        className="h-8 w-12 rounded-none hover:bg-white/10 hover:text-white"
         onClick={handleMaximize}
       >
         {isMaximized ? (
           <div className="relative size-4">
             <div className="absolute inset-0 size-3 border border-current" />
             <div
-              className="bg-background absolute top-1 left-1 size-3 border
+              className="bg-nav-background absolute top-1 left-1 size-3 border
                 border-current"
             />
           </div>


### PR DESCRIPTION
## Before


<img width="277" height="122" alt="screenshot-2026-02-13_17-30-19" src="https://github.com/user-attachments/assets/af81681a-9294-4f25-a554-09b9a80b79e1" />
<img width="299" height="179" alt="screenshot-2026-02-13_17-29-19" src="https://github.com/user-attachments/assets/8e9bd03b-05a3-4f49-b6ac-4aebc2988184" />


## After


<img width="216" height="80" alt="screenshot-2026-02-13_18-03-16" src="https://github.com/user-attachments/assets/ac7658e1-45ed-4f3c-afc7-4500aa046a30" />
<img width="226" height="83" alt="screenshot-2026-02-13_18-03-08" src="https://github.com/user-attachments/assets/740da5d4-b5d6-4274-a7da-842d0664edc3" />
