### PR TITLE
fix(ci): ignore pnpm audit registry errors while npm retires legacy endpoints

### DIFF
--- a/.github/workflows/_security-checks.yml
+++ b/.github/workflows/_security-checks.yml
@@ -31,4 +31,4 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run pnpm audit
-        run: pnpm audit --prod --audit-level=moderate
+        run: pnpm audit --prod --audit-level=moderate --ignore-registry-errors


### PR DESCRIPTION
The npm registry has retired both legacy audit endpoints (`/-/npm/v1/security/audits/quick` and `/-/npm/v1/security/audits`), returning HTTP 410. This breaks `pnpm audit` on all 10.x versions (tracked in [pnpm/pnpm#11265](https://github.com/pnpm/pnpm/issues/11265)). There is no released pnpm version yet that supports the replacement bulk advisory endpoint.

Add `--ignore-registry-errors` to the CI audit step so pipelines are not blocked while a proper fix lands in pnpm. Grype still provides vulnerability scanning coverage in the same workflow.