### PR TITLE
build(release): fix s3 sync command on windows manifest

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -167,8 +167,10 @@ jobs:
           echo "Promoting Windows update files from ${SRC} to ${DST}"
 
           # --delete ensures stale nupkg files from previous releases don't accumulate in latest/
+          # --copy-props none avoids s3:GetObjectTagging calls that the IAM role lacks
           if aws s3 sync "${SRC}/" "${DST}/" \
             --delete \
+            --copy-props none \
             --exclude "*" \
             --include "RELEASES" \
             --include "*.nupkg"; then


### PR DESCRIPTION
in release CI we have a failure on synching the manifest in the latest folder for win32, this should fix that

```
Promoting Windows update files from s3://toolhive-studio-releases/stable/0.24.0/win32/x64 to s3://toolhive-studio-releases/stable/latest/win32/x64
copy failed: s3://toolhive-studio-releases/stable/0.24.0/win32/x64/ToolHive-0.24.0-full.nupkg to s3://toolhive-studio-releases/stable/latest/win32/x64/ToolHive-0.24.0-full.nupkg An error occurred (AccessDenied) when calling the GetObjectTagging operation: User: arn:aws:sts::781189302813:assumed-role/github_actions_toolhive_studio_role/GitHubActions is not authorized to perform: s3:GetObjectTagging on resource: "arn:aws:s3:::toolhive-studio-releases/stable/0.24.0/win32/x64/ToolHive-0.24.0-full.nupkg" because no identity-based policy allows the s3:GetObjectTagging action
Completed 175.0 MiB/361.7 MiB (0 Bytes/s) with 3 file(s) remaining
Completed 175.0 MiB/361.7 MiB (3.1 KiB/s) with 3 file(s) remaining
copy: s3://toolhive-studio-releases/stable/0.24.0/win32/x64/RELEASES to s3://toolhive-studio-releases/stable/latest/win32/x64/RELEASES
Completed 175.0 MiB/361.7 MiB (3.1 KiB/s) with 2 file(s) remaining
delete: s3://toolhive-studio-releases/stable/latest/win32/x64/ToolHive-0.23.0-full.nupkg
copy failed: s3://toolhive-studio-releases/stable/0.24.0/win32/x64/ToolHive-0.24.0-delta.nupkg to s3://toolhive-studio-releases/stable/latest/win32/x64/ToolHive-0.24.0-delta.nupkg An error occurred (AccessDenied) when calling the GetObjectTagging operation: User: arn:aws:sts::781189302813:assumed-role/github_actions_toolhive_studio_role/GitHubActions is not authorized to perform: s3:GetObjectTagging on resource: "arn:aws:s3:::toolhive-studio-releases/stable/0.24.0/win32/x64/ToolHive-0.24.0-delta.nupkg" because no identity-based policy allows the s3:GetObjectTagging action
Completed 175.0 MiB/361.7 MiB (3.1 KiB/s) with 1 file(s) remaining
Warning: No Windows update files found — skipping

```
