### PR TITLE
feat(skills): add registry tab with skill browsing and detail page

### DIFF
--- a/renderer/src/common/components/link-view-transition.tsx
+++ b/renderer/src/common/components/link-view-transition.tsx
@@ -59,8 +59,9 @@ function getViewTransition(
 
 export const LinkViewTransition = forwardRef<
   HTMLAnchorElement,
-  Omit<ComponentProps<typeof Link>, 'viewTransition' | 'params'> & {
+  Omit<ComponentProps<typeof Link>, 'viewTransition' | 'params' | 'search'> & {
     params?: Record<string, unknown>
+    search?: Record<string, unknown>
   }
 >((props, ref) => {
   const routeId = useRouterState({ select: (s) => s.location.pathname })

--- a/renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx
@@ -1,0 +1,161 @@
+import { screen, waitFor } from '@testing-library/react'
+import { expect, it, describe, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import {
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+  createMemoryHistory,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
+import { CardRegistrySkill } from '../card-registry-skill'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { mockedGetApiV1BetaDiscoveryClients } from '@mocks/fixtures/discovery_clients/get'
+
+const baseSkill: RegistrySkill = {
+  name: 'my-skill',
+  namespace: 'io.github.user',
+  description: 'A helpful skill for testing',
+}
+
+function createCardTestRouter(skill: RegistrySkill = baseSkill) {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>{String(error)}</div>,
+  })
+
+  const skillsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills',
+    component: () => <CardRegistrySkill skill={skill} />,
+  })
+
+  const skillDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills/$namespace/$skillName',
+    component: () => <div data-testid="skill-detail-page" />,
+  })
+
+  return new Router({
+    routeTree: rootRoute.addChildren([skillsRoute, skillDetailRoute]),
+    history: createMemoryHistory({ initialEntries: ['/skills'] }),
+    defaultNotFoundComponent: () => null,
+  })
+}
+
+const router = createCardTestRouter() as unknown as ReturnType<
+  typeof createTestRouter
+>
+
+beforeEach(async () => {
+  mockedGetApiV1BetaDiscoveryClients.activateScenario('empty')
+  await router.navigate({ to: '/skills' })
+})
+
+describe('CardRegistrySkill', () => {
+  describe('rendering', () => {
+    it('renders the skill name', () => {
+      renderRoute(router)
+      expect(screen.getByText('my-skill')).toBeVisible()
+    })
+
+    it('renders the namespace', () => {
+      renderRoute(router)
+      expect(screen.getByText('io.github.user')).toBeVisible()
+    })
+
+    it('renders the description', () => {
+      renderRoute(router)
+      expect(screen.getByText('A helpful skill for testing')).toBeVisible()
+    })
+
+    it('shows "Unknown skill" when name is absent', async () => {
+      const skillRouter = createCardTestRouter({
+        namespace: 'io.github.user',
+      }) as unknown as ReturnType<typeof createTestRouter>
+      await skillRouter.navigate({ to: '/skills' })
+      renderRoute(skillRouter)
+      expect(screen.getByText('Unknown skill')).toBeVisible()
+    })
+
+    it('does not render namespace row when namespace is absent', async () => {
+      const skillRouter = createCardTestRouter({
+        name: 'my-skill',
+      }) as unknown as ReturnType<typeof createTestRouter>
+      await skillRouter.navigate({ to: '/skills' })
+      renderRoute(skillRouter)
+      expect(screen.queryByText('io.github.user')).not.toBeInTheDocument()
+    })
+
+    it('does not render description when absent', async () => {
+      const skillRouter = createCardTestRouter({
+        name: 'my-skill',
+        namespace: 'io.github.user',
+      }) as unknown as ReturnType<typeof createTestRouter>
+      await skillRouter.navigate({ to: '/skills' })
+      renderRoute(skillRouter)
+      expect(
+        screen.queryByText('A helpful skill for testing')
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders the Install button', () => {
+      renderRoute(router)
+      expect(screen.getByRole('button', { name: /install/i })).toBeVisible()
+    })
+  })
+
+  describe('navigation', () => {
+    it('navigates to the skill detail page when the card is clicked', async () => {
+      const user = userEvent.setup()
+      renderRoute(router)
+
+      await user.click(screen.getByText('my-skill'))
+
+      await waitFor(() => {
+        expect(router.state.location.pathname).toBe(
+          '/skills/io.github.user/my-skill'
+        )
+      })
+    })
+
+    it('does not navigate when Install button is clicked', async () => {
+      const user = userEvent.setup()
+      renderRoute(router)
+
+      await user.click(screen.getByRole('button', { name: /install/i }))
+
+      expect(router.state.location.pathname).toBe('/skills')
+    })
+  })
+
+  describe('install dialog', () => {
+    it('opens the install dialog when Install button is clicked', async () => {
+      const user = userEvent.setup()
+      renderRoute(router)
+
+      await user.click(screen.getByRole('button', { name: /install/i }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: /install skill/i })
+        ).toBeVisible()
+      })
+    })
+
+    it('prefills the reference as namespace/name in the install dialog', async () => {
+      const user = userEvent.setup()
+      renderRoute(router)
+
+      await user.click(screen.getByRole('button', { name: /install/i }))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
+          'io.github.user/my-skill'
+        )
+      })
+    })
+  })
+})

