### PR TITLE
feat(ci): sign Windows prereleases with Azure Trusted Signing

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -60,16 +60,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [security, static-checks, unit-tests]
     # Activate the `artifact-signing` environment only for the Windows matrix
-    # row when the release is a prerelease. The Azure OIDC federated
-    # credential for Trusted Signing is scoped to
-    # `repo:stacklok/toolhive-studio:environment:artifact-signing`, so only
-    # that row needs to enter the environment for the token exchange to
-    # succeed. Stable releases (Windows and otherwise) and all non-Windows
-    # prerelease rows stay outside the environment, which keeps them on the
-    # existing DigiCert flow and preserves their current OIDC subject for
-    # AWS (the repo-wide trust policy `repo:stacklok/toolhive-studio:*` also
-    # covers the `environment:artifact-signing` subject, so AWS keeps
-    # working from the Windows prerelease job).
+    # row when the release is a prerelease, because that is the only row
+    # that signs with Azure Trusted Signing. The Azure OIDC federated
+    # credential is scoped to
+    # `repo:stacklok/toolhive-studio:environment:artifact-signing`, so the
+    # job must run in that environment for the Azure token exchange to
+    # succeed. Every other row (Linux and macOS on any release, and
+    # Windows on stable releases) stays outside the environment so it
+    # doesn't inherit the environment-scoped Azure signing secrets or
+    # trigger environment approvals. Windows stable releases continue
+    # signing via DigiCert; Linux/macOS don't do Windows signing at all.
+    #
+    # The AWS role assumed later in the job uses OIDC with the repo-wide
+    # trust policy `repo:stacklok/toolhive-studio:*`, which covers both
+    # `ref:refs/tags/*` (default subject) and
+    # `environment:artifact-signing`, so S3 sync and CloudFront
+    # invalidation keep working from the Windows prerelease job.
     environment: ${{ github.event.release.prerelease == true && matrix.os == 'windows-latest' && 'artifact-signing' || '' }}
     strategy:
       matrix:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -59,6 +59,18 @@ jobs:
     name: Build and Release on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [security, static-checks, unit-tests]
+    # Activate the `artifact-signing` environment only for the Windows matrix
+    # row when the release is a prerelease. The Azure OIDC federated
+    # credential for Trusted Signing is scoped to
+    # `repo:stacklok/toolhive-studio:environment:artifact-signing`, so only
+    # that row needs to enter the environment for the token exchange to
+    # succeed. Stable releases (Windows and otherwise) and all non-Windows
+    # prerelease rows stay outside the environment, which keeps them on the
+    # existing DigiCert flow and preserves their current OIDC subject for
+    # AWS (the repo-wide trust policy `repo:stacklok/toolhive-studio:*` also
+    # covers the `environment:artifact-signing` subject, so AWS keeps
+    # working from the Windows prerelease job).
+    environment: ${{ github.event.release.prerelease == true && matrix.os == 'windows-latest' && 'artifact-signing' || '' }}
     strategy:
       matrix:
         include:
@@ -108,9 +120,28 @@ jobs:
           apple-issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
           apple-key-id: ${{ secrets.APPLE_KEY_ID }}
 
