### PR TITLE
feat(playground): add tracing for MCP Apps

### DIFF
--- a/main/src/chat/__tests__/mcp-tools.test.ts
+++ b/main/src/chat/__tests__/mcp-tools.test.ts
@@ -75,6 +75,14 @@ vi.mock('../../utils/mcp-tools', async (importOriginal) => {
   }
 })
 
+vi.mock('@sentry/electron/main', () => ({
+  addBreadcrumb: vi.fn(),
+  startSpan: vi.fn(
+    (_opts: unknown, fn: (span: { setStatus: () => void }) => unknown) =>
+      fn({ setStatus: vi.fn() })
+  ),
+}))
+
 vi.mock('@ai-sdk/mcp', () => ({
   experimental_createMCPClient: mockCreateMCPClient,
 }))
@@ -105,6 +113,7 @@ vi.mock('../../logger', () => ({
 // Module under test (imported after all vi.mock() calls)
 // ---------------------------------------------------------------------------
 
+import * as Sentry from '@sentry/electron/main'
 import {
   getCachedUiMetadata,
   fetchUiResource,
@@ -541,6 +550,7 @@ describe('createMcpTools', () => {
     expect(tools).toEqual({})
     expect(clients).toHaveLength(0)
     expect(enabledTools).toEqual({})
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
   })
 
   it('resets cachedUiMetadata at the start of each call', async () => {
@@ -679,6 +689,14 @@ describe('createMcpTools', () => {
     expect(getCachedUiMetadata()).toEqual({
       'ui-tool': { resourceUri: 'res://ui-tool', serverName: 'test-server' },
     })
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'mcp-apps',
+        message: 'Discovered 1 UI-enabled tool(s)',
+        level: 'info',
+        data: { tools: ['ui-tool'] },
+      })
+    )
   })
 
   it('does not cache UI metadata for tools without resourceUri', async () => {
@@ -696,6 +714,7 @@ describe('createMcpTools', () => {
     await createMcpTools()
 
     expect(getCachedUiMetadata()).toEqual({})
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
   })
 
   it('logs and skips servers whose workload is not found', async () => {

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/electron/main'
 import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp'
 import type { ToolSet } from 'ai'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
@@ -397,6 +398,16 @@ export async function createMcpTools(): Promise<{
     }
   } catch (error) {
     log.error('Failed to create MCP tools:', error)
+  }
+
+  const uiToolCount = Object.keys(cachedUiMetadata).length
+  if (uiToolCount > 0) {
+    Sentry.addBreadcrumb({
+      category: 'mcp-apps',
+      message: `Discovered ${uiToolCount} UI-enabled tool(s)`,
+      level: 'info',
+      data: { tools: Object.keys(cachedUiMetadata) },
+    })
   }
 
   return { tools: mcpTools, clients: mcpClients, enabledTools }

--- a/main/src/ipc-handlers/chat/__tests__/mcp-apps.test.ts
+++ b/main/src/ipc-handlers/chat/__tests__/mcp-apps.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const ctx = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+  const setStatus = vi.fn()
+  return {
+    handlers,
+    setStatus,
+    fetchUiResource: vi.fn(),
+    proxyMcpToolCall: vi.fn(),
+    getCachedUiMetadata: vi.fn(() => ({})),
+    startSpan: vi.fn(
+      (
+        _opts: unknown,
+        fn: (span: { setStatus: typeof setStatus }) => unknown
+      ) => fn({ setStatus })
+    ),
+    addBreadcrumb: vi.fn(),
+    openExternal: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (
+      channel: string,
+      handler: (...args: unknown[]) => Promise<unknown>
+    ) => {
+      ctx.handlers.set(channel, handler)
+    },
+  },
+  shell: {
+    openExternal: ctx.openExternal,
+  },
+}))
+
+vi.mock('../../../chat/mcp-tools', () => ({
+  getCachedUiMetadata: ctx.getCachedUiMetadata,
+  fetchUiResource: ctx.fetchUiResource,
+  proxyMcpToolCall: ctx.proxyMcpToolCall,
+}))
+
+vi.mock('../../../logger', () => ({
+  default: { error: vi.fn() },
+}))
+
+vi.mock('@sentry/electron/main', () => ({
+  startSpan: ctx.startSpan,
+  addBreadcrumb: ctx.addBreadcrumb,
+}))
+
+import { register } from '../mcp-apps'
+
+describe('registerMcpApps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ctx.handlers.clear()
+    register()
+  })
+
+  it('wraps fetch-ui-resource in Sentry.startSpan and returns success', async () => {
+    ctx.fetchUiResource.mockResolvedValue({
+      html: '<p>hi</p>',
+      csp: undefined,
+      permissions: undefined,
+      prefersBorder: true,
+    })
+
+    const handler = ctx.handlers.get('chat:fetch-ui-resource')!
+    const result = await handler(null, 'my-server', 'res://x')
+
+    expect(ctx.startSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'MCP Apps fetch UI resource',
+        op: 'mcp-apps.fetch',
+        attributes: expect.objectContaining({
+          'mcp_apps.server_name': 'my-server',
+          'mcp_apps.resource_uri': 'res://x',
+        }),
+      }),
+      expect.any(Function)
+    )
+    expect(ctx.setStatus).toHaveBeenCalledWith({ code: 1 })
+    expect(result).toMatchObject({ success: true, html: '<p>hi</p>' })
+  })
+
+  it('sets span error status when fetch-ui-resource throws', async () => {
+    ctx.fetchUiResource.mockRejectedValue(new Error('boom'))
+
+    const handler = ctx.handlers.get('chat:fetch-ui-resource')!
+    const result = await handler(null, 's', 'u')
+
+    expect(ctx.setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: 'boom',
+    })
+    expect(result).toEqual({ success: false, error: 'boom' })
+  })
+
+  it('wraps proxy-mcp-tool-call in Sentry.startSpan', async () => {
+    ctx.proxyMcpToolCall.mockResolvedValue({ content: [] })
+
+    const handler = ctx.handlers.get('chat:proxy-mcp-tool-call')!
+    const result = await handler(null, 'srv', 'tool', { a: 1 })
+
+    expect(ctx.startSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'MCP Apps proxy tool call',
+        op: 'mcp-apps.proxy',
+        attributes: expect.objectContaining({
+          'mcp_apps.server_name': 'srv',
+          'mcp_apps.tool_name': 'tool',
+        }),
+      }),
+      expect.any(Function)
+    )
+    expect(result).toEqual({ success: true, result: { content: [] } })
+  })
+
+  it('adds a breadcrumb when open-external-link succeeds', async () => {
+    const handler = ctx.handlers.get('chat:open-external-link')!
+    const result = await handler(null, 'https://example.com/path?q=1')
+
+    expect(ctx.openExternal).toHaveBeenCalledWith(
+      'https://example.com/path?q=1'
+    )
+    expect(ctx.addBreadcrumb).toHaveBeenCalledWith({
+      category: 'mcp-apps',
+      message: 'Opened external link: https://example.com',
+      level: 'info',
+    })
+    expect(result).toEqual({ success: true })
+  })
+
+  it('does not add a breadcrumb when open-external-link rejects protocol', async () => {
+    const handler = ctx.handlers.get('chat:open-external-link')!
+    const result = await handler(null, 'file:///etc/passwd')
+
+    expect(ctx.openExternal).not.toHaveBeenCalled()
+    expect(ctx.addBreadcrumb).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      success: false,
+      error: 'Only http/https URLs are allowed',
+    })
+  })
+})

