### PR TITLE
ci(release): Azure Artifact Signing (OIDC) after Windows publish

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -59,6 +59,10 @@ jobs:
     name: Build and Release on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [security, static-checks, unit-tests]
+    # Required for Azure Artifact Signing OIDC (federated credential subject). Use an
+    # Environment **without** required reviewers, or each matrix leg will wait on its
+    # own deployment approval (see stacklok/infra Azure signing Terraform defaults).
+    environment: artifact-signing
     strategy:
       matrix:
         include:
@@ -145,6 +149,40 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_ISSUER_ID: ${{ env.APPLE_ISSUER_ID }}
           APPLE_KEY_ID: ${{ env.APPLE_KEY_ID }}
+
+      # Optional Azure Artifact Signing (OIDC via user-assigned MI). Configure repo Variables
+      # from stacklok/infra terraform outputs (see infra PR / issue #4395). Runs after DigiCert
+      # publish so we can add an Azure signature (append) during migration.
+      - name: Azure login (Artifact Signing OIDC)
+        if: runner.os == 'Windows' && vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != ''
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v2.2.0
+        with:
+          client-id: ${{ vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_ARTIFACT_SIGNING_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows release artifacts with Azure Artifact Signing
+        if: runner.os == 'Windows' && vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != ''
+        uses: azure/artifact-signing-action@48da903ca5e2d362da62c631a42d77c02ec7eadb # v1.2.0
+        with:
+          azure-tenant-id: ${{ vars.AZURE_ARTIFACT_SIGNING_TENANT_ID }}
+          azure-client-id: ${{ vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files-folder: ${{ github.workspace }}\out\make
+          files-folder-filter: exe,dll
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: 'http://timestamp.acs.microsoft.com'
+          timestamp-digest: SHA256
+          append-signature: true
+          exclude-environment-credential: false
+          exclude-workload-identity-credential: true
+          exclude-managed-identity-credential: true
+          exclude-azure-cli-credential: true
+          exclude-azure-powershell-credential: true
+          exclude-interactive-browser-credential: true
 
       - name: Copy macOS update manifest to stable path
         id: macos-manifest

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -133,7 +133,19 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
+      # Publish: default is a single `electron-forge publish`. When Windows + full Azure Artifact
+      # Signing vars are set, use `publish --dry-run` → Azure sign local artifacts →
+      # `publish --from-dry-run` so GitHub/S3 uploads include the Azure signature (Forge
+      # resumes by artifact path and re-reads files from disk).
       - name: Build and Publish
+        if: >-
+          runner.os != 'Windows' ||
+          vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID == '' ||
+          vars.AZURE_ARTIFACT_SIGNING_TENANT_ID == '' ||
+          vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID == '' ||
+          vars.AZURE_ARTIFACT_SIGNING_ENDPOINT == '' ||
+          vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME == '' ||
+          vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME == ''
         run: pnpm run publish
         env:
           # Ensure the correct Node.js version is used for native modules
@@ -150,9 +162,31 @@ jobs:
           APPLE_ISSUER_ID: ${{ env.APPLE_ISSUER_ID }}
           APPLE_KEY_ID: ${{ env.APPLE_KEY_ID }}
 
+      - name: Build release (publish dry-run, Windows / Azure Artifact Signing)
+        if: >-
+          runner.os == 'Windows' &&
+          vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_TENANT_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_ENDPOINT != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME != ''
+        run: pnpm exec electron-forge publish --dry-run
+        env:
+          npm_config_target_platform: win32
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_SENTRY_THV_DSN: ${{ vars.VITE_SENTRY_THV_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          SENTRY_RELEASE: ${{ env.SENTRY_RELEASE }}
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
+          APPLE_ISSUER_ID: ${{ env.APPLE_ISSUER_ID }}
+          APPLE_KEY_ID: ${{ env.APPLE_KEY_ID }}
+
       # Optional Azure Artifact Signing (OIDC via user-assigned MI). Configure repo Variables
-      # from stacklok/infra terraform outputs (see infra PR / issue #4395). Runs after DigiCert
-      # publish so we can add an Azure signature (append) during migration.
+      # from stacklok/infra terraform outputs (see infra PR / issue #4395).
       # All AZURE_ARTIFACT_SIGNING_* vars below must be set together; partial config is skipped.
       - name: Azure login (Artifact Signing OIDC)
         if: >-
@@ -198,6 +232,29 @@ jobs:
           exclude-azure-cli-credential: false
           exclude-azure-powershell-credential: true
           exclude-interactive-browser-credential: true
+
+      - name: Publish release (from dry-run, Windows / Azure Artifact Signing)
+        if: >-
+          runner.os == 'Windows' &&
+          vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_TENANT_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_ENDPOINT != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME != ''
+        run: pnpm exec electron-forge publish --from-dry-run
+        env:
+          npm_config_target_platform: win32
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_SENTRY_THV_DSN: ${{ vars.VITE_SENTRY_THV_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          SENTRY_RELEASE: ${{ env.SENTRY_RELEASE }}
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
+          APPLE_ISSUER_ID: ${{ env.APPLE_ISSUER_ID }}
+          APPLE_KEY_ID: ${{ env.APPLE_KEY_ID }}
 
       - name: Copy macOS update manifest to stable path
         id: macos-manifest

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -180,7 +180,7 @@ jobs:
           exclude-environment-credential: false
           exclude-workload-identity-credential: true
           exclude-managed-identity-credential: true
-          exclude-azure-cli-credential: true
+          exclude-azure-cli-credential: false
           exclude-azure-powershell-credential: true
           exclude-interactive-browser-credential: true
 

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -153,8 +153,16 @@ jobs:
       # Optional Azure Artifact Signing (OIDC via user-assigned MI). Configure repo Variables
       # from stacklok/infra terraform outputs (see infra PR / issue #4395). Runs after DigiCert
       # publish so we can add an Azure signature (append) during migration.
+      # All AZURE_ARTIFACT_SIGNING_* vars below must be set together; partial config is skipped.
       - name: Azure login (Artifact Signing OIDC)
-        if: runner.os == 'Windows' && vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != ''
+        if: >-
+          runner.os == 'Windows' &&
+          vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_TENANT_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_ENDPOINT != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME != ''
         uses: azure/login@93381592711f247e165c389ebb30b596c84cdc48 # v3.0.0
         with:
           client-id: ${{ vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
@@ -162,7 +170,14 @@ jobs:
           subscription-id: ${{ vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID }}
 
       - name: Sign Windows release artifacts with Azure Artifact Signing
-        if: runner.os == 'Windows' && vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != ''
+        if: >-
+          runner.os == 'Windows' &&
+          vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_TENANT_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_ENDPOINT != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME != '' &&
+          vars.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME != ''
         uses: azure/artifact-signing-action@48da903ca5e2d362da62c631a42d77c02ec7eadb # v1.2.0
         with:
           azure-tenant-id: ${{ vars.AZURE_ARTIFACT_SIGNING_TENANT_ID }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -155,7 +155,7 @@ jobs:
       # publish so we can add an Azure signature (append) during migration.
       - name: Azure login (Artifact Signing OIDC)
         if: runner.os == 'Windows' && vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID != ''
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v2.2.0
+        uses: azure/login@93381592711f247e165c389ebb30b596c84cdc48 # v3.0.0
         with:
           client-id: ${{ vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_ARTIFACT_SIGNING_TENANT_ID }}


### PR DESCRIPTION
## Summary

Adds **optional** Azure Artifact Signing on **Release** Windows builds, coordinated with **stacklok/infra** Phase 4 (UAMI + federated OIDC using GitHub Environment `artifact-signing`).

## Workflow changes (`on-release.yml`)

- Set `environment: artifact-signing` on `build-and-release` so OIDC subjects match Terraform (`repo:stacklok/toolhive-studio:environment:artifact-signing`).
- After `pnpm run publish` (DigiCert path unchanged), when `vars.AZURE_ARTIFACT_SIGNING_CLIENT_ID` is set:
  - `azure/login` (OIDC)
  - `azure/artifact-signing-action` over `out/make` (`exe,dll`, recursive, RFC3161 timestamp, `append-signature: true` for migration).

## Repo setup required

1. **GitHub Environment:** create `artifact-signing` (no required reviewers unless you want every matrix leg to wait separately).
2. **Repository Variables** (from `stacklok/infra` OpenTofu outputs / Azure defaults):
   - `AZURE_ARTIFACT_SIGNING_CLIENT_ID` — signing CI managed identity client id
   - `AZURE_ARTIFACT_SIGNING_TENANT_ID`
   - `AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID`
   - `AZURE_ARTIFACT_SIGNING_ENDPOINT` — e.g. `https://cus.codesigning.azure.net/`
   - `AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME` — e.g. `ToolhiveSigningAccount`
   - `AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME` — e.g. `toolhive-studio-public`

Until those Variables are set, behavior is unchanged (steps are skipped).

## References

- Infra: https://github.com/stacklok/infra/pull/4449
- Refs https://github.com/stacklok/infra/issues/4395


Made with [Cursor](https://cursor.com)