--- a/renderer/src/features/skills/components/__tests__/grid-cards-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/grid-cards-registry-skills.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from '@testing-library/react'
+import { expect, it, describe, beforeEach } from 'vitest'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
+import { GridCardsRegistrySkills } from '../grid-cards-registry-skills'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { mockedGetApiV1BetaDiscoveryClients } from '@mocks/fixtures/discovery_clients/get'
+
+const testSkills: RegistrySkill[] = [
+  {
+    name: 'skill-alpha',
+    namespace: 'io.github.alpha',
+    description: 'First skill',
+  },
+  {
+    name: 'skill-beta',
+    namespace: 'io.github.beta',
+    description: 'Second skill',
+  },
+  {
+    name: 'skill-gamma',
+    namespace: 'io.github.gamma',
+    description: 'Third skill',
+  },
+]
+
+function createGridRouter(skills: RegistrySkill[]) {
+  return createTestRouter(
+    () => <GridCardsRegistrySkills skills={skills} />,
+    '/skills'
+  )
+}
+
+beforeEach(() => {
+  mockedGetApiV1BetaDiscoveryClients.activateScenario('empty')
+})
+
+describe('GridCardsRegistrySkills', () => {
+  it('renders a card for each skill', () => {
+    renderRoute(createGridRouter(testSkills))
+
+    expect(screen.getByText('skill-alpha')).toBeInTheDocument()
+    expect(screen.getByText('skill-beta')).toBeInTheDocument()
+    expect(screen.getByText('skill-gamma')).toBeInTheDocument()
+  })
+
+  it('shows empty message when skills array is empty', () => {
+    renderRoute(createGridRouter([]))
+
+    expect(
+      screen.getByText('No skills found matching the current filter')
+    ).toBeInTheDocument()
+  })
+
+  it('renders descriptions for each skill', () => {
+    renderRoute(createGridRouter(testSkills))
+
+    expect(screen.getByText('First skill')).toBeInTheDocument()
+    expect(screen.getByText('Second skill')).toBeInTheDocument()
+    expect(screen.getByText('Third skill')).toBeInTheDocument()
+  })
+})

--- a/renderer/src/features/skills/components/__tests__/grid-cards-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/grid-cards-registry-skills.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { expect, it, describe, beforeEach } from 'vitest'
 import { renderRoute } from '@/common/test/render-route'
 import { createTestRouter } from '@/common/test/create-test-router'
@@ -36,27 +36,33 @@ beforeEach(() => {
 })
 
 describe('GridCardsRegistrySkills', () => {
-  it('renders a card for each skill', () => {
+  it('renders a card for each skill', async () => {
     renderRoute(createGridRouter(testSkills))
 
-    expect(screen.getByText('skill-alpha')).toBeInTheDocument()
-    expect(screen.getByText('skill-beta')).toBeInTheDocument()
-    expect(screen.getByText('skill-gamma')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('skill-alpha')).toBeInTheDocument()
+      expect(screen.getByText('skill-beta')).toBeInTheDocument()
+      expect(screen.getByText('skill-gamma')).toBeInTheDocument()
+    })
   })
 
-  it('shows empty message when skills array is empty', () => {
+  it('shows empty message when skills array is empty', async () => {
     renderRoute(createGridRouter([]))
 
-    expect(
-      screen.getByText('No skills found matching the current filter')
-    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByText('No skills found matching the current filter')
+      ).toBeInTheDocument()
+    })
   })
 
-  it('renders descriptions for each skill', () => {
+  it('renders descriptions for each skill', async () => {
     renderRoute(createGridRouter(testSkills))
 
-    expect(screen.getByText('First skill')).toBeInTheDocument()
-    expect(screen.getByText('Second skill')).toBeInTheDocument()
-    expect(screen.getByText('Third skill')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('First skill')).toBeInTheDocument()
+      expect(screen.getByText('Second skill')).toBeInTheDocument()
+      expect(screen.getByText('Third skill')).toBeInTheDocument()
+    })
   })
 })

