### PR TITLE
chore: migrate from Trivy to Grype for vulnerability scanning

### DIFF
--- a/.github/workflows/_security-checks.yml
+++ b/.github/workflows/_security-checks.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           path: '.'
           fail-build: true
-          only-fixed: true
           severity-cutoff: 'medium'
           output-format: 'table'
 

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Grype configuration for toolhive-react.
-# - node_modules/: lock file is the source of truth; scanning installed packages is redundant.
-# - dist/:         build artifacts, not source packages.
+# - node_modules/:        lock file is the source of truth; scanning installed packages is redundant.
+# - dist/, out/:          build artifacts produced by Vite / Electron Forge.
+# - bin/:                 downloaded binaries (e.g. thv), scanned by their own pipelines.
+# - .webpack/, .vite/, .cache/: build-tool caches, not source packages.
+# - coverage/, playwright-report/, test-results/, test-videos/: test output, not source packages.
 
 # Only report vulnerabilities that have a fix available — unfixed ones are noise with no actionable remedy.
 only-fixed: true


### PR DESCRIPTION
## Summary
- Replace `aquasecurity/trivy-action` with `anchore/scan-action` (Grype) v7.3.2 for vulnerability scanning

## Test plan
- [ ] Verify Grype scan runs successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)