### PR TITLE
feat: add persisted card/table view toggle for MCP servers and installed skills

### DIFF
--- a/main/src/ipc-handlers/__tests__/index.test.ts
+++ b/main/src/ipc-handlers/__tests__/index.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   registerFeatureFlags: vi.fn(),
   registerTelemetry: vi.fn(),
   registerToolhive: vi.fn(),
+  registerUiPreferences: vi.fn(),
   registerUtils: vi.fn(),
   registerWindow: vi.fn(),
 }))
@@ -23,6 +24,9 @@ vi.mock('../dialogs', () => ({ register: mocks.registerDialogs }))
 vi.mock('../feature-flags', () => ({ register: mocks.registerFeatureFlags }))
 vi.mock('../telemetry', () => ({ register: mocks.registerTelemetry }))
 vi.mock('../toolhive', () => ({ register: mocks.registerToolhive }))
+vi.mock('../ui-preferences', () => ({
+  register: mocks.registerUiPreferences,
+}))
 vi.mock('../utils', () => ({ register: mocks.registerUtils }))
 vi.mock('../window', () => ({ register: mocks.registerWindow }))
 
@@ -45,6 +49,7 @@ describe('registerAllHandlers', () => {
     expect(mocks.registerFeatureFlags).toHaveBeenCalledOnce()
     expect(mocks.registerTelemetry).toHaveBeenCalledOnce()
     expect(mocks.registerToolhive).toHaveBeenCalledOnce()
+    expect(mocks.registerUiPreferences).toHaveBeenCalledOnce()
     expect(mocks.registerUtils).toHaveBeenCalledOnce()
     expect(mocks.registerWindow).toHaveBeenCalledOnce()
   })

--- a/main/src/ipc-handlers/index.ts
+++ b/main/src/ipc-handlers/index.ts
@@ -7,6 +7,7 @@ import { register as registerDialogs } from './dialogs'
 import { register as registerFeatureFlags } from './feature-flags'
 import { register as registerTelemetry } from './telemetry'
 import { register as registerToolhive } from './toolhive'
+import { register as registerUiPreferences } from './ui-preferences'
 import { register as registerUtils } from './utils'
 import { register as registerWindow } from './window'
 
@@ -21,5 +22,6 @@ export function registerAllHandlers() {
   registerFeatureFlags()
   registerChat()
   registerCli()
+  registerUiPreferences()
   registerUtils()
 }

--- a/main/src/ipc-handlers/ui-preferences.ts
+++ b/main/src/ipc-handlers/ui-preferences.ts
@@ -2,19 +2,35 @@ import { ipcMain } from 'electron'
 import {
   getViewModePreference,
   setViewModePreference,
+  UI_PREFERENCE_KEYS,
   type UiPreferenceKey,
   type ViewMode,
 } from '../ui-preferences'
 
+const DEFAULT_VIEW_MODE: ViewMode = 'card'
+
+function isUiPreferenceKey(key: unknown): key is UiPreferenceKey {
+  return (
+    typeof key === 'string' &&
+    (UI_PREFERENCE_KEYS as readonly string[]).includes(key)
+  )
+}
+
+function isViewMode(value: unknown): value is ViewMode {
+  return value === 'card' || value === 'table'
+}
+
 export function register() {
   ipcMain.handle(
     'ui-preferences:get-view-mode',
-    (_event, key: UiPreferenceKey): ViewMode => getViewModePreference(key)
+    (_event, key: unknown): ViewMode =>
+      isUiPreferenceKey(key) ? getViewModePreference(key) : DEFAULT_VIEW_MODE
   )
 
   ipcMain.handle(
     'ui-preferences:set-view-mode',
-    (_event, key: UiPreferenceKey, value: ViewMode): void => {
+    (_event, key: unknown, value: unknown): void => {
+      if (!isUiPreferenceKey(key) || !isViewMode(value)) return
       setViewModePreference(key, value)
     }
   )

--- a/main/src/ipc-handlers/ui-preferences.ts
+++ b/main/src/ipc-handlers/ui-preferences.ts
@@ -1,0 +1,21 @@
+import { ipcMain } from 'electron'
+import {
+  getViewModePreference,
+  setViewModePreference,
+  type UiPreferenceKey,
+  type ViewMode,
+} from '../ui-preferences'
+
+export function register() {
+  ipcMain.handle(
+    'ui-preferences:get-view-mode',
+    (_event, key: UiPreferenceKey): ViewMode => getViewModePreference(key)
+  )
+
+  ipcMain.handle(
+    'ui-preferences:set-view-mode',
+    (_event, key: UiPreferenceKey, value: ViewMode): void => {
+      setViewModePreference(key, value)
+    }
+  )
+}

--- a/main/src/ui-preferences.ts
+++ b/main/src/ui-preferences.ts
@@ -1,0 +1,53 @@
+import log from './logger'
+import { readSetting } from './db/readers/settings-reader'
+import { writeSetting } from './db/writers/settings-writer'
+
+export const UI_PREFERENCE_KEYS = [
+  'ui.viewMode.mcpServers',
+  'ui.viewMode.skillsInstalled',
+] as const
+
+export type UiPreferenceKey = (typeof UI_PREFERENCE_KEYS)[number]
+
+export type ViewMode = 'card' | 'table'
+
+const DEFAULT_VIEW_MODE: ViewMode = 'card'
+
+function isValidKey(key: string): key is UiPreferenceKey {
+  return (UI_PREFERENCE_KEYS as readonly string[]).includes(key)
+}
+
+function isValidViewMode(value: string): value is ViewMode {
+  return value === 'card' || value === 'table'
+}
+
+export function getViewModePreference(key: UiPreferenceKey): ViewMode {
+  try {
+    const raw = readSetting(key)
+    if (raw && isValidViewMode(raw)) {
+      return raw
+    }
+  } catch (err) {
+    log.error(`[DB] Failed to read UI preference "${key}":`, err)
+  }
+  return DEFAULT_VIEW_MODE
+}
+
+export function setViewModePreference(
+  key: UiPreferenceKey,
+  value: ViewMode
+): void {
+  if (!isValidKey(key)) {
+    log.warn(`[DB] Refusing to write unknown UI preference key: ${key}`)
+    return
+  }
+  if (!isValidViewMode(value)) {
+    log.warn(`[DB] Refusing to write invalid view mode: ${value}`)
+    return
+  }
+  try {
+    writeSetting(key, value)
+  } catch (err) {
+    log.error(`[DB] Failed to write UI preference "${key}":`, err)
+  }
+}

--- a/preload/src/api/ui-preferences.ts
+++ b/preload/src/api/ui-preferences.ts
@@ -1,0 +1,21 @@
+import { ipcRenderer } from 'electron'
+import type {
+  UiPreferenceKey,
+  ViewMode,
+} from '../../../main/src/ui-preferences'
+
+export const uiPreferencesApi = {
+  uiPreferences: {
+    getViewMode: (key: UiPreferenceKey): Promise<ViewMode> =>
+      ipcRenderer.invoke('ui-preferences:get-view-mode', key),
+    setViewMode: (key: UiPreferenceKey, value: ViewMode): Promise<void> =>
+      ipcRenderer.invoke('ui-preferences:set-view-mode', key, value),
+  },
+}
+
+export interface UiPreferencesAPI {
+  uiPreferences: {
+    getViewMode: (key: UiPreferenceKey) => Promise<ViewMode>
+    setViewMode: (key: UiPreferenceKey, value: ViewMode) => Promise<void>
+  }
+}

--- a/preload/src/preload.ts
+++ b/preload/src/preload.ts
@@ -12,6 +12,7 @@ import { eventsApi, type EventsAPI } from './api/events'
 import { featureFlagsApi, type FeatureFlagsAPI } from './api/feature-flags'
 import { telemetryApi, type TelemetryAPI } from './api/telemetry'
 import { toolhiveApi, type ToolhiveAPI } from './api/toolhive'
+import { uiPreferencesApi, type UiPreferencesAPI } from './api/ui-preferences'
 import { utilsApi, type UtilsAPI } from './api/utils'
 import { windowApi, type WindowAPI } from './api/window'
 
@@ -25,6 +26,7 @@ export type ElectronAPI = AppAPI &
   FeatureFlagsAPI &
   ChatAPI &
   CliAPI &
+  UiPreferencesAPI &
   UtilsAPI &
   EventsAPI
 
@@ -39,6 +41,7 @@ const electronAPI = {
   ...featureFlagsApi,
   ...chatApi,
   ...cliApi,
+  ...uiPreferencesApi,
   ...utilsApi,
   ...eventsApi,
 } satisfies ElectronAPI

--- a/renderer/src/common/components/__tests__/view-toggle.test.tsx
+++ b/renderer/src/common/components/__tests__/view-toggle.test.tsx
@@ -34,8 +34,15 @@ describe('ViewToggle', () => {
 
     await user.click(screen.getByRole('radio', { name: /table view/i }))
     expect(onChange).toHaveBeenCalledWith('table')
+  })
+
+  it('does not invoke onChange when clicking the already-selected option', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ViewToggle value="card" onChange={onChange} />)
 
     await user.click(screen.getByRole('radio', { name: /card view/i }))
-    expect(onChange).toHaveBeenCalledWith('card')
+    expect(onChange).not.toHaveBeenCalled()
   })
 })

