### PR TITLE
feat(playground): thread ID in URL with sub-route architecture

### DIFF
--- a/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
@@ -59,9 +59,10 @@ beforeEach(() => {
 describe('usePlaygroundThreads', () => {
   describe('initial load', () => {
     it('starts in loading state', () => {
-      const { result } = renderHook(() => usePlaygroundThreads(), {
-        wrapper: createWrapper(),
-      })
+      const { result } = renderHook(
+        () => usePlaygroundThreads('initial-thread'),
+        { wrapper: createWrapper() }
+      )
       expect(result.current.isLoading).toBe(true)
     })
 
@@ -70,108 +71,108 @@ describe('usePlaygroundThreads', () => {
         makeDbThread({ id: 'old', lastEditTimestamp: 1000 }),
         makeDbThread({ id: 'new', lastEditTimestamp: 3000 }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
-        wrapper: createWrapper(),
-      })
+      const { result } = renderHook(
+        () => usePlaygroundThreads('initial-thread'),
+        { wrapper: createWrapper() }
+      )
       await waitFor(() => expect(result.current.isLoading).toBe(false))
       expect(result.current.threads[0]!.id).toBe('new')
       expect(result.current.threads[1]!.id).toBe('old')
     })
 
-    it('sets activeThreadId to the first thread', async () => {
+    it('calls setActiveThreadId with the provided activeThreadId via IPC', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
-        makeDbThread({ id: 'first' }),
+        makeDbThread({ id: 'thread-from-url' }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      renderHook(() => usePlaygroundThreads('thread-from-url'), {
         wrapper: createWrapper(),
       })
-      await waitFor(() => expect(result.current.isLoading).toBe(false))
-      expect(result.current.activeThreadId).toBe('first')
-      expect(mockChatAPI.setActiveThreadId).toHaveBeenCalledWith('first')
+      await waitFor(() =>
+        expect(mockChatAPI.setActiveThreadId).toHaveBeenCalledWith(
+          'thread-from-url'
+        )
+      )
     })
 
-    it('leaves activeThreadId null when DB is empty', async () => {
+    it('updates setActiveThreadId when activeThreadId changes', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      let activeId = 'thread-a'
+      const { rerender } = renderHook(() => usePlaygroundThreads(activeId), {
         wrapper: createWrapper(),
       })
-      await waitFor(() => expect(result.current.isLoading).toBe(false))
-      expect(result.current.activeThreadId).toBeNull()
-      expect(result.current.hasThreads).toBe(false)
-      expect(mockChatAPI.setActiveThreadId).not.toHaveBeenCalled()
+      await waitFor(() =>
+        expect(mockChatAPI.setActiveThreadId).toHaveBeenCalledWith('thread-a')
+      )
+
+      activeId = 'thread-b'
+      rerender()
+
+      await waitFor(() =>
+        expect(mockChatAPI.setActiveThreadId).toHaveBeenCalledWith('thread-b')
+      )
     })
 
     it('maps starred field from DB thread', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ starred: true }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
-        wrapper: createWrapper(),
-      })
+      const { result } = renderHook(
+        () => usePlaygroundThreads('initial-thread'),
+        { wrapper: createWrapper() }
+      )
       await waitFor(() => expect(result.current.isLoading).toBe(false))
       expect(result.current.threads[0]!.starred).toBe(true)
+    })
+
+    it('has no threads when DB is empty', async () => {
+      mockChatAPI.getAllThreads.mockResolvedValue([])
+      const { result } = renderHook(
+        () => usePlaygroundThreads('initial-thread'),
+        { wrapper: createWrapper() }
+      )
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.hasThreads).toBe(false)
     })
   })
 
   describe('createThread', () => {
-    it('calls createChatThread and prepends new thread to list', async () => {
+    it('calls createChatThread, prepends new thread to list, and returns the new thread ID', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'existing' }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('existing'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
+      let returnedId: string | null = null
       await act(async () => {
-        await result.current.createThread()
+        returnedId = await result.current.createThread()
       })
 
       expect(mockChatAPI.createChatThread).toHaveBeenCalledOnce()
       expect(result.current.threads[0]!.id).toBe('new-thread')
-      expect(result.current.activeThreadId).toBe('new-thread')
-      expect(mockChatAPI.setActiveThreadId).toHaveBeenLastCalledWith(
-        'new-thread'
-      )
+      expect(returnedId).toBe('new-thread')
     })
 
-    it('does nothing when createChatThread returns failure', async () => {
+    it('returns null when createChatThread returns failure', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([])
       mockChatAPI.createChatThread.mockResolvedValue({
         success: false,
         error: 'db error',
       })
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('any-thread'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
+      let returnedId: string | null = 'sentinel'
       await act(async () => {
-        await result.current.createThread()
+        returnedId = await result.current.createThread()
       })
 
       expect(result.current.threads).toHaveLength(0)
-      expect(result.current.activeThreadId).toBeNull()
-    })
-  })
-
-  describe('selectThread', () => {
-    it('updates activeThreadId and calls setActiveThreadId IPC', async () => {
-      mockChatAPI.getAllThreads.mockResolvedValue([
-        makeDbThread({ id: 't1' }),
-        makeDbThread({ id: 't2' }),
-      ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
-        wrapper: createWrapper(),
-      })
-      await waitFor(() => expect(result.current.isLoading).toBe(false))
-
-      act(() => {
-        result.current.selectThread('t2')
-      })
-
-      expect(result.current.activeThreadId).toBe('t2')
-      expect(mockChatAPI.setActiveThreadId).toHaveBeenLastCalledWith('t2')
+      expect(returnedId).toBeNull()
     })
   })
 
@@ -180,7 +181,7 @@ describe('usePlaygroundThreads', () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'thread-1' }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('thread-1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -192,43 +193,43 @@ describe('usePlaygroundThreads', () => {
       expect(result.current.threads).toHaveLength(0)
     })
 
-    it('selects the next thread when active thread is deleted', async () => {
+    it('returns the next thread ID when the deleted thread has a successor', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'active', lastEditTimestamp: 2000 }),
         makeDbThread({ id: 'next', lastEditTimestamp: 1000 }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('active'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
-      expect(result.current.activeThreadId).toBe('active')
 
+      let nextId: string | null = null
       await act(async () => {
-        await result.current.deleteThread('active')
+        nextId = await result.current.deleteThread('active')
       })
 
-      expect(result.current.activeThreadId).toBe('next')
-      expect(mockChatAPI.setActiveThreadId).toHaveBeenLastCalledWith('next')
+      expect(nextId).toBe('next')
     })
 
-    it('sets activeThreadId to null when last thread is deleted', async () => {
+    it('returns null when the last thread is deleted', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'only' }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('only'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
+      let nextId: string | null = 'sentinel'
       await act(async () => {
-        await result.current.deleteThread('only')
+        nextId = await result.current.deleteThread('only')
       })
 
-      expect(result.current.activeThreadId).toBeNull()
+      expect(nextId).toBeNull()
       expect(result.current.hasThreads).toBe(false)
     })
 
-    it('does not change state when deleteThread returns failure', async () => {
+    it('returns null and does not change state when deleteThread returns failure', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'thread-1' }),
       ])
@@ -236,16 +237,18 @@ describe('usePlaygroundThreads', () => {
         success: false,
         error: 'not found',
       })
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('thread-1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
+      let nextId: string | null = 'sentinel'
       await act(async () => {
-        await result.current.deleteThread('thread-1')
+        nextId = await result.current.deleteThread('thread-1')
       })
 
       expect(result.current.threads).toHaveLength(1)
+      expect(nextId).toBeNull()
     })
   })
 
@@ -254,7 +257,7 @@ describe('usePlaygroundThreads', () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 't1', title: 'Old' }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('t1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -278,7 +281,7 @@ describe('usePlaygroundThreads', () => {
       mockChatAPI.getThread.mockResolvedValue(
         makeDbThread({ id: 't1', title: 'Renamed' })
       )
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('t1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -303,7 +306,7 @@ describe('usePlaygroundThreads', () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 't1', starred: false }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('t1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -324,7 +327,7 @@ describe('usePlaygroundThreads', () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 't1', starred: true }),
       ])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('t1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -343,7 +346,7 @@ describe('usePlaygroundThreads', () => {
 
     it('is a no-op for an unknown thread id', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([makeDbThread({ id: 't1' })])
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('t1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -364,7 +367,7 @@ describe('usePlaygroundThreads', () => {
       mockChatAPI.getThread.mockResolvedValue(
         makeDbThread({ id: 't1', title: 'After' })
       )
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('t1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -378,12 +381,12 @@ describe('usePlaygroundThreads', () => {
       )
     })
 
-    it('prepends and activates a new thread when it is not in the list', async () => {
+    it('prepends a new thread to the list when it is not found', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([])
       mockChatAPI.getThread.mockResolvedValue(
         makeDbThread({ id: 'brand-new', title: 'New' })
       )
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('brand-new'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -393,13 +396,13 @@ describe('usePlaygroundThreads', () => {
       })
 
       expect(result.current.threads).toHaveLength(1)
-      expect(result.current.activeThreadId).toBe('brand-new')
+      expect(result.current.threads[0]!.id).toBe('brand-new')
     })
 
     it('does nothing when getThread returns null', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([makeDbThread({ id: 't1' })])
       mockChatAPI.getThread.mockResolvedValue(null)
-      const { result } = renderHook(() => usePlaygroundThreads(), {
+      const { result } = renderHook(() => usePlaygroundThreads('t1'), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -432,7 +435,10 @@ describe('usePlaygroundThreads', () => {
           children
         )
 
-      const { result } = renderHook(() => usePlaygroundThreads(), { wrapper })
+      const { result } = renderHook(
+        () => usePlaygroundThreads('streaming-thread'),
+        { wrapper }
+      )
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
       // Simulate the streamingComplete signal

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -14,10 +14,9 @@ export interface PlaygroundThread {
 const sortByRecent = (a: PlaygroundThread, b: PlaygroundThread) =>
   b.lastEditTimestamp - a.lastEditTimestamp
 
-export function usePlaygroundThreads() {
+export function usePlaygroundThreads(activeThreadId: string) {
   const queryClient = useQueryClient()
   const [threads, setThreads] = useState<PlaygroundThread[]>([])
-  const [activeThreadId, setActiveThreadId] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -38,11 +37,6 @@ export function usePlaygroundThreads() {
           })
         )
         setThreads(lightweight)
-
-        if (lightweight.length > 0 && lightweight[0]) {
-          setActiveThreadId(lightweight[0].id)
-          window.electronAPI.chat.setActiveThreadId(lightweight[0].id)
-        }
       } catch (err) {
         log.error('[usePlaygroundThreads] Failed to load threads:', err)
       } finally {
@@ -53,7 +47,13 @@ export function usePlaygroundThreads() {
     loadThreads()
   }, [])
 
-  const createThread = useCallback(async () => {
+  // Persist the URL-driven active thread to IPC whenever it changes
+  useEffect(() => {
+    window.electronAPI.chat.setActiveThreadId(activeThreadId)
+  }, [activeThreadId])
+
+  /** Creates a new thread and returns its ID for navigation, or null on failure. */
+  const createThread = useCallback(async (): Promise<string | null> => {
     try {
       const result = await window.electronAPI.chat.createChatThread()
       if (!result.success || !result.threadId) {
@@ -61,7 +61,7 @@ export function usePlaygroundThreads() {
           '[usePlaygroundThreads] Failed to create thread:',
           result.error
         )
-        return
+        return null
       }
       const now = Date.now()
       const newThread: PlaygroundThread = {
@@ -71,22 +71,20 @@ export function usePlaygroundThreads() {
         createdAt: now,
       }
       setThreads((prev) => [newThread, ...prev])
-      setActiveThreadId(result.threadId)
-      window.electronAPI.chat.setActiveThreadId(result.threadId)
       trackEvent('Playground: create thread')
+      return result.threadId
     } catch (err) {
       log.error('[usePlaygroundThreads] Failed to create thread:', err)
+      return null
     }
   }, [])
 
-  const selectThread = useCallback((threadId: string) => {
-    setActiveThreadId(threadId)
-    window.electronAPI.chat.setActiveThreadId(threadId)
-    trackEvent('Playground: switch thread')
-  }, [])
-
+  /**
+   * Deletes a thread and returns the next thread ID for navigation,
+   * or null when no threads remain.
+   */
   const deleteThread = useCallback(
-    async (threadId: string) => {
+    async (threadId: string): Promise<string | null> => {
       try {
         const result = await window.electronAPI.chat.deleteThread(threadId)
         if (!result.success) {
@@ -94,27 +92,22 @@ export function usePlaygroundThreads() {
             '[usePlaygroundThreads] Failed to delete thread:',
             result.error
           )
-          return
+          return null
         }
         trackEvent('Playground: delete thread', {
           'thread.was_active': activeThreadId === threadId,
         })
-        setThreads((prev) => {
-          const updated = prev.filter((t) => t.id !== threadId)
-          if (activeThreadId === threadId) {
-            const next = updated[0] ?? null
-            setActiveThreadId(next?.id ?? null)
-            if (next) {
-              window.electronAPI.chat.setActiveThreadId(next.id)
-            }
-          }
-          return updated
-        })
+        // Compute remaining list from current closure — avoids relying on
+        // the functional updater running synchronously in React 18.
+        const remaining = threads.filter((t) => t.id !== threadId)
+        setThreads(remaining)
+        return remaining[0]?.id ?? null
       } catch (err) {
         log.error('[usePlaygroundThreads] Failed to delete thread:', err)
+        return null
       }
     },
-    [activeThreadId]
+    [activeThreadId, threads]
   )
 
   const updateThreadTitle = useCallback((threadId: string, title: string) => {
@@ -141,8 +134,6 @@ export function usePlaygroundThreads() {
       setThreads((prev) => {
         const exists = prev.some((t) => t.id === threadId)
         if (!exists) {
-          setActiveThreadId(threadId)
-          window.electronAPI.chat.setActiveThreadId(threadId)
           return [lightweight, ...prev].sort(sortByRecent)
         }
         return prev
@@ -217,11 +208,9 @@ export function usePlaygroundThreads() {
 
   return {
     threads,
-    activeThreadId,
     isLoading,
     hasThreads: threads.length > 0,
     createThread,
-    selectThread,
     deleteThread,
     updateThreadTitle,
     renameThread,

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
 import { trackEvent } from '@/common/lib/analytics'
@@ -18,6 +18,8 @@ export function usePlaygroundThreads(activeThreadId: string) {
   const queryClient = useQueryClient()
   const [threads, setThreads] = useState<PlaygroundThread[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const threadsRef = useRef(threads)
+  threadsRef.current = threads
 
   useEffect(() => {
     async function loadThreads() {
@@ -97,9 +99,9 @@ export function usePlaygroundThreads(activeThreadId: string) {
         trackEvent('Playground: delete thread', {
           'thread.was_active': activeThreadId === threadId,
         })
-        // Compute remaining list from current closure — avoids relying on
-        // the functional updater running synchronously in React 18.
-        const remaining = threads.filter((t) => t.id !== threadId)
+        // Read from ref to get the latest threads snapshot and avoid
+        // overwriting concurrent state updates (e.g. from refreshThread).
+        const remaining = threadsRef.current.filter((t) => t.id !== threadId)
         setThreads(remaining)
         return remaining[0]?.id ?? null
       } catch (err) {
@@ -107,7 +109,7 @@ export function usePlaygroundThreads(activeThreadId: string) {
         return null
       }
     },
-    [activeThreadId, threads]
+    [activeThreadId]
   )
 
   const updateThreadTitle = useCallback((threadId: string, title: string) => {

--- a/renderer/src/route-tree.gen.ts
+++ b/renderer/src/route-tree.gen.ts
@@ -16,10 +16,12 @@ import { Route as PlaygroundRouteImport } from "./routes/playground"
 import { Route as McpOptimizerRouteImport } from "./routes/mcp-optimizer"
 import { Route as CliIssueRouteImport } from "./routes/cli-issue"
 import { Route as IndexRouteImport } from "./routes/index"
+import { Route as PlaygroundIndexRouteImport } from "./routes/playground.index"
 import { Route as GroupGroupNameRouteImport } from "./routes/group.$groupName"
 import { Route as CustomizeToolsServerNameRouteImport } from "./routes/customize-tools.$serverName"
 import { Route as registryRegistryRouteImport } from "./routes/(registry)/registry"
 import { Route as SkillsNamespaceSkillNameRouteImport } from "./routes/skills_.$namespace.$skillName"
+import { Route as PlaygroundChatThreadIdRouteImport } from "./routes/playground.chat.$threadId"
 import { Route as LogsGroupNameServerNameRouteImport } from "./routes/logs.$groupName.$serverName"
 import { Route as registryRegistryNameRouteImport } from "./routes/(registry)/registry_.$name"
 import { Route as registryRegistryGroupNameRouteImport } from "./routes/(registry)/registry-group_.$name"
@@ -59,6 +61,11 @@ const IndexRoute = IndexRouteImport.update({
   path: "/",
   getParentRoute: () => rootRouteImport,
 } as any)
+const PlaygroundIndexRoute = PlaygroundIndexRouteImport.update({
+  id: "/",
+  path: "/",
+  getParentRoute: () => PlaygroundRoute,
+} as any)
 const GroupGroupNameRoute = GroupGroupNameRouteImport.update({
   id: "/group/$groupName",
   path: "/group/$groupName",
@@ -81,6 +88,11 @@ const SkillsNamespaceSkillNameRoute =
     path: "/skills/$namespace/$skillName",
     getParentRoute: () => rootRouteImport,
   } as any)
+const PlaygroundChatThreadIdRoute = PlaygroundChatThreadIdRouteImport.update({
+  id: "/chat/$threadId",
+  path: "/chat/$threadId",
+  getParentRoute: () => PlaygroundRoute,
+} as any)
 const LogsGroupNameServerNameRoute = LogsGroupNameServerNameRouteImport.update({
   id: "/logs/$groupName/$serverName",
   path: "/logs/$groupName/$serverName",
@@ -102,32 +114,35 @@ export interface FileRoutesByFullPath {
   "/": typeof IndexRoute
   "/cli-issue": typeof CliIssueRoute
   "/mcp-optimizer": typeof McpOptimizerRoute
-  "/playground": typeof PlaygroundRoute
+  "/playground": typeof PlaygroundRouteWithChildren
   "/settings": typeof SettingsRoute
   "/shutdown": typeof ShutdownRoute
   "/skills": typeof SkillsRoute
   "/registry": typeof registryRegistryRoute
   "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/group/$groupName": typeof GroupGroupNameRoute
+  "/playground/": typeof PlaygroundIndexRoute
   "/registry-group/$name": typeof registryRegistryGroupNameRoute
   "/registry/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
+  "/playground/chat/$threadId": typeof PlaygroundChatThreadIdRoute
   "/skills/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute
   "/cli-issue": typeof CliIssueRoute
   "/mcp-optimizer": typeof McpOptimizerRoute
-  "/playground": typeof PlaygroundRoute
   "/settings": typeof SettingsRoute
   "/shutdown": typeof ShutdownRoute
   "/skills": typeof SkillsRoute
   "/registry": typeof registryRegistryRoute
   "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/group/$groupName": typeof GroupGroupNameRoute
+  "/playground": typeof PlaygroundIndexRoute
   "/registry-group/$name": typeof registryRegistryGroupNameRoute
   "/registry/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
+  "/playground/chat/$threadId": typeof PlaygroundChatThreadIdRoute
   "/skills/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
 }
 export interface FileRoutesById {
@@ -135,16 +150,18 @@ export interface FileRoutesById {
   "/": typeof IndexRoute
   "/cli-issue": typeof CliIssueRoute
   "/mcp-optimizer": typeof McpOptimizerRoute
-  "/playground": typeof PlaygroundRoute
+  "/playground": typeof PlaygroundRouteWithChildren
   "/settings": typeof SettingsRoute
   "/shutdown": typeof ShutdownRoute
   "/skills": typeof SkillsRoute
   "/(registry)/registry": typeof registryRegistryRoute
   "/customize-tools/$serverName": typeof CustomizeToolsServerNameRoute
   "/group/$groupName": typeof GroupGroupNameRoute
+  "/playground/": typeof PlaygroundIndexRoute
   "/(registry)/registry-group_/$name": typeof registryRegistryGroupNameRoute
   "/(registry)/registry_/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
+  "/playground/chat/$threadId": typeof PlaygroundChatThreadIdRoute
   "/skills_/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
 }
 export interface FileRouteTypes {
@@ -160,25 +177,28 @@ export interface FileRouteTypes {
     | "/registry"
     | "/customize-tools/$serverName"
     | "/group/$groupName"
+    | "/playground/"
     | "/registry-group/$name"
     | "/registry/$name"
     | "/logs/$groupName/$serverName"
+    | "/playground/chat/$threadId"
     | "/skills/$namespace/$skillName"
   fileRoutesByTo: FileRoutesByTo
   to:
     | "/"
     | "/cli-issue"
     | "/mcp-optimizer"
-    | "/playground"
     | "/settings"
     | "/shutdown"
     | "/skills"
     | "/registry"
     | "/customize-tools/$serverName"
     | "/group/$groupName"
+    | "/playground"
     | "/registry-group/$name"
     | "/registry/$name"
     | "/logs/$groupName/$serverName"
+    | "/playground/chat/$threadId"
     | "/skills/$namespace/$skillName"
   id:
     | "__root__"
@@ -192,9 +212,11 @@ export interface FileRouteTypes {
     | "/(registry)/registry"
     | "/customize-tools/$serverName"
     | "/group/$groupName"
+    | "/playground/"
     | "/(registry)/registry-group_/$name"
     | "/(registry)/registry_/$name"
     | "/logs/$groupName/$serverName"
+    | "/playground/chat/$threadId"
     | "/skills_/$namespace/$skillName"
   fileRoutesById: FileRoutesById
 }
@@ -202,7 +224,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CliIssueRoute: typeof CliIssueRoute
   McpOptimizerRoute: typeof McpOptimizerRoute
-  PlaygroundRoute: typeof PlaygroundRoute
+  PlaygroundRoute: typeof PlaygroundRouteWithChildren
   SettingsRoute: typeof SettingsRoute
   ShutdownRoute: typeof ShutdownRoute
   SkillsRoute: typeof SkillsRoute
@@ -266,6 +288,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/playground/": {
+      id: "/playground/"
+      path: "/"
+      fullPath: "/playground/"
+      preLoaderRoute: typeof PlaygroundIndexRouteImport
+      parentRoute: typeof PlaygroundRoute
+    }
     "/group/$groupName": {
       id: "/group/$groupName"
       path: "/group/$groupName"
@@ -294,6 +323,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof SkillsNamespaceSkillNameRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/playground/chat/$threadId": {
+      id: "/playground/chat/$threadId"
+      path: "/chat/$threadId"
+      fullPath: "/playground/chat/$threadId"
+      preLoaderRoute: typeof PlaygroundChatThreadIdRouteImport
+      parentRoute: typeof PlaygroundRoute
+    }
     "/logs/$groupName/$serverName": {
       id: "/logs/$groupName/$serverName"
       path: "/logs/$groupName/$serverName"
@@ -318,11 +354,25 @@ declare module "@tanstack/react-router" {
   }
 }
 
+interface PlaygroundRouteChildren {
+  PlaygroundIndexRoute: typeof PlaygroundIndexRoute
+  PlaygroundChatThreadIdRoute: typeof PlaygroundChatThreadIdRoute
+}
+
+const PlaygroundRouteChildren: PlaygroundRouteChildren = {
+  PlaygroundIndexRoute: PlaygroundIndexRoute,
+  PlaygroundChatThreadIdRoute: PlaygroundChatThreadIdRoute,
+}
+
+const PlaygroundRouteWithChildren = PlaygroundRoute._addFileChildren(
+  PlaygroundRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CliIssueRoute: CliIssueRoute,
   McpOptimizerRoute: McpOptimizerRoute,
-  PlaygroundRoute: PlaygroundRoute,
+  PlaygroundRoute: PlaygroundRouteWithChildren,
   SettingsRoute: SettingsRoute,
   ShutdownRoute: ShutdownRoute,
   SkillsRoute: SkillsRoute,

--- a/renderer/src/routes/__tests__/playground.chat.test.tsx
+++ b/renderer/src/routes/__tests__/playground.chat.test.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import {
   createMemoryHistory,
   createRootRoute,
@@ -37,23 +37,56 @@ vi.mock('@/features/chat/hooks/use-playground-threads', () => ({
 }))
 
 vi.mock('@/features/chat/components/chat-interface', () => ({
-  ChatInterface: (props: Record<string, unknown>) => (
-    <div
-      data-testid="chat-interface"
-      data-thread-id={props.threadId as string}
-      data-thread-title={props.threadTitle as string}
-      data-thread-starred={String(props.threadStarred)}
-    />
-  ),
+  ChatInterface: (props: Record<string, unknown>) => {
+    const onRename = props.onRenameThread as ((t: string) => void) | undefined
+    const onToggle = props.onToggleStar as (() => void) | undefined
+    const onDelete = props.onDeleteThread as (() => void) | undefined
+    return (
+      <div
+        data-testid="chat-interface"
+        data-thread-id={props.threadId as string}
+        data-thread-title={props.threadTitle as string}
+        data-thread-starred={String(props.threadStarred)}
+      >
+        {onRename && (
+          <button
+            data-testid="chat-rename-btn"
+            onClick={() => onRename('Renamed')}
+          />
+        )}
+        {onToggle && (
+          <button data-testid="chat-toggle-star-btn" onClick={onToggle} />
+        )}
+        {onDelete && (
+          <button data-testid="chat-delete-btn" onClick={onDelete} />
+        )}
+      </div>
+    )
+  },
 }))
 
 vi.mock('@/features/chat/components/playground-sidebar', () => ({
-  PlaygroundSidebar: (props: Record<string, unknown>) => (
-    <aside
-      data-testid="playground-sidebar"
-      data-active-thread-id={props.activeThreadId as string}
-    />
-  ),
+  PlaygroundSidebar: (props: Record<string, unknown>) => {
+    const onSelect = props.onSelectThread as (id: string) => void
+    const onCreate = props.onCreateThread as () => void
+    const onDelete = props.onDeleteThread as (id: string) => void
+    return (
+      <aside
+        data-testid="playground-sidebar"
+        data-active-thread-id={props.activeThreadId as string}
+      >
+        <button
+          data-testid="sidebar-select-btn"
+          onClick={() => onSelect('other-thread')}
+        />
+        <button data-testid="sidebar-create-btn" onClick={onCreate} />
+        <button
+          data-testid="sidebar-delete-btn"
+          onClick={() => onDelete('thread-1')}
+        />
+      </aside>
+    )
+  },
 }))
 
 // ---------------------------------------------------------------------------
@@ -97,8 +130,15 @@ function renderChatRoute(
     component: PlaygroundChatComponent,
   })
 
+  // Catch-all so navigate({ to: '/playground' }) doesn't 404
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/playground',
+    component: () => <div data-testid="playground-index" />,
+  })
+
   const router = new Router({
-    routeTree: rootRoute.addChildren([testRoute]),
+    routeTree: rootRoute.addChildren([testRoute, indexRoute]),
     history: createMemoryHistory({
       initialEntries: [`/playground/chat/${threadId}`],
     }),
@@ -109,7 +149,7 @@ function renderChatRoute(
     defaultOptions: { queries: { retry: false } },
   })
 
-  return render(
+  const utils = render(
     <NewsletterModalProvider>
       <PermissionsProvider value={permissions}>
         <PromptProvider>
@@ -120,6 +160,8 @@ function renderChatRoute(
       </PermissionsProvider>
     </NewsletterModalProvider>
   )
+
+  return { ...utils, router }
 }
 
 // ---------------------------------------------------------------------------
@@ -220,7 +262,131 @@ describe('Playground chat route (/playground/chat/$threadId)', () => {
       })
     })
   })
-})
 
-// Keep a simple re-export test to satisfy the unused import warning
-export {}
+  describe('navigation handlers', () => {
+    beforeEach(() => {
+      mockThreadsReturn.isLoading = false
+      mockThreadsReturn.hasThreads = true
+      mockThreadsReturn.threads = [
+        makeThread({ id: 'thread-1', title: 'First' }),
+        makeThread({ id: 'other-thread', title: 'Other' }),
+      ]
+    })
+
+    it('navigates to another thread when sidebar selects it', async () => {
+      const { router } = renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('sidebar-select-btn'))
+
+      await waitFor(() =>
+        expect(router.state.location.pathname).toBe(
+          '/playground/chat/other-thread'
+        )
+      )
+    })
+
+    it('navigates to the new thread after creation', async () => {
+      mockThreadsReturn.createThread.mockResolvedValue('new-thread-id')
+      const { router } = renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('sidebar-create-btn'))
+
+      await waitFor(() =>
+        expect(router.state.location.pathname).toBe(
+          '/playground/chat/new-thread-id'
+        )
+      )
+    })
+
+    it('does not navigate when createThread returns null', async () => {
+      mockThreadsReturn.createThread.mockResolvedValue(null)
+      const { router } = renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('sidebar-create-btn'))
+
+      // Give the async handler time to settle
+      await new Promise((r) => setTimeout(r, 50))
+      expect(router.state.location.pathname).toBe('/playground/chat/thread-1')
+    })
+
+    it('navigates to the next thread after deleting from sidebar', async () => {
+      mockThreadsReturn.deleteThread.mockResolvedValue('other-thread')
+      const { router } = renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('sidebar-delete-btn'))
+
+      await waitFor(() =>
+        expect(router.state.location.pathname).toBe(
+          '/playground/chat/other-thread'
+        )
+      )
+    })
+
+    it('navigates to /playground when deleting the last thread', async () => {
+      mockThreadsReturn.deleteThread.mockResolvedValue(null)
+      const { router } = renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('sidebar-delete-btn'))
+
+      await waitFor(() =>
+        expect(router.state.location.pathname).toBe('/playground')
+      )
+    })
+
+    it('calls renameThread with threadId when ChatInterface renames', async () => {
+      renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-interface')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('chat-rename-btn'))
+
+      expect(mockThreadsReturn.renameThread).toHaveBeenCalledWith(
+        'thread-1',
+        'Renamed'
+      )
+    })
+
+    it('calls toggleStarThread with threadId when ChatInterface toggles star', async () => {
+      renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-interface')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('chat-toggle-star-btn'))
+
+      expect(mockThreadsReturn.toggleStarThread).toHaveBeenCalledWith(
+        'thread-1'
+      )
+    })
+
+    it('navigates to /playground when ChatInterface deletes the last thread', async () => {
+      mockThreadsReturn.deleteThread.mockResolvedValue(null)
+      const { router } = renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-interface')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('chat-delete-btn'))
+
+      await waitFor(() =>
+        expect(router.state.location.pathname).toBe('/playground')
+      )
+    })
+  })
+})

--- a/renderer/src/routes/__tests__/playground.chat.test.tsx
+++ b/renderer/src/routes/__tests__/playground.chat.test.tsx
@@ -1,0 +1,226 @@
+import type { JSX } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+  RouterProvider,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { PermissionsProvider } from '@/common/contexts/permissions/permissions-provider'
+import { PromptProvider } from '@/common/contexts/prompt/provider'
+import { NewsletterModalProvider } from '@/common/contexts/newsletter-modal-provider'
+import { render } from '@testing-library/react'
+import type { PlaygroundThread } from '@/features/chat/hooks/use-playground-threads'
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+const mockThreadsReturn = {
+  threads: [] as PlaygroundThread[],
+  isLoading: true,
+  hasThreads: false,
+  createThread: vi.fn(),
+  deleteThread: vi.fn(),
+  renameThread: vi.fn(),
+  toggleStarThread: vi.fn(),
+  updateThreadTitle: vi.fn(),
+  refreshThread: vi.fn(),
+}
+
+vi.mock('@/features/chat/hooks/use-playground-threads', () => ({
+  usePlaygroundThreads: () => mockThreadsReturn,
+}))
+
+vi.mock('@/features/chat/components/chat-interface', () => ({
+  ChatInterface: (props: Record<string, unknown>) => (
+    <div
+      data-testid="chat-interface"
+      data-thread-id={props.threadId as string}
+      data-thread-title={props.threadTitle as string}
+      data-thread-starred={String(props.threadStarred)}
+    />
+  ),
+}))
+
+vi.mock('@/features/chat/components/playground-sidebar', () => ({
+  PlaygroundSidebar: (props: Record<string, unknown>) => (
+    <aside
+      data-testid="playground-sidebar"
+      data-active-thread-id={props.activeThreadId as string}
+    />
+  ),
+}))
+
+// ---------------------------------------------------------------------------
+// Route import (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { Route as PlaygroundChatRoute } from '../playground.chat.$threadId'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeThread(
+  overrides: Partial<PlaygroundThread> = {}
+): PlaygroundThread {
+  return {
+    id: 'thread-1',
+    title: 'My thread',
+    starred: false,
+    lastEditTimestamp: 2000,
+    createdAt: 1000,
+    ...overrides,
+  }
+}
+
+function renderChatRoute(
+  threadId = 'thread-1',
+  permissions: Record<string, boolean> = {}
+) {
+  const PlaygroundChatComponent = PlaygroundChatRoute.options
+    .component as () => JSX.Element
+
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }: { error: Error }) => <div>{error.message}</div>,
+  })
+
+  const testRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/playground/chat/$threadId',
+    component: PlaygroundChatComponent,
+  })
+
+  const router = new Router({
+    routeTree: rootRoute.addChildren([testRoute]),
+    history: createMemoryHistory({
+      initialEntries: [`/playground/chat/${threadId}`],
+    }),
+    defaultNotFoundComponent: () => null,
+  })
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+  return render(
+    <NewsletterModalProvider>
+      <PermissionsProvider value={permissions}>
+        <PromptProvider>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </PromptProvider>
+      </PermissionsProvider>
+    </NewsletterModalProvider>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Playground chat route (/playground/chat/$threadId)', () => {
+  beforeEach(() => {
+    mockThreadsReturn.threads = []
+    mockThreadsReturn.isLoading = true
+    mockThreadsReturn.hasThreads = false
+  })
+
+  describe('loading state', () => {
+    it('renders a loading spinner while isLoading is true', async () => {
+      mockThreadsReturn.isLoading = true
+      renderChatRoute()
+      await waitFor(() => {
+        expect(screen.queryByTestId('chat-interface')).not.toBeInTheDocument()
+        expect(
+          screen.queryByTestId('playground-sidebar')
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('no threads state', () => {
+    it('renders ChatInterface without sidebar when there are no threads', async () => {
+      mockThreadsReturn.isLoading = false
+      mockThreadsReturn.hasThreads = false
+      mockThreadsReturn.threads = []
+      renderChatRoute()
+      await waitFor(() => {
+        expect(screen.getByTestId('chat-interface')).toBeInTheDocument()
+        expect(
+          screen.queryByTestId('playground-sidebar')
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('has threads state', () => {
+    beforeEach(() => {
+      mockThreadsReturn.isLoading = false
+      mockThreadsReturn.hasThreads = true
+      mockThreadsReturn.threads = [
+        makeThread({ id: 'thread-1', title: 'First', starred: false }),
+      ]
+    })
+
+    it('renders both PlaygroundSidebar and ChatInterface', async () => {
+      renderChatRoute('thread-1')
+      await waitFor(() => {
+        expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
+        expect(screen.getByTestId('chat-interface')).toBeInTheDocument()
+      })
+    })
+
+    it('passes threadId from route param to PlaygroundSidebar as activeThreadId', async () => {
+      renderChatRoute('thread-1')
+      await waitFor(() => {
+        expect(screen.getByTestId('playground-sidebar')).toHaveAttribute(
+          'data-active-thread-id',
+          'thread-1'
+        )
+      })
+    })
+
+    it('passes threadId and threadTitle to ChatInterface', async () => {
+      renderChatRoute('thread-1')
+      await waitFor(() => {
+        const iface = screen.getByTestId('chat-interface')
+        expect(iface).toHaveAttribute('data-thread-id', 'thread-1')
+        expect(iface).toHaveAttribute('data-thread-title', 'First')
+      })
+    })
+
+    it('passes threadStarred from the matching thread to ChatInterface', async () => {
+      mockThreadsReturn.threads = [
+        makeThread({ id: 'thread-1', starred: true }),
+      ]
+      renderChatRoute('thread-1')
+      await waitFor(() => {
+        expect(screen.getByTestId('chat-interface')).toHaveAttribute(
+          'data-thread-starred',
+          'true'
+        )
+      })
+    })
+
+    it('passes undefined threadStarred when route threadId is not in threads list', async () => {
+      renderChatRoute('stale-thread')
+      await waitFor(() => {
+        expect(screen.getByTestId('chat-interface')).toHaveAttribute(
+          'data-thread-starred',
+          'undefined'
+        )
+      })
+    })
+  })
+})
+
+// Keep a simple re-export test to satisfy the unused import warning
+export {}

--- a/renderer/src/routes/__tests__/playground.chat.test.tsx
+++ b/renderer/src/routes/__tests__/playground.chat.test.tsx
@@ -7,13 +7,9 @@ import {
   createRoute,
   Outlet,
   Router,
-  RouterProvider,
 } from '@tanstack/react-router'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { PermissionsProvider } from '@/common/contexts/permissions/permissions-provider'
-import { PromptProvider } from '@/common/contexts/prompt/provider'
-import { NewsletterModalProvider } from '@/common/contexts/newsletter-modal-provider'
-import { render } from '@testing-library/react'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
 import type { PlaygroundThread } from '@/features/chat/hooks/use-playground-threads'
 
 // ---------------------------------------------------------------------------
@@ -145,20 +141,9 @@ function renderChatRoute(
     defaultNotFoundComponent: () => null,
   })
 
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  })
-
-  const utils = render(
-    <NewsletterModalProvider>
-      <PermissionsProvider value={permissions}>
-        <PromptProvider>
-          <QueryClientProvider client={queryClient}>
-            <RouterProvider router={router} />
-          </QueryClientProvider>
-        </PromptProvider>
-      </PermissionsProvider>
-    </NewsletterModalProvider>
+  const utils = renderRoute(
+    router as unknown as ReturnType<typeof createTestRouter>,
+    { permissions }
   )
 
   return { ...utils, router }

--- a/renderer/src/routes/__tests__/playground.index.test.tsx
+++ b/renderer/src/routes/__tests__/playground.index.test.tsx
@@ -6,13 +6,9 @@ import {
   createRoute,
   Outlet,
   Router,
-  RouterProvider,
 } from '@tanstack/react-router'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { PermissionsProvider } from '@/common/contexts/permissions/permissions-provider'
-import { PromptProvider } from '@/common/contexts/prompt/provider'
-import { NewsletterModalProvider } from '@/common/contexts/newsletter-modal-provider'
-import { render } from '@testing-library/react'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -95,20 +91,8 @@ function renderIndexRoute() {
     defaultNotFoundComponent: () => null,
   })
 
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  })
-
-  const utils = render(
-    <NewsletterModalProvider>
-      <PermissionsProvider>
-        <PromptProvider>
-          <QueryClientProvider client={queryClient}>
-            <RouterProvider router={router} />
-          </QueryClientProvider>
-        </PromptProvider>
-      </PermissionsProvider>
-    </NewsletterModalProvider>
+  const utils = renderRoute(
+    router as unknown as ReturnType<typeof createTestRouter>
   )
 
   return { ...utils, router }

--- a/renderer/src/routes/__tests__/playground.index.test.tsx
+++ b/renderer/src/routes/__tests__/playground.index.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+  RouterProvider,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { PermissionsProvider } from '@/common/contexts/permissions/permissions-provider'
+import { PromptProvider } from '@/common/contexts/prompt/provider'
+import { NewsletterModalProvider } from '@/common/contexts/newsletter-modal-provider'
+import { render } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('electron-log/renderer', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+// ---------------------------------------------------------------------------
+// electronAPI.chat stub
+// ---------------------------------------------------------------------------
+
+const mockChatAPI = {
+  getAllThreads: vi.fn(),
+  getActiveThreadId: vi.fn(),
+  createChatThread: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  window.electronAPI = {
+    ...window.electronAPI,
+    chat: mockChatAPI as unknown as typeof window.electronAPI.chat,
+  }
+  mockChatAPI.getAllThreads.mockResolvedValue([])
+  mockChatAPI.getActiveThreadId.mockResolvedValue(undefined)
+  mockChatAPI.createChatThread.mockResolvedValue({
+    success: true,
+    threadId: 'created-thread',
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Route import (after mocks)
+// ---------------------------------------------------------------------------
+
+import { Route as PlaygroundIndexRoute } from '../playground.index'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeDbThread = (overrides: Record<string, unknown> = {}) => ({
+  id: 'thread-1',
+  title: 'Test thread',
+  starred: false,
+  lastEditTimestamp: 2000,
+  createdAt: 1000,
+  messages: [],
+  ...overrides,
+})
+
+function renderIndexRoute() {
+  const IndexComponent = PlaygroundIndexRoute.options.component as () => null
+
+  const rootRoute = createRootRoute({
+    component: Outlet,
+  })
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/playground/',
+    component: IndexComponent,
+  })
+
+  // Catch-all for the redirect target — renders the threadId for assertion
+  const chatRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/playground/chat/$threadId',
+    component: () => {
+      const { threadId } = chatRoute.useParams()
+      return <div data-testid="chat-route" data-thread-id={threadId} />
+    },
+  })
+
+  const router = new Router({
+    routeTree: rootRoute.addChildren([indexRoute, chatRoute]),
+    history: createMemoryHistory({ initialEntries: ['/playground/'] }),
+    defaultNotFoundComponent: () => null,
+  })
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+  const utils = render(
+    <NewsletterModalProvider>
+      <PermissionsProvider>
+        <PromptProvider>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </PromptProvider>
+      </PermissionsProvider>
+    </NewsletterModalProvider>
+  )
+
+  return { ...utils, router }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Playground index route (/playground/)', () => {
+  it('redirects to the stored active thread when it exists', async () => {
+    mockChatAPI.getActiveThreadId.mockResolvedValue('active-thread')
+    mockChatAPI.getAllThreads.mockResolvedValue([
+      makeDbThread({ id: 'active-thread', lastEditTimestamp: 1000 }),
+      makeDbThread({ id: 'other-thread', lastEditTimestamp: 2000 }),
+    ])
+
+    const { router } = renderIndexRoute()
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe(
+        '/playground/chat/active-thread'
+      )
+    )
+  })
+
+  it('falls back to most recent thread when stored active ID is stale', async () => {
+    mockChatAPI.getActiveThreadId.mockResolvedValue('deleted-thread')
+    mockChatAPI.getAllThreads.mockResolvedValue([
+      makeDbThread({ id: 'recent', lastEditTimestamp: 3000 }),
+      makeDbThread({ id: 'old', lastEditTimestamp: 1000 }),
+    ])
+
+    const { router } = renderIndexRoute()
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe('/playground/chat/recent')
+    )
+  })
+
+  it('falls back to most recent thread when no stored active ID exists', async () => {
+    mockChatAPI.getActiveThreadId.mockResolvedValue(undefined)
+    mockChatAPI.getAllThreads.mockResolvedValue([
+      makeDbThread({ id: 'newest', lastEditTimestamp: 5000 }),
+    ])
+
+    const { router } = renderIndexRoute()
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe('/playground/chat/newest')
+    )
+  })
+
+  it('creates a new thread and redirects when no threads exist', async () => {
+    mockChatAPI.getActiveThreadId.mockResolvedValue(undefined)
+    mockChatAPI.getAllThreads.mockResolvedValue([])
+    mockChatAPI.createChatThread.mockResolvedValue({
+      success: true,
+      threadId: 'brand-new',
+    })
+
+    const { router } = renderIndexRoute()
+
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe('/playground/chat/brand-new')
+    )
+    expect(mockChatAPI.createChatThread).toHaveBeenCalledOnce()
+  })
+
+  it('does not redirect when createChatThread fails', async () => {
+    mockChatAPI.getActiveThreadId.mockResolvedValue(undefined)
+    mockChatAPI.getAllThreads.mockResolvedValue([])
+    mockChatAPI.createChatThread.mockResolvedValue({
+      success: false,
+      error: 'db error',
+    })
+
+    const { router } = renderIndexRoute()
+
+    // Give the effect time to run — route should stay on /playground/
+    await new Promise((r) => setTimeout(r, 100))
+    expect(router.state.location.pathname).toBe('/playground/')
+  })
+})

--- a/renderer/src/routes/__tests__/playground.test.tsx
+++ b/renderer/src/routes/__tests__/playground.test.tsx
@@ -1,54 +1,13 @@
 import type { JSX } from 'react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import { renderRoute } from '@/common/test/render-route'
 import { createTestRouter } from '@/common/test/create-test-router'
 import { PERMISSION_KEYS } from '@/common/contexts/permissions/permission-keys'
-import type { PlaygroundThread } from '@/features/chat/hooks/use-playground-threads'
 
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
-
-// usePlaygroundThreads — controlled per test via mockThreadsReturn
-const mockThreadsReturn = {
-  threads: [] as PlaygroundThread[],
-  activeThreadId: null as string | null,
-  isLoading: true,
-  hasThreads: false,
-  createThread: vi.fn(),
-  selectThread: vi.fn(),
-  deleteThread: vi.fn(),
-  renameThread: vi.fn(),
-  toggleStarThread: vi.fn(),
-  updateThreadTitle: vi.fn(),
-  refreshThread: vi.fn(),
-}
-
-vi.mock('@/features/chat/hooks/use-playground-threads', () => ({
-  usePlaygroundThreads: () => mockThreadsReturn,
-}))
-
-// Lightweight mocks for heavy sub-components
-vi.mock('@/features/chat/components/chat-interface', () => ({
-  ChatInterface: (props: Record<string, unknown>) => (
-    <div
-      data-testid="chat-interface"
-      data-thread-id={props.threadId as string}
-      data-thread-title={props.threadTitle as string}
-      data-thread-starred={String(props.threadStarred)}
-    />
-  ),
-}))
-
-vi.mock('@/features/chat/components/playground-sidebar', () => ({
-  PlaygroundSidebar: (props: Record<string, unknown>) => (
-    <aside
-      data-testid="playground-sidebar"
-      data-active-thread-id={props.activeThreadId as string}
-    />
-  ),
-}))
 
 vi.mock('@/common/components/not-found', () => ({
   NotFound: () => <div data-testid="not-found" />,
@@ -58,26 +17,11 @@ vi.mock('@/common/components/not-found', () => ({
 // Route import (after mocks are registered)
 // ---------------------------------------------------------------------------
 
-// Dynamic import to ensure mocks are applied before module evaluation.
-// We use the top-level import but rely on vi.mock hoisting.
 import { Route as PlaygroundRoute } from '../playground'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function makeThread(
-  overrides: Partial<PlaygroundThread> = {}
-): PlaygroundThread {
-  return {
-    id: 'thread-1',
-    title: 'My thread',
-    starred: false,
-    lastEditTimestamp: 2000,
-    createdAt: 1000,
-    ...overrides,
-  }
-}
 
 function renderPlayground(permissions: Record<string, boolean> = {}) {
   const PlaygroundComponent = PlaygroundRoute.options
@@ -90,132 +34,20 @@ function renderPlayground(permissions: Record<string, boolean> = {}) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Playground route', () => {
-  beforeEach(() => {
-    // Reset to loading state
-    mockThreadsReturn.threads = []
-    mockThreadsReturn.activeThreadId = null
-    mockThreadsReturn.isLoading = true
-    mockThreadsReturn.hasThreads = false
-  })
-
+describe('Playground layout route', () => {
   describe('permission gate', () => {
     it('renders NotFound when playground permission is denied', async () => {
-      mockThreadsReturn.isLoading = false
       renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: false })
       await waitFor(() =>
         expect(screen.getByTestId('not-found')).toBeInTheDocument()
       )
     })
 
-    it('renders content when permission is granted', async () => {
-      mockThreadsReturn.isLoading = false
+    it('renders nothing (Outlet) when permission is granted', async () => {
       renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
       await waitFor(() =>
         expect(screen.queryByTestId('not-found')).not.toBeInTheDocument()
       )
-    })
-  })
-
-  describe('loading state', () => {
-    it('renders a loading spinner while isLoading is true', async () => {
-      mockThreadsReturn.isLoading = true
-      renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
-      // The spinner is animated dots with no text — just ensure no chat UI is shown yet
-      await waitFor(() => {
-        expect(screen.queryByTestId('chat-interface')).not.toBeInTheDocument()
-        expect(
-          screen.queryByTestId('playground-sidebar')
-        ).not.toBeInTheDocument()
-      })
-    })
-  })
-
-  describe('no threads state', () => {
-    it('renders ChatInterface without sidebar when there are no threads', async () => {
-      mockThreadsReturn.isLoading = false
-      mockThreadsReturn.hasThreads = false
-      mockThreadsReturn.threads = []
-      renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
-      await waitFor(() => {
-        expect(screen.getByTestId('chat-interface')).toBeInTheDocument()
-        expect(
-          screen.queryByTestId('playground-sidebar')
-        ).not.toBeInTheDocument()
-      })
-    })
-
-    it('renders ChatInterface with no thread props in no-threads state', async () => {
-      mockThreadsReturn.isLoading = false
-      mockThreadsReturn.hasThreads = false
-      renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
-      await waitFor(() => {
-        const iface = screen.getByTestId('chat-interface')
-        expect(iface).not.toHaveAttribute('data-thread-id')
-      })
-    })
-  })
-
-  describe('has threads state', () => {
-    beforeEach(() => {
-      mockThreadsReturn.isLoading = false
-      mockThreadsReturn.hasThreads = true
-      mockThreadsReturn.threads = [
-        makeThread({ id: 'thread-1', title: 'First', starred: false }),
-      ]
-      mockThreadsReturn.activeThreadId = 'thread-1'
-    })
-
-    it('renders both PlaygroundSidebar and ChatInterface', async () => {
-      renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
-      await waitFor(() => {
-        expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
-        expect(screen.getByTestId('chat-interface')).toBeInTheDocument()
-      })
-    })
-
-    it('passes activeThreadId to PlaygroundSidebar', async () => {
-      renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
-      await waitFor(() => {
-        expect(screen.getByTestId('playground-sidebar')).toHaveAttribute(
-          'data-active-thread-id',
-          'thread-1'
-        )
-      })
-    })
-
-    it('passes threadId and threadTitle to ChatInterface', async () => {
-      renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
-      await waitFor(() => {
-        const iface = screen.getByTestId('chat-interface')
-        expect(iface).toHaveAttribute('data-thread-id', 'thread-1')
-        expect(iface).toHaveAttribute('data-thread-title', 'First')
-      })
-    })
-
-    it('passes threadStarred from the active thread to ChatInterface', async () => {
-      mockThreadsReturn.threads = [
-        makeThread({ id: 'thread-1', starred: true }),
-      ]
-      renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
-      await waitFor(() => {
-        expect(screen.getByTestId('chat-interface')).toHaveAttribute(
-          'data-thread-starred',
-          'true'
-        )
-      })
-    })
-
-    it('passes undefined threadStarred when activeThread is not in threads list', async () => {
-      // activeThreadId points to a thread that is no longer in the list (stale)
-      mockThreadsReturn.activeThreadId = 'stale-thread'
-      renderPlayground({ [PERMISSION_KEYS.PLAYGROUND_MENU]: true })
-      await waitFor(() => {
-        expect(screen.getByTestId('chat-interface')).toHaveAttribute(
-          'data-thread-starred',
-          'undefined'
-        )
-      })
     })
   })
 })

--- a/renderer/src/routes/playground.chat.$threadId.tsx
+++ b/renderer/src/routes/playground.chat.$threadId.tsx
@@ -1,0 +1,107 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { ChatInterface } from '@/features/chat/components/chat-interface'
+import { PlaygroundSidebar } from '@/features/chat/components/playground-sidebar'
+import { usePlaygroundThreads } from '@/features/chat/hooks/use-playground-threads'
+
+export const Route = createFileRoute('/playground/chat/$threadId')({
+  component: PlaygroundChat,
+})
+
+function PlaygroundChat() {
+  const { threadId } = Route.useParams()
+  const navigate = useNavigate()
+
+  const {
+    threads,
+    isLoading,
+    hasThreads,
+    createThread,
+    deleteThread,
+    renameThread,
+    toggleStarThread,
+  } = usePlaygroundThreads(threadId)
+
+  if (isLoading) {
+    return (
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="flex space-x-1">
+          <div
+            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full
+              [animation-delay:-0.3s]"
+          />
+          <div
+            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full
+              [animation-delay:-0.15s]"
+          />
+          <div
+            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full"
+          />
+        </div>
+      </div>
+    )
+  }
+
+  const activeThread = threads.find((t) => t.id === threadId)
+
+  const handleSelectThread = (id: string) => {
+    void navigate({
+      to: '/playground/chat/$threadId',
+      params: { threadId: id },
+    })
+  }
+
+  const handleCreateThread = async () => {
+    const newId = await createThread()
+    if (newId) {
+      void navigate({
+        to: '/playground/chat/$threadId',
+        params: { threadId: newId },
+      })
+    }
+  }
+
+  const handleDeleteThread = async (id: string) => {
+    const nextId = await deleteThread(id)
+    if (nextId) {
+      void navigate({
+        to: '/playground/chat/$threadId',
+        params: { threadId: nextId },
+      })
+    } else {
+      // No threads remain — go to index which will create a new one
+      void navigate({ to: '/playground' })
+    }
+  }
+
+  return (
+    <div className="absolute inset-0 flex">
+      {hasThreads && (
+        <PlaygroundSidebar
+          threads={threads}
+          activeThreadId={threadId}
+          onSelectThread={handleSelectThread}
+          onCreateThread={() => void handleCreateThread()}
+          onDeleteThread={(id) => void handleDeleteThread(id)}
+          onRenameThread={renameThread}
+          onToggleStar={toggleStarThread}
+        />
+      )}
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <ChatInterface
+          threadId={hasThreads ? threadId : undefined}
+          threadTitle={activeThread?.title}
+          threadStarred={activeThread?.starred}
+          onRenameThread={
+            hasThreads ? (title) => renameThread(threadId, title) : undefined
+          }
+          onToggleStar={
+            hasThreads ? () => toggleStarThread(threadId) : undefined
+          }
+          onDeleteThread={
+            hasThreads ? () => void handleDeleteThread(threadId) : undefined
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/renderer/src/routes/playground.index.tsx
+++ b/renderer/src/routes/playground.index.tsx
@@ -1,40 +1,72 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
+import { useEffect } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import log from 'electron-log/renderer'
+
+function PlaygroundIndexRedirect() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function resolveThreadAndRedirect() {
+      try {
+        const [allThreads, activeId] = await Promise.all([
+          window.electronAPI.chat.getAllThreads(),
+          window.electronAPI.chat.getActiveThreadId(),
+        ])
+
+        if (cancelled) return
+
+        const sorted = [...allThreads].sort(
+          (a, b) => b.lastEditTimestamp - a.lastEditTimestamp
+        )
+
+        const activeThread = activeId
+          ? sorted.find((t) => t.id === activeId)
+          : undefined
+
+        const target = activeThread ?? sorted[0]
+
+        if (target) {
+          void navigate({
+            to: '/playground/chat/$threadId',
+            params: { threadId: target.id },
+            replace: true,
+          })
+          return
+        }
+
+        const result = await window.electronAPI.chat.createChatThread()
+        if (cancelled) return
+
+        if (result.success && result.threadId) {
+          void navigate({
+            to: '/playground/chat/$threadId',
+            params: { threadId: result.threadId },
+            replace: true,
+          })
+          return
+        }
+
+        log.error(
+          '[PlaygroundIndexRedirect] Failed to create initial thread:',
+          result.error
+        )
+      } catch (err) {
+        log.error('[PlaygroundIndexRedirect] Failed to resolve thread:', err)
+      }
+    }
+
+    void resolveThreadAndRedirect()
+
+    return () => {
+      cancelled = true
+    }
+  }, [navigate])
+
+  return null
+}
 
 export const Route = createFileRoute('/playground/')({
-  beforeLoad: async () => {
-    const [allThreads, activeId] = await Promise.all([
-      window.electronAPI.chat.getAllThreads(),
-      window.electronAPI.chat.getActiveThreadId(),
-    ])
-
-    const sorted = [...allThreads].sort(
-      (a, b) => b.lastEditTimestamp - a.lastEditTimestamp
-    )
-
-    // Prefer the stored active thread if it still exists
-    const activeThread = activeId
-      ? sorted.find((t) => t.id === activeId)
-      : undefined
-
-    const target = activeThread ?? sorted[0]
-
-    if (target) {
-      throw redirect({
-        to: '/playground/chat/$threadId',
-        params: { threadId: target.id },
-        replace: true,
-      })
-    }
-
-    // No threads exist — create one first
-    const result = await window.electronAPI.chat.createChatThread()
-    if (result.success && result.threadId) {
-      throw redirect({
-        to: '/playground/chat/$threadId',
-        params: { threadId: result.threadId },
-        replace: true,
-      })
-    }
-  },
-  component: () => null,
+  component: PlaygroundIndexRedirect,
 })

--- a/renderer/src/routes/playground.index.tsx
+++ b/renderer/src/routes/playground.index.tsx
@@ -1,0 +1,40 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/playground/')({
+  beforeLoad: async () => {
+    const [allThreads, activeId] = await Promise.all([
+      window.electronAPI.chat.getAllThreads(),
+      window.electronAPI.chat.getActiveThreadId(),
+    ])
+
+    const sorted = [...allThreads].sort(
+      (a, b) => b.lastEditTimestamp - a.lastEditTimestamp
+    )
+
+    // Prefer the stored active thread if it still exists
+    const activeThread = activeId
+      ? sorted.find((t) => t.id === activeId)
+      : undefined
+
+    const target = activeThread ?? sorted[0]
+
+    if (target) {
+      throw redirect({
+        to: '/playground/chat/$threadId',
+        params: { threadId: target.id },
+        replace: true,
+      })
+    }
+
+    // No threads exist — create one first
+    const result = await window.electronAPI.chat.createChatThread()
+    if (result.success && result.threadId) {
+      throw redirect({
+        to: '/playground/chat/$threadId',
+        params: { threadId: result.threadId },
+        replace: true,
+      })
+    }
+  },
+  component: () => null,
+})

--- a/renderer/src/routes/playground.tsx
+++ b/renderer/src/routes/playground.tsx
@@ -1,97 +1,18 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { ChatInterface } from '@/features/chat/components/chat-interface'
-import { PlaygroundSidebar } from '@/features/chat/components/playground-sidebar'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { NotFound } from '@/common/components/not-found'
 import { usePermissions } from '@/common/contexts/permissions'
 import { PERMISSION_KEYS } from '@/common/contexts/permissions/permission-keys'
-import { usePlaygroundThreads } from '@/features/chat/hooks/use-playground-threads'
 
 export const Route = createFileRoute('/playground')({
-  component: Playground,
+  component: PlaygroundLayout,
 })
 
-function Playground() {
+function PlaygroundLayout() {
   const { canShow } = usePermissions()
 
   if (!canShow(PERMISSION_KEYS.PLAYGROUND_MENU)) {
     return <NotFound />
   }
 
-  return <PlaygroundContent />
-}
-
-function PlaygroundContent() {
-  const {
-    threads,
-    activeThreadId,
-    isLoading,
-    hasThreads,
-    createThread,
-    selectThread,
-    deleteThread,
-    renameThread,
-    toggleStarThread,
-  } = usePlaygroundThreads()
-
-  if (isLoading) {
-    return (
-      <div className="absolute inset-0 flex items-center justify-center">
-        <div className="flex space-x-1">
-          <div
-            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full
-              [animation-delay:-0.3s]"
-          />
-          <div
-            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full
-              [animation-delay:-0.15s]"
-          />
-          <div
-            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full"
-          />
-        </div>
-      </div>
-    )
-  }
-
-  const activeThread = hasThreads
-    ? threads.find((t) => t.id === activeThreadId)
-    : undefined
-
-  return (
-    <div className="absolute inset-0 flex">
-      {hasThreads && (
-        <PlaygroundSidebar
-          threads={threads}
-          activeThreadId={activeThreadId}
-          onSelectThread={selectThread}
-          onCreateThread={createThread}
-          onDeleteThread={deleteThread}
-          onRenameThread={renameThread}
-          onToggleStar={toggleStarThread}
-        />
-      )}
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <ChatInterface
-          threadId={hasThreads ? activeThreadId : undefined}
-          threadTitle={activeThread?.title}
-          threadStarred={activeThread?.starred}
-          onRenameThread={
-            activeThreadId && hasThreads
-              ? (title) => renameThread(activeThreadId, title)
-              : undefined
-          }
-          onToggleStar={
-            activeThreadId && hasThreads
-              ? () => toggleStarThread(activeThreadId)
-              : undefined
-          }
-          onDeleteThread={
-            activeThreadId && hasThreads
-              ? () => deleteThread(activeThreadId)
-              : undefined
-          }
-        />
-      </div>
-    </div>
-  )
+  return <Outlet />
 }


### PR DESCRIPTION
The Playground route was a single flat page with thread selection managed as React state. This refactors it into a proper sub-route hierarchy so the active thread is always reflected in the URL, enabling deep linking, back-navigation, and a foundation for future sub-sections (evals, prompt templates, etc.).

- Convert `/playground` to a layout route (permission gate + Outlet) and add a `/playground/` index that resolves the last-viewed thread, validating the stored active ID against the real thread list, falling back to most-recent, or creating a new thread —> then redirects to `/playground/chat/$threadId`
- Add `/playground/chat/$threadId` as the chat sub-route; thread ID comes from the URL and navigation (select, create, delete thread) is driven by `useNavigate` rather than `setState`
- Refactor `usePlaygroundThreads` to accept `activeThreadId` as input, persist it to IPC as a side-effect, and return thread IDs from `createThread` / `deleteThread` so the route component can navigate
- Update and extend tests for the new route structure and hook signature