### PR TITLE
feat(ui): add card/table view toggle for registry and skills tabs

### DIFF
--- a/main/src/ui-preferences.ts
+++ b/main/src/ui-preferences.ts
@@ -5,6 +5,9 @@ import { writeSetting } from './db/writers/settings-writer'
 export const UI_PREFERENCE_KEYS = [
   'ui.viewMode.mcpServers',
   'ui.viewMode.skillsInstalled',
+  'ui.viewMode.registry',
+  'ui.viewMode.skillsRegistry',
+  'ui.viewMode.skillsBuilds',
 ] as const
 
 export type UiPreferenceKey = (typeof UI_PREFERENCE_KEYS)[number]

--- a/renderer/src/features/mcp-servers/components/table-mcp-servers.tsx
+++ b/renderer/src/features/mcp-servers/components/table-mcp-servers.tsx
@@ -135,7 +135,7 @@ function McpServerRow({ mcpServer }: { mcpServer: CoreWorkload }) {
           <TooltipTrigger asChild>
             <span
               className={cn(
-                'block truncate',
+                'block max-w-[260px] truncate',
                 isStopped && 'text-foreground/65'
               )}
             >
@@ -146,7 +146,10 @@ function McpServerRow({ mcpServer }: { mcpServer: CoreWorkload }) {
         </Tooltip>
       </TableCell>
 
-      <TableCell className="text-muted-foreground hidden py-3 md:table-cell">
+      <TableCell
+        className="text-muted-foreground hidden w-full max-w-0 py-3
+          md:table-cell"
+      >
         {description ? (
           <Tooltip onlyWhenTruncated>
             <TooltipTrigger asChild>
@@ -232,19 +235,14 @@ export function TableMcpServers({
   }
 
   return (
-    <Table
-      className="table-fixed"
-      containerClassName="overflow-hidden rounded-lg border"
-    >
+    <Table containerClassName="rounded-lg border">
       <TableHeader>
         <TableRow className="bg-muted/40 hover:bg-muted/40">
-          <TableHead
-            className="text-muted-foreground w-auto font-medium md:w-[28%]"
-          >
+          <TableHead className="text-muted-foreground font-medium">
             Server
           </TableHead>
           <TableHead
-            className="text-muted-foreground hidden w-auto font-medium
+            className="text-muted-foreground hidden w-full max-w-0 font-medium
               md:table-cell"
           >
             About

--- a/renderer/src/features/registry-servers/components/__tests__/table-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/table-registry.test.tsx
@@ -94,16 +94,13 @@ describe('TableRegistry', () => {
     expect(
       screen.getByRole('columnheader', { name: /stars/i })
     ).toBeInTheDocument()
-    expect(
-      screen.getByRole('columnheader', { name: /status/i })
-    ).toBeInTheDocument()
 
     expect(screen.getByText('Postgres')).toBeVisible()
     expect(screen.getByText('Remote API')).toBeVisible()
     expect(screen.getByText('ai-tools')).toBeVisible()
   })
 
-  it('shows stars, type icon, GitHub link, and status pill for servers', async () => {
+  it('shows stars, type icon, and GitHub link for servers', async () => {
     const router = makeRouter(
       <TableRegistry items={[localServer, remoteServer]} />
     )
@@ -119,8 +116,6 @@ describe('TableRegistry', () => {
       name: /open repository on github/i,
     })
     expect(github).toHaveAttribute('href', 'https://github.com/org/postgres')
-
-    expect(screen.getByText('deprecated')).toBeVisible()
   })
 
   it('shows the Group badge and server count for groups', async () => {

--- a/renderer/src/features/registry-servers/components/__tests__/table-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/table-registry.test.tsx
@@ -1,0 +1,236 @@
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import type { createTestRouter } from '@/common/test/create-test-router'
+import type { RegistryItem } from '../../types'
+import { TableRegistry } from '../table-registry'
+
+const localServer: RegistryItem = {
+  type: 'server',
+  name: 'postgres',
+  title: 'Postgres',
+  description: 'Manage Postgres databases',
+  image: 'ghcr.io/org/postgres:1',
+  status: 'active',
+  metadata: { stars: 1234 },
+  repository_url: 'https://github.com/org/postgres',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any
+
+const remoteServer: RegistryItem = {
+  type: 'server',
+  name: 'remote-api',
+  title: 'Remote API',
+  description: 'A remote MCP server',
+  url: 'https://example.com/mcp',
+  status: 'deprecated',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any
+
+const group: RegistryItem = {
+  type: 'group',
+  name: 'ai-tools',
+  description: 'Group of AI tools',
+  servers: { a: {}, b: {} },
+  remote_servers: { c: {} },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any
+
+function makeRouter(element: React.ReactElement) {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>{error.message}</div>,
+  })
+  const tableRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/registry',
+    component: () => element,
+  })
+  const serverDetail = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/registry/$name',
+    component: () => <div data-testid="server-detail" />,
+  })
+  const groupDetail = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/registry-group/$name',
+    component: () => <div data-testid="group-detail" />,
+  })
+  return new Router({
+    routeTree: rootRoute.addChildren([tableRoute, serverDetail, groupDetail]),
+    history: createMemoryHistory({ initialEntries: ['/registry'] }),
+    defaultNotFoundComponent: () => null,
+  }) as unknown as ReturnType<typeof createTestRouter>
+}
+
+describe('TableRegistry', () => {
+  it('renders headers and rows for servers and groups', async () => {
+    const router = makeRouter(
+      <TableRegistry items={[localServer, remoteServer, group]} />
+    )
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('Postgres')).toBeVisible()
+    })
+
+    expect(
+      screen.getByRole('columnheader', { name: /name/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /about/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /type/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /stars/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /status/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText('Postgres')).toBeVisible()
+    expect(screen.getByText('Remote API')).toBeVisible()
+    expect(screen.getByText('ai-tools')).toBeVisible()
+  })
+
+  it('shows stars, type icon, GitHub link, and status pill for servers', async () => {
+    const router = makeRouter(
+      <TableRegistry items={[localServer, remoteServer]} />
+    )
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('1,234')).toBeVisible()
+    })
+    expect(screen.getByLabelText(/local mcp server/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/remote mcp server/i)).toBeInTheDocument()
+
+    const github = screen.getByRole('link', {
+      name: /open repository on github/i,
+    })
+    expect(github).toHaveAttribute('href', 'https://github.com/org/postgres')
+
+    expect(screen.getByText('deprecated')).toBeVisible()
+  })
+
+  it('shows the Group badge and server count for groups', async () => {
+    const router = makeRouter(<TableRegistry items={[group]} />)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('Group')).toBeVisible()
+    })
+    expect(screen.getByText('3 servers')).toBeVisible()
+  })
+
+  it('navigates to /registry/$name when a server row is clicked', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter(<TableRegistry items={[localServer]} />)
+    renderRoute(router)
+
+    const row = await screen.findByRole('button', { name: 'Postgres' })
+    await user.click(row)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/registry/postgres')
+    })
+  })
+
+  it('navigates to /registry-group/$name when a group row is clicked', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter(<TableRegistry items={[group]} />)
+    renderRoute(router)
+
+    const row = await screen.findByRole('button', { name: 'ai-tools' })
+    await user.click(row)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/registry-group/ai-tools')
+    })
+  })
+
+  it('activates a row with Enter or Space keys', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter(<TableRegistry items={[localServer]} />)
+    renderRoute(router)
+
+    const row = await screen.findByRole('button', { name: 'Postgres' })
+    row.focus()
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/registry/postgres')
+    })
+  })
+
+  it('does not navigate when clicking the GitHub link', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter(<TableRegistry items={[localServer]} />)
+    renderRoute(router)
+
+    const github = await screen.findByRole('link', {
+      name: /open repository on github/i,
+    })
+    await user.click(github)
+
+    expect(router.state.location.pathname).toBe('/registry')
+  })
+
+  it('renders the promo row at index 6 when showPromo is set', async () => {
+    const items: RegistryItem[] = Array.from({ length: 8 }, (_, i) => ({
+      ...localServer,
+      name: `server-${i}`,
+      title: `Server ${i}`,
+    }))
+    const router = makeRouter(<TableRegistry items={items} showPromo />)
+    renderRoute(router)
+
+    const promo = await screen.findByTestId('registry-promo-row')
+    expect(promo).toBeInTheDocument()
+    expect(screen.getByText(/build a custom registry/i)).toBeVisible()
+
+    const body = promo.closest('tbody')
+    expect(body).not.toBeNull()
+    const rows = body!.querySelectorAll('tr')
+    expect(rows[6]).toBe(promo)
+  })
+
+  it('does not render the promo row when showPromo is not set', async () => {
+    const items: RegistryItem[] = Array.from({ length: 8 }, (_, i) => ({
+      ...localServer,
+      name: `server-${i}`,
+      title: `Server ${i}`,
+    }))
+    const router = makeRouter(<TableRegistry items={items} />)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('Server 0')).toBeVisible()
+    })
+
+    expect(screen.queryByTestId('registry-promo-row')).toBeNull()
+  })
+
+  it('shows empty state when items is empty', async () => {
+    const router = makeRouter(<TableRegistry items={[]} />)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /no servers or groups found matching the current filter/i
+        )
+      ).toBeVisible()
+    })
+  })
+})