--- a/renderer/src/common/components/__tests__/view-toggle.test.tsx
+++ b/renderer/src/common/components/__tests__/view-toggle.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ViewToggle } from '../view-toggle'
+
+describe('ViewToggle', () => {
+  it('marks the card option as checked when value is "card"', () => {
+    render(<ViewToggle value="card" onChange={vi.fn()} />)
+
+    expect(screen.getByRole('radio', { name: /card view/i })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+    expect(screen.getByRole('radio', { name: /table view/i })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    )
+  })
+
+  it('marks the table option as checked when value is "table"', () => {
+    render(<ViewToggle value="table" onChange={vi.fn()} />)
+
+    expect(screen.getByRole('radio', { name: /table view/i })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    )
+  })
+
+  it('invokes onChange with the new value when a button is clicked', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ViewToggle value="card" onChange={onChange} />)
+
+    await user.click(screen.getByRole('radio', { name: /table view/i }))
+    expect(onChange).toHaveBeenCalledWith('table')
+
+    await user.click(screen.getByRole('radio', { name: /card view/i }))
+    expect(onChange).toHaveBeenCalledWith('card')
+  })
+})

--- a/renderer/src/common/components/ui/table.tsx
+++ b/renderer/src/common/components/ui/table.tsx
@@ -2,11 +2,15 @@ import * as React from 'react'
 
 import { cn } from '@/common/lib/utils'
 
