### PR TITLE
ci: do not record videos by default locally

### DIFF
--- a/e2e-tests/fixtures/electron.ts
+++ b/e2e-tests/fixtures/electron.ts
@@ -93,7 +93,7 @@ export const test = base.extend<ElectronFixtures>({
 
     const app = await electron.launch({
       executablePath: getExecutablePath(),
-      recordVideo: { dir: 'test-videos' },
+      ...(process.env.CI ? { recordVideo: { dir: 'test-videos' } } : {}),
       args: ['--no-sandbox'],
       env: {
         ...process.env,


### PR DESCRIPTION
I realized that I have been getting undebuggable silent failures in the end to end tests locally, and that was because of the video recording pipeline... This is essential in CI, so I cannot remove it from there. In any case, it has always worked in the CI and the environment there is quite standardized. But locally you can run the UI mode, so videos are usually not even needed at all...

So this is a more reasonable behavior.