--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react'
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/common/components/ui/card'
+import { Button } from '@/common/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { cn } from '@/common/lib/utils'
+import { useNavigate } from '@tanstack/react-router'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { DialogInstallSkill } from './dialog-install-skill'
+
+export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
+  const [installOpen, setInstallOpen] = useState(false)
+  const navigate = useNavigate()
+
+  const name = skill.name ?? 'Unknown skill'
+  const namespace = skill.namespace
+  const description = skill.description
+  const defaultReference =
+    namespace && name !== 'Unknown skill' ? `${namespace}/${name}` : name
+
+  const canNavigate = !!(namespace && skill.name)
+
+  function handleCardClick() {
+    if (!canNavigate) return
+    void navigate({
+      to: '/skills/$namespace/$skillName',
+      params: { namespace: namespace!, skillName: skill.name! },
+    })
+  }
+
+  return (
+    <>
+      <Card
+        className={cn(
+          'relative flex flex-col',
+          'transition-[box-shadow,color]',
+          canNavigate && 'cursor-pointer hover:ring',
+          'has-[button:focus-visible]:ring'
+        )}
+        onClick={handleCardClick}
+      >
+        <CardHeader>
+          <CardTitle className="flex items-start justify-between gap-2 text-xl">
+            <Tooltip onlyWhenTruncated>
+              <TooltipTrigger asChild>
+                <span className="truncate select-none">{name}</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">{name}</TooltipContent>
+            </Tooltip>
+          </CardTitle>
+          {namespace && (
+            <p className="text-muted-foreground truncate text-sm select-none">
+              {namespace}
+            </p>
+          )}
+        </CardHeader>
+
+        <CardContent className="flex-1">
+          {description && (
+            <Tooltip onlyWhenTruncated>
+              <TooltipTrigger asChild>
+                <p
+                  className="text-muted-foreground line-clamp-3 text-sm
+                    select-none"
+                >
+                  {description}
+                </p>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                {description}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </CardContent>
+
+        <CardFooter className="mt-auto">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation()
+              setInstallOpen(true)
+            }}
+          >
+            Install
+          </Button>
+        </CardFooter>
+      </Card>
+
+      <DialogInstallSkill
+        open={installOpen}
+        onOpenChange={setInstallOpen}
+        defaultReference={defaultReference}
+      />
+    </>
+  )
+}

--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -24,8 +24,11 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
   const name = skill.name ?? 'Unknown skill'
   const namespace = skill.namespace
   const description = skill.description
-  const defaultReference =
+  const isOci = skill.packages?.some((p) => p.registryType === 'oci')
+  const base =
     namespace && name !== 'Unknown skill' ? `${namespace}/${name}` : name
+  const defaultReference =
+    isOci && skill.version ? `${base}:${skill.version}` : base
 
   const canNavigate = !!(namespace && skill.name)
 

--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -44,9 +44,18 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
           'relative flex flex-col',
           'transition-[box-shadow,color]',
           canNavigate && 'cursor-pointer hover:ring',
-          'has-[button:focus-visible]:ring'
+          'has-[button:focus-visible]:ring',
+          'focus-visible:ring focus-visible:outline-none'
         )}
         onClick={handleCardClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handleCardClick()
+          }
+        }}
+        role={canNavigate ? 'link' : undefined}
+        tabIndex={canNavigate ? 0 : undefined}
       >
         <CardHeader>
           <CardTitle className="flex items-start justify-between gap-2 text-xl">

