### PR TITLE
feat: support hiding experimental features via isEnterprise prop

### DIFF
--- a/renderer/src/common/components/settings/tabs/__tests__/general-tab.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/general-tab.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { GeneralTab } from '../general-tab'
+import { GeneralTabWrapper } from '../components/general-tab-wrapper'
 import { PromptProvider } from '@/common/contexts/prompt/provider'
 import {
   useAutoLaunchStatus,
@@ -212,6 +213,18 @@ describe('GeneralTab', () => {
     expect(window.electronAPI.setSkipQuitConfirmation).toHaveBeenCalledWith(
       false
     )
+  })
+
+  it('hides experimental features section when isEnterprise is true', async () => {
+    renderWithProviders(<GeneralTabWrapper isEnterprise={true} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'General' })).toBeVisible()
+    })
+
+    expect(
+      screen.queryByRole('heading', { name: 'Experimental' })
+    ).not.toBeInTheDocument()
   })
 
   describe('Experimental Features', () => {

--- a/renderer/src/common/components/settings/tabs/components/general-tab-wrapper.tsx
+++ b/renderer/src/common/components/settings/tabs/components/general-tab-wrapper.tsx
@@ -174,8 +174,10 @@ function QuitConfirmationField() {
 
 export function GeneralTabWrapper({
   children = null,
+  isEnterprise = false,
 }: {
   children?: React.ReactNode
+  isEnterprise?: boolean
 }) {
   return (
     <div className="space-y-3">
@@ -191,7 +193,7 @@ export function GeneralTabWrapper({
         <Separator />
         {children}
       </div>
-      <ExperimentalFeatures />
+      {!isEnterprise && <ExperimentalFeatures />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add `isEnterprise` prop (default `false`) to `GeneralTabWrapper`
- Conditionally hide `<ExperimentalFeatures />` when `isEnterprise` is `true`
- Add unit test for the enterprise case

Follows the same pattern used by `TopNav` and `HelpDropdown` for enterprise conditional rendering.

Related: stacklok/stacklok-enterprise-platform#413

## Test plan
- [x] Existing tests pass (12/12)
- [x] New test verifies experimental section is hidden when `isEnterprise={true}`
- [x] Type-check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)