### PR TITLE
refactor: use alias import for GeneralTab in settings-tabs

### DIFF
--- a/renderer/src/common/components/settings/tabs/settings-tabs.tsx
+++ b/renderer/src/common/components/settings/tabs/settings-tabs.tsx
@@ -1,6 +1,6 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../ui/tabs'
 import { ScrollArea } from '../../ui/scroll-area'
-import { GeneralTab } from './general-tab'
+import { GeneralTab } from '@/common/components/settings/tabs/general-tab'
 import { VersionTab } from './version-tab'
 import { LogsTab } from './logs-tab'
 import { CliTab } from './cli-tab'


### PR DESCRIPTION
## Summary
- Change the `GeneralTab` import in `settings-tabs.tsx` from relative (`./general-tab`) to alias-based (`@/common/components/settings/tabs/general-tab`)
- This allows enterprise overlays to swap the `GeneralTab` component via Vite alias without having to duplicate the entire `settings-tabs.tsx` file

## Test plan
- [ ] Verify settings page loads correctly with all tabs
- [ ] Verify General tab renders theme, auto-launch, telemetry, quit confirmation fields
- [ ] Run `pnpm run type-check` and `pnpm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes https://github.com/stacklok/toolhive-studio/issues/2017