### PR TITLE
fix(build): resolve Windows auto-update checksum failure

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,6 +11,7 @@ import { ensureThv } from './utils/fetch-thv'
 import MakerTarGz from './utils/forge-makers/MakerTarGz'
 import MakerDMGWithArch from './utils/forge-makers/MakerDMGWithArch'
 import { isPrerelease } from './utils/pre-release'
+import { stripBomFromReleasesFiles } from './utils/forge-makers/strip-bom-from-releases'
 import packageJson from './package.json'
 
 function isValidPlatform(platform: string): platform is NodeJS.Platform {
@@ -112,14 +113,14 @@ const config: ForgeConfig = {
   makers: [
     {
       name: '@electron-forge/maker-squirrel',
-      config: (arch: string) => ({
+      config: () => ({
         setupIcon: './icons/icon.ico',
         setupExe: 'ToolHive Setup.exe',
         noMsi: true,
         authors: 'Stacklok',
         exe: 'ToolHive.exe',
         name: 'ToolHive',
-        remoteReleases: `https://releases.toolhive.dev/${isPrerelease() ? 'pre-release' : 'stable'}/latest/win32/${arch}`,
+        noDelta: true,
         windowsSign:
           process.env.SM_HOST && process.env.SM_API_KEY
             ? { hookModulePath: './utils/digicert-hook.js' }
@@ -217,6 +218,10 @@ const config: ForgeConfig = {
   ],
 
   hooks: {
+    postMake: async (_config, makeResults) => {
+      await stripBomFromReleasesFiles(makeResults)
+      return makeResults
+    },
     // copy sqlite deps that already compiled
     packageAfterCopy: async (_config, buildPath) => {
       const fs = await import('node:fs')

--- a/utils/forge-makers/strip-bom-from-releases.ts
+++ b/utils/forge-makers/strip-bom-from-releases.ts
@@ -1,0 +1,39 @@
+import { promises as fs } from 'node:fs'
+import type { ForgeMakeResult } from '@electron-forge/shared-types'
+
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf])
+
+/**
+ * Strips the UTF-8 BOM from RELEASES files produced by Squirrel.Windows.
+ *
+ * electron-winstaller generates RELEASES files with a UTF-8 BOM prefix (EF BB BF).
+ * Squirrel.Windows fails to parse BOM-prefixed RELEASES when computing checksums,
+ * causing "Checksummed file size doesn't match" errors during client updates.
+ */
+export async function stripBomFromReleasesFiles(
+  makeResults: ForgeMakeResult[]
+): Promise<void> {
+  for (const result of makeResults) {
+    const releasesFiles = result.artifacts.filter((f) => f.endsWith('RELEASES'))
+
+    for (const releasesPath of releasesFiles) {
+      try {
+        const content = await fs.readFile(releasesPath)
+
+        if (
+          content.length >= 3 &&
+          content[0] === UTF8_BOM[0] &&
+          content[1] === UTF8_BOM[1] &&
+          content[2] === UTF8_BOM[2]
+        ) {
+          await fs.writeFile(releasesPath, content.subarray(3))
+          console.log(`[postMake] Stripped UTF-8 BOM from ${releasesPath}`)
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          console.warn(`[postMake] Could not process RELEASES file: ${error}`)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes the Windows auto-update failure where Squirrel.Windows throws "Checksummed file size doesn't match" on every update check. Follows up on #1738 which switched to the S3/CloudFront update source.

The root cause: `remoteReleases` in maker-squirrel fetches the CDN's existing RELEASES file and appends the new version's entries, so the RELEASES file accumulates references to all past versions. But the CI promotion step (`aws s3 sync --delete`) correctly removes old nupkg files from `latest/`, creating a mismatch — the RELEASES file references nupkgs that no longer exist (HTTP 403), which causes Squirrel's checksum validation to fail.

Verified on the live CDN — the RELEASES file at `releases.toolhive.dev/stable/latest/win32/x64/RELEASES` listed 5 entries but only the 2 current nupkgs (0.25.0) were actually accessible:

| File | Status |
|---|---|
| `ToolHive-0.23.0-full.nupkg` | 403 |
| `ToolHive-0.24.0-delta.nupkg` | 403 |
| `ToolHive-0.24.0-full.nupkg` | 403 |
| `ToolHive-0.25.0-delta.nupkg` | 200 |
| `ToolHive-0.25.0-full.nupkg` | 200 |

Changes:
- Remove `remoteReleases` and set `noDelta: true` — each build now produces a RELEASES file with only the current version's entry, staying in sync with what's on S3. Trade-off: no more delta updates (~10 MB), only full updates (~184 MB). Acceptable since Squirrel.Windows delta updates are fragile and Squirrel is no longer maintained.
- Add a `postMake` hook that strips the UTF-8 BOM from RELEASES files (defense-in-depth — `electron-winstaller` adds a BOM that can cause edge-case parsing failures).

The CDN's RELEASES file was also manually fixed via `aws s3 cp` + CloudFront invalidation to unblock existing users immediately.
