### PR TITLE
feat(sentry): enable/disable by env var

### DIFF
--- a/main/src/sentry.ts
+++ b/main/src/sentry.ts
@@ -9,6 +9,7 @@ const store = telemetryStore
 
 export function initSentry() {
   Sentry.init({
+    enabled: !!import.meta.env.VITE_SENTRY_DSN,
     dsn: isE2E ? undefined : import.meta.env.VITE_SENTRY_DSN,
     propagateTraceparent: true,
     tracePropagationTargets: ['localhost', /^https?:\/\/127\.0\.0\.1/],

--- a/renderer/src/lib/sentry.ts
+++ b/renderer/src/lib/sentry.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/electron/renderer'
 
 export function initSentry() {
   Sentry.init({
+    enabled: !!import.meta.env.VITE_SENTRY_DSN,
     // Adds request headers and IP for users, for more info visit:
     // https://docs.sentry.io/platforms/javascript/guides/electron/configuration/options/#sendDefaultPii
     sendDefaultPii: true,


### PR DESCRIPTION
When `VITE_SENTRY_DSN` is not set, Sentry is initialized but still active — `beforeSend` callbacks run, integrations are registered, and the SDK attempts to send events (which silently fail without a DSN). Adding `enabled: !!import.meta.env.VITE_SENTRY_DSN` skips initialization entirely when no DSN is configured, avoiding unnecessary overhead in local dev and downstream distributions.