--- a/renderer/src/features/skills/components/grid-cards-registry-skills.tsx
+++ b/renderer/src/features/skills/components/grid-cards-registry-skills.tsx
@@ -1,0 +1,39 @@
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { CardRegistrySkill } from './card-registry-skill'
+import { cn } from '@/common/lib/utils'
+
+export function GridCardsRegistrySkills({
+  skills,
+}: {
+  skills: RegistrySkill[]
+}) {
+  if (skills.length === 0) {
+    return (
+      <div className="text-muted-foreground py-12 text-center">
+        <p className="text-sm">No skills found matching the current filter</p>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'grid gap-4',
+        skills.length <= 3
+          ? 'grid-cols-[repeat(auto-fill,minmax(max(200px,min(300px,100%)),1fr))]'
+          : 'grid-cols-[repeat(auto-fit,minmax(max(200px,min(300px,100%)),1fr))]'
+      )}
+    >
+      {skills.map((skill, index) => (
+        <CardRegistrySkill
+          key={
+            skill.namespace && skill.name
+              ? `${skill.namespace}/${skill.name}`
+              : `skill-${index}`
+          }
+          skill={skill}
+        />
+      ))}
+    </div>
+  )
+}

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -17,8 +17,10 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
   const description = skill.description
   const version = skill.version
   const license = skill.license
-  const defaultReference =
+  const isOci = skill.packages?.some((p) => p.registryType === 'oci')
+  const base =
     namespace && name !== 'Unknown skill' ? `${namespace}/${name}` : name