-      - name: Setup Windows code signing
+      # Windows prerelease builds sign with Azure Trusted Signing (OIDC, no
+      # long-lived secrets). The calling job must be in the
+      # `artifact-signing` environment above so the federated credential
+      # subject `repo:.../environment:artifact-signing` is satisfied.
+      - name: Setup Windows code signing (Azure Trusted Signing — prerelease)
+        uses: ./.github/actions/setup-azure-trusted-signing
+        if: runner.os == 'Windows' && github.event.release.prerelease == true
+        with:
+          azure-client-id: ${{ secrets.AZURE_ARTIFACT_SIGNING_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_ARTIFACT_SIGNING_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_ARTIFACT_SIGNING_SUBSCRIPTION_ID }}
+          azure-endpoint: ${{ secrets.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          azure-account-name: ${{ secrets.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          azure-certificate-profile-name: ${{ secrets.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+
+      # Windows stable releases continue to sign with DigiCert KeyLocker
+      # until the Azure flow is validated end-to-end via prereleases. Remove
+      # this step (and the `setup-windows-codesign` action) once stable
+      # releases are also migrated to Azure Trusted Signing.
+      - name: Setup Windows code signing (DigiCert KeyLocker — stable)
         uses: ./.github/actions/setup-windows-codesign
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && github.event.release.prerelease != true
         with:
           sm-host: ${{ secrets.SM_HOST }}
           sm-api-key: ${{ secrets.SM_API_KEY }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -270,16 +270,15 @@ Where it's wired up today:
   only (`*-alpha`, `*-beta`, `*-rc`). Stable releases still sign via DigiCert
   until the Azure flow is validated end-to-end on prereleases.
 
-The `artifact-signing` environment is activated only for the Windows matrix
-row of those jobs. Non-Windows rows and stable Windows releases stay outside
-the environment, so they don't pick up its secrets or gating.
+The `artifact-signing` environment is activated only for the Windows matrix row
+of those jobs. Non-Windows rows and stable Windows releases stay outside the
+environment, so they don't pick up its secrets or gating.
 
 #### Windows Signing (DigiCert KeyLocker — legacy fallback)
 
 Kept for stable releases while Azure Trusted Signing is validated on
-prereleases. Used by
-[`on-release.yml`](../.github/workflows/on-release.yml) when
-`github.event.release.prerelease != true`. Remove the step and the
+prereleases. Used by [`on-release.yml`](../.github/workflows/on-release.yml)
+when `github.event.release.prerelease != true`. Remove the step and the
 [`setup-windows-codesign`](../.github/actions/setup-windows-codesign/action.yml)
 action once stable releases are also migrated. Requires these GitHub secrets:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -262,13 +262,26 @@ picks this up through
 [`utils/windows-sign-azure.ts`](../utils/windows-sign-azure.ts) and signs the
 app + installer during `pnpm run make` / `pnpm run publish`.
 
-Try it on a PR by commenting `/build-test --sign-windows`.
+Where it's wired up today:
+
+- [`pr-build-test.yml`](../.github/workflows/pr-build-test.yml) — any PR that
+  opts in via `/build-test --sign-windows`.
+- [`on-release.yml`](../.github/workflows/on-release.yml) — **prerelease** tags
+  only (`*-alpha`, `*-beta`, `*-rc`). Stable releases still sign via DigiCert
+  until the Azure flow is validated end-to-end on prereleases.
+
+The `artifact-signing` environment is activated only for the Windows matrix
+row of those jobs. Non-Windows rows and stable Windows releases stay outside
+the environment, so they don't pick up its secrets or gating.
 
 #### Windows Signing (DigiCert KeyLocker — legacy fallback)
 
-Kept as a fallback while Azure Trusted Signing is being validated. Used by
-[`on-release.yml`](../.github/workflows/on-release.yml) until the migration is
-complete. Requires these GitHub secrets:
+Kept for stable releases while Azure Trusted Signing is validated on
+prereleases. Used by
+[`on-release.yml`](../.github/workflows/on-release.yml) when
+`github.event.release.prerelease != true`. Remove the step and the
+[`setup-windows-codesign`](../.github/actions/setup-windows-codesign/action.yml)
+action once stable releases are also migrated. Requires these GitHub secrets:
 
 - `SM_HOST` - DigiCert KeyLocker host URL
 - `SM_API_KEY` - DigiCert KeyLocker API key


### PR DESCRIPTION
Follow-up to #2021. That PR migrated the PR test-build signing path (`/build-test --sign-windows`) to Azure Trusted Signing; this PR extends the same flow to **prerelease tags** (`*-alpha`, `*-beta`, `*-rc`) in `on-release.yml`. Stable releases continue to sign via DigiCert KeyLocker until the Azure flow is confirmed end-to-end on prereleases, after which the DigiCert step and `setup-windows-codesign` action can be removed.

- Replace the single Windows signing step in `on-release.yml`'s `build-and-release` job with two conditional steps: the `setup-azure-trusted-signing` composite action (OIDC, no long-lived secrets) for `github.event.release.prerelease == true`, and the existing `setup-windows-codesign` action (DigiCert KeyLocker) for stable releases
- Scope the `artifact-signing` GitHub environment to the Windows matrix row only (`matrix.os == 'windows-latest' && github.event.release.prerelease == true`), so the Azure OIDC federated credential subject (`repo:stacklok/toolhive-studio:environment:artifact-signing`) is satisfied without enrolling Linux/macOS rows or stable Windows releases into the environment
- No changes to `forge.config.ts` / `utils/windows-sign-azure.ts`: the existing helper already prefers Azure when its env vars are present and falls back to DigiCert, so both flows work with the same build entrypoint
- Update `docs/README.md` to note that Azure Trusted Signing is wired into both `pr-build-test.yml` and `on-release.yml` (for prereleases), and scope the DigiCert fallback note to stable releases

### AWS OIDC compatibility

The `build-and-release` job assumes an AWS IAM role via OIDC for S3 sync and CloudFront invalidation. Entering the `artifact-signing` environment changes the OIDC token subject from `repo:.../ref:refs/tags/vX.Y.Z` to `repo:.../environment:artifact-signing`. The existing trust policy already uses the wildcard `repo:stacklok/toolhive-studio:*`, so both subjects are accepted and AWS steps on the Windows prerelease runner keep working unchanged.

### How to validate

Cut a prerelease tag (e.g. `v0.X.Y-rc.1`) and watch the `Build and Release on windows-latest` job:

- It should enter the `artifact-signing` environment
- The `Setup Windows code signing (Azure Trusted Signing — prerelease)` step should run (the DigiCert step will be skipped via `if:`)
- `pnpm run publish` should produce signed artifacts via `signtool.exe` + Azure Code Signing DLib

Stable tags (no `-alpha`/`-beta`/`-rc`) should continue to run the DigiCert step exactly as before.

### Not changed in this PR (deliberate, follow-up)

- Stable releases still sign via DigiCert. Once prereleases have successfully signed a few times, a follow-up will flip the remaining branch of the conditional and remove the `setup-windows-codesign` composite action entirely.