### PR TITLE
feat(skills): align skills page and cards with design

### DIFF
--- a/renderer/src/common/components/ui/tabs.tsx
+++ b/renderer/src/common/components/ui/tabs.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react'
 import * as TabsPrimitive from '@radix-ui/react-tabs'
+import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/common/lib/utils'
+
+type TabsVariant = 'default' | 'pill'
+
+const TabsVariantContext = React.createContext<TabsVariant>('default')
 
 function Tabs({
   className,
@@ -16,41 +21,80 @@ function Tabs({
   )
 }
 
+const tabsListVariants = cva(
+  'text-muted-foreground inline-flex w-fit items-center justify-center',
+  {
+    variants: {
+      variant: {
+        default: 'bg-muted h-9 rounded-lg p-[3px]',
+        pill: 'h-auto rounded-full bg-zinc-200 p-1 dark:bg-zinc-800',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
 function TabsList({
   className,
+  variant,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  const resolvedVariant: TabsVariant = variant ?? 'default'
   return (
-    <TabsPrimitive.List
-      data-slot="tabs-list"
-      className={cn(
-        `bg-muted text-muted-foreground inline-flex h-9 w-fit items-center
-        justify-center rounded-lg p-[3px]`,
-        className
-      )}
-      {...props}
-    />
+    <TabsVariantContext.Provider value={resolvedVariant}>
+      <TabsPrimitive.List
+        data-slot="tabs-list"
+        data-variant={resolvedVariant}
+        className={cn(
+          tabsListVariants({ variant: resolvedVariant }),
+          className
+        )}
+        {...props}
+      />
+    </TabsVariantContext.Provider>
   )
 }
 
+const tabsTriggerVariants = cva(
+  `data-[state=active]:bg-background dark:data-[state=active]:bg-card
+  dark:data-[state=active]:text-foreground focus-visible:border-ring
+  focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground
+  dark:text-muted-foreground inline-flex flex-1 items-center justify-center
+  gap-1.5 border border-transparent text-sm font-medium whitespace-nowrap
+  transition-[color,box-shadow] focus-visible:ring-[3px]
+  focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50
+  [&_svg]:pointer-events-none [&_svg]:shrink-0
+  [&_svg:not([class*='size-'])]:size-4`,
+  {
+    variants: {
+      variant: {
+        default:
+          'h-[calc(100%-1px)] rounded-md px-2 py-1 data-[state=active]:shadow-sm',
+        pill: 'rounded-full px-3 py-1.5',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
 function TabsTrigger({
   className,
+  variant,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+}: React.ComponentProps<typeof TabsPrimitive.Trigger> &
+  VariantProps<typeof tabsTriggerVariants>) {
+  const contextVariant = React.useContext(TabsVariantContext)
+  const resolvedVariant: TabsVariant = variant ?? contextVariant
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        `data-[state=active]:bg-background dark:data-[state=active]:bg-card
-        dark:data-[state=active]:text-foreground focus-visible:border-ring
-        focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground
-        dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1
-        items-center justify-center gap-1.5 rounded-md border border-transparent
-        px-2 py-1 text-sm font-medium whitespace-nowrap
-        transition-[color,box-shadow] focus-visible:ring-[3px]
-        focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50
-        data-[state=active]:shadow-sm [&_svg]:pointer-events-none
-        [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`,
+        tabsTriggerVariants({ variant: resolvedVariant }),
         className
       )}
       {...props}

--- a/renderer/src/features/skills/components/__tests__/card-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-skill.test.tsx
@@ -111,8 +111,10 @@ describe('CardSkill', () => {
       const overflow = screen.getByRole('button', { name: '2 more clients' })
       overflow.focus()
 
-      expect(await screen.findByText('vscode')).toBeInTheDocument()
-      expect(screen.getByText('windsurf')).toBeInTheDocument()
+      // Radix renders tooltip content twice (visible + aria-describedby
+      // mirror for screen readers), so both matches are expected.
+      expect((await screen.findAllByText('vscode')).length).toBeGreaterThan(0)
+      expect(screen.getAllByText('windsurf').length).toBeGreaterThan(0)
     })
   })
 

--- a/renderer/src/features/skills/components/__tests__/card-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-skill.test.tsx
@@ -72,4 +72,63 @@ describe('CardSkill', () => {
       screen.getByRole('heading', { name: /uninstall skill/i })
     ).toBeInTheDocument()
   })
+
+  describe('client badges overflow', () => {
+    it('renders all clients inline when count is at or below the cap', () => {
+      renderWithProviders(
+        <CardSkill
+          skill={{ ...baseSkill, clients: ['cursor', 'claude-code', 'codex'] }}
+        />
+      )
+
+      expect(screen.getByText('cursor')).toBeInTheDocument()
+      expect(screen.getByText('claude-code')).toBeInTheDocument()
+      expect(screen.getByText('codex')).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /more clients/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('caps visible client badges at 3 and shows a "+N" overflow trigger', () => {
+      const clients = ['cursor', 'claude-code', 'codex', 'vscode', 'windsurf']
+      renderWithProviders(<CardSkill skill={{ ...baseSkill, clients }} />)
+
+      expect(screen.getByText('cursor')).toBeInTheDocument()
+      expect(screen.getByText('claude-code')).toBeInTheDocument()
+      expect(screen.getByText('codex')).toBeInTheDocument()
+      expect(screen.queryByText('vscode')).not.toBeInTheDocument()
+      expect(screen.queryByText('windsurf')).not.toBeInTheDocument()
+
+      const overflow = screen.getByRole('button', { name: '2 more clients' })
+      expect(overflow).toBeInTheDocument()
+      expect(overflow).toHaveTextContent('+2')
+    })
+
+    it('reveals hidden clients in the overflow tooltip on focus', async () => {
+      const clients = ['cursor', 'claude-code', 'codex', 'vscode', 'windsurf']
+      renderWithProviders(<CardSkill skill={{ ...baseSkill, clients }} />)
+
+      const overflow = screen.getByRole('button', { name: '2 more clients' })
+      overflow.focus()
+
+      expect(await screen.findByText('vscode')).toBeInTheDocument()
+      expect(screen.getByText('windsurf')).toBeInTheDocument()
+    })
+  })
+
+  describe('project-scoped card layout', () => {
+    it('shows project root badge derived from project_root', () => {
+      renderWithProviders(
+        <CardSkill
+          skill={{
+            ...baseSkill,
+            scope: 'project',
+            project_root: '/Users/me/code/my-repo',
+          }}
+        />
+      )
+
+      expect(screen.getByText('/my-repo')).toBeInTheDocument()
+    })
+  })
 })

--- a/renderer/src/features/skills/components/card-skill-base.tsx
+++ b/renderer/src/features/skills/components/card-skill-base.tsx
@@ -76,17 +76,9 @@ export function CardSkillBase({
 
       <CardContent className="flex-1">
         {description && (
-          <Tooltip onlyWhenTruncated>
-            <TooltipTrigger asChild>
-              <p
-                className="text-muted-foreground line-clamp-3 text-sm
-                  select-none"
-              >
-                {description}
-              </p>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-xs">{description}</TooltipContent>
-          </Tooltip>
+          <p className="text-muted-foreground line-clamp-3 text-sm select-none">
+            {description}
+          </p>
         )}
       </CardContent>
 

--- a/renderer/src/features/skills/components/card-skill.tsx
+++ b/renderer/src/features/skills/components/card-skill.tsx
@@ -43,11 +43,13 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
       {hiddenClients.length > 0 && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Badge
-              variant="outline"
-              aria-label={`${hiddenClients.length} more clients`}
-            >
-              +{hiddenClients.length}
+            <Badge asChild variant="outline">
+              <button
+                type="button"
+                aria-label={`${hiddenClients.length} more clients`}
+              >
+                +{hiddenClients.length}
+              </button>
             </Badge>
           </TooltipTrigger>
           <TooltipContent className="max-w-xs">

--- a/renderer/src/features/skills/components/card-skill.tsx
+++ b/renderer/src/features/skills/components/card-skill.tsx
@@ -6,7 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/common/components/ui/tooltip'
-import { Trash2Icon } from 'lucide-react'
+import { FolderGit2Icon, Trash2Icon, UserIcon } from 'lucide-react'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { DialogUninstallSkill } from './dialog-uninstall-skill'
 import { CardSkillBase } from './card-skill-base'
@@ -17,47 +17,88 @@ const statusVariantMap = {
   failed: 'destructive',
 } as const
 
+const MAX_VISIBLE_CLIENTS = 3
+
 export function CardSkill({ skill }: { skill: InstalledSkill }) {
   const [uninstallOpen, setUninstallOpen] = useState(false)
 
   const title = skill.metadata?.name ?? skill.reference ?? 'Unknown skill'
   const status = skill.status
   const scope = skill.scope
-  const clients = skill.clients
+  const clients = skill.clients ?? []
+  const visibleClients = clients.slice(0, MAX_VISIBLE_CLIENTS)
+  const hiddenClients = clients.slice(MAX_VISIBLE_CLIENTS)
   const projectRoot = scope === 'project' ? skill.project_root : undefined
   const projectRootLabel = projectRoot
     ? `/${projectRoot.split(/[\\/]/).filter(Boolean).at(-1) ?? projectRoot}`
     : null
 
-  const badges = (
-    <div className="flex flex-wrap gap-1.5">
-      {status && (
-        <Badge variant={statusVariantMap[status] ?? 'secondary'}>
-          {status}
-        </Badge>
-      )}
-      {scope && (
-        <Badge variant="outline" className="capitalize">
-          {scope}
-        </Badge>
-      )}
-      {projectRootLabel && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Badge variant="outline" className="font-mono">
-              {projectRootLabel}
-            </Badge>
-          </TooltipTrigger>
-          <TooltipContent className="max-w-xs font-mono text-xs break-all">
-            {projectRoot}
-          </TooltipContent>
-        </Tooltip>
-      )}
-      {clients?.map((client) => (
+  const clientBadges = (
+    <>
+      {visibleClients.map((client) => (
         <Badge key={client} variant="outline">
           {client}
         </Badge>
       ))}
+      {hiddenClients.length > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge
+              variant="outline"
+              aria-label={`${hiddenClients.length} more clients`}
+            >
+              +{hiddenClients.length}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            <ul className="flex flex-col gap-0.5 text-xs">
+              {hiddenClients.map((client) => (
+                <li key={client}>{client}</li>
+              ))}
+            </ul>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </>
+  )
+
+  const isProjectScope = scope === 'project'
+
+  const badges = (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-wrap gap-1.5">
+        {status && (
+          <Badge variant={statusVariantMap[status] ?? 'secondary'}>
+            {status}
+          </Badge>
+        )}
+        {scope && (
+          <Badge variant="secondary" className="capitalize">
+            {scope === 'project' ? (
+              <FolderGit2Icon aria-hidden />
+            ) : (
+              <UserIcon aria-hidden />
+            )}
+            {scope}
+          </Badge>
+        )}
+        {projectRootLabel && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge variant="outline" className="font-mono">
+                {projectRootLabel}
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs font-mono text-xs break-all">
+              {projectRoot}
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {!isProjectScope && clientBadges}
+      </div>
+      {isProjectScope && clients.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">{clientBadges}</div>
+      )}
     </div>
   )
 

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -4,7 +4,6 @@ import {
   getApiV1BetaSkillsOptions,
   getRegistryByRegistryNameV01xDevToolhiveSkillsOptions,
 } from '@common/api/generated/@tanstack/react-query.gen'
-import { TitlePage } from '@/common/components/title-page'
 import { InputSearch } from '@/common/components/ui/input-search'
 import { Button } from '@/common/components/ui/button'
 import { EmptyState } from '@/common/components/empty-state'
@@ -20,16 +19,14 @@ import {
 import { GridCardsSkills } from './grid-cards-skills'
 import { GridCardsBuilds } from './grid-cards-builds'
 import { GridCardsRegistrySkills } from './grid-cards-registry-skills'
-import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogBuildSkill } from './dialog-build-skill'
-import { PlusIcon, HammerIcon } from 'lucide-react'
+import { HammerIcon } from 'lucide-react'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 
 type Tab = 'registry' | 'installed' | 'builds'
 
 export function SkillsPage() {
-  const [installOpen, setInstallOpen] = useState(false)
   const [buildOpen, setBuildOpen] = useState(false)
   const { tab } = useSearch({ from: '/skills' })
   const navigate = useNavigate({ from: '/skills' })
@@ -84,60 +81,52 @@ export function SkillsPage() {
 
   const hasSkills = skills.length > 0
 
-  const currentFilter =
-    tab === 'registry'
-      ? registrySearch
-      : tab === 'installed'
-        ? installedFilter
-        : buildsFilter
-
-  const setCurrentFilter =
-    tab === 'registry'
-      ? handleRegistrySearchChange
-      : tab === 'installed'
-        ? setInstalledFilter
-        : setBuildsFilter
-
-  const showSearch =
-    tab === 'registry' || (tab === 'installed' && hasSkills) || tab === 'builds'
-
   return (
     <>
-      <TitlePage title="Skills">
-        <div className="flex items-center gap-3">
-          <Button
-            variant="secondary"
-            onClick={() => setBuildOpen(true)}
-            className="shrink-0"
-          >
-            <HammerIcon className="size-4" />
-            Build skill
-          </Button>
-          <Button
-            variant="action"
-            onClick={() => setInstallOpen(true)}
-            className="shrink-0"
-          >
-            <PlusIcon className="size-4" />
-            Install skill
-          </Button>
-        </div>
-      </TitlePage>
-
-      <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
+      <Tabs
+        value={tab}
+        onValueChange={(v) => setTab(v as Tab)}
+        className="gap-4"
+      >
         <div className="flex items-center justify-between gap-4">
-          <TabsList>
+          <TabsList variant="pill">
             <TabsTrigger value="registry">Registry</TabsTrigger>
             <TabsTrigger value="installed">Installed</TabsTrigger>
             <TabsTrigger value="builds">Local Builds</TabsTrigger>
           </TabsList>
-          {showSearch && (
-            <InputSearch
-              value={currentFilter}
-              onChange={(v) => setCurrentFilter(v)}
-              placeholder="Search..."
-            />
-          )}
+          <div className="flex items-center gap-3">
+            {tab === 'registry' && (
+              <InputSearch
+                value={registrySearch}
+                onChange={handleRegistrySearchChange}
+                placeholder="Search..."
+              />
+            )}
+            {tab === 'installed' && hasSkills && (
+              <InputSearch
+                value={installedFilter}
+                onChange={setInstalledFilter}
+                placeholder="Search..."
+              />
+            )}
+            {tab === 'builds' && (
+              <>
+                <InputSearch
+                  value={buildsFilter}
+                  onChange={setBuildsFilter}
+                  placeholder="Search..."
+                />
+                <Button
+                  variant="action"
+                  onClick={() => setBuildOpen(true)}
+                  className="shrink-0"
+                >
+                  <HammerIcon className="size-4" />
+                  Build skill
+                </Button>
+              </>
+            )}
+          </div>
         </div>
 
         <TabsContent value="registry">
@@ -151,12 +140,11 @@ export function SkillsPage() {
               body="Install a skill to extend your AI agent's capabilities."
               actions={[
                 <Button
-                  key="install"
+                  key="browse"
                   variant="action"
-                  onClick={() => setInstallOpen(true)}
+                  onClick={() => setTab('registry')}
                 >
-                  <PlusIcon className="size-4" />
-                  Install skill
+                  Browse registry
                 </Button>,
               ]}
               illustration={IllustrationPackage}
@@ -174,7 +162,6 @@ export function SkillsPage() {
         </TabsContent>
       </Tabs>
 
-      <DialogInstallSkill open={installOpen} onOpenChange={setInstallOpen} />
       <DialogBuildSkill open={buildOpen} onOpenChange={setBuildOpen} />
     </>
   )


### PR DESCRIPTION
The skills page and installed skill cards had drifted from the current Figma design ([registry tab](https://www.figma.com/design/KuQGsgrNzRCGmSTl520Hwh/Toolhive-Open-Source?node-id=4217-12912), [installed tab](https://www.figma.com/design/KuQGsgrNzRCGmSTl520Hwh/Toolhive-Open-Source?node-id=4217-13004)). This PR aligns the page header, tabs, search/actions placement, and card internals with the mockups.

- Drop the `Skills` page title row and move per-tab actions into the tabs row in `skills-page.tsx`. Registry and Installed tabs show only a search input; Local Builds shows search + the `Build skill` action. The Installed empty state no longer exposes an install action — install is now reached via registry cards and the build flow — and instead points users at the Registry tab. The global `DialogInstallSkill`, `PlusIcon`, and `TitlePage` imports plus the `installOpen` state are removed from `SkillsPage`. The `Tabs` root is given `gap-4` so the 16px Figma spacing between the tabs row and the content is honoured.
- Introduce a reusable `pill` variant for the `Tabs` primitive in `tabs.tsx` using `class-variance-authority`. A small `TabsVariantContext` lets `TabsList` propagate its variant to child `TabsTrigger`s so callers only set `variant="pill"` in one place, with the option to override per-trigger. The default variant is unchanged, so `dialog-form-local-mcp.tsx` and `form-run-from-registry` keep their existing look. The pill list uses `bg-zinc-200 dark:bg-zinc-800` (≈ Figma `#e4e4e4`) because the global `--muted` token (`oklch(0.97 0 0)` in light mode) is too light to show a pill container against the page background.
- Move client badges on the installed skill card to their own row when the skill is project-scoped, so the first row holds only identity/metadata (status + scope + `/path`). User-scoped skills keep clients inline with scope to stay compact on short cards. Cap visible client badges at 3 and render a `+N` outline badge for the remainder; hovering it opens a `Tooltip` listing all hidden clients as a `<ul>`, and the badge exposes `aria-label="<n> more clients"` for accessibility.
- Differentiate the scope badge from client badges with a leading icon (`UserIcon` for `user`, `FolderGit2Icon` for `project`) instead of a variant swap, which barely renders in dark mode where `secondary` is nearly identical to the card background.
- Remove the card description tooltip in `card-skill-base.tsx`. The description still truncates visually via `line-clamp-3`, but the full text now lives on the detail page reached by clicking the card, so the hover tooltip was redundant. Title tooltip is kept as a quick affordance.

### Not changed in this PR (deliberate, follow-up)

- The `+ Create` action on the Registry tab shown in the Figma is deferred — we don't have a UX for creating registry entries yet.
- The "All registries" selector and the grid/list view-switcher icons shown in the Figma are not wired up here.
- The base `--muted` token is not changed globally. Raising its lightness would ripple into skeletons, disabled states, and other consumers; the pill container opts into a dedicated colour instead.



https://github.com/user-attachments/assets/4fa804a5-0fb0-4397-abe2-0b687e3bde76