--- a/renderer/src/features/registry-servers/components/table-registry.tsx
+++ b/renderer/src/features/registry-servers/components/table-registry.tsx
@@ -1,0 +1,321 @@
+import type {
+  RegistryImageMetadata,
+  RegistryRemoteServerMetadata,
+  RegistryGroup,
+} from '@common/api/registry-types'
+import type { RegistryItem } from '../types'
+import { useNavigate } from '@tanstack/react-router'
+import { CloudIcon, GitFork, Github, LaptopIcon } from 'lucide-react'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/common/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { Badge } from '@/common/components/ui/badge'
+import { cn } from '@/common/lib/utils'
+import { Stars } from './stars'
+import { CardRegistryPromo } from './card-registry-promo'
+
+const PROMO_INDEX = 6
+
+type RegistryServerItem =
+  | (RegistryImageMetadata & { type: 'server' })
+  | (RegistryRemoteServerMetadata & { type: 'server' })
+
+type RegistryGroupItem = RegistryGroup & { type: 'group' }
+
+function isGroupItem(item: RegistryItem): item is RegistryGroupItem {
+  return item.type === 'group'
+}
+
+function activateOnKey(e: React.KeyboardEvent, onActivate: () => void) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    onActivate()
+  }
+}
+
+function ServerRow({ server }: { server: RegistryServerItem }) {
+  const navigate = useNavigate()
+  const isRemote = 'url' in server
+  const title = server.title ?? server.name ?? ''
+  const stars = server.metadata?.stars
+  const repositoryUrl = server.repository_url
+  const isDeprecated = server.status === 'deprecated'
+
+  function goToDetail() {
+    if (!server.name) return
+    void navigate({
+      to: '/registry/$name',
+      params: { name: server.name },
+    })
+  }
+
+  return (
+    <TableRow
+      role="button"
+      tabIndex={0}
+      aria-label={title}
+      onClick={goToDetail}
+      onKeyDown={(e) => activateOnKey(e, goToDetail)}
+      className="cursor-pointer"
+    >
+      <TableCell className="py-3 font-medium">
+        <Tooltip onlyWhenTruncated>
+          <TooltipTrigger asChild>
+            <span className="block max-w-[260px] truncate">{title}</span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">{title}</TooltipContent>
+        </Tooltip>
+      </TableCell>
+
+      <TableCell
+        className="text-muted-foreground hidden w-full max-w-0 py-3
+          md:table-cell"
+      >
+        {server.description ? (
+          <Tooltip onlyWhenTruncated>
+            <TooltipTrigger asChild>
+              <span className="block truncate text-sm">
+                {server.description}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-sm">
+              {server.description}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <span className="text-muted-foreground/60 text-sm">—</span>
+        )}
+      </TableCell>
+
+      <TableCell className="text-muted-foreground py-3">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex items-center gap-2 text-sm">
+              {isRemote ? (
+                <CloudIcon className="size-5" aria-label="Remote MCP server" />
+              ) : (
+                <LaptopIcon className="size-5" aria-label="Local MCP server" />
+              )}
+              <span className="capitalize">
+                {isRemote ? 'Remote' : 'Local'}
+              </span>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            {isRemote ? 'Remote MCP server' : 'Local MCP server'}
+          </TooltipContent>
+        </Tooltip>
+      </TableCell>
+
+      <TableCell className="py-3">
+        {stars ? (
+          <Stars stars={stars} />
+        ) : (
+          <span className="text-muted-foreground/60 text-sm">—</span>
+        )}
+      </TableCell>
+
+      <TableCell className="py-3">
+        {repositoryUrl ? (
+          <a
+            href={repositoryUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="text-muted-foreground hover:bg-accent inline-flex size-8
+              items-center justify-center rounded-md"
+            aria-label="Open repository on GitHub"
+          >
+            <Github className="size-4" />
+          </a>
+        ) : null}
+      </TableCell>
+
+      <TableCell className="py-3 pr-3">
+        {isDeprecated ? (
+          <span
+            className="border-border text-muted-foreground bg-muted/20
+              inline-block rounded-md border px-1.5 py-0.5 text-xs"
+          >
+            {server.status}
+          </span>
+        ) : null}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function GroupRow({ group }: { group: RegistryGroupItem }) {
+  const navigate = useNavigate()
+  const serverCount =
+    (group.servers ? Object.keys(group.servers).length : 0) +
+    (group.remote_servers ? Object.keys(group.remote_servers).length : 0)
+
+  function goToDetail() {
+    if (!group.name) return
+    void navigate({
+      to: '/registry-group/$name',
+      params: { name: group.name },
+    })
+  }
+
+  return (
+    <TableRow
+      role="button"
+      tabIndex={0}
+      aria-label={group.name ?? 'Registry group'}
+      onClick={goToDetail}
+      onKeyDown={(e) => activateOnKey(e, goToDetail)}
+      className="cursor-pointer"
+    >
+      <TableCell className="py-3 font-medium">
+        <div className="flex flex-col gap-1">
+          <Tooltip onlyWhenTruncated>
+            <TooltipTrigger asChild>
+              <span className="block max-w-[260px] truncate">{group.name}</span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">{group.name}</TooltipContent>
+          </Tooltip>
+          <Badge
+            variant="secondary"
+            className="bg-foreground/5 w-fit rounded-full px-2.5 py-0.5 text-xs"
+          >
+            Group
+          </Badge>
+        </div>
+      </TableCell>
+
+      <TableCell
+        className="text-muted-foreground hidden w-full max-w-0 py-3
+          md:table-cell"
+      >
+        {group.description ? (
+          <Tooltip onlyWhenTruncated>
+            <TooltipTrigger asChild>
+              <span className="block truncate text-sm">
+                {group.description}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-sm">
+              {group.description}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <span className="text-muted-foreground/60 text-sm">—</span>
+        )}
+      </TableCell>
+
+      <TableCell className="text-muted-foreground py-3">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex items-center gap-2 text-sm">
+              <GitFork className="size-5" aria-label="Group" />
+              <span>
+                {serverCount} {serverCount === 1 ? 'server' : 'servers'}
+              </span>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            This group contains {serverCount} MCP{' '}
+            {serverCount === 1 ? 'server' : 'servers'}
+          </TooltipContent>
+        </Tooltip>
+      </TableCell>
+
+      <TableCell className="py-3" aria-hidden>
+        <span className="text-muted-foreground/60 text-sm">—</span>
+      </TableCell>
+
+      <TableCell className="py-3" aria-hidden />
+
+      <TableCell className="py-3 pr-3" aria-hidden />
+    </TableRow>
+  )
+}
+
+function PromoRow() {
+  return (
+    <TableRow
+      data-testid="registry-promo-row"
+      className={cn('hover:bg-transparent', 'border-b')}
+    >
+      <TableCell colSpan={6} className="p-4">
+        <CardRegistryPromo />
+      </TableCell>
+    </TableRow>
+  )
+}
+
+export function TableRegistry({
+  items,
+  showPromo,
+}: {
+  items: RegistryItem[]
+  showPromo?: boolean
+}) {
+  const insertAt = Math.min(PROMO_INDEX, items.length)
+  const before = items.slice(0, insertAt)
+  const after = items.slice(insertAt)
+
+  if (items.length === 0) {
+    return (
+      <div className="text-muted-foreground py-12 text-center">
+        <p className="text-sm">
+          No servers or groups found matching the current filter
+        </p>
+      </div>
+    )
+  }
+
+  const renderRow = (item: RegistryItem) =>
+    isGroupItem(item) ? (
+      <GroupRow key={`group-${item.name}`} group={item} />
+    ) : (
+      <ServerRow key={`server-${item.name}`} server={item} />
+    )
+
+  return (
+    <Table containerClassName="rounded-lg border">
+      <TableHeader>
+        <TableRow className="bg-muted/40 hover:bg-muted/40">
+          <TableHead className="text-muted-foreground font-medium">
+            Name
+          </TableHead>
+          <TableHead
+            className="text-muted-foreground hidden w-full max-w-0 font-medium
+              md:table-cell"
+          >
+            About
+          </TableHead>
+          <TableHead className="text-muted-foreground w-[150px] font-medium">
+            Type
+          </TableHead>
+          <TableHead className="text-muted-foreground w-[110px] font-medium">
+            Stars
+          </TableHead>
+          <TableHead className="w-12" aria-label="Repository" />
+          <TableHead
+            className="text-muted-foreground w-[110px] pr-3 font-medium"
+          >
+            Status
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {before.map(renderRow)}
+        {showPromo && <PromoRow />}
+        {after.map(renderRow)}
+      </TableBody>
+    </Table>
+  )
+}

--- a/renderer/src/features/registry-servers/components/table-registry.tsx
+++ b/renderer/src/features/registry-servers/components/table-registry.tsx
@@ -49,7 +49,6 @@ function ServerRow({ server }: { server: RegistryServerItem }) {
   const title = server.title ?? server.name ?? ''
   const stars = server.metadata?.stars
   const repositoryUrl = server.repository_url
-  const isDeprecated = server.status === 'deprecated'
 
   function goToDetail() {
     if (!server.name) return
@@ -125,7 +124,7 @@ function ServerRow({ server }: { server: RegistryServerItem }) {
         )}
       </TableCell>
 
-      <TableCell className="py-3">
+      <TableCell className="py-3 pr-3">
         {repositoryUrl ? (
           <a
             href={repositoryUrl}
@@ -138,17 +137,6 @@ function ServerRow({ server }: { server: RegistryServerItem }) {
           >
             <Github className="size-4" />
           </a>
-        ) : null}
-      </TableCell>
-
-      <TableCell className="py-3 pr-3">
-        {isDeprecated ? (
-          <span
-            className="border-border text-muted-foreground bg-muted/20
-              inline-block rounded-md border px-1.5 py-0.5 text-xs"
-          >
-            {server.status}
-          </span>
         ) : null}
       </TableCell>
     </TableRow>
@@ -236,8 +224,6 @@ function GroupRow({ group }: { group: RegistryGroupItem }) {
         <span className="text-muted-foreground/60 text-sm">—</span>
       </TableCell>
 
-      <TableCell className="py-3" aria-hidden />
-
       <TableCell className="py-3 pr-3" aria-hidden />
     </TableRow>
   )
@@ -249,7 +235,7 @@ function PromoRow() {
       data-testid="registry-promo-row"
       className={cn('hover:bg-transparent', 'border-b')}
     >
-      <TableCell colSpan={6} className="p-4">
+      <TableCell colSpan={5} className="p-4">
         <CardRegistryPromo />
       </TableCell>
     </TableRow>
@@ -303,12 +289,7 @@ export function TableRegistry({
           <TableHead className="text-muted-foreground w-[110px] font-medium">
             Stars
           </TableHead>
-          <TableHead className="w-12" aria-label="Repository" />
-          <TableHead
-            className="text-muted-foreground w-[110px] pr-3 font-medium"
-          >
-            Status
-          </TableHead>
+          <TableHead className="w-12 pr-3" aria-label="Repository" />
         </TableRow>
       </TableHeader>
       <TableBody>

--- a/renderer/src/features/skills/components/__tests__/table-builds.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-builds.test.tsx
@@ -1,0 +1,160 @@
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import type { createTestRouter } from '@/common/test/create-test-router'
+import { TableBuilds } from '../table-builds'
+import { mockedGetApiV1BetaSkillsBuilds } from '@mocks/fixtures/skills_builds/get'
+import { mockedGetApiV1BetaDiscoveryClients } from '@mocks/fixtures/discovery_clients/get'
+
+function makeRouter(
+  props: { filter: string; onBuild: () => void } = {
+    filter: '',
+    onBuild: vi.fn(),
+  }
+) {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>{error.message}</div>,
+  })
+  const listRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills',
+    component: () => (
+      <TableBuilds filter={props.filter} onBuild={props.onBuild} />
+    ),
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills/builds/$tag',
+    component: () => <div data-testid="build-detail-page" />,
+  })
+  return new Router({
+    routeTree: rootRoute.addChildren([listRoute, detailRoute]),
+    history: createMemoryHistory({ initialEntries: ['/skills'] }),
+    defaultNotFoundComponent: () => null,
+  }) as unknown as ReturnType<typeof createTestRouter>
+}
+
+beforeEach(() => {
+  mockedGetApiV1BetaSkillsBuilds.reset()
+  mockedGetApiV1BetaDiscoveryClients.activateScenario('empty')
+})
+
+describe('TableBuilds', () => {
+  it('renders a row per build with name, version, digest, and description', async () => {
+    const router = makeRouter()
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('my-skill')).toBeVisible()
+    })
+
+    expect(
+      screen.getByRole('columnheader', { name: /build/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /version/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /about/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText('v1.0.0')).toBeVisible()
+    expect(screen.getByText('A locally built skill')).toBeVisible()
+    expect(screen.getAllByText(/^sha256:/)[0]).toBeVisible()
+  })
+
+  it('shows the empty-state CTA when there are no builds', async () => {
+    mockedGetApiV1BetaSkillsBuilds.activateScenario('empty')
+    const onBuild = vi.fn()
+    const router = makeRouter({ filter: '', onBuild })
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText(/no local builds/i)).toBeVisible()
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /build skill/i }))
+    expect(onBuild).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the filtered-empty message when the filter matches nothing', async () => {
+    const router = makeRouter({ filter: 'zzz-no-match-zzz', onBuild: vi.fn() })
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no builds found matching the current filter/i)
+      ).toBeVisible()
+    })
+  })
+
+  it('opens install dialog prefilled with the build tag', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter()
+    renderRoute(router)
+
+    const install = await screen.findByRole('button', {
+      name: /install my-skill/i,
+    })
+    await user.click(install)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
+        'localhost/my-skill:v1.0.0'
+      )
+    })
+  })
+
+  it('opens remove dialog when Remove is clicked', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter()
+    renderRoute(router)
+
+    const remove = await screen.findByRole('button', {
+      name: /remove my-skill/i,
+    })
+    await user.click(remove)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /remove build/i })
+      ).toBeVisible()
+    })
+  })
+
+  it('navigates to the build detail page when a row is clicked', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter()
+    renderRoute(router)
+
+    const row = await screen.findByRole('button', { name: 'my-skill' })
+    await user.click(row)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toMatch(/\/skills\/builds\//)
+    })
+  })
+
+  it('does not navigate when Install button is clicked', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter()
+    renderRoute(router)
+
+    const install = await screen.findByRole('button', {
+      name: /install my-skill/i,
+    })
+    await user.click(install)
+
+    expect(router.state.location.pathname).toBe('/skills')
+  })
+})

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -73,6 +73,9 @@ describe('TableRegistrySkills', () => {
       screen.getByRole('columnheader', { name: /skill/i })
     ).toBeInTheDocument()
     expect(
+      screen.getByRole('columnheader', { name: /author/i })
+    ).toBeInTheDocument()
+    expect(
       screen.getByRole('columnheader', { name: /about/i })
     ).toBeInTheDocument()
 

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -1,0 +1,182 @@
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import type { createTestRouter } from '@/common/test/create-test-router'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { TableRegistrySkills } from '../table-registry-skills'
+import { mockedGetApiV1BetaDiscoveryClients } from '@mocks/fixtures/discovery_clients/get'
+
+const ociSkill: RegistrySkill = {
+  name: 'my-skill',
+  namespace: 'io.github.user',
+  description: 'A helpful skill',
+  version: 'v1.0.0',
+  packages: [{ registryType: 'oci', identifier: 'ghcr.io/org/my-skill' }],
+}
+
+const gitSkill: RegistrySkill = {
+  name: 'git-skill',
+  namespace: 'io.github.other',
+  description: 'A git-based skill',
+  version: 'v2.0.0',
+  packages: [{ registryType: 'git', identifier: 'https://github.com/x/y' }],
+}
+
+const skillNoNamespace: RegistrySkill = {
+  name: 'standalone',
+}
+
+function makeRouter(skills: RegistrySkill[]) {
+  const rootRoute = createRootRoute({
+    component: Outlet,
+    errorComponent: ({ error }) => <div>{error.message}</div>,
+  })
+  const listRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills',
+    component: () => <TableRegistrySkills skills={skills} />,
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills/$namespace/$skillName',
+    component: () => <div data-testid="skill-detail-page" />,
+  })
+  return new Router({
+    routeTree: rootRoute.addChildren([listRoute, detailRoute]),
+    history: createMemoryHistory({ initialEntries: ['/skills'] }),
+    defaultNotFoundComponent: () => null,
+  }) as unknown as ReturnType<typeof createTestRouter>
+}
+
+beforeEach(() => {
+  mockedGetApiV1BetaDiscoveryClients.activateScenario('empty')
+})
+
+describe('TableRegistrySkills', () => {
+  it('renders column headers and rows', async () => {
+    const router = makeRouter([ociSkill, gitSkill])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('my-skill')).toBeVisible()
+    })
+
+    expect(
+      screen.getByRole('columnheader', { name: /skill/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /about/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText('io.github.user')).toBeVisible()
+    expect(screen.getByText('git-skill')).toBeVisible()
+    expect(screen.getByText('A helpful skill')).toBeVisible()
+  })
+
+  it('shows an empty state when skills is empty', async () => {
+    const router = makeRouter([])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no skills found matching the current filter/i)
+      ).toBeVisible()
+    })
+  })
+
+  it('navigates to the skill detail page when a row is clicked', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter([ociSkill])
+    renderRoute(router)
+
+    const row = await screen.findByRole('button', { name: 'my-skill' })
+    await user.click(row)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(
+        '/skills/io.github.user/my-skill'
+      )
+    })
+  })
+
+  it('activates a row via the Enter key', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter([ociSkill])
+    renderRoute(router)
+
+    const row = await screen.findByRole('button', { name: 'my-skill' })
+    row.focus()
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(
+        '/skills/io.github.user/my-skill'
+      )
+    })
+  })
+
+  it('does not treat a row without namespace/name as a navigable button', async () => {
+    const router = makeRouter([skillNoNamespace])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('standalone')).toBeVisible()
+    })
+    expect(screen.queryByRole('button', { name: 'standalone' })).toBeNull()
+  })
+
+  it('opens install dialog with OCI reference including version', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter([ociSkill])
+    renderRoute(router)
+
+    const install = await screen.findByRole('button', {
+      name: /install my-skill/i,
+    })
+    await user.click(install)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
+        'io.github.user/my-skill:v1.0.0'
+      )
+    })
+  })
+
+  it('opens install dialog with git reference without version suffix', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter([gitSkill])
+    renderRoute(router)
+
+    const install = await screen.findByRole('button', {
+      name: /install git-skill/i,
+    })
+    await user.click(install)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
+        'io.github.other/git-skill'
+      )
+    })
+  })
+
+  it('does not navigate when Install button is clicked', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter([ociSkill])
+    renderRoute(router)
+
+    const install = await screen.findByRole('button', {
+      name: /install my-skill/i,
+    })
+    await user.click(install)
+
+    expect(router.state.location.pathname).toBe('/skills')
+  })
+})

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -20,6 +20,8 @@ import { GridCardsSkills } from './grid-cards-skills'
 import { GridCardsBuilds } from './grid-cards-builds'
 import { GridCardsRegistrySkills } from './grid-cards-registry-skills'
 import { TableInstalledSkills } from './table-installed-skills'
