### PR TITLE
chore: switch from npx to pnpm dlx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+pnpm dlx lint-staged


### PR DESCRIPTION
as per title, this avoid to use npx and use pnpm for lint-staged