### PR TITLE
feat(registry): add tooltip on card name

### DIFF
--- a/renderer/src/features/registry-servers/components/card-registry-base.tsx
+++ b/renderer/src/features/registry-servers/components/card-registry-base.tsx
@@ -5,6 +5,11 @@ import {
   CardContent,
   CardFooter,
 } from '@/common/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
 import { cn } from '@/common/lib/utils'
 import type { ReactNode } from 'react'
 
@@ -36,13 +41,18 @@ export function CardRegistryBase({
           className="grid grid-cols-[auto_calc(var(--spacing)_*_5)] items-center
             text-xl"
         >
-          <button
-            className="truncate text-left !outline-none select-none"
-            onClick={() => onClick?.()}
-          >
-            {title}
-            <span className="absolute inset-0 rounded-md" />
-          </button>
+          <Tooltip onlyWhenTruncated>
+            <TooltipTrigger asChild>
+              <button
+                className="truncate text-left !outline-none select-none"
+                onClick={() => onClick?.()}
+              >
+                {title}
+                <span className="absolute inset-0 rounded-md" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">{title}</TooltipContent>
+          </Tooltip>
         </CardTitle>
         {badge}
       </CardHeader>


### PR DESCRIPTION
as per title, replicating what we have in the servers page and adding a tooltip on names that are long

<img width="997" height="802" alt="Screenshot 2026-03-05 at 16 12 26" src="https://github.com/user-attachments/assets/eec162da-8426-400c-881b-e967dcbea9aa" />
