### PR TITLE
fix(ci): validate release tag starts with 'v' prefix

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -18,8 +18,8 @@ jobs:
         shell: bash
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "::error::Tag '$TAG' must start with 'v' followed by semver (e.g. v1.2.3)"
+          if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
+            echo "::error::Tag '$TAG' is not valid semver (e.g. v1.2.3, v1.2.3-rc.1)"
             exit 1
           fi
           echo "Valid tag: $TAG"


### PR DESCRIPTION
## Summary
- Adds an early validation step in the release workflow that rejects tags not starting with `v`
- Prevents the `npm version` failure we hit with tag `0.26.0` (without `v`), where the version extracted as `refs/tags/0.26.0` instead of `0.26.0`
- Fail-fast before wasting time on security checks, static analysis, tests, and build matrix

## Test plan
- [ ] Create a test prerelease with a tag like `0.0.0-test` (no `v`) → should fail at validation
- [ ] Create a test prerelease with `v0.0.0-rc.1` → should pass validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)