### PR TITLE
feat(registry): on card use title and fallback to name

### DIFF
--- a/renderer/src/features/registry-servers/components/card-registry-server.tsx
+++ b/renderer/src/features/registry-servers/components/card-registry-server.tsx
@@ -78,7 +78,7 @@ export function CardRegistryServer({
 
   return (
     <CardRegistryBase
-      title={server.name!}
+      title={server?.title ?? server.name!}
       description={server.description}
       badge={badge}
       footer={footer}


### PR DESCRIPTION
as per title, with the new data from upstream now the name is the repository URL, if is declared we need to use title

before:
<img width="1281" height="796" alt="Screenshot 2026-03-23 at 16 47 34" src="https://github.com/user-attachments/assets/04d044b5-4afa-4564-ad88-488932da59af" />


after:
<img width="1281" height="798" alt="Screenshot 2026-03-23 at 16 47 17" src="https://github.com/user-attachments/assets/cbd523cf-8cc9-43f1-9b85-f5c02cc6ca0e" />
