### PR TITLE
fix: radio group bg and button sytle in he optimizer page

### DIFF
--- a/renderer/src/features/meta-mcp/components/group-selector-form.tsx
+++ b/renderer/src/features/meta-mcp/components/group-selector-form.tsx
@@ -148,7 +148,7 @@ export function GroupSelectorForm({
               className="gap-0"
               disabled={isPending}
             >
-              <div className="rounded-xl border">
+              <div className="bg-card rounded-md border">
                 {groups.map((group) => {
                   const groupName = group.name ?? ''
                   const servers = group.servers
@@ -184,6 +184,7 @@ export function GroupSelectorForm({
         <div className="mt-6 flex justify-end">
           <Button
             type="submit"
+            variant="action"
             disabled={isPending || !isSelectedGroup || !isDirty}
           >
             Set Optimized Group


### PR DESCRIPTION
Align mcp optimizer to the new branding

<img width="1364" height="817" alt="Screenshot 2026-02-17 at 18 08 50" src="https://github.com/user-attachments/assets/13be6f3c-59cb-4bf4-9397-d12d04a78a53" />
