### PR TITLE
feat(skills): multi-select clients in install dialog and enrich installed skill card

### DIFF
--- a/renderer/src/features/skills/components/__tests__/card-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-skill.test.tsx
@@ -41,27 +41,13 @@ describe('CardSkill', () => {
       scope: 'user',
     }
     renderWithProviders(<CardSkill skill={skill} />)
-    // Reference appears as the title (fallback) and also as the monospace ref text
-    expect(
-      screen.getAllByText('ghcr.io/org/my-skill:v1').length
-    ).toBeGreaterThan(0)
+    expect(screen.getByText('ghcr.io/org/my-skill:v1')).toBeInTheDocument()
   })
 
   it('shows "Unknown skill" when neither name nor reference', () => {
     const skill: InstalledSkill = {}
     renderWithProviders(<CardSkill skill={skill} />)
     expect(screen.getByText('Unknown skill')).toBeInTheDocument()
-  })
-
-  it('renders description when present', () => {
-    renderWithProviders(<CardSkill skill={baseSkill} />)
-    expect(screen.getByText('A test skill description')).toBeInTheDocument()
-  })
-
-  it('renders reference in monospace', () => {
-    renderWithProviders(<CardSkill skill={baseSkill} />)
-    const refElement = screen.getByText('ghcr.io/org/my-skill:v1')
-    expect(refElement).toHaveClass('font-mono')
   })
 
   it('shows status badge with "installed" variant', () => {

--- a/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import { DialogInstallSkill } from '../dialog-install-skill'
 import { recordRequests } from '@/common/mocks/node'
 import { mockedGetApiV1BetaDiscoveryClients } from '@/common/mocks/fixtures/discovery_clients/get'
+import { mockedPostApiV1BetaSkills } from '@/common/mocks/fixtures/skills/post'
 
 const renderWithProviders = (component: React.ReactElement) => {
   const queryClient = new QueryClient({
@@ -20,7 +21,7 @@ const renderWithProviders = (component: React.ReactElement) => {
 }
 
 beforeEach(() => {
-  // Default: no installed clients so we get plain text input for client field
+  // Default: no installed clients so we get the empty state for clients field
   mockedGetApiV1BetaDiscoveryClients.activateScenario('empty')
 })
 
@@ -33,7 +34,7 @@ describe('DialogInstallSkill', () => {
     ).toBeInTheDocument()
     expect(screen.getByLabelText(/name or reference/i)).toBeInTheDocument()
     expect(screen.getByText(/scope/i)).toBeInTheDocument()
-    expect(screen.getByText(/client/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/clients/i).length).toBeGreaterThan(0)
     expect(screen.getByText(/version/i)).toBeInTheDocument()
   })
 
@@ -64,7 +65,7 @@ describe('DialogInstallSkill', () => {
     })
   })
 
-  it('sends POST to /api/v1beta/skills with correct body on submit', async () => {
+  it('sends POST to /api/v1beta/skills without clients when none selected', async () => {
     const user = userEvent.setup()
     const rec = recordRequests()
 
@@ -85,6 +86,53 @@ describe('DialogInstallSkill', () => {
         name: 'ghcr.io/org/skill:v1',
         scope: 'user',
       })
+      expect(postCall?.payload).not.toHaveProperty('clients')
+    })
+  })
+
+  it('sends clients array when specific clients are checked', async () => {
+    const user = userEvent.setup()
+    const rec = recordRequests()
+    mockedGetApiV1BetaDiscoveryClients.reset()
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /select clients/i })
+      ).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /select clients/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menuitemcheckbox', { name: 'claude-code' })
+      ).toBeInTheDocument()
+    })
+
+    await user.click(
+      screen.getByRole('menuitemcheckbox', { name: 'claude-code' })
+    )
+    await user.click(screen.getByRole('menuitemcheckbox', { name: 'opencode' }))
+
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      const postCall = rec.recordedRequests.find(
+        (r) => r.method === 'POST' && r.pathname === '/api/v1beta/skills'
+      )
+      expect(postCall).toBeDefined()
+      expect(postCall?.payload).toMatchObject({
+        name: 'my-skill',
+        scope: 'user',
+        clients: expect.arrayContaining(['claude-code', 'opencode']),
+      })
+      expect((postCall?.payload as { clients: string[] }).clients).toHaveLength(
+        2
+      )
     })
   })
 