-function Table({ className, ...props }: React.ComponentProps<'table'>) {
+function Table({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<'table'> & { containerClassName?: string }) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className={cn('relative w-full overflow-x-auto', containerClassName)}
     >
       <table
         data-slot="table"

--- a/renderer/src/common/components/view-toggle.tsx
+++ b/renderer/src/common/components/view-toggle.tsx
@@ -1,3 +1,4 @@
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import { LayoutGrid, List } from 'lucide-react'
 import { cn } from '@/common/lib/utils'
 import type { ViewMode } from '../../../../main/src/ui-preferences'
@@ -9,6 +10,13 @@ interface ViewToggleProps {
   ariaLabel?: string
 }
 
+const ITEM_STYLES = `focus-visible:ring-ring/50 text-foreground
+  dark:text-muted-foreground inline-flex size-7 cursor-pointer items-center
+  justify-center rounded-full transition-colors focus-visible:ring-[3px]
+  focus-visible:outline-none
+  data-[state=checked]:bg-background data-[state=checked]:shadow-sm
+  data-[state=checked]:dark:bg-card data-[state=checked]:dark:text-foreground`
+
 export function ViewToggle({
   value,
   onChange,
@@ -16,8 +24,11 @@ export function ViewToggle({
   ariaLabel = 'View mode',
 }: ViewToggleProps) {
   return (
-    <div
-      role="radiogroup"
+    <RadioGroupPrimitive.Root
+      value={value}
+      onValueChange={(next) => {
+        if (next && next !== value) onChange(next as ViewMode)
+      }}
       aria-label={ariaLabel}
       className={cn(
         `inline-flex h-auto items-center gap-1 rounded-full bg-zinc-200 p-1
@@ -25,42 +36,20 @@ export function ViewToggle({
         className
       )}
     >
-      <button
-        type="button"
-        role="radio"
-        aria-checked={value === 'card'}
+      <RadioGroupPrimitive.Item
+        value="card"
         aria-label="Card view"
-        data-state={value === 'card' ? 'active' : 'inactive'}
-        onClick={() => onChange('card')}
-        className={cn(
-          `focus-visible:ring-ring/50 text-foreground dark:text-muted-foreground
-          inline-flex size-7 cursor-pointer items-center justify-center
-          rounded-full transition-colors focus-visible:ring-[3px]
-          focus-visible:outline-none`,
-          value === 'card' &&
-            'bg-background dark:bg-card dark:text-foreground shadow-sm'
-        )}
+        className={cn(ITEM_STYLES)}
       >
         <LayoutGrid className="size-4" aria-hidden />
-      </button>
-      <button
-        type="button"
-        role="radio"
-        aria-checked={value === 'table'}
+      </RadioGroupPrimitive.Item>
+      <RadioGroupPrimitive.Item
+        value="table"
         aria-label="Table view"
-        data-state={value === 'table' ? 'active' : 'inactive'}
-        onClick={() => onChange('table')}
-        className={cn(
-          `focus-visible:ring-ring/50 text-foreground dark:text-muted-foreground
-          inline-flex size-7 cursor-pointer items-center justify-center
-          rounded-full transition-colors focus-visible:ring-[3px]
-          focus-visible:outline-none`,
-          value === 'table' &&
-            'bg-background dark:bg-card dark:text-foreground shadow-sm'
-        )}
+        className={cn(ITEM_STYLES)}
       >
         <List className="size-4" aria-hidden />
-      </button>
-    </div>
+      </RadioGroupPrimitive.Item>
+    </RadioGroupPrimitive.Root>
   )
 }

--- a/renderer/src/common/components/view-toggle.tsx
+++ b/renderer/src/common/components/view-toggle.tsx
@@ -1,0 +1,66 @@
+import { LayoutGrid, List } from 'lucide-react'
+import { cn } from '@/common/lib/utils'
+import type { ViewMode } from '../../../../main/src/ui-preferences'
+
+interface ViewToggleProps {
+  value: ViewMode
+  onChange: (value: ViewMode) => void
+  className?: string
+  ariaLabel?: string
+}
+
+export function ViewToggle({
+  value,
+  onChange,
+  className,
+  ariaLabel = 'View mode',
+}: ViewToggleProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={cn(
+        `inline-flex h-auto items-center gap-1 rounded-full bg-zinc-200 p-1
+        dark:bg-zinc-800`,
+        className
+      )}
+    >
+      <button
+        type="button"
+        role="radio"
+        aria-checked={value === 'card'}
+        aria-label="Card view"
+        data-state={value === 'card' ? 'active' : 'inactive'}
+        onClick={() => onChange('card')}
+        className={cn(
+          `focus-visible:ring-ring/50 text-foreground dark:text-muted-foreground
+          inline-flex size-7 cursor-pointer items-center justify-center
+          rounded-full transition-colors focus-visible:ring-[3px]
+          focus-visible:outline-none`,
+          value === 'card' &&
+            'bg-background dark:bg-card dark:text-foreground shadow-sm'
+        )}
+      >
+        <LayoutGrid className="size-4" aria-hidden />
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={value === 'table'}
+        aria-label="Table view"
+        data-state={value === 'table' ? 'active' : 'inactive'}
+        onClick={() => onChange('table')}
+        className={cn(
+          `focus-visible:ring-ring/50 text-foreground dark:text-muted-foreground
+          inline-flex size-7 cursor-pointer items-center justify-center
+          rounded-full transition-colors focus-visible:ring-[3px]
+          focus-visible:outline-none`,
+          value === 'table' &&
+            'bg-background dark:bg-card dark:text-foreground shadow-sm'
+        )}
+      >
+        <List className="size-4" aria-hidden />
+      </button>
+    </div>
+  )
+}

--- a/renderer/src/common/hooks/__tests__/use-view-preference.test.tsx
+++ b/renderer/src/common/hooks/__tests__/use-view-preference.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useViewPreference } from '../use-view-preference'
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useViewPreference', () => {
+  beforeEach(() => {
+    window.electronAPI.uiPreferences.getViewMode = vi
+      .fn()
+      .mockResolvedValue('card')
+    window.electronAPI.uiPreferences.setViewMode = vi
+      .fn()
+      .mockResolvedValue(undefined)
+  })
+
+  it('returns the default card view while the initial read is in flight', () => {
+    const { result } = renderHook(
+      () => useViewPreference('ui.viewMode.mcpServers'),
+      { wrapper: makeWrapper() }
+    )
+
+    expect(result.current.view).toBe('card')
+  })
+
+  it('reads the persisted table view from the main process', async () => {
+    window.electronAPI.uiPreferences.getViewMode = vi
+      .fn()
+      .mockResolvedValue('table')
+
+    const { result } = renderHook(
+      () => useViewPreference('ui.viewMode.skillsInstalled'),
+      { wrapper: makeWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.view).toBe('table')
+    })
+    expect(window.electronAPI.uiPreferences.getViewMode).toHaveBeenCalledWith(
+      'ui.viewMode.skillsInstalled'
+    )
+  })
+
+  it('persists the new view via IPC and updates state optimistically', async () => {
+    const { result } = renderHook(
+      () => useViewPreference('ui.viewMode.mcpServers'),
+      { wrapper: makeWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.view).toBe('card')
+    })
+
+    act(() => {
+      result.current.setView('table')
+    })
+
+    await waitFor(() => {
+      expect(result.current.view).toBe('table')
+    })
+
+    await waitFor(() => {
+      expect(window.electronAPI.uiPreferences.setViewMode).toHaveBeenCalledWith(
+        'ui.viewMode.mcpServers',
+        'table'
+      )
+    })
+  })
+})

--- a/renderer/src/common/hooks/use-view-preference.ts
+++ b/renderer/src/common/hooks/use-view-preference.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import log from 'electron-log/renderer'
+import { useCallback } from 'react'
+import type {
+  UiPreferenceKey,
+  ViewMode,
+} from '../../../../main/src/ui-preferences'
+
+const DEFAULT_VIEW_MODE: ViewMode = 'card'
+
+function viewPreferenceQueryKey(key: UiPreferenceKey) {
+  return ['ui-preference', 'view-mode', key] as const
+}
+
+/**
+ * Reads and writes a persisted card/table view preference for a given page,
+ * backed by the main-process SQLite `settings` table via IPC.
+ *
+ * Returns `card` as the optimistic default while the initial read resolves so
+ * the UI can render without a flicker.
+ */
+export function useViewPreference(key: UiPreferenceKey) {
+  const queryClient = useQueryClient()
+
+  const { data } = useQuery({
+    queryKey: viewPreferenceQueryKey(key),
+    queryFn: async (): Promise<ViewMode> => {
+      try {
+        return await window.electronAPI.uiPreferences.getViewMode(key)
+      } catch (error) {
+        log.error(`Failed to read view preference "${key}":`, error)
+        return DEFAULT_VIEW_MODE
+      }
+    },
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  })
+
+  const { mutate } = useMutation({
+    mutationFn: async (value: ViewMode) => {
+      await window.electronAPI.uiPreferences.setViewMode(key, value)
+      return value
+    },
+    onMutate: async (value: ViewMode) => {
+      await queryClient.cancelQueries({
+        queryKey: viewPreferenceQueryKey(key),
+      })
+      const previous = queryClient.getQueryData<ViewMode>(
+        viewPreferenceQueryKey(key)
+      )
+      queryClient.setQueryData(viewPreferenceQueryKey(key), value)
+      return { previous }
+    },
+    onError: (error, _value, context) => {
+      log.error(`Failed to persist view preference "${key}":`, error)
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(viewPreferenceQueryKey(key), context.previous)
+      }
+    },
+  })
+
+  const setView = useCallback(
+    (value: ViewMode) => {
+      mutate(value)
+    },
+    [mutate]
+  )
+
+  return {
+    view: data ?? DEFAULT_VIEW_MODE,
+    setView,
+  }
+}

--- a/renderer/src/common/mocks/electronAPI.ts
+++ b/renderer/src/common/mocks/electronAPI.ts
@@ -40,6 +40,10 @@ function createElectronStub(): Partial<ElectronAPI> {
       disable: vi.fn().mockResolvedValue(undefined),
       getAll: vi.fn().mockResolvedValue({}),
     } as ElectronAPI['featureFlags'],
+    uiPreferences: {
+      getViewMode: vi.fn().mockResolvedValue('card'),
+      setViewMode: vi.fn().mockResolvedValue(undefined),
+    } as ElectronAPI['uiPreferences'],
     chat: {
       stream: vi.fn(),
     } as unknown as ElectronAPI['chat'],

--- a/renderer/src/features/mcp-servers/components/__tests__/grid-cards-mcp-server.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/grid-cards-mcp-server.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import type { createTestRouter } from '@/common/test/create-test-router'
+import { mockedGetApiV1BetaRegistryByNameServers } from '@mocks/fixtures/registry_name_servers/get'
+import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
+import { GridCardsMcpServers } from '../grid-cards-mcp-server'
+
+const baseServer: CoreWorkload = {
+  name: 'postgres-db',
+  status: 'running',
+  package: 'ghcr.io/postgres/postgres-mcp-server:v1.0.0',
+  transport_type: 'stdio',
+  group: 'default',
+  url: 'http://localhost:8080',
+  remote: false,
+}
+
+function makeRouter(servers: CoreWorkload[]) {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>{error.message}</div>,
+  })
+
+  const groupRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/group/$groupName',
+    component: () => <GridCardsMcpServers mcpServers={servers} />,
+  })
+
+  return new Router({
+    routeTree: rootRoute.addChildren([groupRoute]),
+    history: createMemoryHistory({ initialEntries: ['/group/default'] }),
+    defaultNotFoundComponent: () => null,
+  }) as unknown as ReturnType<typeof createTestRouter>
+}
+
+describe('GridCardsMcpServers view toggle', () => {
+  beforeEach(() => {
+    mockedGetApiV1BetaRegistryByNameServers.override(() => ({
+      servers: [],
+      remote_servers: [],
+    }))
+
+    window.electronAPI.uiPreferences.getViewMode = vi
+      .fn()
+      .mockResolvedValue('card')
+    window.electronAPI.uiPreferences.setViewMode = vi
+      .fn()
+      .mockResolvedValue(undefined)
+  })
+
+  it('renders cards by default and swaps to the table when toggled', async () => {
+    const router = makeRouter([baseServer])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('postgres-db')).toBeVisible()
+    })
+
+    expect(screen.queryByRole('columnheader', { name: /server/i })).toBeNull()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('radio', { name: /table view/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /server/i })
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByText('postgres-db')).toBeVisible()
+  })
+
+  it('persists the table preference through the electronAPI', async () => {
+    const router = makeRouter([baseServer])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('postgres-db')).toBeVisible()
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('radio', { name: /table view/i }))
+
+    await waitFor(() => {
+      expect(window.electronAPI.uiPreferences.setViewMode).toHaveBeenCalledWith(
+        'ui.viewMode.mcpServers',
+        'table'
+      )
+    })
+  })
+
+  it('reads the previously persisted view on mount', async () => {
+    window.electronAPI.uiPreferences.getViewMode = vi
+      .fn()
+      .mockResolvedValue('table')
+
+    const router = makeRouter([baseServer])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /server/i })
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/renderer/src/features/mcp-servers/components/__tests__/table-mcp-servers.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/table-mcp-servers.test.tsx
@@ -1,0 +1,176 @@
+import { screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import type { createTestRouter } from '@/common/test/create-test-router'
+import { mockedGetApiV1BetaWorkloadsByName } from '@mocks/fixtures/workloads_name/get'
+import { mockedGetApiV1BetaRegistryByNameServers } from '@mocks/fixtures/registry_name_servers/get'
+import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
+import { TableMcpServers } from '../table-mcp-servers'
+import { EditServerDialogProvider } from '../../contexts/edit-server-dialog-provider'
+
+function makeRouter(servers: CoreWorkload[]) {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>{error.message}</div>,
+  })
+
+  const groupRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/group/$groupName',
+    component: () => (
+      <EditServerDialogProvider>
+        <TableMcpServers mcpServers={servers} />
+      </EditServerDialogProvider>
+    ),
+  })
+
+  return new Router({
+    routeTree: rootRoute.addChildren([groupRoute]),
+    history: createMemoryHistory({ initialEntries: ['/group/default'] }),
+    defaultNotFoundComponent: () => null,
+  }) as unknown as ReturnType<typeof createTestRouter>
+}
+
+const baseServer: CoreWorkload = {
+  name: 'postgres-db',
+  status: 'running',
+  package: 'ghcr.io/postgres/postgres-mcp-server:v1.0.0',
+  transport_type: 'stdio',
+  group: 'default',
+  url: 'http://localhost:8080',
+  remote: false,
+}
+
+describe('TableMcpServers', () => {
+  beforeEach(() => {
+    mockedGetApiV1BetaRegistryByNameServers.override(() => ({
+      servers: [],
+      remote_servers: [],
+    }))
+  })
+
+  it('renders a header row and one row per server', async () => {
+    const router = makeRouter([
+      baseServer,
+      { ...baseServer, name: 'sequentialthinking', status: 'stopped' },
+    ])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('postgres-db')).toBeVisible()
+    })
+
+    expect(
+      screen.getByRole('columnheader', { name: /server/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /about/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText('sequentialthinking')).toBeVisible()
+  })
+
+  it('renders the status text and a toggle switch per row', async () => {
+    const router = makeRouter([baseServer])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('postgres-db')).toBeVisible()
+    })
+
+    expect(screen.getByText(/running/i)).toBeVisible()
+    expect(screen.getByRole('switch', { name: /mutate server/i })).toBeChecked()
+  })
+
+  it('exposes the full server actions dropdown on each row', async () => {
+    const router = makeRouter([baseServer])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('postgres-db')).toBeVisible()
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /more options/i }))
+
+    expect(
+      screen.getByRole('menuitem', { name: /edit configuration/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /logs/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('menuitem', { name: /remove/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('menuitem', { name: /copy server to a group/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the update-version button when registry drift is detected', async () => {
+    mockedGetApiV1BetaWorkloadsByName.override((data) => ({
+      ...data,
+      name: 'postgres-db',
+      image: 'ghcr.io/postgres/postgres-mcp-server:v1.0.0',
+    }))
+    mockedGetApiV1BetaRegistryByNameServers.override(() => ({
+      servers: [
+        {
+          name: 'postgres',
+          image: 'ghcr.io/postgres/postgres-mcp-server:v2.0.0',
+          description: 'Postgres MCP server',
+          transport: 'stdio',
+          tools: ['query', 'execute'],
+          env_vars: [],
+          args: [],
+        },
+      ],
+      remote_servers: [],
+    }))
+
+    const router = makeRouter([baseServer])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /update to v2\.0\.0/i })
+      ).toBeVisible()
+    })
+  })
+
+  it('shows the registry description in the About column when available', async () => {
+    mockedGetApiV1BetaWorkloadsByName.override((data) => ({
+      ...data,
+      name: 'postgres-db',
+      image: 'ghcr.io/postgres/postgres-mcp-server:v1.0.0',
+    }))
+    mockedGetApiV1BetaRegistryByNameServers.override(() => ({
+      servers: [
+        {
+          name: 'postgres',
+          image: 'ghcr.io/postgres/postgres-mcp-server:v1.0.0',
+          description: 'Connects AI assistants to PostgreSQL databases.',
+          transport: 'stdio',
+          tools: ['query'],
+          env_vars: [],
+          args: [],
+        },
+      ],
+      remote_servers: [],
+    }))
+
+    const router = makeRouter([baseServer])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/connects ai assistants to postgresql databases\./i)
+      ).toBeVisible()
+    })
+  })
+})

--- a/renderer/src/features/mcp-servers/components/grid-cards-mcp-server.tsx
+++ b/renderer/src/features/mcp-servers/components/grid-cards-mcp-server.tsx
@@ -2,9 +2,12 @@ import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@
 import { CardMcpServer } from './card-mcp-server'
 import { useMemo, useState } from 'react'
 import { InputSearch } from '@/common/components/ui/input-search'
+import { ViewToggle } from '@/common/components/view-toggle'
+import { useViewPreference } from '@/common/hooks/use-view-preference'
 import { cn } from '@/common/lib/utils'
 import { EditServerDialogProvider } from '../contexts/edit-server-dialog-provider'
 import { useEditServerDialog } from '../hooks/use-edit-server-dialog'
+import { TableMcpServers } from './table-mcp-servers'
 import { WrapperDialogFormMcp } from './wrapper-dialog-mcp'
 
 function GridCardsMcpServersContent({
@@ -13,6 +16,7 @@ function GridCardsMcpServersContent({
   mcpServers: CoreWorkload[]
 }) {
   const { state, closeDialog } = useEditServerDialog()
+  const { view, setView } = useViewPreference('ui.viewMode.mcpServers')
   const [filters, setFilters] = useState({
     text: '',
     state: 'all',
@@ -45,35 +49,42 @@ function GridCardsMcpServersContent({
 
   return (
     <div className="space-y-6">
-      <InputSearch
-        onChange={(v) => setFilters((prev) => ({ ...prev, text: v }))}
-        value={filters.text}
-        placeholder="Search..."
-      />
-
-      <div
-        className={cn(
-          'grid gap-4',
-          visibleMcpServers.length <= 3
-            ? 'grid-cols-[repeat(auto-fill,minmax(max(200px,min(300px,100%)),1fr))]'
-            : 'grid-cols-[repeat(auto-fit,minmax(max(200px,min(300px,100%)),1fr))]'
-        )}
-      >
-        {visibleMcpServers.map((mcpServer) =>
-          mcpServer.name ? (
-            <CardMcpServer
-              key={mcpServer.name}
-              name={mcpServer.name}
-              status={mcpServer.status}
-              remote={mcpServer.remote}
-              statusContext={mcpServer.status_context}
-              url={mcpServer.url ?? ''}
-              transport={mcpServer.transport_type}
-              group={mcpServer.group}
-            />
-          ) : null
-        )}
+      <div className="flex items-center justify-between gap-3">
+        <InputSearch
+          onChange={(v) => setFilters((prev) => ({ ...prev, text: v }))}
+          value={filters.text}
+          placeholder="Search..."
+        />
+        <ViewToggle value={view} onChange={setView} />
       </div>
+
+      {view === 'table' ? (
+        <TableMcpServers mcpServers={visibleMcpServers} />
+      ) : (
+        <div
+          className={cn(
+            'grid gap-4',
+            visibleMcpServers.length <= 3
+              ? 'grid-cols-[repeat(auto-fill,minmax(max(200px,min(300px,100%)),1fr))]'
+              : 'grid-cols-[repeat(auto-fit,minmax(max(200px,min(300px,100%)),1fr))]'
+          )}
+        >
+          {visibleMcpServers.map((mcpServer) =>
+            mcpServer.name ? (
+              <CardMcpServer
+                key={mcpServer.name}
+                name={mcpServer.name}
+                status={mcpServer.status}
+                remote={mcpServer.remote}
+                statusContext={mcpServer.status_context}
+                url={mcpServer.url ?? ''}
+                transport={mcpServer.transport_type}
+                group={mcpServer.group}
+              />
+            ) : null
+          )}
+        </div>
+      )}
 
       {visibleMcpServers.length === 0 &&
         (filters.text || filters.state !== 'all') && (

--- a/renderer/src/features/mcp-servers/components/table-mcp-servers.tsx
+++ b/renderer/src/features/mcp-servers/components/table-mcp-servers.tsx
@@ -14,6 +14,7 @@ import {
   TooltipTrigger,
 } from '@/common/components/ui/tooltip'
 import { Switch } from '@/common/components/ui/switch'
+import { Button } from '@/common/components/ui/button'
 import { cn } from '@/common/lib/utils'
 import { trackEvent } from '@/common/lib/analytics'
 import { ArrowUpCircle, CloudIcon, LaptopIcon } from 'lucide-react'
@@ -53,19 +54,19 @@ function UpdateVersionButton({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <button
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
           onClick={(e) => {
             e.stopPropagation()
             void promptUpdate('card_button')
           }}
           disabled={disabled || !isReady}
-          className="hover:bg-accent inline-flex size-8 cursor-pointer
-            items-center justify-center rounded-md disabled:pointer-events-none
-            disabled:opacity-50"
           aria-label={`Update to ${drift.registryTag}`}
         >
           <ArrowUpCircle className="size-5 text-amber-500" />
-        </button>
+        </Button>
       </TooltipTrigger>
       <TooltipContent className="max-w-xs">
         Update available: {drift.localTag} → {drift.registryTag}

--- a/renderer/src/features/mcp-servers/components/table-mcp-servers.tsx
+++ b/renderer/src/features/mcp-servers/components/table-mcp-servers.tsx
@@ -1,0 +1,266 @@
+import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
+import type { RegistryEnvVar } from '@common/api/registry-types'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/common/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { Switch } from '@/common/components/ui/switch'
+import { cn } from '@/common/lib/utils'
+import { trackEvent } from '@/common/lib/analytics'
+import { ArrowUpCircle, CloudIcon, LaptopIcon } from 'lucide-react'
+import { useIsServerFromRegistry } from '../hooks/use-is-server-from-registry'
+import { useMutationRestartServer } from '../hooks/use-mutation-restart-server'
+import { useMutationStopServerList } from '../hooks/use-mutation-stop-server'
+import { useUpdateVersion } from '../hooks/use-update-version'
+import { ServerActionsDropdown } from './card-mcp-server/server-actions'
+
+function getStatusText(status: CoreWorkload['status'] | 'restarting') {
+  if (status === 'removing') return 'Deleting'
+  if (status === 'restarting') return 'Restarting'
+  return status
+}
+
+function UpdateVersionButton({
+  serverName,
+  registryImage,
+  drift,
+  registryEnvVars,
+  disabled,
+}: {
+  serverName: string
+  registryImage: string
+  drift: { localTag: string; registryTag: string }
+  registryEnvVars?: RegistryEnvVar[]
+  disabled?: boolean
+}) {
+  const { promptUpdate, isReady } = useUpdateVersion({
+    serverName,
+    registryImage,
+    localTag: drift.localTag,
+    registryTag: drift.registryTag,
+    registryEnvVars,
+  })
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            void promptUpdate('card_button')
+          }}
+          disabled={disabled || !isReady}
+          className="hover:bg-accent inline-flex size-8 cursor-pointer
+            items-center justify-center rounded-md disabled:pointer-events-none
+            disabled:opacity-50"
+          aria-label={`Update to ${drift.registryTag}`}
+        >
+          <ArrowUpCircle className="size-5 text-amber-500" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs">
+        Update available: {drift.localTag} → {drift.registryTag}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function McpServerRow({ mcpServer }: { mcpServer: CoreWorkload }) {
+  const name = mcpServer.name ?? ''
+  const status = mcpServer.status
+  const remote = mcpServer.remote
+  const transport = mcpServer.transport_type
+  const group = mcpServer.group
+  const url = mcpServer.url ?? ''
+
+  const { isFromRegistry, drift, matchedRegistryItem } =
+    useIsServerFromRegistry(name)
+  const hasUpdate = Boolean(isFromRegistry && drift)
+
+  const registryImage =
+    hasUpdate && matchedRegistryItem && 'image' in matchedRegistryItem
+      ? (matchedRegistryItem.image ?? null)
+      : null
+  const registryEnvVars = hasUpdate ? matchedRegistryItem?.env_vars : undefined
+
+  const description =
+    matchedRegistryItem?.description ?? mcpServer.package ?? ''
+
+  const isRunning = status === 'running'
+  const isStarting = status === 'starting'
+  const isStopped = status === 'stopped' || status === 'stopping'
+  const isDeleting = status === 'removing'
+  const isUpdating = `${status}` === 'updating'
+
+  const { mutateAsync: restartMutate, isPending: isRestartPending } =
+    useMutationRestartServer({ name, group })
+  const { mutateAsync: stopMutate, isPending: isStopPending } =
+    useMutationStopServerList({ name, group })
+
+  const toggleServer = () => {
+    if (isRunning) {
+      stopMutate({ path: { name } })
+      trackEvent(`Workload ${name} stopped`, {
+        workload: name,
+        transport,
+      })
+      return
+    }
+    restartMutate({ path: { name } })
+    trackEvent(`Workload ${name} started`, {
+      workload: name,
+      transport,
+    })
+  }
+
+  return (
+    <TableRow
+      className={cn(
+        isDeleting && 'pointer-events-none opacity-50',
+        isStopped && 'bg-card/65'
+      )}
+    >
+      <TableCell className="py-3 font-medium">
+        <Tooltip onlyWhenTruncated>
+          <TooltipTrigger asChild>
+            <span
+              className={cn(
+                'block truncate',
+                isStopped && 'text-foreground/65'
+              )}
+            >
+              {name}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">{name}</TooltipContent>
+        </Tooltip>
+      </TableCell>
+
+      <TableCell className="text-muted-foreground hidden py-3 md:table-cell">
+        {description ? (
+          <Tooltip onlyWhenTruncated>
+            <TooltipTrigger asChild>
+              <span className="block truncate text-sm">{description}</span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-sm">{description}</TooltipContent>
+          </Tooltip>
+        ) : (
+          <span className="text-muted-foreground/60 text-sm">—</span>
+        )}
+      </TableCell>
+
+      <TableCell className="py-3 text-right">
+        {hasUpdate && drift && registryImage && (
+          <UpdateVersionButton
+            serverName={name}
+            registryImage={registryImage}
+            drift={drift}
+            registryEnvVars={registryEnvVars}
+            disabled={isUpdating || isDeleting}
+          />
+        )}
+      </TableCell>
+
+      <TableCell className="py-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Switch
+            aria-label="Mutate server"
+            checked={isRunning || isStarting}
+            disabled={isStarting || isRestartPending || isStopPending}
+            onClick={(e) => e.stopPropagation()}
+            onCheckedChange={toggleServer}
+          />
+          <span
+            className="text-muted-foreground min-w-0 flex-1 truncate text-sm
+              capitalize"
+          >
+            {getStatusText(status)}
+          </span>
+        </div>
+      </TableCell>
+
+      <TableCell className="py-3">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex size-5 items-center justify-center">
+              {remote ? (
+                <CloudIcon className="size-5" aria-label="Remote MCP server" />
+              ) : (
+                <LaptopIcon className="size-5" aria-label="Local MCP server" />
+              )}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            {remote ? 'Remote MCP server' : 'Local MCP server'}
+          </TooltipContent>
+        </Tooltip>
+      </TableCell>
+
+      <TableCell className="py-3 pr-3 text-right">
+        <ServerActionsDropdown
+          name={name}
+          url={url}
+          status={status}
+          remote={!!remote}
+          group={group}
+          isFromRegistry={!!isFromRegistry}
+          drift={drift}
+          matchedRegistryItem={matchedRegistryItem}
+        />
+      </TableCell>
+    </TableRow>
+  )
+}
+
+export function TableMcpServers({
+  mcpServers,
+}: {
+  mcpServers: CoreWorkload[]
+}) {
+  if (mcpServers.length === 0) {
+    return null
+  }
+
+  return (
+    <Table
+      className="table-fixed"
+      containerClassName="overflow-hidden rounded-lg border"
+    >
+      <TableHeader>
+        <TableRow className="bg-muted/40 hover:bg-muted/40">
+          <TableHead
+            className="text-muted-foreground w-auto font-medium md:w-[28%]"
+          >
+            Server
+          </TableHead>
+          <TableHead
+            className="text-muted-foreground hidden w-auto font-medium
+              md:table-cell"
+          >
+            About
+          </TableHead>
+          <TableHead className="w-11" aria-label="Update" />
+          <TableHead className="w-[132px]" aria-label="Status" />
+          <TableHead className="w-10" aria-label="Type" />
+          <TableHead className="w-16 pr-3" aria-label="Actions" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {mcpServers.map((mcpServer) =>
+          mcpServer.name ? (
+            <McpServerRow key={mcpServer.name} mcpServer={mcpServer} />
+          ) : null
+        )}
+      </TableBody>
+    </Table>
+  )
+}

--- a/renderer/src/features/skills/components/__tests__/table-installed-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-installed-skills.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { TableInstalledSkills } from '../table-installed-skills'
+import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
+
+function renderWithProviders(component: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
+  )
+}
+
+const userSkill: InstalledSkill = {
+  reference: 'ghcr.io/org/skill-user:v1',
+  status: 'installed',
+  scope: 'user',
+  metadata: { name: 'skill-user' },
+  clients: ['claude-code', 'cursor', 'vscode', 'windsurf'],
+}
+
+const projectSkill: InstalledSkill = {
+  reference: 'ghcr.io/org/skill-repo:v1',
+  status: 'pending',
+  scope: 'project',
+  metadata: { name: 'skill-repo' },
+  project_root: '/Users/me/Projects/my-project',
+  clients: ['claude-code'],
+}
+
+describe('TableInstalledSkills', () => {
+  it('renders all column headers and one row per skill', () => {
+    renderWithProviders(
+      <TableInstalledSkills skills={[userSkill, projectSkill]} />
+    )
+
+    expect(
+      screen.getByRole('columnheader', { name: /skill/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /mode/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /destination/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /status/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText('skill-user')).toBeVisible()
+    expect(screen.getByText('skill-repo')).toBeVisible()
+  })
+
+  it('shows client badges and a +N overflow chip for user-scoped skills', () => {
+    renderWithProviders(<TableInstalledSkills skills={[userSkill]} />)
+
+    expect(screen.getByText('claude-code')).toBeVisible()
+    expect(screen.getByText('cursor')).toBeVisible()
+    expect(screen.getByText('vscode')).toBeVisible()
+    expect(screen.getByText(/\+1/)).toBeVisible()
+  })
+
+  it('renders the Repo mode label and project-root chip for project-scoped skills', () => {
+    renderWithProviders(<TableInstalledSkills skills={[projectSkill]} />)
+
+    expect(screen.getByText('Repo')).toBeVisible()
+    expect(screen.getByText('/my-project')).toBeVisible()
+  })
+
+  it('renders the installed status badge with the expected variant', () => {
+    renderWithProviders(<TableInstalledSkills skills={[userSkill]} />)
+
+    expect(screen.getByText('installed')).toBeVisible()
+  })
+
+  it('opens the uninstall dialog when the uninstall button is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TableInstalledSkills skills={[userSkill]} />)
+
+    await user.click(
+      screen.getByRole('button', { name: /uninstall skill-user/i })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    expect(
+      screen.getByRole('heading', { name: /uninstall skill/i })
+    ).toBeVisible()
+  })
+
+  it('shows an empty state when the skills array is empty', () => {
+    renderWithProviders(<TableInstalledSkills skills={[]} />)
+
+    expect(
+      screen.getByText(/no skills found matching the current filter/i)
+    ).toBeVisible()
+  })
+})

--- a/renderer/src/features/skills/components/card-skill.tsx
+++ b/renderer/src/features/skills/components/card-skill.tsx
@@ -10,14 +10,8 @@ import { FolderGit2Icon, Trash2Icon, UserIcon } from 'lucide-react'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { DialogUninstallSkill } from './dialog-uninstall-skill'
 import { CardSkillBase } from './card-skill-base'
-
-const statusVariantMap = {
-  installed: 'success',
-  pending: 'secondary',
-  failed: 'destructive',
-} as const
-
-const MAX_VISIBLE_CLIENTS = 3
+import { SkillClientsBadges } from './skill-clients-badges'
+import { skillStatusVariantMap } from './skill-status'
 
 export function CardSkill({ skill }: { skill: InstalledSkill }) {
   const [uninstallOpen, setUninstallOpen] = useState(false)
@@ -26,43 +20,10 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
   const status = skill.status
   const scope = skill.scope
   const clients = skill.clients ?? []
-  const visibleClients = clients.slice(0, MAX_VISIBLE_CLIENTS)
-  const hiddenClients = clients.slice(MAX_VISIBLE_CLIENTS)
   const projectRoot = scope === 'project' ? skill.project_root : undefined
   const projectRootLabel = projectRoot
     ? `/${projectRoot.split(/[\\/]/).filter(Boolean).at(-1) ?? projectRoot}`
     : null
-
-  const clientBadges = (
-    <>
-      {visibleClients.map((client) => (
-        <Badge key={client} variant="outline">
-          {client}
-        </Badge>
-      ))}
-      {hiddenClients.length > 0 && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Badge asChild variant="outline">
-              <button
-                type="button"
-                aria-label={`${hiddenClients.length} more clients`}
-              >
-                +{hiddenClients.length}
-              </button>
-            </Badge>
-          </TooltipTrigger>
-          <TooltipContent className="max-w-xs">
-            <ul className="flex flex-col gap-0.5 text-xs">
-              {hiddenClients.map((client) => (
-                <li key={client}>{client}</li>
-              ))}
-            </ul>
-          </TooltipContent>
-        </Tooltip>
-      )}
-    </>
-  )
 
   const isProjectScope = scope === 'project'
 
@@ -70,7 +31,7 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
     <div className="flex flex-col gap-1.5">
       <div className="flex flex-wrap gap-1.5">
         {status && (
-          <Badge variant={statusVariantMap[status] ?? 'secondary'}>
+          <Badge variant={skillStatusVariantMap[status] ?? 'secondary'}>
             {status}
           </Badge>
         )}
@@ -96,10 +57,12 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
             </TooltipContent>
           </Tooltip>
         )}
-        {!isProjectScope && clientBadges}
+        {!isProjectScope && <SkillClientsBadges clients={clients} />}
       </div>
       {isProjectScope && clients.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">{clientBadges}</div>
+        <div className="flex flex-wrap gap-1.5">
+          <SkillClientsBadges clients={clients} />
+        </div>
       )}
     </div>
   )

--- a/renderer/src/features/skills/components/skill-clients-badges.tsx
+++ b/renderer/src/features/skills/components/skill-clients-badges.tsx
@@ -1,0 +1,54 @@
+import { Badge } from '@/common/components/ui/badge'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+
+const MAX_VISIBLE_CLIENTS = 3
+
+export function SkillClientsBadges({
+  clients,
+  maxVisible = MAX_VISIBLE_CLIENTS,
+}: {
+  clients: string[]
+  maxVisible?: number
+}) {
+  if (!clients.length) {
+    return null
+  }
+
+  const visibleClients = clients.slice(0, maxVisible)
+  const hiddenClients = clients.slice(maxVisible)
+
+  return (
+    <>
+      {visibleClients.map((client) => (
+        <Badge key={client} variant="outline">
+          {client}
+        </Badge>
+      ))}
+      {hiddenClients.length > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge asChild variant="outline">
+              <button
+                type="button"
+                aria-label={`${hiddenClients.length} more clients`}
+              >
+                +{hiddenClients.length}
+              </button>
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            <ul className="flex flex-col gap-0.5 text-xs">
+              {hiddenClients.map((client) => (
+                <li key={client}>{client}</li>
+              ))}
+            </ul>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </>
+  )
+}

--- a/renderer/src/features/skills/components/skill-clients-badges.tsx
+++ b/renderer/src/features/skills/components/skill-clients-badges.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/common/components/ui/badge'
+import { Button } from '@/common/components/ui/button'
 import {
   Tooltip,
   TooltipContent,
@@ -31,14 +32,14 @@ export function SkillClientsBadges({
       {hiddenClients.length > 0 && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Badge asChild variant="outline">
-              <button
-                type="button"
-                aria-label={`${hiddenClients.length} more clients`}
-              >
-                +{hiddenClients.length}
-              </button>
-            </Badge>
+            <Button
+              variant="outline"
+              size="xs"
+              className="rounded-md px-2 font-normal"
+              aria-label={`${hiddenClients.length} more clients`}
+            >
+              +{hiddenClients.length}
+            </Button>
           </TooltipTrigger>
           <TooltipContent className="max-w-xs">
             <ul className="flex flex-col gap-0.5 text-xs">

--- a/renderer/src/features/skills/components/skill-status.ts
+++ b/renderer/src/features/skills/components/skill-status.ts
@@ -1,0 +1,5 @@
+export const skillStatusVariantMap = {
+  installed: 'success',
+  pending: 'secondary',
+  failed: 'destructive',
+} as const

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -19,8 +19,11 @@ import {
 import { GridCardsSkills } from './grid-cards-skills'
 import { GridCardsBuilds } from './grid-cards-builds'
 import { GridCardsRegistrySkills } from './grid-cards-registry-skills'
+import { TableInstalledSkills } from './table-installed-skills'
 import { DialogBuildSkill } from './dialog-build-skill'
 import { HammerIcon } from 'lucide-react'
+import { ViewToggle } from '@/common/components/view-toggle'
+import { useViewPreference } from '@/common/hooks/use-view-preference'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 
@@ -81,6 +84,10 @@ export function SkillsPage() {
 
   const hasSkills = skills.length > 0
 
+  const { view: installedView, setView: setInstalledView } = useViewPreference(
+    'ui.viewMode.skillsInstalled'
+  )
+
   return (
     <>
       <Tabs
@@ -103,11 +110,14 @@ export function SkillsPage() {
               />
             )}
             {tab === 'installed' && hasSkills && (
-              <InputSearch
-                value={installedFilter}
-                onChange={setInstalledFilter}
-                placeholder="Search..."
-              />
+              <>
+                <InputSearch
+                  value={installedFilter}
+                  onChange={setInstalledFilter}
+                  placeholder="Search..."
+                />
+                <ViewToggle value={installedView} onChange={setInstalledView} />
+              </>
             )}
             {tab === 'builds' && (
               <>
@@ -149,6 +159,8 @@ export function SkillsPage() {
               ]}
               illustration={IllustrationPackage}
             />
+          ) : installedView === 'table' ? (
+            <TableInstalledSkills skills={filteredSkills} />
           ) : (
             <GridCardsSkills skills={filteredSkills} />
           )}

--- a/renderer/src/features/skills/components/table-installed-skills.tsx
+++ b/renderer/src/features/skills/components/table-installed-skills.tsx
@@ -110,7 +110,7 @@ function SkillRow({ skill }: { skill: InstalledSkill }) {
           )}
         </TableCell>
 
-        <TableCell className="w-[120px] py-3">
+        <TableCell className="w-[1%] py-3 whitespace-nowrap">
           {status ? (
             <Badge variant={skillStatusVariantMap[status] ?? 'secondary'}>
               {status}
@@ -156,34 +156,35 @@ export function TableInstalledSkills({ skills }: { skills: InstalledSkill[] }) {
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow className="bg-muted/40 hover:bg-muted/40">
-            <TableHead className="text-muted-foreground font-medium">
-              Skill
-            </TableHead>
-            <TableHead className="text-muted-foreground font-medium">
-              Mode
-            </TableHead>
-            <TableHead className="text-muted-foreground font-medium">
-              Destination
-            </TableHead>
-            <TableHead className="text-muted-foreground w-[120px] font-medium">
-              Status
-            </TableHead>
-            <TableHead className="w-[120px]" aria-label="Actions" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {skills.map((skill, index) => (
-            <SkillRow
-              key={skill.reference ?? skill.metadata?.name ?? `skill-${index}`}
-              skill={skill}
-            />
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+    <Table containerClassName="overflow-hidden rounded-lg border">
+      <TableHeader>
+        <TableRow className="bg-muted/40 hover:bg-muted/40">
+          <TableHead className="text-muted-foreground font-medium">
+            Skill
+          </TableHead>
+          <TableHead className="text-muted-foreground font-medium">
+            Mode
+          </TableHead>
+          <TableHead className="text-muted-foreground font-medium">
+            Destination
+          </TableHead>
+          <TableHead
+            className="text-muted-foreground w-[1%] font-medium
+              whitespace-nowrap"
+          >
+            Status
+          </TableHead>
+          <TableHead className="w-[120px]" aria-label="Actions" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {skills.map((skill, index) => (
+          <SkillRow
+            key={skill.reference ?? skill.metadata?.name ?? `skill-${index}`}
+            skill={skill}
+          />
+        ))}
+      </TableBody>
+    </Table>
   )
 }

--- a/renderer/src/features/skills/components/table-installed-skills.tsx
+++ b/renderer/src/features/skills/components/table-installed-skills.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react'
+import { Button } from '@/common/components/ui/button'
+import { Badge } from '@/common/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/common/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { FolderGit2Icon, Trash2Icon, UserIcon } from 'lucide-react'
+import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
+import { DialogUninstallSkill } from './dialog-uninstall-skill'
+import { SkillClientsBadges } from './skill-clients-badges'
+import { skillStatusVariantMap } from './skill-status'
+
+function SkillRow({ skill }: { skill: InstalledSkill }) {
+  const [uninstallOpen, setUninstallOpen] = useState(false)
+
+  const title = skill.metadata?.name ?? skill.reference ?? 'Unknown skill'
+  const subtitle =
+    skill.reference && skill.reference !== title ? skill.reference : undefined
+  const status = skill.status
+  const scope = skill.scope
+  const clients = skill.clients ?? []
+  const projectRoot = scope === 'project' ? skill.project_root : undefined
+  const projectRootLabel = projectRoot
+    ? `/${projectRoot.split(/[\\/]/).filter(Boolean).at(-1) ?? projectRoot}`
+    : null
+  const isProjectScope = scope === 'project'
+  const modeLabel = isProjectScope ? 'Repo' : scope === 'user' ? 'User' : null
+
+  return (
+    <>
+      <TableRow>
+        <TableCell className="py-3 font-medium">
+          <div className="flex min-w-0 flex-col">
+            <Tooltip onlyWhenTruncated>
+              <TooltipTrigger asChild>
+                <span className="block max-w-[260px] truncate">{title}</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">{title}</TooltipContent>
+            </Tooltip>
+            {subtitle && (
+              <Tooltip onlyWhenTruncated>
+                <TooltipTrigger asChild>
+                  <span
+                    className="text-muted-foreground block max-w-[260px]
+                      truncate text-xs"
+                  >
+                    {subtitle}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">{subtitle}</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </TableCell>
+
+        <TableCell className="py-3">
+          {modeLabel ? (
+            <span className="inline-flex items-center gap-1.5 text-sm">
+              {isProjectScope ? (
+                <FolderGit2Icon aria-hidden className="size-3.5" />
+              ) : (
+                <UserIcon aria-hidden className="size-3.5" />
+              )}
+              {modeLabel}
+            </span>
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
+        </TableCell>
+
+        <TableCell className="py-3">
+          {isProjectScope ? (
+            <div className="flex flex-col items-start gap-1.5">
+              {projectRootLabel && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge variant="outline" className="font-mono">
+                      {projectRootLabel}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    className="max-w-xs font-mono text-xs break-all"
+                  >
+                    {projectRoot}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+              {clients.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  <SkillClientsBadges clients={clients} />
+                </div>
+              )}
+            </div>
+          ) : clients.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              <SkillClientsBadges clients={clients} />
+            </div>
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
+        </TableCell>
+
+        <TableCell className="w-[120px] py-3">
+          {status ? (
+            <Badge variant={skillStatusVariantMap[status] ?? 'secondary'}>
+              {status}
+            </Badge>
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
+        </TableCell>
+
+        <TableCell className="w-[120px] py-3 text-right">
+          <Button
+            variant="outline"
+            size="sm"
+            className="rounded-full"
+            onClick={(e) => {
+              e.stopPropagation()
+              setUninstallOpen(true)
+            }}
+            aria-label={`Uninstall ${title}`}
+          >
+            <Trash2Icon className="size-4" />
+            Uninstall
+          </Button>
+        </TableCell>
+      </TableRow>
+
+      <DialogUninstallSkill
+        open={uninstallOpen}
+        onOpenChange={setUninstallOpen}
+        skill={skill}
+      />
+    </>
+  )
+}
+
+export function TableInstalledSkills({ skills }: { skills: InstalledSkill[] }) {
+  if (skills.length === 0) {
+    return (
+      <div className="text-muted-foreground py-12 text-center">
+        <p className="text-sm">No skills found matching the current filter</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/40 hover:bg-muted/40">
+            <TableHead className="text-muted-foreground font-medium">
+              Skill
+            </TableHead>
+            <TableHead className="text-muted-foreground font-medium">
+              Mode
+            </TableHead>
+            <TableHead className="text-muted-foreground font-medium">
+              Destination
+            </TableHead>
+            <TableHead className="text-muted-foreground w-[120px] font-medium">
+              Status
+            </TableHead>
+            <TableHead className="w-[120px]" aria-label="Actions" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {skills.map((skill, index) => (
+            <SkillRow
+              key={skill.reference ?? skill.metadata?.name ?? `skill-${index}`}
+              skill={skill}
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}


### PR DESCRIPTION
The installed MCP servers page and the Skills "Installed" tab only rendered cards, and the registry tab Figma hints at a grid/list view switcher. This PR wires up a `ViewToggle` on both pages, adds a table rendering path that surfaces every affordance the card already exposes, and persists the user's choice per-page in the existing SQLite `settings` table so a reload brings them back to the same view.

The Figma frames for the MCP servers table and the skills table were used as a compass for the layout, but the goal was to preserve parity with the current cards — every piece of info, every conditional control (update button, status badge, client overflow tooltip), and every kebab action — not just the columns shown in the mockups.

related task https://github.com/stacklok/toolhive-studio/issues/2033


https://github.com/user-attachments/assets/e6fda555-2c21-4227-a9e6-82707493cd08


### Persistence (`main/` + `preload/`)

- Add a `ui-preferences` IPC namespace backed by the existing SQLite `settings` table. `UI_PREFERENCE_KEYS` enumerates the allowed keys (`ui.viewMode.mcpServers`, `ui.viewMode.skillsInstalled`) and the handlers reject anything that isn't `'card' | 'table'` at the main-process boundary. Unknown keys default to `'card'`.
- Expose `window.electronAPI.uiPreferences.{getViewMode, setViewMode}` from the preload, typed from the main-side source of truth so renderer callers never see `unknown`.
- Add matching stubs to the shared `electronAPI` mock so renderer tests don't need to touch IPC.

### Renderer primitives

- Add `useViewPreference(key)` hook (React Query) that loads the persisted value, defaults to `'card'` while the query is in-flight or errors out, and writes back optimistically so the UI flips without waiting on the DB round-trip.
- Add a `ViewToggle` segmented control (`LayoutGrid` / `List` from `lucide-react`) as two radios in a pill container, with proper aria state and an `onChange` that only fires on actual changes.
- Extend the shadcn `Table` primitive with an optional `containerClassName` prop. Its default wrapper uses `overflow-x-auto`, which produced an internal horizontal scrollbar inside rounded-border wrappers even with `table-layout: fixed`; callers can now merge/override those utilities via `tailwind-merge` without dropping the primitive.

### MCP servers page

- Render `ViewToggle` alongside the search input and branch between `CardMcpServer` grid and a new `TableMcpServers` based on `ui.viewMode.mcpServers`.
- `TableMcpServers` uses `table-layout: fixed` with **Server** `w-auto md:w-[28%]`, **About** `w-auto` (hidden below `md`, Server grows to fill), and fixed pixel widths for **Update** (`w-11`), **Status** (`w-[132px]`), **Type** (`w-10`), and **Actions** (`w-16 pr-3`). Row contents mirror `CardMcpServer`: truncated name + tooltip, truncated description + tooltip, the conditional `UpdateVersionButton` (amber, icon-only when there's registry drift), a start/stop `Switch` with live status label (`min-w-0 + flex-1` so "Unauthenticated" / "Transitioning" truncate cleanly inside 132px), local/remote icon with tooltip, and the full `ServerActionsDropdown` kebab.
- The Actions column is sized to comfortably fit the `size-9` trigger plus its `ml-2` and `pr-3` so the dropdown no longer hugs the rounded border.

### Skills Installed tab

- Render `ViewToggle` next to the search on the Installed tab only; Registry and Local Builds are intentionally unchanged.
- `TableInstalledSkills` mirrors every installed-card affordance: skill name with `reference` subtitle when it differs from `metadata.name`, scope column with `UserIcon` / `FolderGit2Icon`, destination column that shows `SkillClientsBadges` for user-scoped installs and a `project_root` chip for repo-scoped ones (both when applicable), status badge with the same variant map, and the `Uninstall` button that opens `DialogUninstallSkill`.
- Extract `SkillClientsBadges` so the `+N` overflow tooltip behaves identically in cards and rows, and lift `skillStatusVariantMap` into `skill-status.ts` to keep `card-skill.tsx` compatible with `react-refresh/only-export-components`.

### Tests

- Unit tests for `useViewPreference` (default, persisted read, optimistic write), `ViewToggle` (aria + onChange), `TableMcpServers` (header, row rendering, status, update-button visibility, kebab menu), `GridCardsMcpServers` (toggle persistence + default), and `TableInstalledSkills` (columns, client badges, project root, status, uninstall flow).
- Updated `main/src/ipc-handlers/__tests__/index.test.ts` to mock the new `ui-preferences` registrar so it doesn't transitively pull `main/src/logger.ts` (`app.isPackaged`) in a non-Electron test environment.

### Not changed in this PR (deliberate, follow-up)

- The table view on the MCP servers page is per-installed-servers only — the Registry view still renders as cards.
- No sort/filter by column in the tables yet; the existing search input + status filter still drive row visibility.
- The About column hides below `md` (768px). If that breakpoint feels too aggressive for sidebar layouts, it's a one-line swap to `lg`.
- No automatic migration for users who already had a non-persisted mental default — first load in either page lands on the card view until they touch the toggle.