--- a/main/src/ipc-handlers/chat/mcp-apps.ts
+++ b/main/src/ipc-handlers/chat/mcp-apps.ts
@@ -1,4 +1,5 @@
 import { ipcMain, shell } from 'electron'
+import * as Sentry from '@sentry/electron/main'
 import {
   getCachedUiMetadata,
   fetchUiResource,
@@ -14,16 +15,35 @@ export function register() {
   ipcMain.handle(
     'chat:fetch-ui-resource',
     async (_, serverName: string, resourceUri: string) => {
-      try {
-        const metadata = await fetchUiResource(serverName, resourceUri)
-        return { success: true, ...metadata }
-      } catch (error) {
-        log.error('[MCP Apps] Failed to fetch UI resource:', error)
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
+      return Sentry.startSpan(
+        {
+          name: 'MCP Apps fetch UI resource',
+          op: 'mcp-apps.fetch',
+          attributes: {
+            'analytics.source': 'tracking',
+            'analytics.type': 'event',
+            'mcp_apps.server_name': serverName,
+            'mcp_apps.resource_uri': resourceUri,
+          },
+        },
+        async (span) => {
+          try {
+            const metadata = await fetchUiResource(serverName, resourceUri)
+            span.setStatus({ code: 1 })
+            return { success: true, ...metadata }
+          } catch (error) {
+            span.setStatus({
+              code: 2,
+              message: error instanceof Error ? error.message : String(error),
+            })
+            log.error('[MCP Apps] Failed to fetch UI resource:', error)
+            return {
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            }
+          }
         }
-      }
+      )
     }
   )
 
@@ -35,16 +55,35 @@ export function register() {
       toolName: string,
       args: Record<string, unknown>
     ) => {
-      try {
-        const result = await proxyMcpToolCall(serverName, toolName, args)
-        return { success: true, result }
-      } catch (error) {
-        log.error('[MCP Apps] Failed to proxy MCP tool call:', error)
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
+      return Sentry.startSpan(
+        {
+          name: 'MCP Apps proxy tool call',
+          op: 'mcp-apps.proxy',
+          attributes: {
+            'analytics.source': 'tracking',
+            'analytics.type': 'event',
+            'mcp_apps.server_name': serverName,
+            'mcp_apps.tool_name': toolName,
+          },
+        },
+        async (span) => {
+          try {
+            const result = await proxyMcpToolCall(serverName, toolName, args)
+            span.setStatus({ code: 1 })
+            return { success: true, result }
+          } catch (error) {
+            span.setStatus({
+              code: 2,
+              message: error instanceof Error ? error.message : String(error),
+            })
+            log.error('[MCP Apps] Failed to proxy MCP tool call:', error)
+            return {
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            }
+          }
         }
-      }
+      )
     }
   )
 
@@ -53,6 +92,11 @@ export function register() {
       const parsed = new URL(url)
       if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
         await shell.openExternal(parsed.toString())
+        Sentry.addBreadcrumb({
+          category: 'mcp-apps',
+          message: `Opened external link: ${parsed.origin}`,
+          level: 'info',
+        })
         return { success: true }
       }
       return { success: false, error: 'Only http/https URLs are allowed' }


### PR DESCRIPTION
Adds observability for the playground MCP Apps flow so fetch/proxy IPC work and UI tool discovery show up in Sentry alongside existing chat streaming instrumentation.
## Changes
- Wrap `chat:fetch-ui-resource` and `chat:proxy-mcp-tool-call` in `Sentry.startSpan` (`mcp-apps.fetch` / `mcp-apps.proxy`) with analytics-style attributes and span status on success/failure.
- Record a breadcrumb when `chat:open-external-link` successfully opens an http(s) URL (message uses origin only to avoid leaking path/query).
- Emit a breadcrumb from `createMcpTools()` when any tools expose `_meta.ui` with a resource URI (tool names in breadcrumb `data`).
- Tests: `mcp-apps` IPC handler suite and extended `mcp-tools` tests with Sentry mocks/assertions.
