### PR TITLE
fix(build): adjust detaction on manifest

### DIFF
--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -73,13 +73,13 @@ jobs:
             SIZE=$(echo "$asset" | jq -r '.size')
 
             # Infer platform from asset name
-            if echo "$NAME" | grep -qi "darwin"; then PLATFORM="darwin"
-            elif echo "$NAME" | grep -qi "Setup\|\.nupkg\|^RELEASES$\|win32"; then PLATFORM="win32"
+            if echo "$NAME" | grep -qiE "darwin|\.dmg|RELEASES\.json"; then PLATFORM="darwin"
+            elif echo "$NAME" | grep -qiE "Setup|\.nupkg|\.exe|win32|^RELEASES$"; then PLATFORM="win32"
             else PLATFORM="linux"
             fi
 
             # Infer arch from asset name
-            if echo "$NAME" | grep -qi "arm64\|aarch64"; then ARCH="arm64"
+            if echo "$NAME" | grep -qiE "arm64|aarch64"; then ARCH="arm64"
             else ARCH="x64"
             fi
 


### PR DESCRIPTION
- Fix incorrect platform classification for `.dmg` files and `RELEASES.json` in the GitHub Pages release manifest. These macOS assets were incorrectly mapped to `linux/` URLs instead of `darwin/`, causing broken download links.
- Switch from basic regex (`grep \|`) to extended regex (`grep -E |`) for reliable alternation behavior across both GNU and BSD grep (fixes `^RELEASES$` anchor not matching on macOS).
### What was wrong
The manifest generated by `mirror-to-gh-pages.yml` produced incorrect CDN URLs for three assets:
| Asset | Before (wrong) | After (correct) |
|---|---|---|
| `ToolHive-x64.dmg` | `linux/x64/` | `darwin/x64/` |
| `ToolHive-arm64.dmg` | `linux/arm64/` | `darwin/arm64/` |
| `RELEASES.json` | `linux/x64/` | `darwin/x64/` |
| `RELEASES` | `linux/x64/` | `win32/x64/` |
## Changes
- Added `.dmg` and `RELEASES.json` to the `darwin` platform detection pattern
- Added `.exe` to the `win32` platform detection pattern
- Switched all `grep` calls from BRE (`\|`) to ERE (`-E |`) for portable anchor support