### PR TITLE
ci(post-upgrade): change condition after github app

### DIFF
--- a/.github/workflows/renovate-post-upgrade.yml
+++ b/.github/workflows/renovate-post-upgrade.yml
@@ -15,7 +15,7 @@ jobs:
   regenerate-artifacts:
     name: Regenerate Artifacts
     runs-on: ubuntu-latest
-    if: github.actor == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'renovate[bot]'
     steps:
       - name: Check what was updated
         id: check


### PR DESCRIPTION
The problem: Renovate is running through your toolhive-studio-ci GitHub App, so github.actor is toolhive-studio-ci[bot] instead of renovate[bot]. The if condition on line 18 was only checking for renovate[bot], so the job was skipped.

example log:
```
2026-03-27T08:58:27.5070000Z Evaluating regenerate-artifacts.if
2026-03-27T08:58:27.5070000Z Evaluating: (success() && ((github.actor == 'renovate[bot]')))
2026-03-27T08:58:27.5070000Z Expanded: (true && ('toolhive-studio-ci[bot]' == 'renovate[bot]'))
2026-03-27T08:58:27.5070000Z Result: false
```

using github.event.pull_request.user.login instead, I think it will fix it