### PR TITLE
fix(build): adjust win32 exe on manifest

### DIFF
--- a/.github/workflows/mirror-to-gh-pages.yml
+++ b/.github/workflows/mirror-to-gh-pages.yml
@@ -83,7 +83,10 @@ jobs:
             else ARCH="x64"
             fi
 
-            ENCODED_NAME=$(jq -rn --arg n "$NAME" '$n | @uri')
+            # GitHub replaces spaces with dots in release asset filenames;
+            # reverse for the S3 path which uses the original filename.
+            S3_NAME=$(echo "$NAME" | sed 's/\.Setup\.exe/ Setup.exe/')
+            ENCODED_NAME=$(jq -rn --arg n "$S3_NAME" '$n | @uri')
             CDN_URL="${CDN_BASE}/${PLATFORM}/${ARCH}/${ENCODED_NAME}"
             echo "Adding asset: $NAME -> $CDN_URL"
 


### PR DESCRIPTION
- Fix Windows installer URL in the GitHub Pages release manifest. GitHub replaces spaces with dots in release asset filenames (`ToolHive Setup.exe` → `ToolHive.Setup.exe`), but S3 stores the original filename with a space. The manifest now reverses this transformation so the CDN URL correctly resolves.

### What was wrong

The manifest at [`latest/index.json`](https://stacklok.github.io/toolhive-studio/latest/index.json) generated a broken URL for the Windows installer:

| | URL |
|---|---|
| **Before (broken)** | `.../win32/x64/ToolHive.Setup.exe` |
| **After (fixed)** | `.../win32/x64/ToolHive%20Setup.exe` |

GitHub's release API returns asset names with dots replacing spaces, but the S3 publisher (Electron Forge) uploads with the original filename containing a space.

### Changes
- Added `sed` transformation to convert `.Setup.exe` back to ` Setup.exe` before URL-encoding the CDN path
