### PR TITLE
feat(skills): align skill cards with registry design and add local build detail page

### DIFF
--- a/renderer/src/features/registry-servers/components/registry-detail-header.tsx
+++ b/renderer/src/features/registry-servers/components/registry-detail-header.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react'
 type RegistryDetailHeaderProps = {
   title: string
   backTo?: string
+  backSearch?: Record<string, unknown>
   badges?: ReactNode
   description?: string | null
 }
@@ -13,13 +14,14 @@ type RegistryDetailHeaderProps = {
 export function RegistryDetailHeader({
   title,
   backTo = '/registry',
+  backSearch,
   badges,
   description,
 }: RegistryDetailHeaderProps) {
   return (
     <div className="w-full">
       <div className="mb-5">
-        <LinkViewTransition to={backTo}>
+        <LinkViewTransition to={backTo} search={backSearch}>
           <Button variant="outline" aria-label="Back" className="rounded-full">
             <ChevronLeft className="size-4" />
             Back

--- a/renderer/src/features/skills/components/__tests__/card-build.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-build.test.tsx
@@ -1,22 +1,17 @@
-import { render, screen } from '@testing-library/react'
-import { expect, it, describe } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { expect, it, describe, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import React from 'react'
+import {
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+  createMemoryHistory,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
 import { CardBuild } from '../card-build'
 import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from '@common/api/generated/types.gen'
-
-const renderWithProviders = (component: React.ReactElement) => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  })
-  return render(
-    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
-  )
-}
 
 const baseBuild: LocalBuild = {
   name: 'my-skill',
@@ -27,76 +22,137 @@ const baseBuild: LocalBuild = {
     'sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
 }
 
+function createCardTestRouter(build: LocalBuild = baseBuild) {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>{String(error)}</div>,
+  })
+
+  const buildsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills',
+    component: () => <CardBuild build={build} />,
+  })
+
+  const buildDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills/builds/$tag',
+    component: () => <div data-testid="build-detail-page" />,
+  })
+
+  return new Router({
+    routeTree: rootRoute.addChildren([buildsRoute, buildDetailRoute]),
+    history: createMemoryHistory({ initialEntries: ['/skills'] }),
+    defaultNotFoundComponent: () => null,
+  })
+}
+
+const router = createCardTestRouter() as unknown as ReturnType<
+  typeof createTestRouter
+>
+
+beforeEach(async () => {
+  await router.navigate({ to: '/skills' })
+})
+
 describe('CardBuild', () => {
   it('renders skill name from build.name', () => {
-    renderWithProviders(<CardBuild build={baseBuild} />)
+    renderRoute(router)
     expect(screen.getByText('my-skill')).toBeInTheDocument()
   })
 
-  it('falls back to tag when name is absent', () => {
-    const build: LocalBuild = { tag: 'localhost/my-skill:v1.0.0' }
-    renderWithProviders(<CardBuild build={build} />)
+  it('falls back to tag when name is absent', async () => {
+    const buildRouter = createCardTestRouter({
+      tag: 'localhost/my-skill:v1.0.0',
+    }) as unknown as ReturnType<typeof createTestRouter>
+    await buildRouter.navigate({ to: '/skills' })
+    renderRoute(buildRouter)
     expect(
       screen.getAllByText('localhost/my-skill:v1.0.0').length
     ).toBeGreaterThan(0)
   })
 
-  it('shows "Unnamed build" when neither name nor tag', () => {
-    renderWithProviders(<CardBuild build={{}} />)
+  it('shows "Unnamed build" when neither name nor tag', async () => {
+    const buildRouter = createCardTestRouter({}) as unknown as ReturnType<
+      typeof createTestRouter
+    >
+    await buildRouter.navigate({ to: '/skills' })
+    renderRoute(buildRouter)
     expect(screen.getByText('Unnamed build')).toBeInTheDocument()
   })
 
   it('renders description and digest in content', () => {
-    renderWithProviders(<CardBuild build={baseBuild} />)
-    expect(screen.getByText(/A locally built skill/)).toBeInTheDocument()
-    expect(screen.getByText(/sha256:/)).toBeInTheDocument()
+    renderRoute(router)
+    expect(screen.getAllByText(/A locally built skill/).length).toBeGreaterThan(
+      0
+    )
+    expect(screen.getAllByText(/sha256:/).length).toBeGreaterThan(0)
   })
 
   it('renders version badge', () => {
-    renderWithProviders(<CardBuild build={baseBuild} />)
+    renderRoute(router)
     expect(screen.getByText('v1.0.0')).toBeInTheDocument()
   })
 
   it('opens install dialog when Install button is clicked', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<CardBuild build={baseBuild} />)
+    renderRoute(router)
 
     await user.click(screen.getByRole('button', { name: /install my-skill/i }))
 
-    expect(
-      screen.getByRole('heading', { name: /install skill/i })
-    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /install skill/i })
+      ).toBeInTheDocument()
+    })
   })
 
   it('prefills install dialog with the build tag as reference', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<CardBuild build={baseBuild} />)
+    renderRoute(router)
 
     await user.click(screen.getByRole('button', { name: /install my-skill/i }))
 
-    expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
-      'localhost/my-skill:v1.0.0'
-    )
+    await waitFor(() => {
+      expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
+        'localhost/my-skill:v1.0.0'
+      )
+    })
   })
 
   it('opens remove dialog when Remove button is clicked', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<CardBuild build={baseBuild} />)