+  const defaultReference = isOci && version ? `${base}:${version}` : base
 
   return (
     <>

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -62,9 +62,9 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
         </div>
 
         {/* Main content: two columns */}
-        <div className="flex gap-10">
+        <div className="flex flex-col gap-10 md:flex-row">
           {/* Left: Summary + Install */}
-          <div className="flex w-5/12 flex-col gap-6">
+          <div className="flex w-full flex-col gap-6 md:w-5/12">
             <div className="flex flex-col gap-2">
               <h4
                 className="text-foreground text-xl font-semibold tracking-tight"

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { Button } from '@/common/components/ui/button'
+import { LinkViewTransition } from '@/common/components/link-view-transition'
+import { ChevronLeft, TagIcon, GitForkIcon, ScaleIcon } from 'lucide-react'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { DialogInstallSkill } from './dialog-install-skill'
+
+interface SkillDetailPageProps {
+  skill: RegistrySkill
+}
+
+export function SkillDetailPage({ skill }: SkillDetailPageProps) {
+  const [installOpen, setInstallOpen] = useState(false)
+
+  const name = skill.name ?? 'Unknown skill'
+  const namespace = skill.namespace
+  const description = skill.description
+  const version = skill.version
+  const license = skill.license
+  const defaultReference =
+    namespace && name !== 'Unknown skill' ? `${namespace}/${name}` : name
+
+  return (
+    <>
+      <div className="flex w-full flex-col gap-8">
+        {/* Header */}
+        <div className="flex flex-col gap-3">
+          <div>
+            <LinkViewTransition to="/skills" search={{ tab: 'registry' }}>
+              <Button variant="outline" className="rounded-full">
+                <ChevronLeft className="size-4" />
+                Back
+              </Button>
+            </LinkViewTransition>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <h1 className="text-page-title m-0 p-0">{name}</h1>
+            <div
+              className="text-muted-foreground flex items-center gap-4 text-sm"
+            >
+              {version && (
+                <span className="flex items-center gap-1">
+                  <TagIcon className="size-4" />
+                  {version}
+                </span>
+              )}
+              {namespace && (
+                <span className="flex items-center gap-1">
+                  <GitForkIcon className="size-4" />
+                  {namespace}
+                </span>
+              )}
+              {license && (
+                <span className="flex items-center gap-1">
+                  <ScaleIcon className="size-4" />
+                  {license}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Main content: two columns */}
+        <div className="flex gap-10">
+          {/* Left: Summary + Install */}
+          <div className="flex w-5/12 flex-col gap-6">
+            <div className="flex flex-col gap-2">
+              <h4
+                className="text-foreground text-xl font-semibold tracking-tight"
+              >
+                Summary
+              </h4>
+              {description && (
+                <p className="text-muted-foreground text-base leading-7">
+                  {description}
+                </p>
+              )}
+            </div>
+            <div>
+              <Button variant="action" onClick={() => setInstallOpen(true)}>
+                Install
+              </Button>
+            </div>
+          </div>
+
+          {/* Right: Skill.md */}
+          <div className="flex flex-1 flex-col gap-3">
+            <h4 className="text-foreground text-xl font-semibold tracking-tight">
+              Skill.md
+            </h4>
+            <div
+              className="border-border rounded-2xl border bg-white p-6
+                dark:bg-transparent"
+            >
+              <p
+                className="text-muted-foreground font-mono text-sm
+                  leading-relaxed"
+              >
+                Skill.md rendering is not yet available.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <DialogInstallSkill
+        open={installOpen}
+        onOpenChange={setInstallOpen}
+        defaultReference={defaultReference}
+      />
+    </>
+  )
+}

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -54,7 +54,9 @@ export function SkillsPage() {
   const { data: registryData } = useQuery(
     getRegistryByRegistryNameV01xDevToolhiveSkillsOptions({
       path: { registryName: 'default' },
-      query: debouncedRegistrySearch ? { q: debouncedRegistrySearch } : {},
+      query: debouncedRegistrySearch
+        ? { q: debouncedRegistrySearch }
+        : undefined,
     })
   )
   const registrySkills = registryData?.skills ?? []

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -1,12 +1,16 @@
 import { useState } from 'react'
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { getApiV1BetaSkillsOptions } from '@common/api/generated/@tanstack/react-query.gen'
+import { useSuspenseQuery, useQuery } from '@tanstack/react-query'
+import {
+  getApiV1BetaSkillsOptions,
+  getRegistryByRegistryNameV01xDevToolhiveSkillsOptions,
+} from '@common/api/generated/@tanstack/react-query.gen'
 import { TitlePage } from '@/common/components/title-page'
 import { InputSearch } from '@/common/components/ui/input-search'
 import { Button } from '@/common/components/ui/button'
 import { EmptyState } from '@/common/components/empty-state'
 import { IllustrationPackage } from '@/common/components/illustrations/illustration-package'
 import { useFilterSort } from '@/common/hooks/use-filter-sort'
+import { useDebouncedCallback } from '@/common/hooks/use-debounced-callback'
 import {
   Tabs,
   TabsList,
@@ -15,16 +19,47 @@ import {
 } from '@/common/components/ui/tabs'
 import { GridCardsSkills } from './grid-cards-skills'
 import { GridCardsBuilds } from './grid-cards-builds'
+import { GridCardsRegistrySkills } from './grid-cards-registry-skills'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogBuildSkill } from './dialog-build-skill'
 import { PlusIcon, HammerIcon } from 'lucide-react'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
+import { useNavigate, useSearch } from '@tanstack/react-router'
+
+type Tab = 'registry' | 'installed' | 'builds'
 
 export function SkillsPage() {
   const [installOpen, setInstallOpen] = useState(false)
   const [buildOpen, setBuildOpen] = useState(false)
-  const [tab, setTab] = useState<'installed' | 'builds'>('installed')
+  const { tab } = useSearch({ from: '/skills' })
+  const navigate = useNavigate({ from: '/skills' })
 
+  function setTab(value: Tab) {
+    void navigate({ search: { tab: value }, replace: true })
+  }
+
+  // Registry tab search (server-side, debounced)
+  const [registrySearch, setRegistrySearch] = useState('')
+  const [debouncedRegistrySearch, setDebouncedRegistrySearch] = useState('')
+  const debouncedSetRegistrySearch = useDebouncedCallback(
+    setDebouncedRegistrySearch,
+    300
+  )
+
+  function handleRegistrySearchChange(value: string) {
+    setRegistrySearch(value)
+    debouncedSetRegistrySearch(value)
+  }
+
+  const { data: registryData } = useQuery(
+    getRegistryByRegistryNameV01xDevToolhiveSkillsOptions({
+      path: { registryName: 'default' },
+      query: debouncedRegistrySearch ? { q: debouncedRegistrySearch } : {},
+    })
+  )
+  const registrySkills = registryData?.skills ?? []
+
+  // Installed tab
   const { data } = useSuspenseQuery(getApiV1BetaSkillsOptions())
   const skills: InstalledSkill[] = data?.skills ?? []
 
@@ -42,15 +77,27 @@ export function SkillsPage() {
     sortBy: (skill) => skill.metadata?.name ?? skill.reference ?? '',
   })
 
+  // Builds tab
   const [buildsFilter, setBuildsFilter] = useState('')
 
   const hasSkills = skills.length > 0
 
-  const currentFilter = tab === 'installed' ? installedFilter : buildsFilter
-  const setCurrentFilter =
-    tab === 'installed' ? setInstalledFilter : setBuildsFilter
+  const currentFilter =
+    tab === 'registry'
+      ? registrySearch
+      : tab === 'installed'
+        ? installedFilter
+        : buildsFilter
 
-  const showSearch = (tab === 'installed' && hasSkills) || tab === 'builds'
+  const setCurrentFilter =
+    tab === 'registry'
+      ? handleRegistrySearchChange
+      : tab === 'installed'
+        ? setInstalledFilter
+        : setBuildsFilter
+
+  const showSearch =
+    tab === 'registry' || (tab === 'installed' && hasSkills) || tab === 'builds'
 
   return (
     <>
@@ -75,12 +122,10 @@ export function SkillsPage() {
         </div>
       </TitlePage>
 
-      <Tabs
-        value={tab}
-        onValueChange={(v) => setTab(v as 'installed' | 'builds')}
-      >
+      <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
         <div className="flex items-center justify-between gap-4">
           <TabsList>
+            <TabsTrigger value="registry">Registry</TabsTrigger>
             <TabsTrigger value="installed">Installed</TabsTrigger>
             <TabsTrigger value="builds">Local Builds</TabsTrigger>
           </TabsList>
@@ -92,6 +137,10 @@ export function SkillsPage() {
             />
           )}
         </div>
+
+        <TabsContent value="registry">
+          <GridCardsRegistrySkills skills={registrySkills} />
+        </TabsContent>
 
         <TabsContent value="installed">
           {!hasSkills ? (

--- a/renderer/src/route-tree.gen.ts
+++ b/renderer/src/route-tree.gen.ts
@@ -19,6 +19,7 @@ import { Route as IndexRouteImport } from "./routes/index"
 import { Route as GroupGroupNameRouteImport } from "./routes/group.$groupName"
 import { Route as CustomizeToolsServerNameRouteImport } from "./routes/customize-tools.$serverName"
 import { Route as registryRegistryRouteImport } from "./routes/(registry)/registry"
+import { Route as SkillsNamespaceSkillNameRouteImport } from "./routes/skills_.$namespace.$skillName"
 import { Route as LogsGroupNameServerNameRouteImport } from "./routes/logs.$groupName.$serverName"
 import { Route as registryRegistryNameRouteImport } from "./routes/(registry)/registry_.$name"
 import { Route as registryRegistryGroupNameRouteImport } from "./routes/(registry)/registry-group_.$name"
@@ -74,6 +75,12 @@ const registryRegistryRoute = registryRegistryRouteImport.update({
   path: "/registry",
   getParentRoute: () => rootRouteImport,
 } as any)
+const SkillsNamespaceSkillNameRoute =
+  SkillsNamespaceSkillNameRouteImport.update({
+    id: "/skills_/$namespace/$skillName",
+    path: "/skills/$namespace/$skillName",
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const LogsGroupNameServerNameRoute = LogsGroupNameServerNameRouteImport.update({
   id: "/logs/$groupName/$serverName",
   path: "/logs/$groupName/$serverName",
@@ -105,6 +112,7 @@ export interface FileRoutesByFullPath {
   "/registry-group/$name": typeof registryRegistryGroupNameRoute
   "/registry/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
+  "/skills/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute
@@ -120,6 +128,7 @@ export interface FileRoutesByTo {
   "/registry-group/$name": typeof registryRegistryGroupNameRoute
   "/registry/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
+  "/skills/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -136,6 +145,7 @@ export interface FileRoutesById {
   "/(registry)/registry-group_/$name": typeof registryRegistryGroupNameRoute
   "/(registry)/registry_/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
+  "/skills_/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -153,6 +163,7 @@ export interface FileRouteTypes {
     | "/registry-group/$name"
     | "/registry/$name"
     | "/logs/$groupName/$serverName"
+    | "/skills/$namespace/$skillName"
   fileRoutesByTo: FileRoutesByTo
   to:
     | "/"
@@ -168,6 +179,7 @@ export interface FileRouteTypes {
     | "/registry-group/$name"
     | "/registry/$name"
     | "/logs/$groupName/$serverName"
+    | "/skills/$namespace/$skillName"
   id:
     | "__root__"
     | "/"
@@ -183,6 +195,7 @@ export interface FileRouteTypes {
     | "/(registry)/registry-group_/$name"
     | "/(registry)/registry_/$name"
     | "/logs/$groupName/$serverName"
+    | "/skills_/$namespace/$skillName"
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -199,6 +212,7 @@ export interface RootRouteChildren {
   registryRegistryGroupNameRoute: typeof registryRegistryGroupNameRoute
   registryRegistryNameRoute: typeof registryRegistryNameRoute
   LogsGroupNameServerNameRoute: typeof LogsGroupNameServerNameRoute
+  SkillsNamespaceSkillNameRoute: typeof SkillsNamespaceSkillNameRoute
 }
 
 declare module "@tanstack/react-router" {
@@ -273,6 +287,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof registryRegistryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/skills_/$namespace/$skillName": {
+      id: "/skills_/$namespace/$skillName"
+      path: "/skills/$namespace/$skillName"
+      fullPath: "/skills/$namespace/$skillName"
+      preLoaderRoute: typeof SkillsNamespaceSkillNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     "/logs/$groupName/$serverName": {
       id: "/logs/$groupName/$serverName"
       path: "/logs/$groupName/$serverName"
@@ -311,6 +332,7 @@ const rootRouteChildren: RootRouteChildren = {
   registryRegistryGroupNameRoute: registryRegistryGroupNameRoute,
   registryRegistryNameRoute: registryRegistryNameRoute,
   LogsGroupNameServerNameRoute: LogsGroupNameServerNameRoute,
+  SkillsNamespaceSkillNameRoute: SkillsNamespaceSkillNameRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/renderer/src/routes/skills.tsx
+++ b/renderer/src/routes/skills.tsx
@@ -2,14 +2,28 @@ import { createFileRoute } from '@tanstack/react-router'
 import {
   getApiV1BetaSkillsOptions,
   getApiV1BetaSkillsBuildsOptions,
+  getRegistryByRegistryNameV01xDevToolhiveSkillsOptions,
 } from '@common/api/generated/@tanstack/react-query.gen'
 import { SkillsPage } from '@/features/skills/components/skills-page'
 
+const VALID_TABS = ['registry', 'installed', 'builds'] as const
+type SkillsTab = (typeof VALID_TABS)[number]
+
 export const Route = createFileRoute('/skills')({
+  validateSearch: (search: Record<string, unknown>): { tab: SkillsTab } => ({
+    tab: VALID_TABS.includes(search.tab as SkillsTab)
+      ? (search.tab as SkillsTab)
+      : 'installed',
+  }),
   loader: ({ context: { queryClient } }) =>
     Promise.all([
       queryClient.ensureQueryData(getApiV1BetaSkillsOptions()),
       queryClient.ensureQueryData(getApiV1BetaSkillsBuildsOptions()),
+      queryClient.ensureQueryData(
+        getRegistryByRegistryNameV01xDevToolhiveSkillsOptions({
+          path: { registryName: 'default' },
+        })
+      ),
     ]),
   component: SkillsPage,
 })

--- a/renderer/src/routes/skills_.$namespace.$skillName.tsx
+++ b/renderer/src/routes/skills_.$namespace.$skillName.tsx
@@ -1,0 +1,79 @@
+import { createFileRoute, notFound, useParams } from '@tanstack/react-router'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillNameOptions } from '@common/api/generated/@tanstack/react-query.gen'
+import { getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillName } from '@common/api/generated/sdk.gen'
+import { Button } from '@/common/components/ui/button'
+import { LinkViewTransition } from '@/common/components/link-view-transition'
+import { EmptyState } from '@/common/components/empty-state'
+import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
+import { SkillDetailPage } from '@/features/skills/components/skill-detail-page'
+
+function SkillNotFound() {
+  return (
+    <div className="flex max-h-full w-full flex-1 flex-col">
+      <EmptyState
+        illustration={IllustrationNoSearchResults}
+        title="Skill Not Found"
+        body="The skill you're looking for doesn't exist in the registry or has been removed."
+        actions={[
+          <Button asChild key="skills" variant="action">
+            <LinkViewTransition to="/skills">Browse Skills</LinkViewTransition>
+          </Button>,
+        ]}
+      />
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/skills_/$namespace/$skillName')({
+  loader: async ({ context: { queryClient }, params }) => {
+    const pathOptions = {
+      path: {
+        registryName: 'default' as const,
+        namespace: params.namespace,
+        skillName: params.skillName,
+      },
+    }
+    return queryClient.ensureQueryData({
+      ...getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillNameOptions(
+        pathOptions
+      ),
+      queryFn: async ({ signal }) => {
+        const result =
+          await getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillName(
+            { ...pathOptions, signal }
+          )
+        if (result.error !== undefined) {
+          if (result.response.status === 404) {
+            throw notFound()
+          }
+          throw result.error
+        }
+        return result.data
+      },
+    })
+  },
+  component: SkillDetail,
+  notFoundComponent: SkillNotFound,
+})
+
+function SkillDetail() {
+  const { namespace, skillName } = useParams({
+    from: '/skills_/$namespace/$skillName',
+  })
+  const { data: skill } = useSuspenseQuery(
+    getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillNameOptions(
+      {
+        path: {
+          registryName: 'default',
+          namespace,
+          skillName,
+        },
+      }
+    )
+  )
+
+  if (!skill) return null
+
+  return <SkillDetailPage skill={skill} />
+}

--- a/renderer/src/routes/skills_.$namespace.$skillName.tsx
+++ b/renderer/src/routes/skills_.$namespace.$skillName.tsx
@@ -8,6 +8,34 @@ import { EmptyState } from '@/common/components/empty-state'
 import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
 import { SkillDetailPage } from '@/features/skills/components/skill-detail-page'
 
+function skillQueryOptions(params: { namespace: string; skillName: string }) {
+  const pathOptions = {
+    path: {
+      registryName: 'default' as const,
+      namespace: params.namespace,
+      skillName: params.skillName,
+    },
+  }
+  return {
+    ...getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillNameOptions(
+      pathOptions
+    ),
+    queryFn: async ({ signal }: { signal: AbortSignal }) => {
+      const result =
+        await getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillName(
+          { ...pathOptions, signal }
+        )
+      if (result.error !== undefined) {
+        if (result.response?.status === 404) {
+          throw notFound()
+        }
+        throw result.error
+      }
+      return result.data
+    },
+  }
+}
+
 function SkillNotFound() {
   return (
     <div className="flex max-h-full w-full flex-1 flex-col">
@@ -17,7 +45,9 @@ function SkillNotFound() {
         body="The skill you're looking for doesn't exist in the registry or has been removed."
         actions={[
           <Button asChild key="skills" variant="action">
-            <LinkViewTransition to="/skills">Browse Skills</LinkViewTransition>
+            <LinkViewTransition to="/skills" search={{ tab: 'registry' }}>
+              Browse Skills
+            </LinkViewTransition>
           </Button>,
         ]}
       />
@@ -26,52 +56,15 @@ function SkillNotFound() {
 }
 
 export const Route = createFileRoute('/skills_/$namespace/$skillName')({
-  loader: async ({ context: { queryClient }, params }) => {
-    const pathOptions = {
-      path: {
-        registryName: 'default' as const,
-        namespace: params.namespace,
-        skillName: params.skillName,
-      },
-    }
-    return queryClient.ensureQueryData({
-      ...getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillNameOptions(
-        pathOptions
-      ),
-      queryFn: async ({ signal }) => {
-        const result =
-          await getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillName(
-            { ...pathOptions, signal }
-          )
-        if (result.error !== undefined) {
-          if (result.response.status === 404) {
-            throw notFound()
-          }
-          throw result.error
-        }
-        return result.data
-      },
-    })
-  },
+  loader: ({ context: { queryClient }, params }) =>
+    queryClient.ensureQueryData(skillQueryOptions(params)),
   component: SkillDetail,
   notFoundComponent: SkillNotFound,
 })
 
 function SkillDetail() {
-  const { namespace, skillName } = useParams({
-    from: '/skills_/$namespace/$skillName',
-  })
-  const { data: skill } = useSuspenseQuery(
-    getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillNameOptions(
-      {
-        path: {
-          registryName: 'default',
-          namespace,
-          skillName,
-        },
-      }
-    )
-  )
+  const params = useParams({ from: '/skills_/$namespace/$skillName' })
+  const { data: skill } = useSuspenseQuery(skillQueryOptions(params))
 
   if (!skill) return null
 


### PR DESCRIPTION
The Skills page previously only showed installed skills and local builds. This adds a read-only Registry tab that lets users browse skills from the default registry without installing them first.

- Add a Registry tab as the first tab on the Skills page, with a debounced server-side search input and a responsive card grid showing each skill's name, namespace, description (clamped to 3 lines with a tooltip on overflow), and an Install button that pre-fills the reference
- Persist the active tab in the URL (?tab=registry|installed|builds) so navigating away and back restores the correct tab
- Add a skill detail page at /skills/$namespace/$skillName with a two-column layout (summary + Install on the left, Skill.md placeholder on the right), loaded via the single-skill API endpoint with 404 handling; the Back button returns to /skills?tab=registry
- Add unit tests for CardRegistrySkill covering rendering, card navigation, and install dialog pre-fill


https://github.com/user-attachments/assets/9f859f15-49c8-428f-909c-76563ccd580b

