### PR TITLE
chore(deps): update toolhive to v0.19.0

### DIFF
--- a/common/api/generated/types.gen.ts
+++ b/common/api/generated/types.gen.ts
@@ -36,8 +36,8 @@ export type GithubComStacklokToolhiveCoreRegistryTypesRegistry = {
 }
 
 /**
- * Shared defines a token bucket shared across all users for this specific tool.
- * +kubebuilder:validation:Required
+ * PerUser token bucket configuration for this tool.
+ * +optional
  */
 export type GithubComStacklokToolhiveCmdThvOperatorApiV1Alpha1RateLimitBucket =
   {
@@ -58,6 +58,7 @@ export type GithubComStacklokToolhiveCmdThvOperatorApiV1Alpha1RateLimitBucket =
  */
 export type GithubComStacklokToolhiveCmdThvOperatorApiV1Alpha1RateLimitConfig =
   {
+    perUser?: GithubComStacklokToolhiveCmdThvOperatorApiV1Alpha1RateLimitBucket
     shared?: GithubComStacklokToolhiveCmdThvOperatorApiV1Alpha1RateLimitBucket
     /**
      * Tools defines per-tool rate limit overrides.
@@ -78,6 +79,7 @@ export type GithubComStacklokToolhiveCmdThvOperatorApiV1Alpha1ToolRateLimitConfi
      * +kubebuilder:validation:MinLength=1
      */
     name?: string
+    perUser?: GithubComStacklokToolhiveCmdThvOperatorApiV1Alpha1RateLimitBucket
     shared?: GithubComStacklokToolhiveCmdThvOperatorApiV1Alpha1RateLimitBucket
   }
 
@@ -1814,6 +1816,7 @@ export type PkgApiV1CreateRequest = {
    * Port for the HTTP proxy to listen on
    */
   proxy_port?: number
+  runtime_config?: GithubComStacklokToolhivePkgContainerTemplatesRuntimeConfig
   /**
    * Secret parameters to inject
    */
@@ -1992,9 +1995,11 @@ export type PkgApiV1HeaderForwardConfig = {
  */
 export type PkgApiV1InstallSkillRequest = {
   /**
-   * Client is the target client (e.g., "claude-code")
+   * Clients lists target client identifiers (e.g., "claude-code"),
+   * or ["all"] to target every skill-supporting client.
+   * Omitting this field installs to all available clients.
    */
-  client?: string
+  clients?: Array<string>
   /**
    * Force allows overwriting unmanaged skill directories
    */
@@ -2333,6 +2338,7 @@ export type PkgApiV1UpdateRequest = {
    * Port for the HTTP proxy to listen on
    */
   proxy_port?: number
+  runtime_config?: GithubComStacklokToolhivePkgContainerTemplatesRuntimeConfig
   /**
    * Secret parameters to inject
    */

--- a/common/api/openapi.json
+++ b/common/api/openapi.json
@@ -38,7 +38,7 @@
         "type": "object"
       },
       "github_com_stacklok_toolhive_cmd_thv-operator_api_v1alpha1.RateLimitBucket": {
-        "description": "Shared defines a token bucket shared across all users for this specific tool.\n+kubebuilder:validation:Required",
+        "description": "PerUser token bucket configuration for this tool.\n+optional",
         "properties": {
           "maxTokens": {
             "description": "MaxTokens is the maximum number of tokens (bucket capacity).\nThis is also the burst size: the maximum number of requests that can be served\ninstantaneously before the bucket is depleted.\n+kubebuilder:validation:Required\n+kubebuilder:validation:Minimum=1",
@@ -53,6 +53,9 @@
       "github_com_stacklok_toolhive_cmd_thv-operator_api_v1alpha1.RateLimitConfig": {
         "description": "RateLimitConfig contains the CRD rate limiting configuration.\nWhen set, rate limiting middleware is added to the proxy middleware chain.",
         "properties": {
+          "perUser": {
+            "$ref": "#/components/schemas/github_com_stacklok_toolhive_cmd_thv-operator_api_v1alpha1.RateLimitBucket"
+          },
           "shared": {
             "$ref": "#/components/schemas/github_com_stacklok_toolhive_cmd_thv-operator_api_v1alpha1.RateLimitBucket"
           },
@@ -72,6 +75,9 @@
           "name": {
             "description": "Name is the MCP tool name this limit applies to.\n+kubebuilder:validation:Required\n+kubebuilder:validation:MinLength=1",
             "type": "string"
+          },
+          "perUser": {
+            "$ref": "#/components/schemas/github_com_stacklok_toolhive_cmd_thv-operator_api_v1alpha1.RateLimitBucket"
           },
           "shared": {
             "$ref": "#/components/schemas/github_com_stacklok_toolhive_cmd_thv-operator_api_v1alpha1.RateLimitBucket"
@@ -2093,6 +2099,9 @@
             "description": "Port for the HTTP proxy to listen on",
             "type": "integer"
           },
+          "runtime_config": {
+            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
+          },
           "secrets": {
             "description": "Secret parameters to inject",
             "items": {
@@ -2297,9 +2306,13 @@
       "pkg_api_v1.installSkillRequest": {
         "description": "Request to install a skill",
         "properties": {
-          "client": {
-            "description": "Client is the target client (e.g., \"claude-code\")",
-            "type": "string"
+          "clients": {
+            "description": "Clients lists target client identifiers (e.g., \"claude-code\"),\nor [\"all\"] to target every skill-supporting client.\nOmitting this field installs to all available clients.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
           },
           "force": {
             "description": "Force allows overwriting unmanaged skill directories",
@@ -2693,6 +2706,9 @@
           "proxy_port": {
             "description": "Port for the HTTP proxy to listen on",
             "type": "integer"
+          },
+          "runtime_config": {
+            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
           },
           "secrets": {
             "description": "Secret parameters to inject",

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -3,4 +3,4 @@
  * This is managed by Renovate and updated automatically when new versions are released.
  * renovate: datasource=github-releases depName=stacklok/toolhive versioning=semver
  */
-export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.17.0'
+export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.19.0'


### PR DESCRIPTION
## Summary
- Update ToolHive CLI version from v0.17.0 to v0.19.0
- Regenerate API client types from the new OpenAPI spec

## Test plan
- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test:nonInteractive` passes (1787 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)