### PR TITLE
feat(build): migrate Windows code signing to Azure Trusted Signing

### DIFF
--- a/.github/actions/setup-azure-trusted-signing/action.yml
+++ b/.github/actions/setup-azure-trusted-signing/action.yml
@@ -1,0 +1,116 @@
+name: 'Setup Azure Trusted Signing'
+description: >-
+  Authenticates to Azure via OIDC and prepares the environment for Windows code
+  signing with Azure Trusted Signing (Azure Code Signing DLib + signtool.exe).
+
+inputs:
+  azure-client-id:
+    description: 'Azure App Registration (service principal) client ID'
+    required: true
+  azure-tenant-id:
+    description: 'Azure AD tenant ID'
+    required: true
+  azure-subscription-id:
+    description: 'Azure subscription ID'
+    required: true
+  azure-endpoint:
+    description: 'Azure Trusted Signing account endpoint URL'
+    required: true
+  azure-account-name:
+    description: 'Azure Trusted Signing account name'
+    required: true
+  azure-certificate-profile-name:
+    description: 'Azure Trusted Signing certificate profile name'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    # Authenticate to Azure via OIDC workload identity federation.
+    # Relies on the calling job running in the `artifact-signing` environment,
+    # which must match the federated credential subject configured on the
+    # Azure App Registration (e.g.
+    # `repo:<owner>/<repo>:environment:artifact-signing`).
+    #
+    # `azure/login@v2` exports AZURE_CLIENT_ID, AZURE_TENANT_ID,
+    # AZURE_SUBSCRIPTION_ID and AZURE_FEDERATED_TOKEN_FILE, which the Azure
+    # SDK's DefaultAzureCredential (used by the Trusted Signing DLib) picks
+    # up without any additional credential configuration.
+    - name: Azure login (OIDC)
+      if: runner.os == 'Windows'
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+      with:
+        client-id: ${{ inputs.azure-client-id }}
+        tenant-id: ${{ inputs.azure-tenant-id }}
+        subscription-id: ${{ inputs.azure-subscription-id }}
+
+    # Install the Azure Code Signing DLib and write metadata.json.
+    #
+    # Both `AZURE_CODE_SIGNING_DLIB` and `AZURE_METADATA_JSON` must live at
+    # paths WITHOUT spaces, otherwise signing fails (@electron/windows-sign
+    # cannot quote the paths passed through `signWithParams`). We stage them
+    # under `C:\azsign\` to avoid `C:\Program Files (x86)\...`.
+    #
+    # See https://github.com/electron/windows-sign/issues/45
+    - name: Install Trusted Signing DLib and prepare metadata
+      if: runner.os == 'Windows'
+      shell: powershell
+      env:
+        AZURE_ENDPOINT: ${{ inputs.azure-endpoint }}
+        AZURE_ACCOUNT_NAME: ${{ inputs.azure-account-name }}
+        AZURE_CERTIFICATE_PROFILE_NAME: ${{ inputs.azure-certificate-profile-name }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        $stage = 'C:\azsign'
+        New-Item -ItemType Directory -Force -Path $stage | Out-Null
+
+        Write-Host "Downloading Microsoft.Trusted.Signing.Client from NuGet..."
+        nuget install Microsoft.Trusted.Signing.Client `
+          -OutputDirectory $stage `
+          -ExcludeVersion `
+          -Verbosity quiet
+        if ($LASTEXITCODE -ne 0) {
+          throw "nuget install failed with exit code $LASTEXITCODE"
+        }
+
+        $dlib = Join-Path $stage 'Microsoft.Trusted.Signing.Client\bin\x64\Azure.CodeSigning.Dlib.dll'
+        if (-not (Test-Path $dlib)) {
+          throw "Azure.CodeSigning.Dlib.dll not found at expected path: $dlib"
+        }
+        if ($dlib -match ' ') {
+          throw "DLib path contains spaces, which breaks @electron/windows-sign: $dlib"
+        }
+        Write-Host "DLib located at: $dlib"
+
+        Write-Host "Locating signtool.exe in the Windows SDK..."
+        $signtool = Get-ChildItem `
+          -Path 'C:\Program Files (x86)\Windows Kits\10\bin' `
+          -Recurse -Filter 'signtool.exe' -ErrorAction SilentlyContinue |
+          Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+          Sort-Object -Property FullName -Descending |
+          Select-Object -First 1
+        if (-not $signtool) {
+          throw 'signtool.exe (x64) not found in the Windows SDK'
+        }
+        Write-Host "signtool located at: $($signtool.FullName)"
+
+        Write-Host "Writing Trusted Signing metadata.json..."
+        $metadataPath = Join-Path $stage 'metadata.json'
+        $metadata = [ordered]@{
+          Endpoint               = $env:AZURE_ENDPOINT
+          CodeSigningAccountName = $env:AZURE_ACCOUNT_NAME
+          CertificateProfileName = $env:AZURE_CERTIFICATE_PROFILE_NAME
+        }
+        ($metadata | ConvertTo-Json -Compress) |
+          Set-Content -Path $metadataPath -Encoding ascii -NoNewline
+        if ($metadataPath -match ' ') {
+          throw "metadata.json path contains spaces: $metadataPath"
+        }
+
+        Write-Host "Exporting environment variables for subsequent steps..."
+        "AZURE_CODE_SIGNING_DLIB=$dlib"       | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "AZURE_METADATA_JSON=$metadataPath"   | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "SIGNTOOL_PATH=$($signtool.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+        Write-Host "Azure Trusted Signing setup complete."

--- a/.github/actions/setup-azure-trusted-signing/action.yml
+++ b/.github/actions/setup-azure-trusted-signing/action.yml
@@ -62,11 +62,19 @@ runs:
       run: |
         $ErrorActionPreference = 'Stop'
 
+        # Pin the Trusted Signing client package so CI is deterministic and a
+        # future release that reorganises the DLib path cannot silently break
+        # signing. Bump this version intentionally and re-run the signing
+        # pipeline end-to-end when upgrading. Available versions:
+        # https://www.nuget.org/packages/Microsoft.Trusted.Signing.Client
+        $trustedSigningClientVersion = '1.0.95'
+
         $stage = 'C:\azsign'
         New-Item -ItemType Directory -Force -Path $stage | Out-Null
 
-        Write-Host "Downloading Microsoft.Trusted.Signing.Client from NuGet..."
+        Write-Host "Downloading Microsoft.Trusted.Signing.Client $trustedSigningClientVersion from NuGet..."
         nuget install Microsoft.Trusted.Signing.Client `
+          -Version $trustedSigningClientVersion `
           -OutputDirectory $stage `
           -ExcludeVersion `
           -Verbosity quiet

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -133,12 +133,16 @@ jobs:
     name: Build on ${{ matrix.os }}${{ matrix.arch && format(' ({0})', matrix.arch) || '' }}
     needs: check-trigger
     runs-on: ${{ matrix.os }}
-    # Activate the `artifact-signing` environment only when Windows signing is
-    # requested. The Azure OIDC federated credential is scoped to
-    # `repo:stacklok/toolhive-studio:environment:artifact-signing`, so the
-    # job must run in that environment for the token exchange to succeed.
-    # Leaving it empty keeps unsigned builds from requiring any approvals.
-    environment: ${{ needs.check-trigger.outputs.sign_windows == 'true' && 'artifact-signing' || '' }}
+    # Activate the `artifact-signing` environment only for the Windows matrix
+    # row when Windows signing is requested. The Azure OIDC federated
+    # credential is scoped to
+    # `repo:stacklok/toolhive-studio:environment:artifact-signing`, so only
+    # the Windows signing job should run in that environment for the token
+    # exchange to succeed. Scoping to `matrix.platform == 'win32'` keeps the
+    # Linux/macOS matrix rows out of the environment so they don't receive
+    # environment-scoped signing secrets or trigger environment approvals.
+    # Leaving it empty for non-signing builds keeps them free of approvals.
+    environment: ${{ needs.check-trigger.outputs.sign_windows == 'true' && matrix.platform == 'win32' && 'artifact-signing' || '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -133,6 +133,12 @@ jobs:
     name: Build on ${{ matrix.os }}${{ matrix.arch && format(' ({0})', matrix.arch) || '' }}
     needs: check-trigger
     runs-on: ${{ matrix.os }}
+    # Activate the `artifact-signing` environment only when Windows signing is
+    # requested. The Azure OIDC federated credential is scoped to
+    # `repo:stacklok/toolhive-studio:environment:artifact-signing`, so the
+    # job must run in that environment for the token exchange to succeed.
+    # Leaving it empty keeps unsigned builds from requiring any approvals.
+    environment: ${{ needs.check-trigger.outputs.sign_windows == 'true' && 'artifact-signing' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -189,15 +195,16 @@ jobs:
           apple-issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
           apple-key-id: ${{ secrets.APPLE_KEY_ID }}
 
-      - name: Setup Windows code signing
-        uses: ./.github/actions/setup-windows-codesign
+      - name: Setup Windows code signing (Azure Trusted Signing)
+        uses: ./.github/actions/setup-azure-trusted-signing
         if: runner.os == 'Windows' && needs.check-trigger.outputs.sign_windows == 'true'
         with:
-          sm-host: ${{ secrets.SM_HOST }}
-          sm-api-key: ${{ secrets.SM_API_KEY }}
-          sm-client-cert-file-b64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
-          sm-client-cert-password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-          sm-code-signing-cert-sha1-hash: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+          azure-client-id: ${{ secrets.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_ARTIFACT_SIGNING_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID }}
+          azure-endpoint: ${{ secrets.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          azure-account-name: ${{ secrets.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          azure-certificate-profile-name: ${{ secrets.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
 
       - name: Setup Flatpak (Linux only)
         uses: ./.github/actions/setup-flatpak

--- a/docs/README.md
+++ b/docs/README.md
@@ -209,8 +209,9 @@ works in development mode only; packaged builds use the embedded binary.
 
 ## Code signing
 
-Supports both macOS and Windows code signing. macOS uses Apple certificates,
-Windows uses DigiCert KeyLocker for EV certificates.
+Supports both macOS and Windows code signing. macOS uses Apple certificates.
+Windows uses Azure Trusted Signing (preferred) with a DigiCert KeyLocker
+fallback during the migration.
 
 ### Local development
 
@@ -237,9 +238,37 @@ Requires these GitHub secrets:
 - `APPLE_ISSUER_ID` - Apple API Issuer ID
 - `APPLE_KEY_ID` - Apple API Key ID
 
-#### Windows Signing (DigiCert KeyLocker)
+#### Windows Signing (Azure Trusted Signing)
 
-Requires these GitHub secrets for EV certificate signing:
+Authentication uses OIDC workload identity federation — no client secret is
+stored in the repo. The signing job must run in the `artifact-signing` GitHub
+environment (its federated credential subject is
+`repo:stacklok/toolhive-studio:environment:artifact-signing`), and the six
+values below must be stored as **environment secrets** on that environment
+(Settings → Environments → `artifact-signing`):
+
+- `AZURE_ARTIFACT_SIGNING_CLIENT_ID` - Service principal client ID
+- `AZURE_ARTIFACT_SIGNING_TENANT_ID` - Azure AD tenant ID
+- `AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID` - Azure subscription ID
+- `AZURE_ARTIFACT_SIGNING_ENDPOINT` - Trusted Signing account endpoint URL
+- `AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME` - Trusted Signing account name
+- `AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME` - Certificate profile name
+
+The
+[`setup-azure-trusted-signing`](../.github/actions/setup-azure-trusted-signing/action.yml)
+composite action handles Azure login (OIDC), installs the Azure Code Signing
+DLib, and writes the `metadata.json` consumed by `signtool.exe`. Electron Forge
+picks this up through
+[`utils/windows-sign-azure.ts`](../utils/windows-sign-azure.ts) and signs the
+app + installer during `pnpm run make` / `pnpm run publish`.
+
+Try it on a PR by commenting `/build-test --sign-windows`.
+
+#### Windows Signing (DigiCert KeyLocker — legacy fallback)
+
+Kept as a fallback while Azure Trusted Signing is being validated. Used by
+[`on-release.yml`](../.github/workflows/on-release.yml) until the migration is
+complete. Requires these GitHub secrets:
 
 - `SM_HOST` - DigiCert KeyLocker host URL
 - `SM_API_KEY` - DigiCert KeyLocker API key
@@ -248,8 +277,9 @@ Requires these GitHub secrets for EV certificate signing:
 - `SM_CODE_SIGNING_CERT_SHA1_HASH` - SHA1 fingerprint of the code signing
   certificate
 
-CI auto-detects the certificates. Apps are signed automatically during the build
-process.
+`forge.config.ts` prefers Azure Trusted Signing when its env vars are present,
+and falls back to DigiCert when `SM_HOST` + `SM_API_KEY` are set. If neither is
+configured the build produces unsigned artifacts.
 
 ## ESLint configuration
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -25,6 +25,7 @@ import MakerTarGz from './utils/forge-makers/MakerTarGz'
 import MakerDMGWithArch from './utils/forge-makers/MakerDMGWithArch'
 import { isPrerelease } from './utils/pre-release'
 import { stripBomFromReleasesFiles } from './utils/forge-makers/strip-bom-from-releases'
+import { getAzureTrustedSigningConfig } from './utils/windows-sign-azure'
 import packageJson from './package.json'
 
 function isValidPlatform(platform: string): platform is NodeJS.Platform {
@@ -33,6 +34,23 @@ function isValidPlatform(platform: string): platform is NodeJS.Platform {
 
 function isValidArchitecture(arch: string): arch is NodeJS.Architecture {
   return ['x64', 'arm64'].includes(arch)
+}
+
+/**
+ * Resolve the Windows code-signing configuration for Electron Forge.
+ *
+ * Prefers Azure Trusted Signing (new) and falls back to DigiCert KeyLocker
+ * (legacy) during the migration. Returns `undefined` when neither is
+ * configured, which leaves the build unsigned (safe default for local dev
+ * and non-Windows CI jobs).
+ */
+function getWindowsSignConfig() {
+  const azure = getAzureTrustedSigningConfig()
+  if (azure) return azure
+  if (process.env.SM_HOST && process.env.SM_API_KEY) {
+    return { hookModulePath: './utils/digicert-hook.js' }
+  }
+  return undefined
 }
 
 const config: ForgeConfig = {
@@ -67,13 +85,9 @@ const config: ForgeConfig = {
       ? { identity: process.env.MAC_DEVELOPER_IDENTITY }
       : {}, // Auto-detect certificates
 
-    // Windows Code Signing Configuration - DigiCert KeyLocker
-    windowsSign:
-      process.env.SM_HOST && process.env.SM_API_KEY
-        ? {
-            hookModulePath: './utils/digicert-hook.js',
-          }
-        : undefined,
+    // Windows Code Signing Configuration
+    // Azure Trusted Signing (preferred) with DigiCert KeyLocker fallback.
+    windowsSign: getWindowsSignConfig(),
 
     // MacOS Notarization Configuration
     osxNotarize: (() => {
@@ -134,10 +148,7 @@ const config: ForgeConfig = {
         exe: `${EXECUTABLE_NAME}.exe`,
         name: APP_NAME,
         noDelta: true,
-        windowsSign:
-          process.env.SM_HOST && process.env.SM_API_KEY
-            ? { hookModulePath: './utils/digicert-hook.js' }
-            : undefined,
+        windowsSign: getWindowsSignConfig(),
       }),
     },
     new MakerDMGWithArch(

--- a/utils/windows-sign-azure.ts
+++ b/utils/windows-sign-azure.ts
@@ -1,0 +1,47 @@
+/**
+ * Azure Trusted Signing configuration for `@electron/windows-sign`.
+ *
+ * Follows the official Electron Forge guide:
+ * https://www.electronforge.io/guides/code-signing/code-signing-windows#using-azure-trusted-signing
+ *
+ * The returned config is a plain options object consumed by `@electron/windows-sign`
+ * (via `signWithParams`), which invokes `signtool.exe` with the Azure Code Signing
+ * DLib to sign files through Azure Trusted Signing.
+ *
+ * Authentication to Azure Trusted Signing is handled by the Azure SDK's
+ * `DefaultAzureCredential` inside the DLib. In CI this picks up the OIDC
+ * workload-identity token exported by `azure/login@v2` (AZURE_CLIENT_ID,
+ * AZURE_TENANT_ID, AZURE_FEDERATED_TOKEN_FILE), so no client secret is
+ * required.
+ *
+ * Important caveat: `AZURE_CODE_SIGNING_DLIB` and `AZURE_METADATA_JSON` must
+ * not contain spaces, or signing will fail. See
+ * https://github.com/electron/windows-sign/issues/45
+ */
+
+// `HASHES` is a const enum inside `@electron/windows-sign`; importing it as
+// a type and casting the literal matches the official Electron Forge guide
+// and keeps string values structurally compatible with `WindowsSignOptions`.
+import type { HASHES } from '@electron/windows-sign/dist/esm/types'
+
+type AzureSignConfig = {
+  signToolPath?: string
+  signWithParams: string
+  timestampServer: string
+  hashes: HASHES[]
+}
+
+export function getAzureTrustedSigningConfig(): AzureSignConfig | undefined {
+  const dlib = process.env.AZURE_CODE_SIGNING_DLIB
+  const metadata = process.env.AZURE_METADATA_JSON
+  if (!dlib || !metadata) return undefined
+
+  return {
+    ...(process.env.SIGNTOOL_PATH
+      ? { signToolPath: process.env.SIGNTOOL_PATH }
+      : {}),
+    signWithParams: `/v /debug /dlib ${dlib} /dmdf ${metadata}`,
+    timestampServer: 'http://timestamp.acs.microsoft.com',
+    hashes: ['sha256' as HASHES],
+  }
+}


### PR DESCRIPTION
The Windows code signing pipeline has been on DigiCert KeyLocker, which requires storing client cert files + API keys as repo secrets and shells out to `smctl.exe` from a custom `@electron/windows-sign` hook. This PR migrates Windows signing to Azure Trusted Signing, authenticated via OIDC workload identity federation (no client secret stored anywhere). DigiCert is kept as a runtime fallback so `on-release.yml` keeps working until the new path is validated end-to-end via `/build-test --sign-windows`.

- Add `utils/windows-sign-azure.ts` returning an `@electron/windows-sign` config (`signWithParams` + Azure Code Signing DLib + metadata.json), following the [official Electron Forge Trusted Signing guide](https://www.electronforge.io/guides/code-signing/code-signing-windows#using-azure-trusted-signing); env-driven, returns `undefined` when not configured so it's safe to call unconditionally
- Add a `getWindowsSignConfig()` helper in `forge.config.ts` that prefers Azure and falls back to the existing DigiCert hook when only `SM_HOST` + `SM_API_KEY` are set; both `packagerConfig.windowsSign` and the maker-squirrel `windowsSign` use it
- Add `.github/actions/setup-azure-trusted-signing` composite action: `azure/login@v2.3.0` (OIDC), `nuget install Microsoft.Trusted.Signing.Client` into `C:\azsign\` (no-space path to avoid [electron/windows-sign#45](https://github.com/electron/windows-sign/issues/45)), locate the latest x64 `signtool.exe` in the Windows SDK, write `metadata.json`, export `AZURE_CODE_SIGNING_DLIB` / `AZURE_METADATA_JSON` / `SIGNTOOL_PATH` to `GITHUB_ENV`
- Wire the new action into `pr-build-test.yml` with the 6 `AZURE_ARTIFACT_SIGNING_*` env-scoped secrets; conditionally activate the `artifact-signing` GitHub environment (`environment: ${{ ... && 'artifact-signing' || '' }}`) so the OIDC federated credential subject `repo:stacklok/toolhive-studio:environment:artifact-signing` is satisfied only when signing is requested — unsigned PR builds are unaffected
- Document the new flow in `docs/README.md` (OIDC, environment-scoped secrets, composite action, how to test) and demote the DigiCert section to a legacy fallback note

Not changed in this PR (deliberate, follow-up):
- `on-release.yml` still signs production releases via DigiCert; the follow-up will add `environment: artifact-signing` to its build job, swap to the Azure composite action, and remove the DigiCert hook + `setup-windows-codesign` action.
