### PR TITLE
feat(skills): render SKILL.md content and sticky detail layout

### DIFF
--- a/renderer/src/common/lib/streamdown-prose.ts
+++ b/renderer/src/common/lib/streamdown-prose.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared Tailwind class list for Streamdown-rendered markdown content.
+ *
+ * Keep in sync across all sites that render prose through Streamdown
+ * (chat messages, SKILL.md viewer, etc.) so tweaks don't drift between
+ * features.
+ */
+export const STREAMDOWN_PROSE_CLASS =
+  'prose prose-sm text-foreground/80 [&_h1]:text-foreground/85 [&_h2]:text-foreground/80 [&_h3]:text-foreground/75 [&_table]:border-border [&_th]:border-border [&_th]:bg-muted/50 [&_th]:text-foreground/75 [&_td]:border-border [&_a]:text-primary [&_strong]:text-foreground/90 [&_em]:text-foreground/75 [&_blockquote]:border-muted-foreground/30 max-w-none [&_a:hover]:underline [&_blockquote]:mb-3 [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:italic [&_code]:text-xs [&_em]:italic [&_h1]:mt-3 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h1:first-child]:mt-0 [&_h2]:mt-3 [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2:first-child]:mt-0 [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_h3:first-child]:mt-0 [&_li]:ml-2 [&_li]:text-sm [&_ol]:mb-2 [&_ol]:list-inside [&_ol]:list-decimal [&_ol]:space-y-0.5 [&_p]:mb-2 [&_p]:leading-relaxed [&_p:last-child]:mb-0 [&_pre]:text-xs [&_strong]:font-medium [&_table]:mb-4 [&_table]:min-w-full [&_table]:rounded-md [&_table]:border [&_td]:border [&_td]:px-3 [&_td]:py-2 [&_td]:text-xs [&_th]:border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-xs [&_th]:font-medium [&_ul]:mb-2 [&_ul]:list-inside [&_ul]:list-disc [&_ul]:space-y-0.5'

--- a/renderer/src/common/mocks/fixtures/skills_content/get.ts
+++ b/renderer/src/common/mocks/fixtures/skills_content/get.ts
@@ -1,0 +1,16 @@
+import type {
+  GetApiV1BetaSkillsContentResponse,
+  GetApiV1BetaSkillsContentData,
+} from '@common/api/generated/types.gen'
+import { AutoAPIMock } from '@mocks'
+
+export const mockedGetApiV1BetaSkillsContent = AutoAPIMock<
+  GetApiV1BetaSkillsContentResponse,
+  GetApiV1BetaSkillsContentData
+>({
+  name: 'my-skill',
+  description: 'A helpful skill',
+  version: 'v1.0.0',
+  body: '# My Skill\n\nThis is the SKILL.md body.\n\n## Usage\n\nUse this skill to do things.',
+  files: [{ path: 'SKILL.md', size: 60 }],
+})

--- a/renderer/src/features/chat/components/chat-message.tsx
+++ b/renderer/src/features/chat/components/chat-message.tsx
@@ -23,6 +23,7 @@ import type { ChatUIMessage } from '../types'
 import { getProviderIconByModel } from './provider-icons'
 import type { ChatStatus } from 'ai'
 import type { ToolUiMetadataEntry } from '../hooks/use-mcp-app-metadata'
