### PR TITLE
feat: show registry tab as read-only when permission is disabled

### DIFF
--- a/renderer/src/common/components/settings/registry/registry-form.tsx
+++ b/renderer/src/common/components/settings/registry/registry-form.tsx
@@ -17,6 +17,7 @@ interface RegistryFormProps {
   hasRegistryError: boolean
   isUnavailableError: boolean
   registryAuthRequiredMessage?: string
+  readOnly?: boolean
 }
 
 function getSubmitLabel(isLoading: boolean, hasOAuthFields: boolean): string {
@@ -33,6 +34,7 @@ export function RegistryForm({
   hasRegistryError,
   isUnavailableError,
   registryAuthRequiredMessage,
+  readOnly = false,
 }: RegistryFormProps) {
   const [type, clientId, issuerUrl] = form.watch([
     'type',
@@ -43,6 +45,7 @@ export function RegistryForm({
     type === 'api_url' && !!(clientId?.trim() && issuerUrl?.trim())
   const isDefault = type === 'default'
   const isSaving = isLoading && !isResetting
+  const isDisabled = isLoading || readOnly
   return (
     <Form {...form}>
       <form
@@ -51,9 +54,9 @@ export function RegistryForm({
       >
         <div className="flex w-full flex-col gap-3 py-1">
           <div className="flex max-w-xl flex-col gap-3">
-            <RegistryTypeField isPending={isLoading} form={form} />
+            <RegistryTypeField isPending={isDisabled} form={form} />
             <RegistrySourceField
-              isPending={isLoading}
+              isPending={isDisabled}
               form={form}
               hasRegistryError={hasRegistryError}
               isUnavailableError={isUnavailableError}
@@ -61,31 +64,33 @@ export function RegistryForm({
             />
           </div>
           <RegistryApiOAuthFields
-            isPending={isLoading}
+            isPending={isDisabled}
             form={form}
             hasRegistryError={hasRegistryError}
             registryAuthRequiredMessage={registryAuthRequiredMessage}
           />
           <Separator className="my-1 w-full" />
         </div>
-        <div className="flex gap-2">
-          <Button variant="action" type="submit" disabled={isLoading}>
-            {isSaving && <Loader2 className="size-4 animate-spin" />}
-            {getSubmitLabel(isSaving, hasOAuthFields)}
-          </Button>
-          {!isDefault && (
-            <Button
-              variant="secondary"
-              className="rounded-full"
-              type="button"
-              disabled={isLoading}
-              onClick={onReset}
-            >
-              {isResetting && <Loader2 className="size-4 animate-spin" />}
-              {isResetting ? 'Resetting...' : 'Reset Registry'}
+        {!readOnly && (
+          <div className="flex gap-2">
+            <Button variant="action" type="submit" disabled={isLoading}>
+              {isSaving && <Loader2 className="size-4 animate-spin" />}
+              {getSubmitLabel(isSaving, hasOAuthFields)}
             </Button>
-          )}
-        </div>
+            {!isDefault && (
+              <Button
+                variant="secondary"
+                className="rounded-full"
+                type="button"
+                disabled={isLoading}
+                onClick={onReset}
+              >
+                {isResetting && <Loader2 className="size-4 animate-spin" />}
+                {isResetting ? 'Resetting...' : 'Reset Registry'}
+              </Button>
+            )}
+          </div>
+        )}
       </form>
     </Form>
   )

--- a/renderer/src/common/components/settings/registry/registry-tab.tsx
+++ b/renderer/src/common/components/settings/registry/registry-tab.tsx
@@ -1,8 +1,12 @@
 import { RegistryForm } from './registry-form'
 import { SettingsSectionTitle } from '../tabs/components/settings-section-title'
 import { useRegistryForm } from './use-registry-form'
+import { usePermissions } from '@/common/contexts/permissions'
+import { PERMISSION_KEYS } from '@/common/contexts/permissions/permission-keys'
 
 export function RegistryTab() {
+  const { canShow } = usePermissions()
+  const readOnly = !canShow(PERMISSION_KEYS.SETTINGS_REGISTRY_TAB)
   const {
     form,
     onSubmit,
@@ -33,6 +37,7 @@ export function RegistryTab() {
         hasRegistryError={hasRegistryError}
         isUnavailableError={isUnavailableError}
         registryAuthRequiredMessage={registryAuthRequiredMessage}
+        readOnly={readOnly}
       />
     </div>
   )

--- a/renderer/src/common/components/settings/tabs/__tests__/registry-tab.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/registry-tab.test.tsx
@@ -14,8 +14,14 @@ import {
   REGISTRY_WRONG_AUTH_TOAST,
   REGISTRY_AUTH_REQUIRED_UI_MESSAGE,
 } from '../../registry/registry-errors-message'
+import { PermissionsProvider } from '@/common/contexts/permissions/permissions-provider'
+import type { Permissions } from '@/common/contexts/permissions'
+import { PERMISSION_KEYS } from '@/common/contexts/permissions/permission-keys'
 
-const renderWithProviders = (component: React.ReactElement) => {
+const renderWithProviders = (
+  component: React.ReactElement,
+  options?: { permissions?: Partial<Permissions> }
+) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -25,11 +31,13 @@ const renderWithProviders = (component: React.ReactElement) => {
 
   return {
     ...render(
-      <PromptProvider>
-        <QueryClientProvider client={queryClient}>
-          {component}
-        </QueryClientProvider>
-      </PromptProvider>
+      <PermissionsProvider value={options?.permissions}>
+        <PromptProvider>
+          <QueryClientProvider client={queryClient}>
+            {component}
+          </QueryClientProvider>
+        </PromptProvider>
+      </PermissionsProvider>
     ),
     queryClient,
   }
@@ -1067,5 +1075,22 @@ describe('RegistryTab', () => {
     expect(screen.getByRole('combobox')).toHaveTextContent(
       'Registry Server API'
     )
+  })
+
+  it('disables form fields and hides buttons when permission is disabled', async () => {
+    renderWithProviders(<RegistryTab />, {
+      permissions: { [PERMISSION_KEYS.SETTINGS_REGISTRY_TAB]: false },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeDisabled()
+    })
+
+    expect(
+      screen.queryByRole('button', { name: 'Save' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Reset Registry' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/renderer/src/common/components/settings/tabs/__tests__/settings-tabs.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/settings-tabs.test.tsx
@@ -244,19 +244,26 @@ describe('SettingsTabs', () => {
     expect(updateIcon).not.toBeInTheDocument()
   })
 
-  it('hides Registry tab when SETTINGS_REGISTRY_TAB permission is disabled', () => {
+  it('shows Registry tab as read-only when SETTINGS_REGISTRY_TAB permission is disabled', async () => {
     renderWithProviders(<SettingsTabs />, {
       permissions: { [PERMISSION_KEYS.SETTINGS_REGISTRY_TAB]: false },
     })
 
-    expect(
-      screen.queryByRole('tab', { name: 'Registry' })
-    ).not.toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Registry' })).toBeVisible()
     expect(screen.getByRole('tab', { name: 'General' })).toBeVisible()
     expect(screen.getByRole('tab', { name: 'Secrets' })).toBeVisible()
     expect(screen.getByRole('tab', { name: 'CLI' })).toBeVisible()
     expect(screen.getByRole('tab', { name: 'Version' })).toBeVisible()
     expect(screen.getByRole('tab', { name: 'Logs' })).toBeVisible()
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Registry' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeDisabled()
+    })
+    expect(
+      screen.queryByRole('button', { name: 'Save' })
+    ).not.toBeInTheDocument()
   })
 
   it('does not show update icon on other tabs', async () => {

--- a/renderer/src/common/components/settings/tabs/settings-tabs.tsx
+++ b/renderer/src/common/components/settings/tabs/settings-tabs.tsx
@@ -7,11 +7,6 @@ import { CliTab } from './cli-tab'
 import { RegistryTab } from '../registry/registry-tab'
 import { SecretsTab } from './secrets-tab'
 import { useAppVersion } from '@/common/hooks/use-app-version'
-import { usePermissions } from '@/common/contexts/permissions'
-import {
-  PERMISSION_KEYS,
-  type PermissionKey,
-} from '@/common/contexts/permissions/permission-keys'
 import {
   ArrowUpCircle,
   Wrench,
@@ -28,17 +23,11 @@ type TabItem = {
   label: string
   value: Tab
   icon: LucideIcon
-  permissionKey?: PermissionKey
 }
 
 const TABS: TabItem[] = [
   { label: 'General', value: 'general', icon: Wrench },
-  {
-    label: 'Registry',
-    value: 'registry',
-    icon: CloudDownload,
-    permissionKey: PERMISSION_KEYS.SETTINGS_REGISTRY_TAB,
-  },
+  { label: 'Registry', value: 'registry', icon: CloudDownload },
   { label: 'Secrets', value: 'secrets', icon: Lock },
   { label: 'CLI', value: 'cli', icon: Command },
   { label: 'Version', value: 'version', icon: AppWindow },
@@ -53,17 +42,10 @@ export function SettingsTabs({ defaultTab }: SettingsTabsProps) {
   const { data: appInfo, isLoading, error } = useAppVersion()
   const isProduction = import.meta.env.MODE === 'production'
   const isNewVersionAvailable = appInfo?.isNewVersionAvailable && isProduction
-  const { canShow } = usePermissions()
-
-  const visibleTabs = TABS.filter(
-    (tab) => !tab.permissionKey || canShow(tab.permissionKey)
-  )
-  const visibleTabValues = new Set(visibleTabs.map((t) => t.value))
-
   const effectiveDefaultTab =
-    defaultTab && visibleTabValues.has(defaultTab)
+    defaultTab && TABS.some((t) => t.value === defaultTab)
       ? defaultTab
-      : (visibleTabs[0]?.value ?? 'general')
+      : (TABS[0]?.value ?? 'general')
 
   return (
     <Tabs
@@ -76,7 +58,7 @@ export function SettingsTabs({ defaultTab }: SettingsTabsProps) {
           className="flex h-fit w-48 flex-col items-stretch justify-start gap-1
             border-none bg-transparent p-0"
         >
-          {visibleTabs.map((tab) => {
+          {TABS.map((tab) => {
             const Icon = tab.icon
             return (
               <TabsTrigger
@@ -107,11 +89,9 @@ export function SettingsTabs({ defaultTab }: SettingsTabsProps) {
           <GeneralTab />
         </TabsContent>
 
-        {visibleTabValues.has('registry') && (
-          <TabsContent value="registry" className="mt-0">
-            <RegistryTab />
-          </TabsContent>
-        )}
+        <TabsContent value="registry" className="mt-0">
+          <RegistryTab />
+        </TabsContent>
 
         <TabsContent value="secrets" className="mt-0">
           <SecretsTab />


### PR DESCRIPTION
## Summary
**Read-only mode**
<img width="1248" height="777" alt="Screenshot 2026-04-14 at 18 20 11" src="https://github.com/user-attachments/assets/b958ef0e-72b0-44eb-ad80-e82941026325" />



- Always show the Registry settings tab, even when the `SETTINGS_REGISTRY_TAB` permission is disabled
- When permission is disabled, form fields are disabled and Save/Reset buttons are hidden (read-only mode)
- Moved permission check from `SettingsTabs` into `RegistryTab` itself, simplifying the tab container

## Test plan
- [x] Existing tests updated: `settings-tabs.test.tsx` verifies tab is visible but read-only
- [x] New test added: `registry-tab.test.tsx` verifies disabled combobox and hidden buttons with permission off
- [x] All 1788 tests pass
- [x] Type-check and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)