### PR TITLE
feat: show dedicated error modal when another ToolHive server is already running

### DIFF
--- a/common/types/toolhive-status.ts
+++ b/common/types/toolhive-status.ts
@@ -1,6 +1,9 @@
 export const REGISTRY_AUTH_REQUIRED = 'registry-auth-required' as const
+export const ALREADY_RUNNING = 'already-running' as const
 
-export type ToolhiveProcessError = typeof REGISTRY_AUTH_REQUIRED
+export type ToolhiveProcessError =
+  | typeof REGISTRY_AUTH_REQUIRED
+  | typeof ALREADY_RUNNING
 
 export interface ToolhiveStatus {
   isRunning: boolean

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -8,6 +8,7 @@ import {
   startToolhive,
   getToolhivePort,
   getToolhiveMcpPort,
+  getToolhiveStatus,
   isToolhiveRunning,
   stopToolhive,
   restartToolhive,
@@ -98,6 +99,7 @@ const mockGetQuittingState = vi.mocked(getQuittingState)
 class MockProcess extends EventEmitter {
   pid = 12345
   killed = false
+  stderr = new EventEmitter()
   kill() {
     // Don't automatically set killed - let tests control this
     // This allows testing delayed SIGKILL scenarios
@@ -462,6 +464,48 @@ describe('toolhive-manager', () => {
 
       const spawnArgs = mockSpawn.mock.calls[0]![1] as string[]
       expect(spawnArgs.some((a) => a.startsWith('--sentry-'))).toBe(false)
+    })
+
+    it('sets processError to ALREADY_RUNNING when stderr reports another server running', async () => {
+      const startPromise = startToolhive()
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
+
+      expect(getToolhiveStatus().processError).toBeUndefined()
+
+      mockProcess.stderr.emit(
+        'data',
+        Buffer.from(
+          'Error: another ToolHive server is already running at http://127.0.0.1:50061 (PID 52799)'
+        )
+      )
+
+      expect(getToolhiveStatus().processError).toBe('already-running')
+    })
+
+    it('resets processError on restart', async () => {
+      const startPromise = startToolhive()
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
+
+      mockProcess.stderr.emit(
+        'data',
+        Buffer.from('Error: another ToolHive server is already running')
+      )
+
+      expect(getToolhiveStatus().processError).toBe('already-running')
+
+      const newMockProcess = new MockProcess()
+      mockSpawn.mockReturnValue(
+        newMockProcess as unknown as ReturnType<typeof spawn>
+      )
+
+      const restartPromise = restartToolhive()
+      await vi.advanceTimersByTimeAsync(50)
+      await restartPromise
+      await vi.advanceTimersByTimeAsync(5000)
+
+      expect(getToolhiveStatus().processError).toBeUndefined()
     })
   })
 

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -9,6 +9,7 @@ import * as Sentry from '@sentry/electron/main'
 import { getQuittingState } from './app-state'
 import { readSetting } from './db/readers/settings-reader'
 import {
+  ALREADY_RUNNING,
   REGISTRY_AUTH_REQUIRED,
   type ToolhiveProcessError,
   type ToolhiveStatus,
@@ -204,6 +205,9 @@ export async function startToolhive(): Promise<void> {
         }
         if (output.includes('registry authentication required')) {
           processError = REGISTRY_AUTH_REQUIRED
+        }
+        if (output.includes('another ToolHive server is already running')) {
+          processError = ALREADY_RUNNING
         }
         log.info(`[ToolHive stderr] ${output}`)
         scope.addBreadcrumb({

--- a/renderer/src/common/components/error/already-running-error.tsx
+++ b/renderer/src/common/components/error/already-running-error.tsx
@@ -8,8 +8,9 @@ export function AlreadyRunningError() {
       icon={<AlertCircle className="text-destructive size-12" />}
     >
       <p>
-        Another ToolHive instance is already running on this machine. Only one
-        instance can run at a time.
+        Another ToolHive HTTP server (
+        <code className="bg-background rounded px-1 py-0.5">thv serve</code>) is
+        already running on this machine. Only one instance can run at a time.
       </p>
       <p>Please close the other ToolHive instance and click "Try Again".</p>
     </BaseErrorScreen>

--- a/renderer/src/common/components/error/already-running-error.tsx
+++ b/renderer/src/common/components/error/already-running-error.tsx
@@ -1,0 +1,17 @@
+import { AlertCircle } from 'lucide-react'
+import { BaseErrorScreen } from './base-error-screen'
+
+export function AlreadyRunningError() {
+  return (
+    <BaseErrorScreen
+      title="ToolHive Is Already Running"
+      icon={<AlertCircle className="text-destructive size-12" />}
+    >
+      <p>
+        Another ToolHive instance is already running on this machine. Only one
+        instance can run at a time.
+      </p>
+      <p>Please close the other ToolHive instance and click "Try Again".</p>
+    </BaseErrorScreen>
+  )
+}

--- a/renderer/src/routes/__root.tsx
+++ b/renderer/src/routes/__root.tsx
@@ -77,11 +77,8 @@ export const Route = createRootRouteWithContext<{
     if (await checkUpdateInProgress()) return
     await validateCliAlignment(location.pathname)
     await ensureToolhiveRunning(queryClient)
-    const toolhiveStatus = await handleRegistryAuthRedirect(
-      queryClient,
-      location.pathname
-    )
-    await checkHealth(queryClient, toolhiveStatus)
+    await handleRegistryAuthRedirect(queryClient, location.pathname)
+    await checkHealth(queryClient)
   },
   loader: async ({ context: { queryClient } }) => {
     const isRunning = await window.electronAPI.isToolhiveRunning()

--- a/renderer/src/routes/__root.tsx
+++ b/renderer/src/routes/__root.tsx
@@ -77,8 +77,8 @@ export const Route = createRootRouteWithContext<{
     if (await checkUpdateInProgress()) return
     await validateCliAlignment(location.pathname)
     await ensureToolhiveRunning(queryClient)
-    await handleRegistryAuthRedirect(queryClient, location.pathname)
     await checkHealth(queryClient)
+    await handleRegistryAuthRedirect(queryClient, location.pathname)
   },
   loader: async ({ context: { queryClient } }) => {
     const isRunning = await window.electronAPI.isToolhiveRunning()

--- a/renderer/src/routes/root/__tests__/root-error.test.tsx
+++ b/renderer/src/routes/root/__tests__/root-error.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ALREADY_RUNNING } from '@common/types/toolhive-status'
 import { RootErrorComponent } from '../root-error'
 
 vi.mock('@tanstack/react-router', () => ({
@@ -80,5 +81,22 @@ describe('RootErrorComponent', () => {
     renderWithProviders(<RootErrorComponent error={error} />)
 
     expect(screen.getByText('Oops, something went wrong')).toBeInTheDocument()
+  })
+
+  it('renders AlreadyRunningError when processError is ALREADY_RUNNING', () => {
+    const error = new Error('Health check failed', {
+      cause: {
+        isToolhiveRunning: false,
+        containerEngineAvailable: true,
+        processError: ALREADY_RUNNING,
+      },
+    })
+
+    renderWithProviders(<RootErrorComponent error={error} />)
+
+    expect(screen.getByText('ToolHive Is Already Running')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Oops, something went wrong')
+    ).not.toBeInTheDocument()
   })
 })

--- a/renderer/src/routes/root/guards/__tests__/check-health.test.ts
+++ b/renderer/src/routes/root/guards/__tests__/check-health.test.ts
@@ -20,6 +20,10 @@ vi.mock('@common/api/generated/client.gen', () => {
 const { getHealth } = await import('@common/api/generated/sdk.gen')
 const { client } = await import('@common/api/generated/client.gen')
 
+function mockToolhiveStatus(status: ToolhiveStatus) {
+  window.electronAPI.getToolhiveStatus = vi.fn().mockResolvedValue(status)
+}
+
 describe('checkHealth', () => {
   let queryClient: QueryClient
 
@@ -30,6 +34,7 @@ describe('checkHealth', () => {
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     })
+    mockToolhiveStatus(runningStatus)
     window.electronAPI.checkContainerEngine = vi.fn().mockResolvedValue({
       available: true,
       docker: true,
@@ -41,16 +46,14 @@ describe('checkHealth', () => {
   it('resolves when health check succeeds', async () => {
     vi.mocked(getHealth).mockResolvedValue(null as never)
 
-    await expect(
-      checkHealth(queryClient, runningStatus)
-    ).resolves.toBeUndefined()
+    await expect(checkHealth(queryClient)).resolves.toBeUndefined()
   })
 
   it('throws with structured cause when health check fails', async () => {
     vi.mocked(getHealth).mockRejectedValue(new Error('fetch failed'))
 
     try {
-      await checkHealth(queryClient, runningStatus)
+      await checkHealth(queryClient)
       expect.fail('should have thrown')
     } catch (error) {
       expect(error).toBeInstanceOf(Error)
@@ -65,8 +68,9 @@ describe('checkHealth', () => {
 
   it('reports to Sentry when toolhive is not running', async () => {
     vi.mocked(getHealth).mockRejectedValue(new Error('fetch failed'))
+    mockToolhiveStatus(stoppedStatus)
 
-    await checkHealth(queryClient, stoppedStatus).catch(() => {})
+    await checkHealth(queryClient).catch(() => {})
 
     expect(Sentry.captureException).toHaveBeenCalledWith(
       expect.any(Error),
@@ -86,7 +90,7 @@ describe('checkHealth', () => {
       rancherDesktop: false,
     })
 
-    await checkHealth(queryClient, runningStatus).catch(() => {})
+    await checkHealth(queryClient).catch(() => {})
 
     expect(Sentry.captureException).toHaveBeenCalled()
   })
@@ -95,7 +99,7 @@ describe('checkHealth', () => {
     vi.mocked(getHealth).mockRejectedValue(new Error('fetch failed'))
     vi.mocked(client.getConfig).mockReturnValue({ baseUrl: '' })
 
-    await checkHealth(queryClient, runningStatus).catch(() => {})
+    await checkHealth(queryClient).catch(() => {})
 
     expect(Sentry.captureException).toHaveBeenCalled()
   })
@@ -106,7 +110,7 @@ describe('checkHealth', () => {
       baseUrl: 'https://foo.bar.com',
     })
 
-    await checkHealth(queryClient, runningStatus).catch(() => {})
+    await checkHealth(queryClient).catch(() => {})
 
     expect(Sentry.captureException).not.toHaveBeenCalled()
   })

--- a/renderer/src/routes/root/guards/__tests__/handle-registry-auth-redirect.test.ts
+++ b/renderer/src/routes/root/guards/__tests__/handle-registry-auth-redirect.test.ts
@@ -60,9 +60,8 @@ describe('handleRegistryAuthRedirect', () => {
         .fn()
         .mockResolvedValue(statusWithAuthError)
 
-      const result = await handleRegistryAuthRedirect(queryClient, '/settings')
+      await handleRegistryAuthRedirect(queryClient, '/settings')
 
-      expect(result).toEqual(statusWithAuthError)
       expect(
         queryClient.getQueryData(REGISTRY_PENDING_TOAST_KEY)
       ).toBeUndefined()
@@ -75,9 +74,8 @@ describe('handleRegistryAuthRedirect', () => {
 
       queryClient.setQueryData(['registry-auth-redirected'], true)
 
-      const result = await handleRegistryAuthRedirect(queryClient, '/')
+      await handleRegistryAuthRedirect(queryClient, '/')
 
-      expect(result).toEqual(statusWithAuthError)
       expect(
         queryClient.getQueryData(REGISTRY_PENDING_TOAST_KEY)
       ).toBeUndefined()
@@ -117,9 +115,8 @@ describe('handleRegistryAuthRedirect', () => {
     it('does not redirect when already on /settings', async () => {
       mockGetRegistry.mockRejectedValue({ code: 'registry_auth_required' })
 
-      const result = await handleRegistryAuthRedirect(queryClient, '/settings')
+      await handleRegistryAuthRedirect(queryClient, '/settings')
 
-      expect(result).toEqual(healthyStatus)
       expect(
         queryClient.getQueryData(REGISTRY_PENDING_TOAST_KEY)
       ).toBeUndefined()
@@ -129,9 +126,8 @@ describe('handleRegistryAuthRedirect', () => {
       mockGetRegistry.mockRejectedValue({ code: 'registry_auth_required' })
       queryClient.setQueryData(['registry-auth-redirected'], true)
 
-      const result = await handleRegistryAuthRedirect(queryClient, '/')
+      await handleRegistryAuthRedirect(queryClient, '/')
 
-      expect(result).toEqual(healthyStatus)
       expect(
         queryClient.getQueryData(REGISTRY_PENDING_TOAST_KEY)
       ).toBeUndefined()
@@ -152,23 +148,21 @@ describe('handleRegistryAuthRedirect', () => {
     it('does not redirect for unknown registry errors', async () => {
       mockGetRegistry.mockRejectedValue({ code: 'some_other_error' })
 
-      const result = await handleRegistryAuthRedirect(queryClient, '/')
+      await handleRegistryAuthRedirect(queryClient, '/')
 
-      expect(result).toEqual(healthyStatus)
       expect(
         queryClient.getQueryData(REGISTRY_PENDING_TOAST_KEY)
       ).toBeUndefined()
     })
   })
 
-  it('returns status without redirect when no auth error', async () => {
+  it('does not redirect when no auth error', async () => {
     window.electronAPI.getToolhiveStatus = vi
       .fn()
       .mockResolvedValue(healthyStatus)
 
-    const result = await handleRegistryAuthRedirect(queryClient, '/')
+    await handleRegistryAuthRedirect(queryClient, '/')
 
-    expect(result).toEqual(healthyStatus)
     expect(queryClient.getQueryData(REGISTRY_PENDING_TOAST_KEY)).toBeUndefined()
   })
 })

--- a/renderer/src/routes/root/guards/check-health.ts
+++ b/renderer/src/routes/root/guards/check-health.ts
@@ -1,5 +1,14 @@
 import type { QueryClient } from '@tanstack/react-query'
-import type { ToolhiveStatus } from '@common/types/toolhive-status'
+import type {
+  ToolhiveProcessError,
+  ToolhiveStatus,
+} from '@common/types/toolhive-status'
+
+export interface HealthCheckErrorCause {
+  isToolhiveRunning: boolean
+  containerEngineAvailable: boolean
+  processError?: ToolhiveProcessError
+}
 import { getHealth } from '@common/api/generated/sdk.gen'
 import { client } from '@common/api/generated/client.gen'
 import * as Sentry from '@sentry/electron/renderer'
@@ -47,13 +56,13 @@ export async function checkHealth(queryClient: QueryClient): Promise<void> {
       clientConfig
     )
 
-    throw new Error('Health check failed', {
-      cause: {
-        isToolhiveRunning: freshStatus.isRunning,
-        containerEngineAvailable: containerEngineStatus.available,
-        processError: freshStatus.processError,
-      },
-    })
+    const cause: HealthCheckErrorCause = {
+      isToolhiveRunning: freshStatus.isRunning,
+      containerEngineAvailable: containerEngineStatus.available,
+      processError: freshStatus.processError,
+    }
+
+    throw new Error('Health check failed', { cause })
   }
 }
 

--- a/renderer/src/routes/root/guards/check-health.ts
+++ b/renderer/src/routes/root/guards/check-health.ts
@@ -15,10 +15,7 @@ import log from 'electron-log/renderer'
  * errorComponent can render the appropriate fallback (StartingToolHive or
  * generic error).
  */
-export async function checkHealth(
-  queryClient: QueryClient,
-  toolhiveStatus: ToolhiveStatus
-): Promise<void> {
+export async function checkHealth(queryClient: QueryClient): Promise<void> {
   try {
     await queryClient.ensureQueryData({
       queryKey: ['health'],
@@ -29,6 +26,9 @@ export async function checkHealth(
       gcTime: 0,
     })
   } catch (error) {
+    // Re-fetch status to capture errors that occurred after the initial check
+    // (e.g. "already running" detected via stderr after process was spawned)
+    const freshStatus = await window.electronAPI.getToolhiveStatus()
     const containerEngineStatus =
       await window.electronAPI.checkContainerEngine()
     const clientConfig = client.getConfig()
@@ -37,21 +37,21 @@ export async function checkHealth(
       `[beforeLoad] Client baseUrl: ${clientConfig.baseUrl || 'NOT SET'}`
     )
     log.error(
-      `[beforeLoad] ToolHive status: running=${toolhiveStatus.isRunning}, processError=${toolhiveStatus.processError ?? 'none'}`
+      `[beforeLoad] ToolHive status: running=${freshStatus.isRunning}, processError=${freshStatus.processError ?? 'none'}`
     )
 
     reportToSentryIfInfraFailure(
       error,
-      toolhiveStatus,
+      freshStatus,
       containerEngineStatus,
       clientConfig
     )
 
     throw new Error('Health check failed', {
       cause: {
-        isToolhiveRunning: toolhiveStatus.isRunning,
+        isToolhiveRunning: freshStatus.isRunning,
         containerEngineAvailable: containerEngineStatus.available,
-        processError: toolhiveStatus.processError,
+        processError: freshStatus.processError,
       },
     })
   }

--- a/renderer/src/routes/root/guards/handle-registry-auth-redirect.ts
+++ b/renderer/src/routes/root/guards/handle-registry-auth-redirect.ts
@@ -1,8 +1,5 @@
 import type { QueryClient } from '@tanstack/react-query'
-import {
-  REGISTRY_AUTH_REQUIRED,
-  type ToolhiveStatus,
-} from '@common/types/toolhive-status'
+import { REGISTRY_AUTH_REQUIRED } from '@common/types/toolhive-status'
 import { redirect } from '@tanstack/react-router'
 import log from 'electron-log/renderer'
 import { getApiV1BetaRegistry } from '@common/api/generated/sdk.gen'
@@ -42,7 +39,7 @@ function performRedirect(queryClient: QueryClient, message: string): never {
 export async function handleRegistryAuthRedirect(
   queryClient: QueryClient,
   pathname: string
-): Promise<ToolhiveStatus> {
+): Promise<void> {
   const toolhiveStatus = await window.electronAPI.getToolhiveStatus()
 
   if (
@@ -60,6 +57,4 @@ export async function handleRegistryAuthRedirect(
       performRedirect(queryClient, toastMessage)
     }
   }
-
-  return toolhiveStatus
 }

--- a/renderer/src/routes/root/root-error.tsx
+++ b/renderer/src/routes/root/root-error.tsx
@@ -2,6 +2,7 @@ import { AlreadyRunningError } from '@/common/components/error/already-running-e
 import { Error as ErrorComponent } from '@/common/components/error'
 import { StartingToolHive } from '@/common/components/starting-toolhive'
 import { ALREADY_RUNNING } from '@common/types/toolhive-status'
+import type { HealthCheckErrorCause } from './guards/check-health'
 import log from 'electron-log/renderer'
 
 /**
@@ -11,29 +12,15 @@ import log from 'electron-log/renderer'
  * Falls back to the generic error page for all other errors.
  */
 export function RootErrorComponent({ error }: { error: unknown }) {
-  const errorData = error as Error & {
-    cause?: { containerEngineAvailable?: boolean }
-  }
+  const errorData = error as Error & { cause?: HealthCheckErrorCause }
   const cause = errorData instanceof Error ? errorData.cause : undefined
 
-  if (
-    cause &&
-    typeof cause === 'object' &&
-    'processError' in cause &&
-    cause.processError === ALREADY_RUNNING
-  ) {
+  if (cause?.processError === ALREADY_RUNNING) {
     log.info('[HealthCheckError] Another ToolHive server is already running')
     return <AlreadyRunningError />
   }
 
-  if (
-    cause &&
-    typeof cause === 'object' &&
-    'isToolhiveRunning' in cause &&
-    'containerEngineAvailable' in cause &&
-    cause.isToolhiveRunning &&
-    cause.containerEngineAvailable
-  ) {
+  if (cause?.isToolhiveRunning && cause.containerEngineAvailable) {
     log.info(`[HealthCheckError] Server not ready`)
     return <StartingToolHive />
   }

--- a/renderer/src/routes/root/root-error.tsx
+++ b/renderer/src/routes/root/root-error.tsx
@@ -1,5 +1,7 @@
+import { AlreadyRunningError } from '@/common/components/error/already-running-error'
 import { Error as ErrorComponent } from '@/common/components/error'
 import { StartingToolHive } from '@/common/components/starting-toolhive'
+import { ALREADY_RUNNING } from '@common/types/toolhive-status'
 import log from 'electron-log/renderer'
 
 /**
@@ -13,6 +15,16 @@ export function RootErrorComponent({ error }: { error: unknown }) {
     cause?: { containerEngineAvailable?: boolean }
   }
   const cause = errorData instanceof Error ? errorData.cause : undefined
+
+  if (
+    cause &&
+    typeof cause === 'object' &&
+    'processError' in cause &&
+    cause.processError === ALREADY_RUNNING
+  ) {
+    log.info('[HealthCheckError] Another ToolHive server is already running')
+    return <AlreadyRunningError />
+  }
 
   if (
     cause &&


### PR DESCRIPTION
## Summary

<img width="1262" height="793" alt="Screenshot 2026-04-13 at 11 22 32" src="https://github.com/user-attachments/assets/c76f6781-5cd4-4b63-a7c6-2b97d32cca33" />


- Detect `"another ToolHive server is already running"` in `thv` stderr and set a specific `ALREADY_RUNNING` process error
- Show a dedicated error screen instead of the generic "Oops, something went wrong" modal
- Follow the existing `REGISTRY_AUTH_REQUIRED` error pattern


Closes #1977

## Test plan
- [ ] Start `thv serve` externally, then launch ToolHive Studio → should show "ToolHive Is Already Running" modal
- [ ] Stop the external `thv`, click "Try Again" → app should start normally
- [ ] Normal startup (no external `thv`) → app starts as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)