### PR TITLE
fix(ipc): validate workload payload on utils:get-workload-available-tools handler

### DIFF
--- a/main/src/ipc-handlers/__tests__/utils.test.ts
+++ b/main/src/ipc-handlers/__tests__/utils.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const ctx = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
+  return {
+    handlers,
+    getHeaders: vi.fn(() => ({ 'x-test': '1' })),
+    getInstanceId: vi.fn().mockResolvedValue('instance-abc'),
+    isOfficialReleaseBuild: vi.fn(() => false),
+    getWorkloadAvailableTools: vi.fn(),
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (
+      channel: string,
+      handler: (...args: unknown[]) => Promise<unknown>
+    ) => {
+      ctx.handlers.set(channel, handler)
+    },
+  },
+}))
+
+vi.mock('../../headers', () => ({
+  getHeaders: ctx.getHeaders,
+}))
+
+vi.mock('../../util', () => ({
+  getInstanceId: ctx.getInstanceId,
+  isOfficialReleaseBuild: ctx.isOfficialReleaseBuild,
+}))
+
+vi.mock('../../utils/mcp-tools', () => ({
+  getWorkloadAvailableTools: ctx.getWorkloadAvailableTools,
+}))
+
+import { register } from '../utils'
+
+describe('utils IPC handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ctx.handlers.clear()
+    register()
+  })
+
+  describe('utils:get-workload-available-tools', () => {
+    const invoke = async (payload: unknown) => {
+      const handler = ctx.handlers.get('utils:get-workload-available-tools')!
+      return handler(null, payload)
+    }
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['string', 'not-an-object'],
+      ['number', 42],
+      ['array', [{ name: 'x' }]],
+    ])(
+      'rejects non-object payload (%s) with TypeError',
+      async (_label, bad) => {
+        await expect(invoke(bad)).rejects.toBeInstanceOf(TypeError)
+        expect(ctx.getWorkloadAvailableTools).not.toHaveBeenCalled()
+      }
+    )
+
+    it('rejects invalid transport_type (prototype key)', async () => {
+      await expect(
+        invoke({ name: 'a', transport_type: '__proto__' })
+      ).rejects.toBeInstanceOf(TypeError)
+      await expect(
+        invoke({ name: 'a', transport_type: 'constructor' })
+      ).rejects.toBeInstanceOf(TypeError)
+      expect(ctx.getWorkloadAvailableTools).not.toHaveBeenCalled()
+    })
+
+    it('rejects invalid proxy_mode', async () => {
+      await expect(
+        invoke({ name: 'a', proxy_mode: 'stdio' })
+      ).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('rejects non-integer or out-of-range port', async () => {
+      await expect(
+        invoke({ name: 'a', port: Number.NaN })
+      ).rejects.toBeInstanceOf(TypeError)
+      await expect(
+        invoke({ name: 'a', port: Number.POSITIVE_INFINITY })
+      ).rejects.toBeInstanceOf(TypeError)
+      await expect(invoke({ name: 'a', port: 3.14 })).rejects.toBeInstanceOf(
+        TypeError
+      )
+      await expect(invoke({ name: 'a', port: -1 })).rejects.toBeInstanceOf(
+        TypeError
+      )
+      await expect(invoke({ name: 'a', port: 70000 })).rejects.toBeInstanceOf(
+        TypeError
+      )
+    })
+
+    it('rejects non-http(s) url', async () => {
+      await expect(
+        invoke({ name: 'a', url: 'file:///etc/passwd' })
+      ).rejects.toBeInstanceOf(TypeError)
+      await expect(
+        invoke({ name: 'a', url: 'javascript:alert(1)' })
+      ).rejects.toBeInstanceOf(TypeError)
+      await expect(
+        invoke({ name: 'a', url: 'not a url' })
+      ).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('rejects non-string name / non-boolean remote', async () => {
+      await expect(invoke({ name: 123 })).rejects.toBeInstanceOf(TypeError)
+      await expect(
+        invoke({ name: 'a', remote: 'true' })
+      ).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('forwards a valid full workload to getWorkloadAvailableTools', async () => {
+      ctx.getWorkloadAvailableTools.mockResolvedValue({ tool: {} })
+      const workload = {
+        name: 'weather',
+        url: 'http://localhost:3000/mcp',
+        transport_type: 'streamable-http',
+        proxy_mode: 'streamable-http',
+        port: 3000,
+        remote: false,
+      }
+
+      const result = await invoke(workload)
+
+      expect(ctx.getWorkloadAvailableTools).toHaveBeenCalledWith(workload)
+      expect(result).toEqual({ tool: {} })
+    })
+
+    it('forwards a valid partial workload (empty object) — consumer returns null when name is missing', async () => {
+      ctx.getWorkloadAvailableTools.mockResolvedValue(null)
+
+      const result = await invoke({})
+
+      expect(ctx.getWorkloadAvailableTools).toHaveBeenCalledWith({})
+      expect(result).toBeNull()
+    })
+
+    it('tolerates empty url string (createTransport falls back to localhost)', async () => {
+      ctx.getWorkloadAvailableTools.mockResolvedValue({})
+      await invoke({ name: 'a', url: '' })
+      expect(ctx.getWorkloadAvailableTools).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('telemetry-headers returns current headers', () => {
+    const handler = ctx.handlers.get('telemetry-headers')!
+    expect(handler(null)).toEqual({ 'x-test': '1' })
+  })
+
+  it('is-official-release-build returns the flag', () => {
+    const handler = ctx.handlers.get('is-official-release-build')!
+    expect(handler(null)).toBe(false)
+  })
+
+  it('get-instance-id returns the resolved id', async () => {
+    const handler = ctx.handlers.get('get-instance-id')!
+    await expect(handler(null)).resolves.toBe('instance-abc')
+  })
+})

--- a/main/src/ipc-handlers/utils.ts
+++ b/main/src/ipc-handlers/utils.ts
@@ -4,22 +4,59 @@ import { getHeaders } from '../headers'
 import { getInstanceId, isOfficialReleaseBuild } from '../util'
 import { getWorkloadAvailableTools } from '../utils/mcp-tools'
 
+// Allowlists for fields that are later used to index into lookup tables or
+// construct URLs/connections in `createTransport`. Keeping these explicit makes
+// the IPC boundary reject unexpected values (including prototype keys like
+// `__proto__` or `constructor`) before they reach the transport layer.
+const VALID_TRANSPORT_TYPES = new Set(['stdio', 'streamable-http', 'sse'])
+const VALID_PROXY_MODES = new Set(['sse', 'streamable-http'])
+const MAX_TCP_PORT = 65535
+
 function isOptionalString(value: unknown): value is string | undefined {
   return value === undefined || typeof value === 'string'
-}
-
-function isOptionalNumber(value: unknown): value is number | undefined {
-  return value === undefined || typeof value === 'number'
 }
 
 function isOptionalBoolean(value: unknown): value is boolean | undefined {
   return value === undefined || typeof value === 'boolean'
 }
 
+function isOptionalEnum(
+  value: unknown,
+  allowed: ReadonlySet<string>
+): value is string | undefined {
+  return (
+    value === undefined || (typeof value === 'string' && allowed.has(value))
+  )
+}
+
+function isOptionalTcpPort(value: unknown): value is number | undefined {
+  if (value === undefined) return true
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= MAX_TCP_PORT
+  )
+}
+
+function isOptionalHttpUrl(value: unknown): value is string | undefined {
+  if (value === undefined) return true
+  if (typeof value !== 'string') return false
+  // Empty string is tolerated: `createTransport` treats it as "no url" and
+  // falls back to `http://localhost:<port>/mcp`.
+  if (value === '') return true
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 // Validates that an untrusted IPC payload matches the subset of `CoreWorkload`
-// that `getWorkloadAvailableTools` relies on. We do not exhaustively validate
-// every field on the generated type; we only enforce the shape required by the
-// consumer so malformed or malicious payloads are rejected at the boundary.
+// that `getWorkloadAvailableTools` / `createTransport` rely on. Only fields
+// consumed by the downstream code are validated; fields like labels or
+// created_at are ignored here because the consumer never reads them.
 function isCoreWorkload(value: unknown): value is CoreWorkload {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return false
@@ -27,10 +64,12 @@ function isCoreWorkload(value: unknown): value is CoreWorkload {
   const workload = value as Record<string, unknown>
 
   if (!isOptionalString(workload.name)) return false
-  if (!isOptionalString(workload.url)) return false
-  if (!isOptionalString(workload.transport_type)) return false
-  if (!isOptionalString(workload.proxy_mode)) return false
-  if (!isOptionalNumber(workload.port)) return false
+  if (!isOptionalHttpUrl(workload.url)) return false
+  if (!isOptionalEnum(workload.transport_type, VALID_TRANSPORT_TYPES)) {
+    return false
+  }
+  if (!isOptionalEnum(workload.proxy_mode, VALID_PROXY_MODES)) return false
+  if (!isOptionalTcpPort(workload.port)) return false
   if (!isOptionalBoolean(workload.remote)) return false
 
   return true

--- a/main/src/ipc-handlers/utils.ts
+++ b/main/src/ipc-handlers/utils.ts
@@ -1,7 +1,40 @@
 import { ipcMain } from 'electron'
+import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
 import { getHeaders } from '../headers'
 import { getInstanceId, isOfficialReleaseBuild } from '../util'
 import { getWorkloadAvailableTools } from '../utils/mcp-tools'
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string'
+}
+
+function isOptionalNumber(value: unknown): value is number | undefined {
+  return value === undefined || typeof value === 'number'
+}
+
+function isOptionalBoolean(value: unknown): value is boolean | undefined {
+  return value === undefined || typeof value === 'boolean'
+}
+
+// Validates that an untrusted IPC payload matches the subset of `CoreWorkload`
+// that `getWorkloadAvailableTools` relies on. We do not exhaustively validate
+// every field on the generated type; we only enforce the shape required by the
+// consumer so malformed or malicious payloads are rejected at the boundary.
+function isCoreWorkload(value: unknown): value is CoreWorkload {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+  const workload = value as Record<string, unknown>
+
+  if (!isOptionalString(workload.name)) return false
+  if (!isOptionalString(workload.url)) return false
+  if (!isOptionalString(workload.transport_type)) return false
+  if (!isOptionalString(workload.proxy_mode)) return false
+  if (!isOptionalNumber(workload.port)) return false
+  if (!isOptionalBoolean(workload.remote)) return false
+
+  return true
+}
 
 export function register() {
   ipcMain.handle('telemetry-headers', () => {
@@ -17,7 +50,15 @@ export function register() {
     return instanceId
   })
 
-  ipcMain.handle('utils:get-workload-available-tools', async (_, workload) =>
-    getWorkloadAvailableTools(workload)
+  ipcMain.handle(
+    'utils:get-workload-available-tools',
+    async (_, workload: unknown) => {
+      if (!isCoreWorkload(workload)) {
+        throw new TypeError(
+          'Invalid workload payload for utils:get-workload-available-tools'
+        )
+      }
+      return getWorkloadAvailableTools(workload)
+    }
   )
 }

--- a/preload/src/api/utils.ts
+++ b/preload/src/api/utils.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
 
 export const utilsApi = {
   isOfficialReleaseBuild: () => ipcRenderer.invoke('is-official-release-build'),
@@ -6,7 +7,7 @@ export const utilsApi = {
   getInstanceId: () => ipcRenderer.invoke('get-instance-id'),
 
   utils: {
-    getWorkloadAvailableTools: (workload: unknown) =>
+    getWorkloadAvailableTools: (workload: CoreWorkload) =>
       ipcRenderer.invoke('utils:get-workload-available-tools', workload),
   },
 }
@@ -16,7 +17,7 @@ export interface UtilsAPI {
   getTelemetryHeaders: () => Promise<Record<string, string>>
   getInstanceId: () => Promise<string>
   utils: {
-    getWorkloadAvailableTools: (workload: unknown) => Promise<
+    getWorkloadAvailableTools: (workload: CoreWorkload) => Promise<
       | Record<
           string,
           {

--- a/preload/src/api/utils.ts
+++ b/preload/src/api/utils.ts
@@ -27,6 +27,7 @@ export interface UtilsAPI {
             }
           }
         >
+      | null
       | undefined
     >
   }


### PR DESCRIPTION
#1978 flagged that the `utils:get-workload-available-tools` IPC handler forwarded its `workload` argument straight into `getWorkloadAvailableTools` without validation. The fix in that PR introduced an ad-hoc `Workload` interface (`name: string`) that didn't match the real `CoreWorkload` type — where `name` is optional — and shipped an `isWorkload` type guard that only checked `typeof value === 'object'` while claiming to verify a `name` property (so the `value is Workload` assertion was unsound). This PR replaces that with a real type guard against the generated `CoreWorkload` shape and tightens the preload API contract so callers aren't handed `unknown`.

- Add `isCoreWorkload` in `main/src/ipc-handlers/utils.ts` that rejects non-objects, `null`, and arrays, and validates `name`, `url`, `transport_type`, `proxy_mode`, `port`, and `remote` match their declared types when present — the subset actually consumed by `createTransport` / `getWorkloadAvailableTools`
- Reject malformed payloads at the IPC boundary with a `TypeError` instead of forwarding `unknown` into the AI SDK / MCP client, while still allowing valid partial workloads (the consumer already handles `!workload.name` by returning `null`)
- Reuse `GithubComStacklokToolhivePkgCoreWorkload` from `@common/api/generated/types.gen` rather than redefining a parallel local `Workload` interface
- Tighten `preload/src/api/utils.ts` so `utils.getWorkloadAvailableTools(workload: CoreWorkload)` is strongly typed on both the runtime wrapper and the exported `UtilsAPI` interface, instead of `unknown`. The sole caller (`renderer/.../customize-tools/page.tsx`) already passes a `CoreWorkload`, so no downstream changes are required

### How to validate

- `pnpm run type-check` and `pnpm run lint` pass
- From the renderer, `window.electronAPI.utils.getWorkloadAvailableTools({})` (or any non-object payload) should reject with a `TypeError` at the main-process boundary rather than reaching `createTransport`
- Passing a well-formed `CoreWorkload` — the only real caller path via the Customize Tools page — should behave exactly as before

### Not changed in this PR (deliberate)

- No change to `getWorkloadAvailableTools` itself; its existing `!workload.name → null` contract is preserved
- No change to other IPC handlers. A broader audit of `ipcMain.handle(...)` call sites for similar unvalidated payloads can be a follow-up

Closes #1978.