@@ -94,7 +142,6 @@ describe('DialogInstallSkill', () => {
 
     expect(screen.queryByText(/project root/i)).not.toBeInTheDocument()
 
-    // Scope select accessible name comes from FormLabel "Scope"
     await user.click(screen.getByRole('combobox', { name: /scope/i }))
     await user.click(screen.getByRole('option', { name: /project/i }))
 
@@ -145,16 +192,30 @@ describe('DialogInstallSkill', () => {
     })
   })
 
-  it('populates client dropdown from discovery API when clients are available', async () => {
-    // Reset to default fixture which has installed clients with supports_skills: true
+  it('renders dropdown items for each skill-supporting client when clients are available', async () => {
+    const user = userEvent.setup()
     mockedGetApiV1BetaDiscoveryClients.reset()
 
     renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
 
-    // When skill-supporting clients are present, the client field renders as a Select (combobox)
-    // so there are 2 comboboxes: scope + client
     await waitFor(() => {
-      expect(screen.getAllByRole('combobox')).toHaveLength(2)
+      expect(
+        screen.getByRole('button', { name: /select clients/i })
+      ).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /select clients/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menuitemcheckbox', { name: 'claude-code' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('menuitemcheckbox', { name: 'opencode' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('menuitemcheckbox', { name: 'codex' })
+      ).toBeInTheDocument()
     })
   })
 
@@ -165,42 +226,84 @@ describe('DialogInstallSkill', () => {
     renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
 
     await waitFor(() => {
-      expect(screen.getAllByRole('combobox')).toHaveLength(2)
+      expect(
+        screen.getByRole('button', { name: /select clients/i })
+      ).toBeInTheDocument()
     })
 
-    await user.click(screen.getByRole('combobox', { name: /client/i }))
+    await user.click(screen.getByRole('button', { name: /select clients/i }))
 
     await waitFor(() => {
-      // Clients with supports_skills: true
       expect(
-        screen.getByRole('option', { name: 'claude-code' })
+        screen.getByRole('menuitemcheckbox', { name: 'claude-code' })
       ).toBeInTheDocument()
-      expect(
-        screen.getByRole('option', { name: 'opencode' })
-      ).toBeInTheDocument()
-      expect(screen.getByRole('option', { name: 'codex' })).toBeInTheDocument()
-      // Installed clients without supports_skills should NOT appear
-      expect(
-        screen.queryByRole('option', { name: 'cline' })
-      ).not.toBeInTheDocument()
-      expect(
-        screen.queryByRole('option', { name: 'cursor' })
-      ).not.toBeInTheDocument()
-      expect(
-        screen.queryByRole('option', { name: 'vscode' })
-      ).not.toBeInTheDocument()
     })
+
+    // Installed clients without supports_skills should NOT appear
+    expect(
+      screen.queryByRole('menuitemcheckbox', { name: 'cline' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('menuitemcheckbox', { name: 'cursor' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('menuitemcheckbox', { name: 'vscode' })
+    ).not.toBeInTheDocument()
   })
 
-  it('falls back to text input for client when no clients discovered', async () => {
+  it('shows empty state message when no skill-supporting clients are detected', async () => {
     // beforeEach already activates 'empty' scenario
     renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
 
     await waitFor(() => {
       expect(
-        screen.getByPlaceholderText(/e\.g\. claude-code/i)
+        screen.getByText(/no skill-supporting clients detected/i)
       ).toBeInTheDocument()
     })
+  })
+
+  it('shows "all detected clients" placeholder when no clients are selected', async () => {
+    mockedGetApiV1BetaDiscoveryClients.reset()
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /select clients/i })
+      ).toHaveTextContent(/all detected clients/i)
+    })
+  })
+
+  it('shows error alert inside the dialog when install fails', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkills.activateScenario('server-error')
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('clears the error alert when the dialog is closed and reopened', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkills.activateScenario('server-error')
+    const onOpenChange = vi.fn()
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={onOpenChange} />)
+
+    await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('calls onOpenChange(false) after successful install', async () => {

--- a/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
@@ -91,6 +91,8 @@ describe('DialogInstallSkill', () => {
   })
 
   it('sends clients array when specific clients are checked', async () => {
+    // Suppress React 19 + Radix "suspended inside act" warning during dropdown close
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const user = userEvent.setup()
     const rec = recordRequests()
     mockedGetApiV1BetaDiscoveryClients.reset()
@@ -99,6 +101,7 @@ describe('DialogInstallSkill', () => {
 
     await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
 
+    // Wait for clients dropdown to appear, open it, and select two clients
     await waitFor(() => {
       expect(
         screen.getByRole('button', { name: /select clients/i })
@@ -118,6 +121,14 @@ describe('DialogInstallSkill', () => {
     )
     await user.click(screen.getByRole('menuitemcheckbox', { name: 'opencode' }))
 
+    // Radix traps focus in the dropdown and sets pointer-events:none on the
+    // dialog, so submit the form via keyboard instead of clicking Install
+    await user.keyboard('{Escape}')
+    // Wait for dropdown to close and dialog to regain pointer events
+    await waitFor(() => {
+      expect(screen.queryByRole('menuitemcheckbox')).not.toBeInTheDocument()
+    })
+
     await user.click(screen.getByRole('button', { name: /^install$/i }))
 
     await waitFor(() => {
@@ -134,6 +145,8 @@ describe('DialogInstallSkill', () => {
         2
       )
     })
+
+    consoleSpy.mockRestore()
   })
 
   it('shows project_root field only when scope is "project"', async () => {
@@ -288,12 +301,11 @@ describe('DialogInstallSkill', () => {
     })
   })
 
-  it('clears the error alert when the dialog is closed and reopened', async () => {
+  it('clears the error alert when the dialog is closed', async () => {
     const user = userEvent.setup()
     mockedPostApiV1BetaSkills.activateScenario('server-error')
-    const onOpenChange = vi.fn()
 
-    renderWithProviders(<DialogInstallSkill open onOpenChange={onOpenChange} />)
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
 
     await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
     await user.click(screen.getByRole('button', { name: /^install$/i }))
@@ -302,8 +314,12 @@ describe('DialogInstallSkill', () => {
       expect(screen.getByRole('alert')).toBeInTheDocument()
     })
 
+    // Cancel runs handleClose which clears the error
     await user.click(screen.getByRole('button', { name: /cancel/i }))
-    expect(onOpenChange).toHaveBeenCalledWith(false)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
   })
 
   it('calls onOpenChange(false) after successful install', async () => {

--- a/renderer/src/features/skills/components/card-skill.tsx
+++ b/renderer/src/features/skills/components/card-skill.tsx
@@ -30,9 +30,9 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
   const status = skill.status
   const scope = skill.scope
   const clients = skill.clients
-  const projectRoot = skill.project_root
+  const projectRoot = scope === 'project' ? skill.project_root : undefined
   const projectRootLabel = projectRoot
-    ? `/${projectRoot.split('/').filter(Boolean).at(-1) ?? projectRoot}`
+    ? `/${projectRoot.split(/[\\/]/).filter(Boolean).at(-1) ?? projectRoot}`
     : null
 
   return (

--- a/renderer/src/features/skills/components/card-skill.tsx
+++ b/renderer/src/features/skills/components/card-skill.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import {
   Card,
-  CardContent,
   CardFooter,
   CardHeader,
   CardTitle,
@@ -28,10 +27,13 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
   const [uninstallOpen, setUninstallOpen] = useState(false)
 
   const title = skill.metadata?.name ?? skill.reference ?? 'Unknown skill'
-  const description = skill.metadata?.description
-  const reference = skill.reference
   const status = skill.status
   const scope = skill.scope
+  const clients = skill.clients
+  const projectRoot = skill.project_root
+  const projectRootLabel = projectRoot
+    ? `/${projectRoot.split('/').filter(Boolean).at(-1) ?? projectRoot}`
+    : null
 
   return (
     <>
@@ -64,23 +66,27 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
                 {scope}
               </Badge>
             )}
+            {projectRootLabel && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge variant="outline" className="font-mono">
+                    {projectRootLabel}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs font-mono text-xs break-all">
+                  {projectRoot}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {clients?.map((client) => (
+              <Badge key={client} variant="outline">
+                {client}
+              </Badge>
+            ))}
           </div>
         </CardHeader>
 
-        <CardContent className="flex-1">
-          {description && (
-            <p className="text-muted-foreground mb-2 text-sm select-none">
-              {description}
-            </p>
-          )}
-          {reference && (
-            <p className="text-muted-foreground truncate font-mono text-xs">
-              {reference}
-            </p>
-          )}
-        </CardContent>
-
-        <CardFooter className="mt-auto flex items-center justify-end gap-2">
+        <CardFooter className="mt-auto flex items-center justify-start gap-2">
           <Button
             variant="ghost"
             size="sm"

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -1,9 +1,17 @@
+import { useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import z from 'zod/v4'
 import { zodV4Resolver } from '@/common/lib/zod-v4-resolver'
 import { useQuery } from '@tanstack/react-query'
 import { getApiV1BetaDiscoveryClientsOptions } from '@common/api/generated/@tanstack/react-query.gen'
+import { Alert, AlertDescription } from '@/common/components/ui/alert'
 import { Button } from '@/common/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/common/components/ui/dropdown-menu'
 import {
   Dialog,
   DialogContent,
@@ -16,6 +24,7 @@ import { Input } from '@/common/components/ui/input'
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -28,7 +37,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/common/components/ui/select'
-import { FolderOpenIcon } from 'lucide-react'
+import { ChevronDown, FolderOpenIcon, TriangleAlertIcon } from 'lucide-react'
 import { useMutationInstallSkill } from '../hooks/use-mutation-install-skill'
 
 const formSchema = z
@@ -36,7 +45,7 @@ const formSchema = z
     name: z.string().min(1, 'Name or reference is required'),
     scope: z.enum(['user', 'project']),
     project_root: z.string().optional(),
-    client: z.string().optional(),
+    clients: z.array(z.string()).optional(),
     version: z.string().optional(),
   })
   .check((ctx) => {
@@ -64,6 +73,7 @@ export function DialogInstallSkill({
   defaultReference,
 }: DialogInstallSkillProps) {
   const { mutateAsync: installSkill, isPending } = useMutationInstallSkill()
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   const { data: clientsData } = useQuery({
     ...getApiV1BetaDiscoveryClientsOptions(),
@@ -81,7 +91,7 @@ export function DialogInstallSkill({
       name: defaultReference ?? '',
       scope: 'user',
       project_root: '',
-      client: '',
+      clients: [],
       version: '',
     },
   })
@@ -90,6 +100,7 @@ export function DialogInstallSkill({
 
   function handleClose() {
     form.reset()
+    setSubmitError(null)
     onOpenChange(false)
   }
 
@@ -101,6 +112,7 @@ export function DialogInstallSkill({
   }
 
   async function onSubmit(values: FormSchema) {
+    setSubmitError(null)
     try {
       await installSkill({
         body: {
@@ -108,13 +120,21 @@ export function DialogInstallSkill({
           scope: values.scope,
           project_root:
             values.scope === 'project' ? values.project_root : undefined,
-          client: values.client || undefined,
+          clients: values.clients?.length ? values.clients : undefined,
           version: values.version || undefined,
         },
       })
       handleClose()
-    } catch {
-      // Error toast is handled by useMutationInstallSkill onError
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : typeof err === 'object' && err !== null && 'error' in err
+            ? String((err as { error: unknown }).error)
+            : typeof err === 'string'
+              ? err
+              : 'Failed to install skill'
+      setSubmitError(message)
     }
   }
 
@@ -127,6 +147,12 @@ export function DialogInstallSkill({
             Install a skill by providing its name or OCI reference.
           </DialogDescription>
         </DialogHeader>
+        {submitError && (
+          <Alert variant="destructive">
+            <TriangleAlertIcon className="size-4" />
+            <AlertDescription>{submitError}</AlertDescription>
+          </Alert>
+        )}
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit)}
@@ -211,41 +237,69 @@ export function DialogInstallSkill({
             )}
             <FormField
               control={form.control}
-              name="client"
+              name="clients"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>
-                    Client{' '}
+                    Clients{' '}
                     <span className="text-muted-foreground font-normal">
                       (optional)
                     </span>
                   </FormLabel>
                   {installedClients.length > 0 ? (
-                    <Select
-                      value={field.value ?? ''}
-                      onValueChange={field.onChange}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select a client..." />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {installedClients.map((c) => (
-                          <SelectItem
-                            key={c.client_type}
-                            value={c.client_type!}
-                          >
-                            {c.client_type}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="w-full justify-between font-normal"
+                          aria-label="Select clients"
+                        >
+                          <span className="truncate">
+                            {field.value?.length
+                              ? field.value.join(', ')
+                              : 'All detected clients'}
+                          </span>
+                          <ChevronDown className="size-4 shrink-0 opacity-50" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        className="w-(--radix-dropdown-menu-trigger-width)"
+                        align="start"
+                      >
+                        {installedClients.map((c) => {
+                          const clientType = c.client_type!
+                          return (
+                            <DropdownMenuCheckboxItem
+                              key={clientType}
+                              checked={
+                                field.value?.includes(clientType) ?? false
+                              }
+                              onCheckedChange={(isChecked) => {
+                                const current = field.value ?? []
+                                field.onChange(
+                                  isChecked
+                                    ? [...current, clientType]
+                                    : current.filter((v) => v !== clientType)
+                                )
+                              }}
+                              onSelect={(e) => e.preventDefault()}
+                            >
+                              {clientType}
+                            </DropdownMenuCheckboxItem>
+                          )
+                        })}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   ) : (
-                    <FormControl>
-                      <Input {...field} placeholder="e.g. claude-code" />
-                    </FormControl>
+                    <p className="text-muted-foreground text-sm">
+                      No skill-supporting clients detected — will install for
+                      all available clients
+                    </p>
                   )}
+                  <FormDescription>
+                    Leave empty to install for all detected clients
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -75,7 +75,7 @@ export function DialogInstallSkill({
   const { mutateAsync: installSkill, isPending } = useMutationInstallSkill()
   const [submitError, setSubmitError] = useState<string | null>(null)
 
-  const { data: clientsData } = useQuery({
+  const { data: clientsData, isLoading: isLoadingClients } = useQuery({
     ...getApiV1BetaDiscoveryClientsOptions(),
     enabled: open,
   })
@@ -291,12 +291,12 @@ export function DialogInstallSkill({
                         })}
                       </DropdownMenuContent>
                     </DropdownMenu>
-                  ) : (
+                  ) : !isLoadingClients ? (
                     <p className="text-muted-foreground text-sm">
                       No skill-supporting clients detected — will install for
                       all available clients
                     </p>
-                  )}
+                  ) : null}
                   <FormDescription>
                     Leave empty to install for all detected clients
                   </FormDescription>

--- a/renderer/src/features/skills/hooks/__tests__/use-mutation-install-skill.test.ts
+++ b/renderer/src/features/skills/hooks/__tests__/use-mutation-install-skill.test.ts
@@ -91,7 +91,7 @@ describe('useMutationInstallSkill', () => {
     )
   })
 
-  it('shows error toast on failure', async () => {
+  it('rejects with an error on failure', async () => {
     mockedPostApiV1BetaSkills.activateScenario('server-error')
 
     const { Wrapper } = createQueryClientWrapper()
@@ -107,8 +107,6 @@ describe('useMutationInstallSkill', () => {
     await waitFor(() => {
       expect(result.current.isError).toBe(true)
     })
-
-    expect(toast.error).toHaveBeenCalledWith('Failed to install skill')
   })
 
   it('invalidates skills list query on success', async () => {

--- a/renderer/src/features/skills/hooks/use-mutation-install-skill.ts
+++ b/renderer/src/features/skills/hooks/use-mutation-install-skill.ts
@@ -18,8 +18,5 @@ export function useMutationInstallSkill() {
         queryKey: getApiV1BetaSkillsQueryKey(),
       })
     },
-    onError: () => {
-      toast.error('Failed to install skill')
-    },
   })
 }


### PR DESCRIPTION
The install skill dialog only allowed selecting a single client, which no longer matched the API accepting `clients: string[]`. The installed skill card also showed no information about which clients or project a skill was installed for.

- Change the `client` (string) form field to `clients` (string[]) to match `PkgApiV1InstallSkillRequest`
- Replace the single-select `<Select>` with a `DropdownMenu` + `DropdownMenuCheckboxItem` multi-select, showing "All detected clients" when nothing is selected
- Omit `clients` from the request body when empty, which the API interprets as "install for all available clients"
- Show an inline destructive `Alert` inside the dialog when the install fails, surfacing the API error message; remove the now-redundant `toast.error` from `useMutationInstallSkill`
- Show each installed client as an outline badge on the skill card, matching the Figma design
- Show the `project_root` as a monospace outline badge (last path segment prefixed with `/`) with a tooltip containing the full path, only for project-scoped skills


https://github.com/user-attachments/assets/3e7a9a74-870e-4734-a1d0-662178b036ac

