### PR TITLE
chore(renovate): configure bump range strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "labels": ["dependencies"],
+  "rangeStrategy": "bump",
   "prConcurrentLimit": 3,
   "timezone": "Europe/London",
   "schedule": ["after 01:00 and before 07:00 every weekday"],


### PR DESCRIPTION
Updates the Renovate configuration to use `bump` as the `rangeStrategy`.

With this change, Renovate will bump range constraints even when the new version already satisfies the existing range. For example, `^1.0.0` will be updated to `^1.1.0` rather than left unchanged.