### PR TITLE
fix(e2e): stabilise Playground Ollama chat test

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   OLLAMA_BASE_URL: http://localhost:11434
-  OLLAMA_MODEL: qwen2.5:1.5b
+  OLLAMA_MODEL: qwen2.5:3b
   OLLAMA_VERSION: 0.18.2
 
 jobs:

--- a/e2e-tests/playground.spec.ts
+++ b/e2e-tests/playground.spec.ts
@@ -218,7 +218,5 @@ test.describe('Playground chat with Ollama', () => {
     ).toBeVisible({
       timeout: LONG_TIMEOUT,
     })
-
-    await clearPlaygroundState(window)
   })
 })

--- a/e2e-tests/playground.spec.ts
+++ b/e2e-tests/playground.spec.ts
@@ -208,7 +208,9 @@ test.describe('Playground chat with Ollama', () => {
 
     await window
       .getByPlaceholder(/type your message/i)
-      .fill('Call the get_secret_code tool and tell me the code it returns.')
+      .fill(
+        'Use the get_secret_code tool, then reply with ONLY the exact code the tool returned. No quotes, no extra words, no punctuation.'
+      )
     await window.keyboard.press('Enter')
 
     await expect(


### PR DESCRIPTION
The `Playground chat with Ollama` e2e test has been flaking intermittently on CI. The test sends a prompt to Ollama, expects the model to call the `get_secret_code` MCP tool, and then asserts that the tool's secret code (e.g. `dragon93`) appears as visible text in the chat. Because that text only renders if the LLM echoes the tool's raw output verbatim, and because `qwen2.5:1.5b` (1.5B params) is small enough to paraphrase, omit, or decorate the code, the assertion times out after 180s.

A second, latent issue compounded the flake: retry #2 in the latest failure actually passed the chat assertion, but then timed out on a trailing `clearPlaygroundState(window)` that isn't needed — each test already starts from a fresh `userDataDir` thanks to the `electronApp` fixture.

- Bump `OLLAMA_MODEL` from `qwen2.5:1.5b` to `qwen2.5:3b` in `.github/workflows/_e2e.yml`. The cache key already interpolates `OLLAMA_MODEL`, so the new weights populate on first run and are cached thereafter. The 3b model is still small enough to run comfortably inside the existing 60-minute job timeout but is materially more reliable at tool-calling and at following format constraints. The test still reads `OLLAMA_MODEL` from env, so local runs can keep using 1.5b via `OLLAMA_MODEL=qwen2.5:1.5b`.
- Tighten the chat prompt to explicitly constrain the model's output format: `Use the get_secret_code tool, then reply with ONLY the exact code the tool returned. No quotes, no extra words, no punctuation.` This gives a small model the best chance of satisfying the existing `toBeVisible(RegExp(secretCode))` assertion on the first try.
- Remove the redundant `await clearPlaygroundState(window)` at the end of the test. The `electronApp` fixture creates a fresh `userDataDir` per test, `afterAll` stops the test MCP server, and the start-of-test `clearPlaygroundState` already handles any lingering provider state. Dropping the trailing call eliminates the exact failure site seen on retry #2.

Not changed in this PR (deliberate, follow-up if flakiness remains):

- Not touching `LONG_TIMEOUT`, Playwright `retries`, or the xvfb step.
- Not switching the assertion from "secret code is visible in chat" to "the `ToolCallComponent` reached `output-available` state". That's the next lever if the 3b + stricter prompt isn't enough.