### PR TITLE
feat(skills): filter install skill client dropdown to supports_skills clients

### DIFF
--- a/renderer/src/common/mocks/fixtures/discovery_clients/get.ts
+++ b/renderer/src/common/mocks/fixtures/discovery_clients/get.ts
@@ -9,11 +9,53 @@ export const mockedGetApiV1BetaDiscoveryClients = AutoAPIMock<
   GetApiV1BetaDiscoveryClientsData
 >({
   clients: [
-    { client_type: 'roo-code', installed: false, registered: false },
-    { client_type: 'cline', installed: true, registered: false },
-    { client_type: 'vscode-insider', installed: true, registered: false },
-    { client_type: 'vscode', installed: true, registered: false },
-    { client_type: 'cursor', installed: true, registered: false },
-    { client_type: 'claude-code', installed: true, registered: false },
+    {
+      client_type: 'roo-code',
+      installed: false,
+      registered: false,
+      supports_skills: false,
+    },
+    {
+      client_type: 'cline',
+      installed: true,
+      registered: false,
+      supports_skills: false,
+    },
+    {
+      client_type: 'vscode-insider',
+      installed: true,
+      registered: false,
+      supports_skills: false,
+    },
+    {
+      client_type: 'vscode',
+      installed: true,
+      registered: false,
+      supports_skills: false,
+    },
+    {
+      client_type: 'cursor',
+      installed: true,
+      registered: false,
+      supports_skills: false,
+    },
+    {
+      client_type: 'claude-code',
+      installed: true,
+      registered: false,
+      supports_skills: true,
+    },
+    {
+      client_type: 'opencode',
+      installed: true,
+      registered: false,
+      supports_skills: true,
+    },
+    {
+      client_type: 'codex',
+      installed: true,
+      registered: false,
+      supports_skills: true,
+    },
   ],
 }).scenario('empty', (mock) => mock.override(() => ({ clients: [] })))

--- a/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
@@ -146,15 +146,49 @@ describe('DialogInstallSkill', () => {
   })
 
   it('populates client dropdown from discovery API when clients are available', async () => {
-    // Reset to default fixture which has installed clients
+    // Reset to default fixture which has installed clients with supports_skills: true
     mockedGetApiV1BetaDiscoveryClients.reset()
 
     renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
 
-    // When installed clients are present, the client field renders as a Select (combobox)
+    // When skill-supporting clients are present, the client field renders as a Select (combobox)
     // so there are 2 comboboxes: scope + client
     await waitFor(() => {
       expect(screen.getAllByRole('combobox')).toHaveLength(2)
+    })
+  })
+
+  it('shows only clients that support skills in the dropdown', async () => {
+    const user = userEvent.setup()
+    mockedGetApiV1BetaDiscoveryClients.reset()
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox')).toHaveLength(2)
+    })
+
+    await user.click(screen.getByRole('combobox', { name: /client/i }))
+
+    await waitFor(() => {
+      // Clients with supports_skills: true
+      expect(
+        screen.getByRole('option', { name: 'claude-code' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('option', { name: 'opencode' })
+      ).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'codex' })).toBeInTheDocument()
+      // Installed clients without supports_skills should NOT appear
+      expect(
+        screen.queryByRole('option', { name: 'cline' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('option', { name: 'cursor' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('option', { name: 'vscode' })
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -70,7 +70,9 @@ export function DialogInstallSkill({
     enabled: open,
   })
   const installedClients = (
-    clientsData?.clients?.filter((c) => c.installed && c.client_type) ?? []
+    clientsData?.clients?.filter(
+      (c) => c.installed && c.client_type && c.supports_skills
+    ) ?? []
   ).sort((a, b) => a.client_type!.localeCompare(b.client_type!))
 
   const form = useForm<FormSchema>({


### PR DESCRIPTION
The install skill dialog showed all installed clients in the client dropdown, including clients that don't support ToolHive skill installation.

- Filter the client dropdown in `DialogInstallSkill` to only include clients where `supports_skills: true`, using the new field added in stacklok/toolhive#4699
- Update the discovery clients mock fixture to include `supports_skills` on all entries, with `true` for claude-code, opencode, and codex
- Add a test asserting that non-skill-supporting clients (cline, cursor, vscode, etc.) are excluded from the dropdown