+    renderRoute(router)
 
     await user.click(screen.getByRole('button', { name: /remove my-skill/i }))
 
-    expect(
-      screen.getByRole('heading', { name: /remove build/i })
-    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /remove build/i })
+      ).toBeInTheDocument()
+    })
   })
 
   it('shows build name in remove dialog confirmation text', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<CardBuild build={baseBuild} />)
+    renderRoute(router)
 
     await user.click(screen.getByRole('button', { name: /remove my-skill/i }))
 
-    const dialog = screen.getByRole('dialog')
-    expect(dialog).toHaveTextContent('my-skill')
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toHaveTextContent('my-skill')
+    })
+  })
+
+  it('navigates to build detail page when card is clicked', async () => {
+    const user = userEvent.setup()
+    renderRoute(router)
+
+    await user.click(screen.getByText('my-skill'))
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toMatch(/\/skills\/builds\//)
+    })
   })
 })

--- a/renderer/src/features/skills/components/__tests__/card-build.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-build.test.tsx
@@ -46,19 +46,15 @@ describe('CardBuild', () => {
     expect(screen.getByText('Unnamed build')).toBeInTheDocument()
   })
 
-  it('renders description when present', () => {
+  it('renders description and digest in content', () => {
     renderWithProviders(<CardBuild build={baseBuild} />)
-    expect(screen.getByText('A locally built skill')).toBeInTheDocument()
+    expect(screen.getByText(/A locally built skill/)).toBeInTheDocument()
+    expect(screen.getByText(/sha256:/)).toBeInTheDocument()
   })
 
   it('renders version badge', () => {
     renderWithProviders(<CardBuild build={baseBuild} />)
     expect(screen.getByText('v1.0.0')).toBeInTheDocument()
-  })
-
-  it('renders a truncated digest', () => {
-    renderWithProviders(<CardBuild build={baseBuild} />)
-    expect(screen.getByText(/sha256:/)).toBeInTheDocument()
   })
 
   it('opens install dialog when Install button is clicked', async () => {

--- a/renderer/src/features/skills/components/__tests__/grid-cards-builds.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/grid-cards-builds.test.tsx
@@ -1,21 +1,48 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { expect, it, vi, describe, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import React from 'react'
+import {
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+  createMemoryHistory,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
 import { GridCardsBuilds } from '../grid-cards-builds'
 import { mockedGetApiV1BetaSkillsBuilds } from '@/common/mocks/fixtures/skills_builds/get'
 
-const renderWithProviders = (component: React.ReactElement) => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
+function createGridTestRouter(
+  props: { filter: string; onBuild: () => void } = {
+    filter: '',
+    onBuild: vi.fn(),
+  }
+) {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>{String(error)}</div>,
   })
-  return render(
-    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
-  )
+
+  const buildsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills',
+    component: () => (
+      <GridCardsBuilds filter={props.filter} onBuild={props.onBuild} />
+    ),
+  })
+
+  const buildDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills/builds/$tag',
+    component: () => <div data-testid="build-detail-page" />,
+  })
+
+  return new Router({
+    routeTree: rootRoute.addChildren([buildsRoute, buildDetailRoute]),
+    history: createMemoryHistory({ initialEntries: ['/skills'] }),
+    defaultNotFoundComponent: () => null,
+  })
 }
 
 beforeEach(() => {
@@ -24,7 +51,11 @@ beforeEach(() => {
 
 describe('GridCardsBuilds', () => {
   it('renders a card for each build', async () => {
-    renderWithProviders(<GridCardsBuilds filter="" onBuild={vi.fn()} />)
+    const router = createGridTestRouter() as unknown as ReturnType<
+      typeof createTestRouter
+    >
+    await router.navigate({ to: '/skills' })
+    renderRoute(router)
 
     await waitFor(() => {
       expect(screen.getByText('my-skill')).toBeInTheDocument()
@@ -34,8 +65,11 @@ describe('GridCardsBuilds', () => {
 
   it('shows empty state when there are no builds', async () => {
     mockedGetApiV1BetaSkillsBuilds.activateScenario('empty')
-
-    renderWithProviders(<GridCardsBuilds filter="" onBuild={vi.fn()} />)
+    const router = createGridTestRouter() as unknown as ReturnType<
+      typeof createTestRouter
+    >
+    await router.navigate({ to: '/skills' })
+    renderRoute(router)
 
     await waitFor(() => {
       expect(screen.getByText('No local builds')).toBeInTheDocument()
@@ -46,8 +80,12 @@ describe('GridCardsBuilds', () => {
     mockedGetApiV1BetaSkillsBuilds.activateScenario('empty')
     const user = userEvent.setup()
     const onBuild = vi.fn()
-
-    renderWithProviders(<GridCardsBuilds filter="" onBuild={onBuild} />)
+    const router = createGridTestRouter({
+      filter: '',
+      onBuild,
+    }) as unknown as ReturnType<typeof createTestRouter>
+    await router.navigate({ to: '/skills' })
+    renderRoute(router)
 
     await waitFor(() => {
       expect(screen.getByText('No local builds')).toBeInTheDocument()
@@ -59,9 +97,12 @@ describe('GridCardsBuilds', () => {
   })
 
   it('shows filtered-empty message when filter matches nothing', async () => {
-    renderWithProviders(
-      <GridCardsBuilds filter="zzz-no-match-zzz" onBuild={vi.fn()} />
-    )
+    const router = createGridTestRouter({
+      filter: 'zzz-no-match-zzz',
+      onBuild: vi.fn(),
+    }) as unknown as ReturnType<typeof createTestRouter>
+    await router.navigate({ to: '/skills' })
+    renderRoute(router)
 
     await waitFor(() => {
       expect(
@@ -71,7 +112,12 @@ describe('GridCardsBuilds', () => {
   })
 
   it('filters builds by name', async () => {
-    renderWithProviders(<GridCardsBuilds filter="my-skill" onBuild={vi.fn()} />)
+    const router = createGridTestRouter({
+      filter: 'my-skill',
+      onBuild: vi.fn(),
+    }) as unknown as ReturnType<typeof createTestRouter>
+    await router.navigate({ to: '/skills' })
+    renderRoute(router)
 
     await waitFor(() => {
       expect(screen.getByText('my-skill')).toBeInTheDocument()

--- a/renderer/src/features/skills/components/build-detail-page.tsx
+++ b/renderer/src/features/skills/components/build-detail-page.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { Button } from '@/common/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { TagIcon, CodeIcon, FingerprintIcon, Trash2Icon } from 'lucide-react'
+import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from '@common/api/generated/types.gen'
+import { DialogInstallSkill } from './dialog-install-skill'
+import { DialogDeleteBuild } from './dialog-delete-build'
+import { SkillDetailLayout } from './skill-detail-layout'
+
+interface BuildDetailPageProps {
+  build: LocalBuild
+}
+
+export function BuildDetailPage({ build }: BuildDetailPageProps) {
+  const [installOpen, setInstallOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const navigate = useNavigate()
+
+  const title = build.name ?? build.tag ?? 'Unnamed build'
+  const version = build.version
+  const tag = build.tag
+  const digest = build.digest
+  const description = build.description
+
+  const shortDigest = digest
+    ? digest.startsWith('sha256:')
+      ? `sha256:${digest.slice(7, 19)}…`
+      : `${digest.slice(0, 12)}…`
+    : undefined
+
+  const hasBadges = !!(version || (tag && tag !== title) || shortDigest)
+
+  return (
+    <>
+      <SkillDetailLayout
+        title={title}
+        backTo="/skills"
+        backSearch={{ tab: 'builds' }}
+        badges={
+          hasBadges ? (
+            <>
+              {version && (
+                <span
+                  className="text-muted-foreground flex items-center gap-1
+                    text-sm"
+                >
+                  <TagIcon className="size-4" />
+                  {version}
+                </span>
+              )}
+              {tag && tag !== title && (
+                <span
+                  className="text-muted-foreground flex items-center gap-1
+                    font-mono text-sm"
+                >
+                  <CodeIcon className="size-4" />
+                  {tag}
+                </span>
+              )}
+              {shortDigest && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="text-muted-foreground flex cursor-default
+                        items-center gap-1 font-mono text-sm"
+                    >
+                      <FingerprintIcon className="size-4" />
+                      {shortDigest}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    className="max-w-xs font-mono text-xs break-all"
+                  >
+                    {digest}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </>
+          ) : undefined
+        }
+        description={description}
+        actions={
+          <div className="flex items-center gap-3">
+            <Button variant="action" onClick={() => setInstallOpen(true)}>
+              Install
+            </Button>
+            <Button variant="secondary" onClick={() => setDeleteOpen(true)}>
+              <Trash2Icon className="size-4" />
+              Remove
+            </Button>
+          </div>
+        }
+        rightPanel={
+          <>
+            <h4 className="text-foreground text-xl font-semibold tracking-tight">
+              Skill.md
+            </h4>
+            <div
+              className="border-border rounded-2xl border bg-white p-6
+                dark:bg-transparent"
+            >
+              <p
+                className="text-muted-foreground font-mono text-sm
+                  leading-relaxed"
+              >
+                Skill.md rendering is not yet available.
+              </p>
+            </div>
+          </>
+        }
+      />
+
+      <DialogInstallSkill
+        key={tag ?? title}
+        open={installOpen}
+        onOpenChange={setInstallOpen}
+        defaultReference={tag ?? build.name}
+      />
+      <DialogDeleteBuild
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        build={build}
+        onSuccess={() =>
+          void navigate({ to: '/skills', search: { tab: 'builds' } })
+        }
+      />
+    </>
+  )
+}

--- a/renderer/src/features/skills/components/card-build.tsx
+++ b/renderer/src/features/skills/components/card-build.tsx
@@ -1,27 +1,17 @@
 import { useState } from 'react'
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/common/components/ui/card'
 import { Button } from '@/common/components/ui/button'
 import { Badge } from '@/common/components/ui/badge'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/common/components/ui/tooltip'
-import { cn } from '@/common/lib/utils'
-import { DownloadIcon, Trash2Icon } from 'lucide-react'
+import { Trash2Icon } from 'lucide-react'
+import { useNavigate } from '@tanstack/react-router'
 import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogDeleteBuild } from './dialog-delete-build'
+import { CardSkillBase } from './card-skill-base'
 
 export function CardBuild({ build }: { build: LocalBuild }) {
   const [installOpen, setInstallOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const navigate = useNavigate()
 
   const title = build.name ?? build.tag ?? 'Unnamed build'
   const description = build.description
@@ -35,72 +25,64 @@ export function CardBuild({ build }: { build: LocalBuild }) {
       : `${digest.slice(0, 12)}…`
     : undefined
 
+  const badges =
+    version || (tag && tag !== title) ? (
+      <div className="flex flex-wrap gap-1.5">
+        {version && <Badge variant="secondary">{version}</Badge>}
+        {tag && tag !== title && (
+          <Badge variant="outline" className="font-mono text-xs">
+            {tag}
+          </Badge>
+        )}
+      </div>
+    ) : undefined
+
+  const descriptionText =
+    [description, shortDigest].filter(Boolean).join(' · ') || undefined
+
   return (
     <>
-      <Card
-        className={cn(
-          'relative flex flex-col',
-          'transition-[box-shadow,color]',
-          'group',
-          'hover:ring',
-          'has-[button:focus-visible]:ring'
-        )}
-      >
-        <CardHeader>
-          <CardTitle className="flex items-start justify-between gap-2 text-xl">
-            <Tooltip onlyWhenTruncated>
-              <TooltipTrigger asChild>
-                <span className="truncate select-none">{title}</span>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">{title}</TooltipContent>
-            </Tooltip>
-          </CardTitle>
-          <div className="flex flex-wrap gap-1.5">
-            {version && <Badge variant="secondary">{version}</Badge>}
-            {tag && tag !== title && (
-              <Badge variant="outline" className="font-mono text-xs">
-                {tag}
-              </Badge>
-            )}
-          </div>
-        </CardHeader>
-
-        <CardContent className="flex-1">
-          {description && (
-            <p className="text-muted-foreground mb-2 text-sm select-none">
-              {description}
-            </p>
-          )}
-          {shortDigest && (
-            <p className="text-muted-foreground truncate font-mono text-xs">
-              {shortDigest}
-            </p>
-          )}
-        </CardContent>
-
-        <CardFooter className="mt-auto flex items-center justify-between gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-destructive hover:text-destructive relative z-10"
-            onClick={() => setDeleteOpen(true)}
-            aria-label={`Remove ${title}`}
-          >
-            <Trash2Icon className="size-4" />
-            Remove
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="relative z-10"
-            onClick={() => setInstallOpen(true)}
-            aria-label={`Install ${title}`}
-          >
-            <DownloadIcon className="size-4" />
-            Install
-          </Button>
-        </CardFooter>
-      </Card>
+      <CardSkillBase
+        title={title}
+        description={descriptionText}
+        badges={badges}
+        onClick={
+          tag
+            ? () =>
+                void navigate({
+                  to: '/skills/builds/$tag',
+                  params: { tag },
+                })
+            : undefined
+        }
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              className="relative z-10 rounded-full"
+              onClick={(e) => {
+                e.stopPropagation()
+                setDeleteOpen(true)
+              }}
+              aria-label={`Remove ${title}`}
+            >
+              <Trash2Icon className="size-4" />
+              Remove
+            </Button>
+            <Button
+              variant="secondary"
+              className="relative z-10 rounded-full"
+              onClick={(e) => {
+                e.stopPropagation()
+                setInstallOpen(true)
+              }}
+              aria-label={`Install ${title}`}
+            >
+              Install
+            </Button>
+          </>
+        }
+      />
 
       <DialogInstallSkill
         key={tag ?? title}

--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -1,21 +1,9 @@
 import { useState } from 'react'
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/common/components/ui/card'
 import { Button } from '@/common/components/ui/button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/common/components/ui/tooltip'
-import { cn } from '@/common/lib/utils'
 import { useNavigate } from '@tanstack/react-router'
 import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
+import { CardSkillBase } from './card-skill-base'
 
 export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
   const [installOpen, setInstallOpen] = useState(false)
@@ -42,62 +30,15 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
 
   return (
     <>
-      <Card
-        className={cn(
-          'relative flex flex-col',
-          'transition-[box-shadow,color]',
-          canNavigate && 'cursor-pointer hover:ring',
-          'has-[button:focus-visible]:ring',
-          'focus-visible:ring focus-visible:outline-none'
-        )}
-        onClick={handleCardClick}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            handleCardClick()
-          }
-        }}
-        role={canNavigate ? 'link' : undefined}
-        tabIndex={canNavigate ? 0 : undefined}
-      >
-        <CardHeader>
-          <CardTitle className="flex items-start justify-between gap-2 text-xl">
-            <Tooltip onlyWhenTruncated>
-              <TooltipTrigger asChild>
-                <span className="truncate select-none">{name}</span>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">{name}</TooltipContent>
-            </Tooltip>
-          </CardTitle>
-          {namespace && (
-            <p className="text-muted-foreground truncate text-sm select-none">
-              {namespace}
-            </p>
-          )}
-        </CardHeader>
-
-        <CardContent className="flex-1">
-          {description && (
-            <Tooltip onlyWhenTruncated>
-              <TooltipTrigger asChild>
-                <p
-                  className="text-muted-foreground line-clamp-3 text-sm
-                    select-none"
-                >
-                  {description}
-                </p>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">
-                {description}
-              </TooltipContent>
-            </Tooltip>
-          )}
-        </CardContent>
-
-        <CardFooter className="mt-auto">
+      <CardSkillBase
+        title={name}
+        subtitle={namespace}
+        description={description}
+        onClick={canNavigate ? handleCardClick : undefined}
+        footer={
           <Button
             variant="secondary"
-            size="sm"
+            className="rounded-full"
             onClick={(e) => {
               e.stopPropagation()
               setInstallOpen(true)
@@ -105,8 +46,8 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
           >
             Install
           </Button>
-        </CardFooter>
-      </Card>
+        }
+      />
 
       <DialogInstallSkill
         open={installOpen}

--- a/renderer/src/features/skills/components/card-skill-base.tsx
+++ b/renderer/src/features/skills/components/card-skill-base.tsx
@@ -52,8 +52,9 @@ export function CardSkillBase({
             <TooltipTrigger asChild>
               {isClickable ? (
                 <button
+                  type="button"
                   className="truncate text-left outline-none! select-none"
-                  onClick={() => onClick()}
+                  onClick={() => onClick?.()}
                 >
                   {title}
                   <span className="absolute inset-0 rounded-md" />

--- a/renderer/src/features/skills/components/card-skill-base.tsx
+++ b/renderer/src/features/skills/components/card-skill-base.tsx
@@ -1,0 +1,99 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from '@/common/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { cn } from '@/common/lib/utils'
+import type { ReactNode } from 'react'
+
+interface CardSkillBaseProps {
+  title: string
+  subtitle?: string
+  description?: string
+  badges?: ReactNode
+  footer?: ReactNode
+  onClick?: () => void
+}
+
+export function CardSkillBase({
+  title,
+  subtitle,
+  description,
+  badges,
+  footer,
+  onClick,
+}: CardSkillBaseProps) {
+  const isClickable = !!onClick
+
+  return (
+    <Card
+      className={cn(
+        'relative flex flex-col',
+        'transition-[box-shadow,color]',
+        'group',
+        isClickable && 'cursor-pointer',
+        'hover:ring',
+        'has-[button:focus-visible]:ring'
+      )}
+    >
+      <CardHeader>
+        <CardTitle
+          className="grid grid-cols-[auto_calc(var(--spacing)*5)] items-center
+            text-xl"
+        >
+          <Tooltip onlyWhenTruncated>
+            <TooltipTrigger asChild>
+              {isClickable ? (
+                <button
+                  className="truncate text-left outline-none! select-none"
+                  onClick={() => onClick()}
+                >
+                  {title}
+                  <span className="absolute inset-0 rounded-md" />
+                </button>
+              ) : (
+                <span className="truncate select-none">{title}</span>
+              )}
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">{title}</TooltipContent>
+          </Tooltip>
+        </CardTitle>
+        {subtitle && (
+          <p className="text-muted-foreground truncate text-sm select-none">
+            {subtitle}
+          </p>
+        )}
+        {badges}
+      </CardHeader>
+
+      <CardContent className="flex-1">
+        {description && (
+          <Tooltip onlyWhenTruncated>
+            <TooltipTrigger asChild>
+              <p
+                className="text-muted-foreground line-clamp-3 text-sm
+                  select-none"
+              >
+                {description}
+              </p>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">{description}</TooltipContent>
+          </Tooltip>
+        )}
+      </CardContent>
+
+      {footer && (
+        <CardFooter className="mt-auto flex items-center gap-2">
+          {footer}
+        </CardFooter>
+      )}
+    </Card>
+  )
+}

--- a/renderer/src/features/skills/components/card-skill.tsx
+++ b/renderer/src/features/skills/components/card-skill.tsx
@@ -1,10 +1,4 @@
 import { useState } from 'react'
-import {
-  Card,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/common/components/ui/card'
 import { Button } from '@/common/components/ui/button'
 import { Badge } from '@/common/components/ui/badge'
 import {
@@ -12,10 +6,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/common/components/ui/tooltip'
-import { cn } from '@/common/lib/utils'
 import { Trash2Icon } from 'lucide-react'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { DialogUninstallSkill } from './dialog-uninstall-skill'
+import { CardSkillBase } from './card-skill-base'
 
 const statusVariantMap = {
   installed: 'success',
@@ -35,70 +29,58 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
     ? `/${projectRoot.split(/[\\/]/).filter(Boolean).at(-1) ?? projectRoot}`
     : null
 
+  const badges = (
+    <div className="flex flex-wrap gap-1.5">
+      {status && (
+        <Badge variant={statusVariantMap[status] ?? 'secondary'}>
+          {status}
+        </Badge>
+      )}
+      {scope && (
+        <Badge variant="outline" className="capitalize">
+          {scope}
+        </Badge>
+      )}
+      {projectRootLabel && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge variant="outline" className="font-mono">
+              {projectRootLabel}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs font-mono text-xs break-all">
+            {projectRoot}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {clients?.map((client) => (
+        <Badge key={client} variant="outline">
+          {client}
+        </Badge>
+      ))}
+    </div>
+  )
+
   return (
     <>
-      <Card
-        className={cn(
-          'relative flex flex-col',
-          'transition-[box-shadow,color]',
-          'group',
-          'hover:ring',
-          'has-[button:focus-visible]:ring'
-        )}
-      >
-        <CardHeader>
-          <CardTitle className="flex items-start justify-between gap-2 text-xl">
-            <Tooltip onlyWhenTruncated>
-              <TooltipTrigger asChild>
-                <span className="truncate select-none">{title}</span>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">{title}</TooltipContent>
-            </Tooltip>
-          </CardTitle>
-          <div className="flex flex-wrap gap-1.5">
-            {status && (
-              <Badge variant={statusVariantMap[status] ?? 'secondary'}>
-                {status}
-              </Badge>
-            )}
-            {scope && (
-              <Badge variant="outline" className="capitalize">
-                {scope}
-              </Badge>
-            )}
-            {projectRootLabel && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge variant="outline" className="font-mono">
-                    {projectRootLabel}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent className="max-w-xs font-mono text-xs break-all">
-                  {projectRoot}
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {clients?.map((client) => (
-              <Badge key={client} variant="outline">
-                {client}
-              </Badge>
-            ))}
-          </div>
-        </CardHeader>
-
-        <CardFooter className="mt-auto flex items-center justify-start gap-2">
+      <CardSkillBase
+        title={title}
+        badges={badges}
+        footer={
           <Button
-            variant="ghost"
-            size="sm"
-            className="text-destructive hover:text-destructive relative z-10"
-            onClick={() => setUninstallOpen(true)}
+            variant="secondary"
+            className="relative z-10 rounded-full"
+            onClick={(e) => {
+              e.stopPropagation()
+              setUninstallOpen(true)
+            }}
             aria-label={`Uninstall ${title}`}
           >
             <Trash2Icon className="size-4" />
             Uninstall
           </Button>
-        </CardFooter>
-      </Card>
+        }
+      />
 
       <DialogUninstallSkill
         open={uninstallOpen}

--- a/renderer/src/features/skills/components/dialog-delete-build.tsx
+++ b/renderer/src/features/skills/components/dialog-delete-build.tsx
@@ -14,12 +14,14 @@ interface DialogDeleteBuildProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   build: LocalBuild | null
+  onSuccess?: () => void
 }
 
 export function DialogDeleteBuild({
   open,
   onOpenChange,
   build,
+  onSuccess,
 }: DialogDeleteBuildProps) {
   const { mutateAsync: deleteBuild, isPending } = useMutationDeleteBuild()
 
@@ -31,6 +33,7 @@ export function DialogDeleteBuild({
     try {
       await deleteBuild({ path: { tag } })
       onOpenChange(false)
+      onSuccess?.()
     } catch {
       // Error toast is handled by useMutationDeleteBuild onError
     }

--- a/renderer/src/features/skills/components/skill-detail-layout.tsx
+++ b/renderer/src/features/skills/components/skill-detail-layout.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react'
+import { RegistryDetailHeader } from '@/features/registry-servers/components/registry-detail-header'
+
+interface SkillDetailLayoutProps {
+  title: string
+  backTo: string
+  backSearch?: Record<string, unknown>
+  badges?: ReactNode
+  description?: string | null
+  actions: ReactNode
+  rightPanel?: ReactNode
+}
+
+export function SkillDetailLayout({
+  title,
+  backTo,
+  backSearch,
+  badges,
+  description,
+  actions,
+  rightPanel,
+}: SkillDetailLayoutProps) {
+  return (
+    <div className="flex max-h-full w-full flex-1 flex-col">
+      <RegistryDetailHeader
+        title={title}
+        backTo={backTo}
+        backSearch={backSearch}
+        badges={badges}
+      />
+
+      <div className="mt-8 flex flex-col gap-10 md:flex-row">
+        <div className="flex w-full flex-col gap-6 md:w-5/12">
+          {description && (
+            <div className="flex flex-col gap-2">
+              <h4
+                className="text-foreground text-xl font-semibold tracking-tight"
+              >
+                Summary
+              </h4>
+              <p className="text-muted-foreground text-base leading-7">
+                {description}
+              </p>
+            </div>
+          )}
+          {actions}
+        </div>
+
+        {rightPanel && (
+          <div className="flex flex-1 flex-col gap-3">{rightPanel}</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import { Button } from '@/common/components/ui/button'
-import { LinkViewTransition } from '@/common/components/link-view-transition'
-import { ChevronLeft, TagIcon, GitForkIcon, ScaleIcon } from 'lucide-react'
+import { TagIcon, GitForkIcon, ScaleIcon } from 'lucide-react'
 import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
+import { SkillDetailLayout } from './skill-detail-layout'
 
 interface SkillDetailPageProps {
   skill: RegistrySkill
@@ -22,72 +22,55 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
     namespace && name !== 'Unknown skill' ? `${namespace}/${name}` : name
   const defaultReference = isOci && version ? `${base}:${version}` : base
 
+  const hasBadges = !!(version || namespace || license)
+
   return (
     <>
-      <div className="flex w-full flex-col gap-8">
-        {/* Header */}
-        <div className="flex flex-col gap-3">
-          <div>
-            <LinkViewTransition to="/skills" search={{ tab: 'registry' }}>
-              <Button variant="outline" className="rounded-full">
-                <ChevronLeft className="size-4" />
-                Back
-              </Button>
-            </LinkViewTransition>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <h1 className="text-page-title m-0 p-0">{name}</h1>
-            <div
-              className="text-muted-foreground flex items-center gap-4 text-sm"
-            >
+      <SkillDetailLayout
+        title={name}
+        backTo="/skills"
+        backSearch={{ tab: 'registry' }}
+        badges={
+          hasBadges ? (
+            <>
               {version && (
-                <span className="flex items-center gap-1">
+                <span
+                  className="text-muted-foreground flex items-center gap-1
+                    text-sm"
+                >
                   <TagIcon className="size-4" />
                   {version}
                 </span>
               )}
               {namespace && (
-                <span className="flex items-center gap-1">
+                <span
+                  className="text-muted-foreground flex items-center gap-1
+                    text-sm"
+                >
                   <GitForkIcon className="size-4" />
                   {namespace}
                 </span>
               )}
               {license && (
-                <span className="flex items-center gap-1">
+                <span
+                  className="text-muted-foreground flex items-center gap-1
+                    text-sm"
+                >
                   <ScaleIcon className="size-4" />
                   {license}
                 </span>
               )}
-            </div>
-          </div>
-        </div>
-
-        {/* Main content: two columns */}
-        <div className="flex flex-col gap-10 md:flex-row">
-          {/* Left: Summary + Install */}
-          <div className="flex w-full flex-col gap-6 md:w-5/12">
-            <div className="flex flex-col gap-2">
-              <h4
-                className="text-foreground text-xl font-semibold tracking-tight"
-              >
-                Summary
-              </h4>
-              {description && (
-                <p className="text-muted-foreground text-base leading-7">
-                  {description}
-                </p>
-              )}
-            </div>
-            <div>
-              <Button variant="action" onClick={() => setInstallOpen(true)}>
-                Install
-              </Button>
-            </div>
-          </div>
-
-          {/* Right: Skill.md */}
-          <div className="flex flex-1 flex-col gap-3">
+            </>
+          ) : undefined
+        }
+        description={description}
+        actions={
+          <Button variant="action" onClick={() => setInstallOpen(true)}>
+            Install
+          </Button>
+        }
+        rightPanel={
+          <>
             <h4 className="text-foreground text-xl font-semibold tracking-tight">
               Skill.md
             </h4>
@@ -102,9 +85,9 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
                 Skill.md rendering is not yet available.
               </p>
             </div>
-          </div>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       <DialogInstallSkill
         open={installOpen}

--- a/renderer/src/route-tree.gen.ts
+++ b/renderer/src/route-tree.gen.ts
@@ -19,6 +19,7 @@ import { Route as IndexRouteImport } from "./routes/index"
 import { Route as GroupGroupNameRouteImport } from "./routes/group.$groupName"
 import { Route as CustomizeToolsServerNameRouteImport } from "./routes/customize-tools.$serverName"
 import { Route as registryRegistryRouteImport } from "./routes/(registry)/registry"
+import { Route as SkillsBuildsTagRouteImport } from "./routes/skills_.builds.$tag"
 import { Route as SkillsNamespaceSkillNameRouteImport } from "./routes/skills_.$namespace.$skillName"
 import { Route as LogsGroupNameServerNameRouteImport } from "./routes/logs.$groupName.$serverName"
 import { Route as registryRegistryNameRouteImport } from "./routes/(registry)/registry_.$name"
@@ -75,6 +76,11 @@ const registryRegistryRoute = registryRegistryRouteImport.update({
   path: "/registry",
   getParentRoute: () => rootRouteImport,
 } as any)
+const SkillsBuildsTagRoute = SkillsBuildsTagRouteImport.update({
+  id: "/skills_/builds/$tag",
+  path: "/skills/builds/$tag",
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SkillsNamespaceSkillNameRoute =
   SkillsNamespaceSkillNameRouteImport.update({
     id: "/skills_/$namespace/$skillName",
@@ -113,6 +119,7 @@ export interface FileRoutesByFullPath {
   "/registry/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
   "/skills/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
+  "/skills/builds/$tag": typeof SkillsBuildsTagRoute
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute
@@ -129,6 +136,7 @@ export interface FileRoutesByTo {
   "/registry/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
   "/skills/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
+  "/skills/builds/$tag": typeof SkillsBuildsTagRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -146,6 +154,7 @@ export interface FileRoutesById {
   "/(registry)/registry_/$name": typeof registryRegistryNameRoute
   "/logs/$groupName/$serverName": typeof LogsGroupNameServerNameRoute
   "/skills_/$namespace/$skillName": typeof SkillsNamespaceSkillNameRoute
+  "/skills_/builds/$tag": typeof SkillsBuildsTagRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -164,6 +173,7 @@ export interface FileRouteTypes {
     | "/registry/$name"
     | "/logs/$groupName/$serverName"
     | "/skills/$namespace/$skillName"
+    | "/skills/builds/$tag"
   fileRoutesByTo: FileRoutesByTo
   to:
     | "/"
@@ -180,6 +190,7 @@ export interface FileRouteTypes {
     | "/registry/$name"
     | "/logs/$groupName/$serverName"
     | "/skills/$namespace/$skillName"
+    | "/skills/builds/$tag"
   id:
     | "__root__"
     | "/"
@@ -196,6 +207,7 @@ export interface FileRouteTypes {
     | "/(registry)/registry_/$name"
     | "/logs/$groupName/$serverName"
     | "/skills_/$namespace/$skillName"
+    | "/skills_/builds/$tag"
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -213,6 +225,7 @@ export interface RootRouteChildren {
   registryRegistryNameRoute: typeof registryRegistryNameRoute
   LogsGroupNameServerNameRoute: typeof LogsGroupNameServerNameRoute
   SkillsNamespaceSkillNameRoute: typeof SkillsNamespaceSkillNameRoute
+  SkillsBuildsTagRoute: typeof SkillsBuildsTagRoute
 }
 
 declare module "@tanstack/react-router" {
@@ -287,6 +300,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof registryRegistryRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/skills_/builds/$tag": {
+      id: "/skills_/builds/$tag"
+      path: "/skills/builds/$tag"
+      fullPath: "/skills/builds/$tag"
+      preLoaderRoute: typeof SkillsBuildsTagRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     "/skills_/$namespace/$skillName": {
       id: "/skills_/$namespace/$skillName"
       path: "/skills/$namespace/$skillName"
@@ -333,6 +353,7 @@ const rootRouteChildren: RootRouteChildren = {
   registryRegistryNameRoute: registryRegistryNameRoute,
   LogsGroupNameServerNameRoute: LogsGroupNameServerNameRoute,
   SkillsNamespaceSkillNameRoute: SkillsNamespaceSkillNameRoute,
+  SkillsBuildsTagRoute: SkillsBuildsTagRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/renderer/src/routes/skills_.builds.$tag.tsx
+++ b/renderer/src/routes/skills_.builds.$tag.tsx
@@ -28,7 +28,13 @@ function BuildNotFound() {
 
 export const Route = createFileRoute('/skills_/builds/$tag')({
   params: {
-    parse: ({ tag }) => ({ tag: decodeURIComponent(tag) }),
+    parse: ({ tag }) => {
+      try {
+        return { tag: decodeURIComponent(tag) }
+      } catch {
+        return { tag }
+      }
+    },
     stringify: ({ tag }) => ({ tag: encodeURIComponent(tag) }),
   },
   loader: ({ context: { queryClient } }) =>

--- a/renderer/src/routes/skills_.builds.$tag.tsx
+++ b/renderer/src/routes/skills_.builds.$tag.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute, notFound, useParams } from '@tanstack/react-router'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { getApiV1BetaSkillsBuildsOptions } from '@common/api/generated/@tanstack/react-query.gen'
+import { Button } from '@/common/components/ui/button'
+import { LinkViewTransition } from '@/common/components/link-view-transition'
+import { EmptyState } from '@/common/components/empty-state'
+import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
+import { BuildDetailPage } from '@/features/skills/components/build-detail-page'
+
+function BuildNotFound() {
+  return (
+    <div className="flex max-h-full w-full flex-1 flex-col">
+      <EmptyState
+        illustration={IllustrationNoSearchResults}
+        title="Build Not Found"
+        body="The build you're looking for doesn't exist or has been removed."
+        actions={[
+          <Button asChild key="builds" variant="action">
+            <LinkViewTransition to="/skills" search={{ tab: 'builds' }}>
+              Browse Builds
+            </LinkViewTransition>
+          </Button>,
+        ]}
+      />
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/skills_/builds/$tag')({
+  params: {
+    parse: ({ tag }) => ({ tag: decodeURIComponent(tag) }),
+    stringify: ({ tag }) => ({ tag: encodeURIComponent(tag) }),
+  },
+  loader: ({ context: { queryClient } }) =>
+    queryClient.ensureQueryData(getApiV1BetaSkillsBuildsOptions()),
+  component: BuildDetail,
+  notFoundComponent: BuildNotFound,
+})
+
+function BuildDetail() {
+  const { tag } = useParams({ from: '/skills_/builds/$tag' })
+  const { data } = useSuspenseQuery(getApiV1BetaSkillsBuildsOptions())
+  const build = data?.builds?.find((b) => b.tag === tag)
+
+  if (!build) throw notFound()
+
+  return <BuildDetailPage build={build} />
+}


### PR DESCRIPTION
The skills feature had three card variants with inconsistent layouts and no detail page for local builds. This PR aligns the visual design across all skill cards and adds a navigable detail page for local builds.

- Extract `CardSkillBase` as a shared card shell for all skill card variants (installed, registry, local builds), matching the layout and interaction pattern of the MCP registry cards — clickable title with overlay, consistent hover/focus rings, optional subtitle, description, badges, and footer slots
- Refactor `CardRegistrySkill`, `CardSkill`, and `CardBuild` to use `CardSkillBase`; card clicks navigate to detail pages, footer actions use stopPropagation
- Extract `SkillDetailLayout` as a shared two-column detail layout (header + Summary + right panel) reused by both the registry skill detail and the new build detail page
- Add `backSearch` prop to RegistryDetailHeader so skills can navigate back to the correct tab
- Add local build detail page at /`skills/builds/$tag` with version/tag/digest metadata, Install + Remove actions, and the Skill.md placeholder panel; encode tag param to handle slashes safely
- Redirect to the builds list after successfully removing a build from its detail page
- Align all card action buttons (Install, Uninstall, Remove) to `secondary` + `rounded-full `per the Figma design



https://github.com/user-attachments/assets/33085636-79fe-4985-b8a0-76260e43c040

