### PR TITLE
feat: hide help menu based on enterprise config directive

### DIFF
--- a/renderer/src/common/components/layout/top-nav/__tests__/top-nav.test.tsx
+++ b/renderer/src/common/components/layout/top-nav/__tests__/top-nav.test.tsx
@@ -64,6 +64,25 @@ describe('TopNav', () => {
     expect(screen.queryByText('Playground')).not.toBeInTheDocument()
   })
 
+  it('renders Help button when HELP_MENU permission is enabled', async () => {
+    renderTopNav()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /help/i })).toBeInTheDocument()
+    })
+  })
+
+  it('hides Help button when HELP_MENU permission is disabled', async () => {
+    renderTopNavWithPermissions({
+      [PERMISSION_KEYS.HELP_MENU]: false,
+    })
+    await waitFor(() => {
+      expect(screen.getByText('MCP Servers')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('button', { name: /help/i })
+    ).not.toBeInTheDocument()
+  })
+
   it('renders Settings button', async () => {
     renderTopNav()
     await waitFor(() => {

--- a/renderer/src/common/components/layout/top-nav/index.tsx
+++ b/renderer/src/common/components/layout/top-nav/index.tsx
@@ -127,6 +127,7 @@ export function TopNav({ isEnterprise = false, ...props }: TopNavProps) {
   const { data: appVersion } = useAppVersion()
   const isProduction = import.meta.env.MODE === 'production'
   const isActive = useIsActive()
+  const { canShow } = usePermissions()
   const showUpdateBadge = !!(appVersion?.isNewVersionAvailable && isProduction)
 
   useEffect(() => {
@@ -186,10 +187,12 @@ export function TopNav({ isEnterprise = false, ...props }: TopNavProps) {
           </Button>
         )}
         <div className="flex h-full items-center gap-1 pl-2">
-          <HelpDropdown
-            className="app-region-no-drag"
-            isEnterprise={isEnterprise}
-          />
+          {canShow(PERMISSION_KEYS.HELP_MENU) && (
+            <HelpDropdown
+              className="app-region-no-drag"
+              isEnterprise={isEnterprise}
+            />
+          )}
           <NavIconButton
             asChild
             isActive={isActive(['/settings'])}

--- a/renderer/src/common/contexts/permissions/permission-keys.ts
+++ b/renderer/src/common/contexts/permissions/permission-keys.ts
@@ -13,6 +13,7 @@
 export const PERMISSION_KEYS = {
   AUTO_UPDATE: 'auto-update',
   CUSTOM_MCP_SERVERS: 'non_registry_servers',
+  HELP_MENU: 'help-menu',
   PLAYGROUND_MENU: 'playground-menu',
   SETTINGS_REGISTRY_TAB: 'settings-registry-tab',
 } as const


### PR DESCRIPTION
## Summary
- Add `HELP_MENU` permission key to gate the `?` help icon visibility
- Conditionally render `HelpDropdown` in `TopNav` using `canShow(PERMISSION_KEYS.HELP_MENU)`
- Add unit tests for both visible and hidden states

When the enterprise config server sets `help_menu.value: false`, the help menu is hidden. Defaults to visible when unset or `true`.

Refs: stacklok/stacklok-enterprise-platform#416

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] TopNav tests pass (12/12 including 2 new)
- [ ] Manual: verify `?` icon visible in OSS build
- [ ] Manual: verify `?` icon hidden when enterprise config sets `help_menu: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)