+import { STREAMDOWN_PROSE_CLASS } from '@/common/lib/streamdown-prose'
 
 interface ChatMessageProps {
   message: ChatUIMessage
@@ -674,7 +675,7 @@ export function ChatMessage({
                   <Streamdown
                     plugins={{ code, mermaid, cjk }}
                     isAnimating={status === 'streaming'}
-                    className="prose prose-sm text-foreground/80 [&_h1]:text-foreground/85 [&_h2]:text-foreground/80 [&_h3]:text-foreground/75 [&_table]:border-border [&_th]:border-border [&_th]:bg-muted/50 [&_th]:text-foreground/75 [&_td]:border-border [&_a]:text-primary [&_strong]:text-foreground/90 [&_em]:text-foreground/75 [&_blockquote]:border-muted-foreground/30 max-w-none [&_a:hover]:underline [&_blockquote]:mb-3 [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:italic [&_code]:text-xs [&_em]:italic [&_h1]:mt-3 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h1:first-child]:mt-0 [&_h2]:mt-3 [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2:first-child]:mt-0 [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_h3:first-child]:mt-0 [&_li]:ml-2 [&_li]:text-sm [&_ol]:mb-2 [&_ol]:list-inside [&_ol]:list-decimal [&_ol]:space-y-0.5 [&_p]:mb-2 [&_p]:leading-relaxed [&_p:last-child]:mb-0 [&_pre]:text-xs [&_strong]:font-medium [&_table]:mb-4 [&_table]:min-w-full [&_table]:rounded-md [&_table]:border [&_td]:border [&_td]:px-3 [&_td]:py-2 [&_td]:text-xs [&_th]:border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-xs [&_th]:font-medium [&_ul]:mb-2 [&_ul]:list-inside [&_ul]:list-disc [&_ul]:space-y-0.5"
+                    className={STREAMDOWN_PROSE_CLASS}
                   >
                     {allTextContent}
                   </Streamdown>

--- a/renderer/src/features/skills/components/__tests__/skill-markdown.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/skill-markdown.test.tsx
@@ -18,7 +18,7 @@ const renderWithProviders = (component: React.ReactElement) => {
   )
 }
 
-const OCI_REF = 'ghcr.io/org/my-skill:v1'
+const SKILL_REF = 'ghcr.io/org/my-skill:v1'
 
 beforeEach(() => {
   mockedGetApiV1BetaSkillsContent.reset()
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 describe('SkillMarkdown', () => {
   it('renders markdown body on successful fetch', async () => {
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} />)
 
     await waitFor(() => {
       expect(screen.getByText('My Skill')).toBeInTheDocument()
@@ -34,7 +34,7 @@ describe('SkillMarkdown', () => {
   })
 
   it('renders a section from the markdown body', async () => {
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} />)
 
     await waitFor(() => {
       expect(screen.getByText('Usage')).toBeInTheDocument()
@@ -42,7 +42,7 @@ describe('SkillMarkdown', () => {
   })
 
   it('shows a skeleton while loading', () => {
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} />)
 
     // Skeletons render before data resolves
     const skeletons = document.querySelectorAll('[data-slot="skeleton"]')
@@ -54,7 +54,7 @@ describe('SkillMarkdown', () => {
       HttpResponse.json({ message: 'Not found' }, { status: 404 })
     )
 
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} />)
 
     await waitFor(() => {
       expect(
@@ -68,7 +68,7 @@ describe('SkillMarkdown', () => {
       HttpResponse.json({ message: 'Service unavailable' }, { status: 503 })
     )
 
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} />)
 
     await waitFor(() => {
       expect(
@@ -82,7 +82,7 @@ describe('SkillMarkdown', () => {
       HttpResponse.json({ message: 'Internal server error' }, { status: 500 })
     )
 
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} />)
 
     await waitFor(() => {
       expect(screen.getByText('Failed to load SKILL.md.')).toBeInTheDocument()
@@ -95,7 +95,7 @@ describe('SkillMarkdown', () => {
       body: '---\nname: my-skill\ndescription: A helpful skill\n---\n\n# My Skill\n\nBody content.',
     }))
 
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} stripFrontmatter />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} stripFrontmatter />)
 
     await waitFor(() => {
       expect(screen.getByText('My Skill')).toBeInTheDocument()
@@ -112,7 +112,7 @@ describe('SkillMarkdown', () => {
       body: '---\nname: my-skill\n---\n\n# Heading',
     }))
 
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} />)
 
     await waitFor(() => {
       expect(screen.getByText(/name: my-skill/)).toBeInTheDocument()
@@ -125,7 +125,7 @@ describe('SkillMarkdown', () => {
       body: undefined,
     }))
 
-    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+    renderWithProviders(<SkillMarkdown skillRef={SKILL_REF} />)
 
     await waitFor(() => {
       expect(

--- a/renderer/src/features/skills/components/__tests__/skill-markdown.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/skill-markdown.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { expect, it, describe, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { HttpResponse } from 'msw'
+import { SkillMarkdown } from '../skill-markdown'
+import { mockedGetApiV1BetaSkillsContent } from '@mocks/fixtures/skills_content/get'
+
+const renderWithProviders = (component: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
+  )
+}
+
+const OCI_REF = 'ghcr.io/org/my-skill:v1'
+
+beforeEach(() => {
+  mockedGetApiV1BetaSkillsContent.reset()
+})
+
+describe('SkillMarkdown', () => {
+  it('renders markdown body on successful fetch', async () => {
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('My Skill')).toBeInTheDocument()
+    })
+  })
+
+  it('renders a section from the markdown body', async () => {
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Usage')).toBeInTheDocument()
+    })
+  })
+
+  it('shows a skeleton while loading', () => {
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+
+    // Skeletons render before data resolves
+    const skeletons = document.querySelectorAll('[data-slot="skeleton"]')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('shows a 404 error message when skill content is not found', async () => {
+    mockedGetApiV1BetaSkillsContent.overrideHandler(() =>
+      HttpResponse.json({ message: 'Not found' }, { status: 404 })
+    )
+
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('SKILL.md not found for this skill.')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows a 503 error message when registry is unavailable', async () => {
+    mockedGetApiV1BetaSkillsContent.overrideHandler(() =>
+      HttpResponse.json({ message: 'Service unavailable' }, { status: 503 })
+    )
+
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Registry is currently unavailable. Try again later.')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows a generic error message for other errors', async () => {
+    mockedGetApiV1BetaSkillsContent.overrideHandler(() =>
+      HttpResponse.json({ message: 'Internal server error' }, { status: 500 })
+    )
+
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load SKILL.md.')).toBeInTheDocument()
+    })
+  })
+
+  it('strips YAML frontmatter when stripFrontmatter is true', async () => {
+    mockedGetApiV1BetaSkillsContent.override((data) => ({
+      ...data,
+      body: '---\nname: my-skill\ndescription: A helpful skill\n---\n\n# My Skill\n\nBody content.',
+    }))
+
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} stripFrontmatter />)
+
+    await waitFor(() => {
+      expect(screen.getByText('My Skill')).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/name: my-skill/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/description: A helpful skill/)
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps frontmatter when stripFrontmatter is not set', async () => {
+    mockedGetApiV1BetaSkillsContent.override((data) => ({
+      ...data,
+      body: '---\nname: my-skill\n---\n\n# Heading',
+    }))
+
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/name: my-skill/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when body is absent from response', async () => {
+    mockedGetApiV1BetaSkillsContent.override((data) => ({
+      ...data,
+      body: undefined,
+    }))
+
+    renderWithProviders(<SkillMarkdown ociRef={OCI_REF} />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No SKILL.md content available.')
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/renderer/src/features/skills/components/build-detail-page.tsx
+++ b/renderer/src/features/skills/components/build-detail-page.tsx
@@ -11,6 +11,7 @@ import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from 
 import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogDeleteBuild } from './dialog-delete-build'
 import { SkillDetailLayout } from './skill-detail-layout'
+import { SkillMarkdown } from './skill-markdown'
 
 interface BuildDetailPageProps {
   build: LocalBuild
@@ -86,30 +87,31 @@ export function BuildDetailPage({ build }: BuildDetailPageProps) {
         description={description}
         actions={
           <div className="flex items-center gap-3">
-            <Button variant="action" onClick={() => setInstallOpen(true)}>
-              Install
-            </Button>
             <Button variant="secondary" onClick={() => setDeleteOpen(true)}>
               <Trash2Icon className="size-4" />
               Remove
+            </Button>
+            <Button variant="action" onClick={() => setInstallOpen(true)}>
+              Install
             </Button>
           </div>
         }
         rightPanel={
           <>
             <h4 className="text-foreground text-xl font-semibold tracking-tight">
-              Skill.md
+              SKILL.md
             </h4>
             <div
-              className="border-border rounded-2xl border bg-white p-6
+              className="border-border mb-8 rounded-2xl border bg-white p-6
                 dark:bg-transparent"
             >
-              <p
-                className="text-muted-foreground font-mono text-sm
-                  leading-relaxed"
-              >
-                Skill.md rendering is not yet available.
-              </p>
+              {tag ? (
+                <SkillMarkdown ociRef={tag} stripFrontmatter />
+              ) : (
+                <p className="text-muted-foreground text-sm">
+                  No SKILL.md available for this build.
+                </p>
+              )}
             </div>
           </>
         }

--- a/renderer/src/features/skills/components/build-detail-page.tsx
+++ b/renderer/src/features/skills/components/build-detail-page.tsx
@@ -106,7 +106,7 @@ export function BuildDetailPage({ build }: BuildDetailPageProps) {
                 dark:bg-transparent"
             >
               {tag ? (
-                <SkillMarkdown ociRef={tag} stripFrontmatter />
+                <SkillMarkdown skillRef={tag} stripFrontmatter />
               ) : (
                 <p className="text-muted-foreground text-sm">
                   No SKILL.md available for this build.

--- a/renderer/src/features/skills/components/skill-detail-layout.tsx
+++ b/renderer/src/features/skills/components/skill-detail-layout.tsx
@@ -1,5 +1,9 @@
-import type { ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { ChevronLeft } from 'lucide-react'
+import { Button } from '@/common/components/ui/button'
+import { LinkViewTransition } from '@/common/components/link-view-transition'
 import { RegistryDetailHeader } from '@/features/registry-servers/components/registry-detail-header'
+import { cn } from '@/common/lib/utils'
 
 interface SkillDetailLayoutProps {
   title: string
@@ -20,17 +24,78 @@ export function SkillDetailLayout({
   actions,
   rightPanel,
 }: SkillDetailLayoutProps) {
+  const headerRef = useRef<HTMLDivElement>(null)
+  const [isHeaderVisible, setIsHeaderVisible] = useState(true)
+
+  useEffect(() => {
+    const target = headerRef.current
+    if (!target) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsHeaderVisible(entry?.isIntersecting ?? true),
+      { threshold: 0 }
+    )
+
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [])
+
+  const showStickyHeader = !isHeaderVisible
+
   return (
     <div className="flex max-h-full w-full flex-1 flex-col">
-      <RegistryDetailHeader
-        title={title}
-        backTo={backTo}
-        backSearch={backSearch}
-        badges={badges}
-      />
+      <div ref={headerRef}>
+        <RegistryDetailHeader
+          title={title}
+          backTo={backTo}
+          backSearch={backSearch}
+          badges={badges}
+        />
+      </div>
 
-      <div className="mt-8 flex flex-col gap-10 md:flex-row">
-        <div className="flex w-full flex-col gap-6 md:w-5/12">
+      <div className="mt-8 flex flex-col gap-10 md:flex-row md:items-start">
+        <div className="flex w-full flex-col gap-6 md:sticky md:top-0 md:w-5/12">
+          <div
+            aria-hidden={!showStickyHeader}
+            className={cn(
+              `hidden grid-rows-[0fr]
+              transition-[grid-template-rows,opacity,margin]`,
+              'duration-200 ease-out motion-reduce:transition-none md:grid',
+              showStickyHeader
+                ? 'mb-0 opacity-100 md:grid-rows-[1fr]'
+                : 'pointer-events-none -mb-6 opacity-0'
+            )}
+          >
+            <div className="overflow-hidden">
+              <div className="flex flex-col gap-3 pb-1">
+                <div>
+                  <LinkViewTransition to={backTo} search={backSearch}>
+                    <Button
+                      variant="outline"
+                      aria-label="Back"
+                      className="rounded-full"
+                      tabIndex={showStickyHeader ? 0 : -1}
+                    >
+                      <ChevronLeft className="size-4" />
+                      Back
+                    </Button>
+                  </LinkViewTransition>
+                </div>
+                <h2
+                  className="text-foreground m-0 truncate p-0 text-2xl
+                    font-semibold tracking-tight"
+                >
+                  {title}
+                </h2>
+                {badges && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    {badges}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
           {description && (
             <div className="flex flex-col gap-2">
               <h4

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -4,6 +4,8 @@ import { TagIcon, GitForkIcon, ScaleIcon } from 'lucide-react'
 import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { SkillDetailLayout } from './skill-detail-layout'
+import { getSkillOciRef } from '../lib/get-skill-oci-ref'
+import { SkillMarkdown } from './skill-markdown'
 
 interface SkillDetailPageProps {
   skill: RegistrySkill
@@ -21,6 +23,7 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
   const base =
     namespace && name !== 'Unknown skill' ? `${namespace}/${name}` : name
   const defaultReference = isOci && version ? `${base}:${version}` : base
+  const ociRef = getSkillOciRef(skill)
 
   const hasBadges = !!(version || namespace || license)
 
@@ -65,25 +68,28 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
         }
         description={description}
         actions={
-          <Button variant="action" onClick={() => setInstallOpen(true)}>
-            Install
-          </Button>
+          <div className="flex items-center gap-3">
+            <Button variant="action" onClick={() => setInstallOpen(true)}>
+              Install
+            </Button>
+          </div>
         }
         rightPanel={
           <>
             <h4 className="text-foreground text-xl font-semibold tracking-tight">
-              Skill.md
+              SKILL.md
             </h4>
             <div
-              className="border-border rounded-2xl border bg-white p-6
+              className="border-border mb-8 rounded-2xl border bg-white p-6
                 dark:bg-transparent"
             >
-              <p
-                className="text-muted-foreground font-mono text-sm
-                  leading-relaxed"
-              >
-                Skill.md rendering is not yet available.
-              </p>
+              {ociRef ? (
+                <SkillMarkdown ociRef={ociRef} />
+              ) : (
+                <p className="text-muted-foreground text-sm">
+                  No SKILL.md available for this skill.
+                </p>
+              )}
             </div>
           </>
         }

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -84,7 +84,7 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
                 dark:bg-transparent"
             >
               {ociRef ? (
-                <SkillMarkdown ociRef={ociRef} />
+                <SkillMarkdown skillRef={ociRef} />
               ) : (
                 <p className="text-muted-foreground text-sm">
                   No SKILL.md available for this skill.

--- a/renderer/src/features/skills/components/skill-markdown.tsx
+++ b/renderer/src/features/skills/components/skill-markdown.tsx
@@ -3,8 +3,17 @@ import { Streamdown } from 'streamdown'
 import { code } from '@streamdown/code'
 import { mermaid } from '@streamdown/mermaid'
 import { cjk } from '@streamdown/cjk'
-import { getApiV1BetaSkillsContentOptions } from '@common/api/generated/@tanstack/react-query.gen'
+import { getApiV1BetaSkillsContent } from '@common/api/generated'
+import { getApiV1BetaSkillsContentQueryKey } from '@common/api/generated/@tanstack/react-query.gen'
 import { Skeleton } from '@/common/components/ui/skeleton'
+
+class SkillContentError extends Error {
+  readonly status?: number
+  constructor(message: string, status?: number) {
+    super(message)
+    this.status = status
+  }
+}
 
 const STREAMDOWN_PLUGINS = { code, mermaid, cjk }
 
@@ -34,7 +43,21 @@ export function SkillMarkdown({
   stripFrontmatter?: boolean
 }) {
   const { data, isLoading, isError, error } = useQuery({
-    ...getApiV1BetaSkillsContentOptions({ query: { ref: ociRef } }),
+    queryKey: getApiV1BetaSkillsContentQueryKey({ query: { ref: ociRef } }),
+    queryFn: async ({ signal }) => {
+      const result = await getApiV1BetaSkillsContent({
+        query: { ref: ociRef },
+        signal,
+      })
+      if (result.error !== undefined) {
+        const message =
+          typeof result.error === 'string'
+            ? result.error
+            : 'Failed to load SKILL.md.'
+        throw new SkillContentError(message, result.response?.status)
+      }
+      return result.data
+    },
     retry: false,
   })
 
@@ -43,8 +66,7 @@ export function SkillMarkdown({
   }
 
   if (isError) {
-    const status = (error as { response?: { status?: number } })?.response
-      ?.status
+    const status = error instanceof SkillContentError ? error.status : undefined
     const message =
       status === 404
         ? 'SKILL.md not found for this skill.'

--- a/renderer/src/features/skills/components/skill-markdown.tsx
+++ b/renderer/src/features/skills/components/skill-markdown.tsx
@@ -1,0 +1,83 @@
+import { useQuery } from '@tanstack/react-query'
+import { Streamdown } from 'streamdown'
+import { code } from '@streamdown/code'
+import { mermaid } from '@streamdown/mermaid'
+import { cjk } from '@streamdown/cjk'
+import { getApiV1BetaSkillsContentOptions } from '@common/api/generated/@tanstack/react-query.gen'
+import { Skeleton } from '@/common/components/ui/skeleton'
+
+const STREAMDOWN_PLUGINS = { code, mermaid, cjk }
+
+const PROSE_CLASS =
+  'prose prose-sm text-foreground/80 [&_h1]:text-foreground/85 [&_h2]:text-foreground/80 [&_h3]:text-foreground/75 [&_table]:border-border [&_th]:border-border [&_th]:bg-muted/50 [&_th]:text-foreground/75 [&_td]:border-border [&_a]:text-primary [&_strong]:text-foreground/90 [&_em]:text-foreground/75 [&_blockquote]:border-muted-foreground/30 max-w-none [&_a:hover]:underline [&_blockquote]:mb-3 [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:italic [&_code]:text-xs [&_em]:italic [&_h1]:mt-3 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h1:first-child]:mt-0 [&_h2]:mt-3 [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2:first-child]:mt-0 [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_h3:first-child]:mt-0 [&_li]:ml-2 [&_li]:text-sm [&_ol]:mb-2 [&_ol]:list-inside [&_ol]:list-decimal [&_ol]:space-y-0.5 [&_p]:mb-2 [&_p]:leading-relaxed [&_p:last-child]:mb-0 [&_pre]:text-xs [&_strong]:font-medium [&_table]:mb-4 [&_table]:min-w-full [&_table]:rounded-md [&_table]:border [&_td]:border [&_td]:px-3 [&_td]:py-2 [&_td]:text-xs [&_th]:border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-xs [&_th]:font-medium [&_ul]:mb-2 [&_ul]:list-inside [&_ul]:list-disc [&_ul]:space-y-0.5'
+
+function SkillMarkdownSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-2/3" />
+    </div>
+  )
+}
+
+const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/
+
+export function SkillMarkdown({
+  ociRef,
+  stripFrontmatter = false,
+}: {
+  ociRef: string
+  stripFrontmatter?: boolean
+}) {
+  const { data, isLoading, isError, error } = useQuery({
+    ...getApiV1BetaSkillsContentOptions({ query: { ref: ociRef } }),
+    retry: false,
+  })
+
+  if (isLoading) {
+    return <SkillMarkdownSkeleton />
+  }
+
+  if (isError) {
+    const status = (error as { response?: { status?: number } })?.response
+      ?.status
+    const message =
+      status === 404
+        ? 'SKILL.md not found for this skill.'
+        : status === 503
+          ? 'Registry is currently unavailable. Try again later.'
+          : 'Failed to load SKILL.md.'
+    return (
+      <p className="text-muted-foreground text-sm" data-testid="skill-md-error">
+        {message}
+      </p>
+    )
+  }
+
+  const rawBody = data?.body
+  const body =
+    stripFrontmatter && rawBody
+      ? rawBody.replace(FRONTMATTER_REGEX, '').trimStart()
+      : rawBody
+  if (!body) {
+    return (
+      <p className="text-muted-foreground text-sm" data-testid="skill-md-empty">
+        No SKILL.md content available.
+      </p>
+    )
+  }
+
+  return (
+    <Streamdown
+      plugins={STREAMDOWN_PLUGINS}
+      isAnimating={false}
+      className={PROSE_CLASS}
+    >
+      {body}
+    </Streamdown>
+  )
+}

--- a/renderer/src/features/skills/components/skill-markdown.tsx
+++ b/renderer/src/features/skills/components/skill-markdown.tsx
@@ -6,6 +6,7 @@ import { cjk } from '@streamdown/cjk'
 import { getApiV1BetaSkillsContent } from '@common/api/generated'
 import { getApiV1BetaSkillsContentQueryKey } from '@common/api/generated/@tanstack/react-query.gen'
 import { Skeleton } from '@/common/components/ui/skeleton'
+import { STREAMDOWN_PROSE_CLASS } from '@/common/lib/streamdown-prose'
 
 class SkillContentError extends Error {
   readonly status?: number
@@ -16,9 +17,6 @@ class SkillContentError extends Error {
 }
 
 const STREAMDOWN_PLUGINS = { code, mermaid, cjk }
-
-const PROSE_CLASS =
-  'prose prose-sm text-foreground/80 [&_h1]:text-foreground/85 [&_h2]:text-foreground/80 [&_h3]:text-foreground/75 [&_table]:border-border [&_th]:border-border [&_th]:bg-muted/50 [&_th]:text-foreground/75 [&_td]:border-border [&_a]:text-primary [&_strong]:text-foreground/90 [&_em]:text-foreground/75 [&_blockquote]:border-muted-foreground/30 max-w-none [&_a:hover]:underline [&_blockquote]:mb-3 [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:italic [&_code]:text-xs [&_em]:italic [&_h1]:mt-3 [&_h1]:mb-2 [&_h1]:text-lg [&_h1]:font-semibold [&_h1:first-child]:mt-0 [&_h2]:mt-3 [&_h2]:mb-2 [&_h2]:text-base [&_h2]:font-semibold [&_h2:first-child]:mt-0 [&_h3]:mt-2 [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_h3:first-child]:mt-0 [&_li]:ml-2 [&_li]:text-sm [&_ol]:mb-2 [&_ol]:list-inside [&_ol]:list-decimal [&_ol]:space-y-0.5 [&_p]:mb-2 [&_p]:leading-relaxed [&_p:last-child]:mb-0 [&_pre]:text-xs [&_strong]:font-medium [&_table]:mb-4 [&_table]:min-w-full [&_table]:rounded-md [&_table]:border [&_td]:border [&_td]:px-3 [&_td]:py-2 [&_td]:text-xs [&_th]:border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-xs [&_th]:font-medium [&_ul]:mb-2 [&_ul]:list-inside [&_ul]:list-disc [&_ul]:space-y-0.5'
 
 function SkillMarkdownSkeleton() {
   return (
@@ -36,17 +34,21 @@ function SkillMarkdownSkeleton() {
 const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/
 
 export function SkillMarkdown({
-  ociRef,
+  skillRef,
   stripFrontmatter = false,
 }: {
-  ociRef: string
+  /**
+   * Content endpoint `ref` query value: an OCI reference, a `namespace/name`
+   * pair, or a local build tag.
+   */
+  skillRef: string
   stripFrontmatter?: boolean
 }) {
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: getApiV1BetaSkillsContentQueryKey({ query: { ref: ociRef } }),
+    queryKey: getApiV1BetaSkillsContentQueryKey({ query: { ref: skillRef } }),
     queryFn: async ({ signal }) => {
       const result = await getApiV1BetaSkillsContent({
-        query: { ref: ociRef },
+        query: { ref: skillRef },
         signal,
       })
       if (result.error !== undefined) {
@@ -97,7 +99,7 @@ export function SkillMarkdown({
     <Streamdown
       plugins={STREAMDOWN_PLUGINS}
       isAnimating={false}
-      className={PROSE_CLASS}
+      className={STREAMDOWN_PROSE_CLASS}
     >
       {body}
     </Streamdown>

--- a/renderer/src/features/skills/lib/__tests__/get-skill-oci-ref.test.ts
+++ b/renderer/src/features/skills/lib/__tests__/get-skill-oci-ref.test.ts
@@ -1,0 +1,77 @@
+import { expect, it, describe } from 'vitest'
+import { getSkillOciRef } from '../get-skill-oci-ref'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+
+describe('getSkillOciRef', () => {
+  it('returns undefined when skill has no packages, namespace, or name', () => {
+    expect(getSkillOciRef({})).toBeUndefined()
+  })
+
+  it('returns the identifier of the first OCI package', () => {
+    const skill: RegistrySkill = {
+      namespace: 'io.github.stacklok',
+      name: 'my-skill',
+      packages: [
+        { registryType: 'oci', identifier: 'ghcr.io/org/my-skill:v1' },
+      ],
+    }
+    expect(getSkillOciRef(skill)).toBe('ghcr.io/org/my-skill:v1')
+  })
+
+  it('skips OCI packages that have no identifier', () => {
+    const skill: RegistrySkill = {
+      namespace: 'io.github.stacklok',
+      name: 'my-skill',
+      packages: [
+        { registryType: 'oci' },
+        { registryType: 'oci', identifier: 'ghcr.io/org/my-skill:v2' },
+      ],
+    }
+    expect(getSkillOciRef(skill)).toBe('ghcr.io/org/my-skill:v2')
+  })
+
+  it('falls back to namespace/name when there are only git packages (catalog skills)', () => {
+    const skill: RegistrySkill = {
+      namespace: 'io.github.stacklok',
+      name: 'skill-creator',
+      packages: [
+        {
+          registryType: 'git',
+          url: 'https://github.com/stacklok/toolhive-catalog',
+          subfolder: 'registries/toolhive/skills/skill-creator',
+        },
+      ],
+    }
+    expect(getSkillOciRef(skill)).toBe('io.github.stacklok/skill-creator')
+  })
+
+  it('falls back to namespace/name when packages is empty', () => {
+    const skill: RegistrySkill = {
+      namespace: 'io.github.stacklok',
+      name: 'my-skill',
+      packages: [],
+    }
+    expect(getSkillOciRef(skill)).toBe('io.github.stacklok/my-skill')
+  })
+
+  it('prefers OCI identifier over namespace/name fallback', () => {
+    const skill: RegistrySkill = {
+      namespace: 'io.github.stacklok',
+      name: 'my-skill',
+      packages: [
+        {
+          registryType: 'git',
+          url: 'https://github.com/stacklok/toolhive-catalog',
+        },
+        { registryType: 'oci', identifier: 'ghcr.io/org/my-skill:v1' },
+      ],
+    }
+    expect(getSkillOciRef(skill)).toBe('ghcr.io/org/my-skill:v1')
+  })
+
+  it('returns undefined when no packages and no namespace/name', () => {
+    expect(
+      getSkillOciRef({ packages: [{ registryType: 'oci' }] })
+    ).toBeUndefined()
+  })
+})

--- a/renderer/src/features/skills/lib/get-skill-oci-ref.ts
+++ b/renderer/src/features/skills/lib/get-skill-oci-ref.ts
@@ -1,0 +1,17 @@
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+
+/**
+ * Derives the ref to use for fetching SKILL.md content via the content API.
+ * Prefers the identifier of the first OCI package. Falls back to
+ * `namespace/name` (e.g. "io.github.stacklok/skill-creator") since the
+ * content endpoint accepts that format directly. Git package URLs are the
+ * catalog repo, not a per-skill ref, so they are intentionally ignored.
+ */
+export function getSkillOciRef(skill: RegistrySkill): string | undefined {
+  const oci = skill.packages?.find(
+    (p) => p.registryType === 'oci' && p.identifier
+  )
+  if (oci) return oci.identifier
+  if (skill.namespace && skill.name) return `${skill.namespace}/${skill.name}`
+  return undefined
+}


### PR DESCRIPTION
The skill and local build detail pages previously rendered a placeholder (`Skill.md rendering is not yet available`) where the SKILL.md body should live. This PR wires both detail pages to the `/api/v1beta/skills/content` endpoint, renders the markdown with streamdown, and reworks the shared detail layout so the summary + actions stay visible while the Skill.md content scrolls.

- Add `SkillMarkdown` component that fetches the body via `getApiV1BetaSkillsContent`, renders with `Streamdown` (code + mermaid + cjk plugins), and handles loading (skeleton), 404, 503, generic errors, and empty body states
- Add a `stripFrontmatter` prop on `SkillMarkdown` that drops the leading YAML frontmatter block before rendering; used on the local build detail page where `name` / `description` duplicate the header and summary
- Add `getSkillOciRef` helper that derives a content-endpoint ref from a `RegistrySkill`, preferring the first OCI package identifier and falling back to `namespace/name` (git package URLs are intentionally ignored — they point at the catalog repo, not a per-skill ref)
- Render the markdown panel on the registry skill detail page and the local build detail page; local builds pass `build.tag` directly since the `ref` query param accepts OCI refs and local build tags
- Swap the local build detail actions to `Remove` + `Install` to match the card footer order and let the single Install button on the registry detail render at its natural width instead of stretching the column
- Rework `SkillDetailLayout` so the left column (title, badges, Summary, actions) becomes `md:sticky md:top-0` while the Skill.md panel scrolls next to it
- When the original header scrolls out of view (via `IntersectionObserver`), reveal a condensed Back + Title + badges block at the top of the sticky column with a smooth `grid-template-rows` + opacity + margin transition; the transition is suppressed under `motion-reduce`
- Keep `Summary` aligned with `Skill.md` when the condensed header is hidden by collapsing the parent `flex gap-6` with a matching `-mb-6` on the reveal container
- Add MSW fixture and unit tests for `SkillMarkdown` covering success, 404, 503, generic errors, empty body, frontmatter stripping, and the non-stripping default; add unit tests for `getSkillOciRef`

**Not changed in this PR (deliberate, follow-up):**

- Registry skill detail page does not strip frontmatter today. We can opt in once we confirm the frontmatter on registry SKILL.md entries is also redundant with the header/summary.


https://github.com/user-attachments/assets/1aa90072-44b6-4f4f-8a94-5cdb9eca4f41