+import { TableRegistrySkills } from './table-registry-skills'
+import { TableBuilds } from './table-builds'
 import { DialogBuildSkill } from './dialog-build-skill'
 import { HammerIcon } from 'lucide-react'
 import { ViewToggle } from '@/common/components/view-toggle'
@@ -87,6 +89,12 @@ export function SkillsPage() {
   const { view: installedView, setView: setInstalledView } = useViewPreference(
     'ui.viewMode.skillsInstalled'
   )
+  const { view: registryView, setView: setRegistryView } = useViewPreference(
+    'ui.viewMode.skillsRegistry'
+  )
+  const { view: buildsView, setView: setBuildsView } = useViewPreference(
+    'ui.viewMode.skillsBuilds'
+  )
 
   return (
     <>
@@ -103,11 +111,14 @@ export function SkillsPage() {
           </TabsList>
           <div className="flex items-center gap-3">
             {tab === 'registry' && (
-              <InputSearch
-                value={registrySearch}
-                onChange={handleRegistrySearchChange}
-                placeholder="Search..."
-              />
+              <>
+                <InputSearch
+                  value={registrySearch}
+                  onChange={handleRegistrySearchChange}
+                  placeholder="Search..."
+                />
+                <ViewToggle value={registryView} onChange={setRegistryView} />
+              </>
             )}
             {tab === 'installed' && hasSkills && (
               <>
@@ -126,6 +137,7 @@ export function SkillsPage() {
                   onChange={setBuildsFilter}
                   placeholder="Search..."
                 />
+                <ViewToggle value={buildsView} onChange={setBuildsView} />
                 <Button
                   variant="action"
                   onClick={() => setBuildOpen(true)}
@@ -140,7 +152,11 @@ export function SkillsPage() {
         </div>
 
         <TabsContent value="registry">
-          <GridCardsRegistrySkills skills={registrySkills} />
+          {registryView === 'table' ? (
+            <TableRegistrySkills skills={registrySkills} />
+          ) : (
+            <GridCardsRegistrySkills skills={registrySkills} />
+          )}
         </TabsContent>
 
         <TabsContent value="installed">
@@ -167,10 +183,17 @@ export function SkillsPage() {
         </TabsContent>
 
         <TabsContent value="builds">
-          <GridCardsBuilds
-            filter={buildsFilter}
-            onBuild={() => setBuildOpen(true)}
-          />
+          {buildsView === 'table' ? (
+            <TableBuilds
+              filter={buildsFilter}
+              onBuild={() => setBuildOpen(true)}
+            />
+          ) : (
+            <GridCardsBuilds
+              filter={buildsFilter}
+              onBuild={() => setBuildOpen(true)}
+            />
+          )}
         </TabsContent>
       </Tabs>
 

--- a/renderer/src/features/skills/components/table-builds.tsx
+++ b/renderer/src/features/skills/components/table-builds.tsx
@@ -1,0 +1,268 @@
+import { useMemo, useState } from 'react'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { getApiV1BetaSkillsBuildsOptions } from '@common/api/generated/@tanstack/react-query.gen'
+import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from '@common/api/generated/types.gen'
+import { Button } from '@/common/components/ui/button'
+import { Badge } from '@/common/components/ui/badge'
+import { EmptyState } from '@/common/components/empty-state'
+import { IllustrationPackage } from '@/common/components/illustrations/illustration-package'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/common/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { HammerIcon, Trash2Icon } from 'lucide-react'
+import { DialogInstallSkill } from './dialog-install-skill'
+import { DialogDeleteBuild } from './dialog-delete-build'
+
+function getShortDigest(digest: string | undefined): string | undefined {
+  if (!digest) return undefined
+  if (digest.startsWith('sha256:')) {
+    return `sha256:${digest.slice(7, 19)}…`
+  }
+  return `${digest.slice(0, 12)}…`
+}
+
+function activateOnKey(e: React.KeyboardEvent, onActivate: () => void) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    onActivate()
+  }
+}
+
+function BuildRow({ build }: { build: LocalBuild }) {
+  const navigate = useNavigate()
+  const [installOpen, setInstallOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  const title = build.name ?? build.tag ?? 'Unnamed build'
+  const tag = build.tag
+  const version = build.version
+  const description = build.description
+  const shortDigest = getShortDigest(build.digest)
+  const subtitle = tag && tag !== title ? tag : undefined
+  const canNavigate = !!tag
+
+  function goToDetail() {
+    if (!tag) return
+    void navigate({
+      to: '/skills/builds/$tag',
+      params: { tag },
+    })
+  }
+
+  return (
+    <>
+      <TableRow
+        role={canNavigate ? 'button' : undefined}
+        tabIndex={canNavigate ? 0 : undefined}
+        aria-label={canNavigate ? title : undefined}
+        onClick={canNavigate ? goToDetail : undefined}
+        onKeyDown={
+          canNavigate ? (e) => activateOnKey(e, goToDetail) : undefined
+        }
+        className={canNavigate ? 'cursor-pointer' : undefined}
+      >
+        <TableCell className="py-3 font-medium">
+          <div className="flex min-w-0 flex-col">
+            <Tooltip onlyWhenTruncated>
+              <TooltipTrigger asChild>
+                <span className="block max-w-[260px] truncate">{title}</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">{title}</TooltipContent>
+            </Tooltip>
+            {subtitle && (
+              <Tooltip onlyWhenTruncated>
+                <TooltipTrigger asChild>
+                  <span
+                    className="text-muted-foreground block max-w-[260px]
+                      truncate font-mono text-xs"
+                  >
+                    {subtitle}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs font-mono text-xs break-all">
+                  {subtitle}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </TableCell>
+
+        <TableCell className="py-3">
+          {version ? (
+            <Badge variant="secondary">{version}</Badge>
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
+        </TableCell>
+
+        <TableCell className="hidden py-3 lg:table-cell">
+          {shortDigest ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="text-muted-foreground block truncate font-mono
+                    text-xs"
+                >
+                  {shortDigest}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-sm font-mono text-xs break-all">
+                {build.digest}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
+        </TableCell>
+
+        <TableCell
+          className="text-muted-foreground hidden w-full max-w-0 py-3
+            md:table-cell"
+        >
+          {description ? (
+            <Tooltip onlyWhenTruncated>
+              <TooltipTrigger asChild>
+                <span className="block truncate text-sm">{description}</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-sm">
+                {description}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
+        </TableCell>
+
+        <TableCell className="py-3 pr-3 text-right">
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              className="rounded-full"
+              onClick={(e) => {
+                e.stopPropagation()
+                setDeleteOpen(true)
+              }}
+              aria-label={`Remove ${title}`}
+            >
+              <Trash2Icon className="size-4" />
+              Remove
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="rounded-full"
+              onClick={(e) => {
+                e.stopPropagation()
+                setInstallOpen(true)
+              }}
+              aria-label={`Install ${title}`}
+            >
+              Install
+            </Button>
+          </div>
+        </TableCell>
+      </TableRow>
+
+      <DialogInstallSkill
+        key={tag ?? title}
+        open={installOpen}
+        onOpenChange={setInstallOpen}
+        defaultReference={tag ?? build.name}
+      />
+      <DialogDeleteBuild
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        build={build}
+      />
+    </>
+  )
+}
+
+interface TableBuildsProps {
+  filter: string
+  onBuild: () => void
+}
+
+export function TableBuilds({ filter, onBuild }: TableBuildsProps) {
+  const { data } = useSuspenseQuery(getApiV1BetaSkillsBuildsOptions())
+  const builds: LocalBuild[] = useMemo(() => data?.builds ?? [], [data])
+  const filteredData = useMemo(() => {
+    return builds.filter((build) =>
+      [build.name ?? '', build.description ?? '', build.tag ?? ''].some((f) =>
+        f.toLowerCase().includes(filter.toLowerCase())
+      )
+    )
+  }, [builds, filter])
+
+  if (builds.length === 0) {
+    return (
+      <EmptyState
+        title="No local builds"
+        body="Build a skill from a local directory to see it here."
+        illustration={IllustrationPackage}
+        actions={[
+          <Button key="build" variant="action" onClick={onBuild}>
+            <HammerIcon className="size-4" />
+            Build skill
+          </Button>,
+        ]}
+      />
+    )
+  }
+
+  if (filteredData.length === 0) {
+    return (
+      <div className="text-muted-foreground py-12 text-center">
+        <p className="text-sm">No builds found matching the current filter</p>
+      </div>
+    )
+  }
+
+  return (
+    <Table containerClassName="rounded-lg border">
+      <TableHeader>
+        <TableRow className="bg-muted/40 hover:bg-muted/40">
+          <TableHead className="text-muted-foreground font-medium">
+            Build
+          </TableHead>
+          <TableHead className="text-muted-foreground w-[110px] font-medium">
+            Version
+          </TableHead>
+          <TableHead
+            className="text-muted-foreground hidden w-[160px] font-medium
+              lg:table-cell"
+          >
+            Digest
+          </TableHead>
+          <TableHead
+            className="text-muted-foreground hidden w-full max-w-0 font-medium
+              md:table-cell"
+          >
+            About
+          </TableHead>
+          <TableHead className="w-[220px] pr-3" aria-label="Actions" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {filteredData.map((build, index) => (
+          <BuildRow
+            key={build.digest ?? build.tag ?? build.name ?? `build-${index}`}
+            build={build}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/renderer/src/features/skills/components/table-builds.tsx
+++ b/renderer/src/features/skills/components/table-builds.tsx
@@ -99,11 +99,7 @@ function BuildRow({ build }: { build: LocalBuild }) {
         </TableCell>
 
         <TableCell className="py-3">
-          {version ? (
-            <Badge variant="secondary">{version}</Badge>
-          ) : (
-            <span className="text-muted-foreground/60 text-sm">—</span>
-          )}
+          <Badge variant="secondary">{version ?? 'latest'}</Badge>
         </TableCell>
 
         <TableCell className="hidden py-3 lg:table-cell">

--- a/renderer/src/features/skills/components/table-installed-skills.tsx
+++ b/renderer/src/features/skills/components/table-installed-skills.tsx
@@ -63,7 +63,7 @@ function SkillRow({ skill }: { skill: InstalledSkill }) {
           </div>
         </TableCell>
 
-        <TableCell className="py-3">
+        <TableCell className="w-[110px] py-3">
           {modeLabel ? (
             <span className="inline-flex items-center gap-1.5 text-sm">
               {isProjectScope ? (
@@ -78,7 +78,7 @@ function SkillRow({ skill }: { skill: InstalledSkill }) {
           )}
         </TableCell>
 
-        <TableCell className="py-3">
+        <TableCell className="w-full max-w-0 py-3">
           {isProjectScope ? (
             <div className="flex flex-col items-start gap-1.5">
               {projectRootLabel && (
@@ -156,16 +156,18 @@ export function TableInstalledSkills({ skills }: { skills: InstalledSkill[] }) {
   }
 
   return (
-    <Table containerClassName="overflow-hidden rounded-lg border">
+    <Table containerClassName="rounded-lg border">
       <TableHeader>
         <TableRow className="bg-muted/40 hover:bg-muted/40">
           <TableHead className="text-muted-foreground font-medium">
             Skill
           </TableHead>
-          <TableHead className="text-muted-foreground font-medium">
+          <TableHead className="text-muted-foreground w-[110px] font-medium">
             Mode
           </TableHead>
-          <TableHead className="text-muted-foreground font-medium">
+          <TableHead
+            className="text-muted-foreground w-full max-w-0 font-medium"
+          >
             Destination
           </TableHead>
           <TableHead

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -62,29 +62,27 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
         className={canNavigate ? 'cursor-pointer' : undefined}
       >
         <TableCell className="py-3 font-medium">
-          <div className="flex min-w-0 flex-col">
+          <Tooltip onlyWhenTruncated>
+            <TooltipTrigger asChild>
+              <span className="block max-w-[280px] truncate">{title}</span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">{title}</TooltipContent>
+          </Tooltip>
+        </TableCell>
+
+        <TableCell className="text-muted-foreground hidden py-3 lg:table-cell">
+          {namespace ? (
             <Tooltip onlyWhenTruncated>
               <TooltipTrigger asChild>
-                <span className="block max-w-[280px] truncate">{title}</span>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">{title}</TooltipContent>
-            </Tooltip>
-            {namespace && (
-              <Tooltip onlyWhenTruncated>
-                <TooltipTrigger asChild>
-                  <span
-                    className="text-muted-foreground block max-w-[280px]
-                      truncate text-xs"
-                  >
-                    {namespace}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent className="max-w-xs">
+                <span className="block max-w-[200px] truncate text-sm">
                   {namespace}
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </div>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">{namespace}</TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
         </TableCell>
 
         <TableCell
@@ -147,6 +145,12 @@ export function TableRegistrySkills({ skills }: { skills: RegistrySkill[] }) {
         <TableRow className="bg-muted/40 hover:bg-muted/40">
           <TableHead className="text-muted-foreground font-medium">
             Skill
+          </TableHead>
+          <TableHead
+            className="text-muted-foreground hidden w-[200px] font-medium
+              lg:table-cell"
+          >
+            Author
           </TableHead>
           <TableHead
             className="text-muted-foreground hidden w-full max-w-0 font-medium

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { Button } from '@/common/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/common/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { DialogInstallSkill } from './dialog-install-skill'
+
+function getDefaultReference(skill: RegistrySkill): string {
+  const name = skill.name ?? 'Unknown skill'
+  const namespace = skill.namespace
+  const base =
+    namespace && name !== 'Unknown skill' ? `${namespace}/${name}` : name
+  const isOci = skill.packages?.some((p) => p.registryType === 'oci')
+  return isOci && skill.version ? `${base}:${skill.version}` : base
+}
+
+function activateOnKey(e: React.KeyboardEvent, onActivate: () => void) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    onActivate()
+  }
+}
+
+function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
+  const navigate = useNavigate()
+  const [installOpen, setInstallOpen] = useState(false)
+
+  const title = skill.name ?? 'Unknown skill'
+  const namespace = skill.namespace
+  const canNavigate = !!(namespace && skill.name)
+
+  function goToDetail() {
+    if (!canNavigate) return
+    void navigate({
+      to: '/skills/$namespace/$skillName',
+      params: { namespace: namespace!, skillName: skill.name! },
+    })
+  }
+
+  return (
+    <>
+      <TableRow
+        role={canNavigate ? 'button' : undefined}
+        tabIndex={canNavigate ? 0 : undefined}
+        aria-label={canNavigate ? title : undefined}
+        onClick={canNavigate ? goToDetail : undefined}
+        onKeyDown={
+          canNavigate ? (e) => activateOnKey(e, goToDetail) : undefined
+        }
+        className={canNavigate ? 'cursor-pointer' : undefined}
+      >
+        <TableCell className="py-3 font-medium">
+          <div className="flex min-w-0 flex-col">
+            <Tooltip onlyWhenTruncated>
+              <TooltipTrigger asChild>
+                <span className="block max-w-[280px] truncate">{title}</span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">{title}</TooltipContent>
+            </Tooltip>
+            {namespace && (
+              <Tooltip onlyWhenTruncated>
+                <TooltipTrigger asChild>
+                  <span
+                    className="text-muted-foreground block max-w-[280px]
+                      truncate text-xs"
+                  >
+                    {namespace}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  {namespace}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </TableCell>
+
+        <TableCell
+          className="text-muted-foreground hidden w-full max-w-0 py-3
+            md:table-cell"
+        >
+          {skill.description ? (
+            <Tooltip onlyWhenTruncated>
+              <TooltipTrigger asChild>
+                <span className="block truncate text-sm">
+                  {skill.description}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-sm">
+                {skill.description}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
+        </TableCell>
+
+        <TableCell className="py-3 pr-3 text-right">
+          <Button
+            variant="secondary"
+            size="sm"
+            className="rounded-full"
+            onClick={(e) => {
+              e.stopPropagation()
+              setInstallOpen(true)
+            }}
+            aria-label={`Install ${title}`}
+          >
+            Install
+          </Button>
+        </TableCell>
+      </TableRow>
+
+      <DialogInstallSkill
+        open={installOpen}
+        onOpenChange={setInstallOpen}
+        defaultReference={getDefaultReference(skill)}
+      />
+    </>
+  )
+}
+
+export function TableRegistrySkills({ skills }: { skills: RegistrySkill[] }) {
+  if (skills.length === 0) {
+    return (
+      <div className="text-muted-foreground py-12 text-center">
+        <p className="text-sm">No skills found matching the current filter</p>
+      </div>
+    )
+  }
+
+  return (
+    <Table containerClassName="rounded-lg border">
+      <TableHeader>
+        <TableRow className="bg-muted/40 hover:bg-muted/40">
+          <TableHead className="text-muted-foreground font-medium">
+            Skill
+          </TableHead>
+          <TableHead
+            className="text-muted-foreground hidden w-full max-w-0 font-medium
+              md:table-cell"
+          >
+            About
+          </TableHead>
+          <TableHead className="w-[120px] pr-3" aria-label="Actions" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {skills.map((skill, index) => (
+          <RegistrySkillRow
+            key={
+              skill.namespace && skill.name
+                ? `${skill.namespace}/${skill.name}`
+                : `skill-${index}`
+            }
+            skill={skill}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/renderer/src/routes/(registry)/-registry.route.tsx
+++ b/renderer/src/routes/(registry)/-registry.route.tsx
@@ -9,13 +9,16 @@ import type {
   V1ListServersResponse,
 } from '@common/api/registry-types'
 import { GridCardsRegistry } from '@/features/registry-servers/components/grid-cards-registry'
+import { TableRegistry } from '@/features/registry-servers/components/table-registry'
 import { EmptyState } from '@/common/components/empty-state'
 import { ExternalLinkIcon } from 'lucide-react'
 import { Button } from '@/common/components/ui/button'
 import { IllustrationNoConnection } from '@/common/components/illustrations/illustration-no-connection'
 import { TitlePage } from '@/common/components/title-page'
 import { InputSearch } from '@/common/components/ui/input-search'
+import { ViewToggle } from '@/common/components/view-toggle'
 import { useFilterSort } from '@/common/hooks/use-filter-sort'
+import { useViewPreference } from '@/common/hooks/use-view-preference'
 import {
   DEPRECATED_MCP_OPTIMIZER_REGISTRY_SERVER_NAME,
   MCP_OPTIMIZER_REGISTRY_SERVER_NAME,
@@ -83,15 +86,20 @@ export default function RegistryRouteComponent() {
 
   const hasContent = servers.length > 0 || groups.length > 0
 
+  const { view, setView } = useViewPreference('ui.viewMode.registry')
+
   return (
     <>
       <TitlePage title="Registry">
         {hasContent && (
-          <InputSearch
-            value={filter}
-            onChange={(v) => setFilter(v)}
-            placeholder="Search..."
-          />
+          <div className="flex items-center gap-3">
+            <InputSearch
+              value={filter}
+              onChange={(v) => setFilter(v)}
+              placeholder="Search..."
+            />
+            <ViewToggle value={view} onChange={setView} />
+          </div>
         )}
       </TitlePage>
       {!hasContent ? (
@@ -111,6 +119,8 @@ export default function RegistryRouteComponent() {
           ]}
           illustration={IllustrationNoConnection}
         />
+      ) : view === 'table' ? (
+        <TableRegistry items={filteredData} showPromo={isDefaultRegistry} />
       ) : (
         <GridCardsRegistry items={filteredData} showPromo={isDefaultRegistry} />
       )}


### PR DESCRIPTION
The MCP Registry, Skills Registry, and Skills Local Builds screens only offered a card grid. This PR extends the card/table view toggle already available on MCP Servers and Installed Skills to those three surfaces, and retrofits the two pre-existing tables with a dynamic Name column.


https://github.com/user-attachments/assets/a7528c27-6000-4f2f-93b5-4dcf4c0b0041



- Extend `UI_PREFERENCE_KEYS` with `ui.viewMode.registry`, `ui.viewMode.skillsRegistry`, and `ui.viewMode.skillsBuilds` so each surface persists its own card/table preference via the settings table. `useViewPreference` and the `ViewToggle` primitive are reused without changes.
- Add `TableRegistry` for the MCP Registry page. It renders server and group entries in a single table (Name, About, Type, Stars, repository link), slots the `CardRegistryPromo` at index 6 as a full-width `colSpan` row when the default registry is active, and supports row-level navigation via click and keyboard `Enter` with `stopPropagation` on the inline GitHub link. Wire it into `-registry.route.tsx` next to the existing `GridCardsRegistry`.
- Add `TableRegistrySkills` for the Skills Registry tab. Columns are Skill, Author (namespace, shown on `lg+`), About, and an Install action. Rows with both a namespace and a name navigate to `/skills/$namespace/$skillName`; the Install button generates the correct `defaultReference` for OCI vs Git packages and stops propagation. Wire it into the Registry tab in `skills-page.tsx`.
- Add `TableBuilds` for the Skills Local Builds tab. Columns are Build (title + tag subtitle), Version (shows a `latest` badge when `build.version` is unset), Digest (truncated with tooltip, hidden below `lg`), About, and Remove + Install actions. Runs the same `getApiV1BetaSkillsBuildsOptions` query as `GridCardsBuilds` with local filtering, and exposes an empty state with a `Build skill` CTA. Wire it into the Local Builds tab in `skills-page.tsx`.
- Make the Name/Skill/Build column dynamic across **every** table (MCP Servers, Installed Skills, MCP Registry, Skills Registry, Local Builds). The column now shrinks to the longest content up to a `max-w-[260/280px]` cap instead of a fixed percentage, using `table-auto` layout with a truncating inner span. The flexible column (About or Destination) uses the classic `w-full max-w-0` trick so its content truncates against the remaining space.
- Drop the `overflow-hidden` wrapper that was clipping vertical scroll on the MCP Registry page when the table grew past the viewport. With the auto layout the tables no longer overflow horizontally, so the default `overflow-x-auto` on the shadcn `Table` primitive is sufficient.

### Not changed in this PR (deliberate, follow-up)

- The toolbar on the Registry page does not gain a registry selector or a `+ Create` button shown in the mockups; the toggle replaces only the grid/list affordance.
- The columns on each table mirror the *full* card content (all badges, kebab items, conditional controls) rather than strictly matching the Figma column list, so nothing is lost when switching from cards.

### Tests

- New unit tests for `TableRegistry`, `TableRegistrySkills`, and `TableBuilds` covering column headers, row rendering, promo placement, dialog wiring, `stopPropagation` on inline actions, and click/`Enter` navigation.
- Existing `TableMcpServers` and `TableInstalledSkills` tests continue to pass after the dynamic-column refactor.
- `pnpm run lint`, `pnpm run type-check`, and the full Vitest suite are green.

