### PR TITLE
fix(ci): pin Coveralls git-commit to PR head to dedupe status posts

### DIFF
--- a/.github/workflows/_unit-tests.yml
+++ b/.github/workflows/_unit-tests.yml
@@ -21,3 +21,5 @@ jobs:
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           file: ./coverage/lcov.info
+          git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          git-branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
Every PR has been getting two `coverage/coveralls` status posts on the same head SHA, 2–3 minutes apart, each pointing at a different `coveralls.io/builds/<id>` URL (see PR #2032 — `builds/78939336` and `builds/78939464` both landed on the same SHA with identical `Coverage decreased (-0.02%) to 63.188%` descriptions). This is not the Coveralls GitHub App double-posting the same build; it's the Coveralls service creating two separate **builds** for a single upload, then posting one status per build.

The root cause (docted in [lemurheavy/coveralls-public#1739](https://github.com/lemurheavy/coveralls-public/issues/1739)) is that on `pull_request` events GitHub runs the workflow against a temporary merge SHA (`refs/pull/N/merge`) and `$GITHUB_SHA` points at that merge commit. `coverallsapp/github-action` auto-detects the commit from `$GITHUB_SHA`, so Coveralls registers a build against the merge SHA; it then *also* associates the build with the PR head SHA, producing the second build + second status.

- Pass `git-commit: ${{ github.event.pull_request.head.sha || github.sha }}` to `coverallsapp/github-action` so on PRs the build is bound directly to the PR head SHA (eliminating the phantom merge-commit build), and on pushes to `main` it falls back to `github.sha` unchanged
- Pass `git-branch: ${{ github.head_ref || github.ref_name }}` so the Coveralls build card shows the PR's real source branch instead of `refs/pull/N/merge` on pull_request events, and the actual branch name (`main`) on push events
- No change to upload payload, lcov path, token, or workflow triggers. The reusable workflow is still called from both `on-pr.yml` (pull_request) and `on-main.yml` (push); both expressions resolve correctly in each caller

### Validation

On any PR opened after this merges, `gh api repos/stacklok/toolhive-studio/commits/<head-sha>/statuses --jq '.[] | select(.context=="coverage/coveralls")'` should return exactly one entry (not two), and the single `coveralls.io/builds/<id>` page should show the PR's source branch name (not `refs/pull/N/merge`).

### Not changed in this PR (deliberate)

- No change to the Coveralls repo settings on coveralls.io (no need — pinning the commit removes the duplicate at the source)
- No change to the action version, token, or any other input. `github-token` keeps its default `${{ github.token }}`
- Companion to the test-side fix in #<PR-for-coveralls-fix-branch>, which removes the `-0.02%` flake itself. This PR removes the *double* post; that PR removes the *spurious* regression.