### PR TITLE
feat(playground): persist composer drafts per thread across route changes

### DIFF
--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import type { ChatStatus, FileUIPart } from 'ai'
 import log from 'electron-log/renderer'
 import {
@@ -28,6 +28,7 @@ import { McpServerSelector } from './mcp-server-selector'
 import type { ChatSettings } from '../types'
 import { toast } from 'sonner'
 import { toastVariants } from '@/common/lib/toast'
+import { useThreadDraft } from '../hooks/use-thread-draft'
 
 const errorToastConfig = {
   max_files: {
@@ -60,6 +61,7 @@ interface ChatInputProps {
   handleProviderChange: (providerId: string) => void
   hasProviderAndModel: boolean
   hasMessages: boolean
+  threadId?: string
 }
 
 function InputWithAttachments({
@@ -177,8 +179,9 @@ export function ChatInputPrompt({
   handleProviderChange,
   hasProviderAndModel,
   hasMessages,
+  threadId,
 }: ChatInputProps) {
-  const [text, setText] = useState<string>('')
+  const [text, setText] = useThreadDraft(threadId)
 
   const handleSubmit = (message: PromptInputMessage) => {
     const hasText = Boolean(message.text)

--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -61,7 +61,7 @@ interface ChatInputProps {
   handleProviderChange: (providerId: string) => void
   hasProviderAndModel: boolean
   hasMessages: boolean
-  threadId?: string
+  threadId?: string | null
 }
 
 function InputWithAttachments({

--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -219,6 +219,7 @@ export function ChatInterface({
                 {hasProviderAndModel && (
                   <div className="mx-auto max-w-2xl space-y-4">
                     <ChatInputPrompt
+                      key={threadId ?? 'no-thread'}
                       onSendMessage={sendMessage}
                       onStopGeneration={cancelRequest}
                       onSettingsOpen={setIsSettingsOpen}
@@ -228,6 +229,7 @@ export function ChatInterface({
                       handleProviderChange={handleProviderChange}
                       hasProviderAndModel={hasProviderAndModel}
                       hasMessages={hasMessages}
+                      threadId={threadId}
                     />
                   </div>
                 )}
@@ -263,6 +265,7 @@ export function ChatInterface({
               before:from-transparent before:content-['']"
           >
             <ChatInputPrompt
+              key={threadId ?? 'no-thread'}
               onSendMessage={sendMessage}
               onStopGeneration={cancelRequest}
               onSettingsOpen={setIsSettingsOpen}
@@ -272,6 +275,7 @@ export function ChatInterface({
               handleProviderChange={handleProviderChange}
               hasProviderAndModel={hasProviderAndModel}
               hasMessages={hasMessages}
+              threadId={threadId}
             />
           </div>
         )}

--- a/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
@@ -203,15 +203,17 @@ describe('usePlaygroundThreads', () => {
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-      let nextId: string | null = null
+      let res: Awaited<ReturnType<typeof result.current.deleteThread>> = {
+        success: false,
+      }
       await act(async () => {
-        nextId = await result.current.deleteThread('active')
+        res = await result.current.deleteThread('active')
       })
 
-      expect(nextId).toBe('next')
+      expect(res).toEqual({ success: true, nextId: 'next' })
     })
 
-    it('returns null when the last thread is deleted', async () => {
+    it('returns a success result with null nextId when the last thread is deleted', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'only' }),
       ])
@@ -220,16 +222,18 @@ describe('usePlaygroundThreads', () => {
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-      let nextId: string | null = 'sentinel'
+      let res: Awaited<ReturnType<typeof result.current.deleteThread>> = {
+        success: false,
+      }
       await act(async () => {
-        nextId = await result.current.deleteThread('only')
+        res = await result.current.deleteThread('only')
       })
 
-      expect(nextId).toBeNull()
+      expect(res).toEqual({ success: true, nextId: null })
       expect(result.current.hasThreads).toBe(false)
     })
 
-    it('returns null and does not change state when deleteThread returns failure', async () => {
+    it('returns a failure result and does not change state when deleteThread returns failure', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'thread-1' }),
       ])
@@ -242,13 +246,16 @@ describe('usePlaygroundThreads', () => {
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-      let nextId: string | null = 'sentinel'
+      let res: Awaited<ReturnType<typeof result.current.deleteThread>> = {
+        success: true,
+        nextId: null,
+      }
       await act(async () => {
-        nextId = await result.current.deleteThread('thread-1')
+        res = await result.current.deleteThread('thread-1')
       })
 
       expect(result.current.threads).toHaveLength(1)
-      expect(nextId).toBeNull()
+      expect(res).toEqual({ success: false })
     })
   })
 

--- a/renderer/src/features/chat/hooks/__tests__/use-thread-draft.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-thread-draft.test.ts
@@ -1,15 +1,18 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useThreadDraft, clearThreadDraft } from '../use-thread-draft'
 
 const STORAGE_PREFIX = 'toolhive.playground.draft.'
+const DEBOUNCE_MS = 200
 
 describe('useThreadDraft', () => {
   beforeEach(() => {
     localStorage.clear()
+    vi.useFakeTimers()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     localStorage.clear()
   })
 
@@ -24,7 +27,7 @@ describe('useThreadDraft', () => {
     expect(result.current[0]).toBe('hello')
   })
 
-  it('persists updates to localStorage', () => {
+  it('updates in-memory state synchronously but debounces the localStorage write', () => {
     const { result } = renderHook(() => useThreadDraft('t1'))
 
     act(() => {
@@ -32,10 +35,40 @@ describe('useThreadDraft', () => {
     })
 
     expect(result.current[0]).toBe('draft text')
+    // Not yet written — debounce hasn't fired
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS)
+    })
+
     expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBe('draft text')
   })
 
-  it('removes the key when cleared to empty string', () => {
+  it('coalesces rapid consecutive updates into a single write', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+    const { result } = renderHook(() => useThreadDraft('t1'))
+
+    act(() => {
+      result.current[1]('h')
+      result.current[1]('he')
+      result.current[1]('hel')
+      result.current[1]('hell')
+      result.current[1]('hello')
+    })
+
+    expect(setItemSpy).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS)
+    })
+
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBe('hello')
+    expect(setItemSpy).toHaveBeenCalledTimes(1)
+    setItemSpy.mockRestore()
+  })
+
+  it('removes the key when cleared to empty string (after debounce)', () => {
     localStorage.setItem(`${STORAGE_PREFIX}t1`, 'existing')
     const { result } = renderHook(() => useThreadDraft('t1'))
 
@@ -43,8 +76,28 @@ describe('useThreadDraft', () => {
       result.current[1]('')
     })
 
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS)
+    })
+
     expect(result.current[0]).toBe('')
     expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
+  })
+
+  it('flushes the pending write on unmount', () => {
+    const { result, unmount } = renderHook(() => useThreadDraft('t1'))
+
+    act(() => {
+      result.current[1]('typed just before unmount')
+    })
+
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
+
+    unmount()
+
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBe(
+      'typed just before unmount'
+    )
   })
 
   // The hook relies on the consuming component being keyed by threadId,
@@ -70,6 +123,9 @@ describe('useThreadDraft', () => {
     act(() => {
       result.current[1]('written to t2')
     })
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS)
+    })
 
     expect(localStorage.getItem(`${STORAGE_PREFIX}t2`)).toBe('written to t2')
     expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
@@ -80,6 +136,9 @@ describe('useThreadDraft', () => {
 
     act(() => {
       result.current[1]('in-memory only')
+    })
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS)
     })
 
     expect(result.current[0]).toBe('in-memory only')
@@ -101,6 +160,12 @@ describe('clearThreadDraft', () => {
   it('is a no-op for undefined threadId', () => {
     localStorage.setItem(`${STORAGE_PREFIX}t1`, 'hello')
     clearThreadDraft(undefined)
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBe('hello')
+  })
+
+  it('is a no-op for null threadId', () => {
+    localStorage.setItem(`${STORAGE_PREFIX}t1`, 'hello')
+    clearThreadDraft(null)
     expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBe('hello')
   })
 })

--- a/renderer/src/features/chat/hooks/__tests__/use-thread-draft.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-thread-draft.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useThreadDraft, clearThreadDraft } from '../use-thread-draft'
+
+const STORAGE_PREFIX = 'toolhive.playground.draft.'
+
+describe('useThreadDraft', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns empty string when no draft exists', () => {
+    const { result } = renderHook(() => useThreadDraft('t1'))
+    expect(result.current[0]).toBe('')
+  })
+
+  it('reads existing draft from localStorage on mount', () => {
+    localStorage.setItem(`${STORAGE_PREFIX}t1`, 'hello')
+    const { result } = renderHook(() => useThreadDraft('t1'))
+    expect(result.current[0]).toBe('hello')
+  })
+
+  it('persists updates to localStorage', () => {
+    const { result } = renderHook(() => useThreadDraft('t1'))
+
+    act(() => {
+      result.current[1]('draft text')
+    })
+
+    expect(result.current[0]).toBe('draft text')
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBe('draft text')
+  })
+
+  it('removes the key when cleared to empty string', () => {
+    localStorage.setItem(`${STORAGE_PREFIX}t1`, 'existing')
+    const { result } = renderHook(() => useThreadDraft('t1'))
+
+    act(() => {
+      result.current[1]('')
+    })
+
+    expect(result.current[0]).toBe('')
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
+  })
+
+  // The hook relies on the consuming component being keyed by threadId,
+  // so switching threads remounts and the lazy initializer picks up the
+  // new draft. These tests simulate that remount.
+  it('loads the correct draft on remount with a different threadId', () => {
+    localStorage.setItem(`${STORAGE_PREFIX}t1`, 'from t1')
+    localStorage.setItem(`${STORAGE_PREFIX}t2`, 'from t2')
+
+    const { result: r1, unmount } = renderHook(() => useThreadDraft('t1'))
+    expect(r1.current[0]).toBe('from t1')
+    unmount()
+
+    const { result: r2 } = renderHook(() => useThreadDraft('t2'))
+    expect(r2.current[0]).toBe('from t2')
+  })
+
+  it('writes to the correct thread key after remount', () => {
+    const { unmount } = renderHook(() => useThreadDraft('t1'))
+    unmount()
+
+    const { result } = renderHook(() => useThreadDraft('t2'))
+    act(() => {
+      result.current[1]('written to t2')
+    })
+
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t2`)).toBe('written to t2')
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
+  })
+
+  it('does not persist when threadId is undefined', () => {
+    const { result } = renderHook(() => useThreadDraft(undefined))
+
+    act(() => {
+      result.current[1]('in-memory only')
+    })
+
+    expect(result.current[0]).toBe('in-memory only')
+    expect(localStorage.length).toBe(0)
+  })
+})
+
+describe('clearThreadDraft', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('removes the stored draft for a thread', () => {
+    localStorage.setItem(`${STORAGE_PREFIX}t1`, 'hello')
+    clearThreadDraft('t1')
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
+  })
+
+  it('is a no-op for undefined threadId', () => {
+    localStorage.setItem(`${STORAGE_PREFIX}t1`, 'hello')
+    clearThreadDraft(undefined)
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBe('hello')
+  })
+})

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -82,11 +82,19 @@ export function usePlaygroundThreads(activeThreadId: string) {
   }, [])
 
   /**
-   * Deletes a thread and returns the next thread ID for navigation,
-   * or null when no threads remain.
+   * Deletes a thread. On success returns `{ success: true, nextId }` where
+   * `nextId` is the next thread ID for navigation (or `null` when no threads
+   * remain). On failure returns `{ success: false }` so the caller can
+   * distinguish "the thread was deleted and had no neighbors" from "the
+   * delete failed and the thread still exists" — important for side effects
+   * like clearing persisted drafts.
    */
   const deleteThread = useCallback(
-    async (threadId: string): Promise<string | null> => {
+    async (
+      threadId: string
+    ): Promise<
+      { success: true; nextId: string | null } | { success: false }
+    > => {
       try {
         const result = await window.electronAPI.chat.deleteThread(threadId)
         if (!result.success) {
@@ -94,7 +102,7 @@ export function usePlaygroundThreads(activeThreadId: string) {
             '[usePlaygroundThreads] Failed to delete thread:',
             result.error
           )
-          return null
+          return { success: false }
         }
         trackEvent('Playground: delete thread', {
           'thread.was_active': activeThreadId === threadId,
@@ -103,10 +111,10 @@ export function usePlaygroundThreads(activeThreadId: string) {
         // overwriting concurrent state updates (e.g. from refreshThread).
         const remaining = threadsRef.current.filter((t) => t.id !== threadId)
         setThreads(remaining)
-        return remaining[0]?.id ?? null
+        return { success: true, nextId: remaining[0]?.id ?? null }
       } catch (err) {
         log.error('[usePlaygroundThreads] Failed to delete thread:', err)
-        return null
+        return { success: false }
       }
     },
     [activeThreadId]

--- a/renderer/src/features/chat/hooks/use-thread-draft.ts
+++ b/renderer/src/features/chat/hooks/use-thread-draft.ts
@@ -1,6 +1,12 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 const STORAGE_PREFIX = 'toolhive.playground.draft.'
+
+// Debounce window for persisting the composer text to localStorage. Keeps
+// typing off the synchronous write path while being short enough that a
+// trailing keystroke followed by a quick thread switch still flushes via
+// the unmount cleanup below.
+const WRITE_DEBOUNCE_MS = 200
 
 function storageKey(threadId: string): string {
   return `${STORAGE_PREFIX}${threadId}`
@@ -15,6 +21,18 @@ function readDraft(threadId: string | null | undefined): string {
   }
 }
 
+function writeDraft(threadId: string, value: string): void {
+  try {
+    if (value) {
+      localStorage.setItem(storageKey(threadId), value)
+    } else {
+      localStorage.removeItem(storageKey(threadId))
+    }
+  } catch {
+    // ignore quota/serialization errors
+  }
+}
+
 export function clearThreadDraft(threadId: string | null | undefined): void {
   if (!threadId) return
   try {
@@ -26,26 +44,44 @@ export function clearThreadDraft(threadId: string | null | undefined): void {
 
 // Expects the consuming component to be keyed by `threadId`, so switching
 // threads remounts and the lazy initializer re-reads the stored draft.
+//
+// Writes are debounced (WRITE_DEBOUNCE_MS) to keep synchronous localStorage
+// off the keypress path; any pending write is flushed on unmount so a thread
+// switch or component teardown doesn't drop the trailing keystrokes.
 export function useThreadDraft(
   threadId: string | null | undefined
 ): readonly [string, (next: string) => void] {
   const [text, setText] = useState<string>(() => readDraft(threadId))
 
+  const latestRef = useRef(text)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const flush = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    if (!threadId) return
+    writeDraft(threadId, latestRef.current)
+  }, [threadId])
+
+  useEffect(() => {
+    return () => {
+      flush()
+    }
+  }, [flush])
+
   const update = useCallback(
     (next: string) => {
       setText(next)
+      latestRef.current = next
       if (!threadId) return
-      try {
-        if (next) {
-          localStorage.setItem(storageKey(threadId), next)
-        } else {
-          localStorage.removeItem(storageKey(threadId))
-        }
-      } catch {
-        // ignore quota/serialization errors
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
       }
+      timerRef.current = setTimeout(flush, WRITE_DEBOUNCE_MS)
     },
-    [threadId]
+    [threadId, flush]
   )
 
   return [text, update] as const

--- a/renderer/src/features/chat/hooks/use-thread-draft.ts
+++ b/renderer/src/features/chat/hooks/use-thread-draft.ts
@@ -6,7 +6,7 @@ function storageKey(threadId: string): string {
   return `${STORAGE_PREFIX}${threadId}`
 }
 
-function readDraft(threadId: string | undefined): string {
+function readDraft(threadId: string | null | undefined): string {
   if (!threadId) return ''
   try {
     return localStorage.getItem(storageKey(threadId)) ?? ''
@@ -15,7 +15,7 @@ function readDraft(threadId: string | undefined): string {
   }
 }
 
-export function clearThreadDraft(threadId: string | undefined): void {
+export function clearThreadDraft(threadId: string | null | undefined): void {
   if (!threadId) return
   try {
     localStorage.removeItem(storageKey(threadId))
@@ -27,7 +27,7 @@ export function clearThreadDraft(threadId: string | undefined): void {
 // Expects the consuming component to be keyed by `threadId`, so switching
 // threads remounts and the lazy initializer re-reads the stored draft.
 export function useThreadDraft(
-  threadId: string | undefined
+  threadId: string | null | undefined
 ): readonly [string, (next: string) => void] {
   const [text, setText] = useState<string>(() => readDraft(threadId))
 

--- a/renderer/src/features/chat/hooks/use-thread-draft.ts
+++ b/renderer/src/features/chat/hooks/use-thread-draft.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'react'
+
+const STORAGE_PREFIX = 'toolhive.playground.draft.'
+
+function storageKey(threadId: string): string {
+  return `${STORAGE_PREFIX}${threadId}`
+}
+
+function readDraft(threadId: string | undefined): string {
+  if (!threadId) return ''
+  try {
+    return localStorage.getItem(storageKey(threadId)) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function clearThreadDraft(threadId: string | undefined): void {
+  if (!threadId) return
+  try {
+    localStorage.removeItem(storageKey(threadId))
+  } catch {
+    // ignore
+  }
+}
+
+// Expects the consuming component to be keyed by `threadId`, so switching
+// threads remounts and the lazy initializer re-reads the stored draft.
+export function useThreadDraft(
+  threadId: string | undefined
+): readonly [string, (next: string) => void] {
+  const [text, setText] = useState<string>(() => readDraft(threadId))
+
+  const update = useCallback(
+    (next: string) => {
+      setText(next)
+      if (!threadId) return
+      try {
+        if (next) {
+          localStorage.setItem(storageKey(threadId), next)
+        } else {
+          localStorage.removeItem(storageKey(threadId))
+        }
+      } catch {
+        // ignore quota/serialization errors
+      }
+    },
+    [threadId]
+  )
+
+  return [text, update] as const
+}

--- a/renderer/src/routes/__tests__/playground.chat.test.tsx
+++ b/renderer/src/routes/__tests__/playground.chat.test.tsx
@@ -304,7 +304,10 @@ describe('Playground chat route (/playground/chat/$threadId)', () => {
     })
 
     it('navigates to the next thread after deleting from sidebar', async () => {
-      mockThreadsReturn.deleteThread.mockResolvedValue('other-thread')
+      mockThreadsReturn.deleteThread.mockResolvedValue({
+        success: true,
+        nextId: 'other-thread',
+      })
       const { router } = renderChatRoute('thread-1')
       await waitFor(() =>
         expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
@@ -320,7 +323,10 @@ describe('Playground chat route (/playground/chat/$threadId)', () => {
     })
 
     it('navigates to /playground when deleting the last thread', async () => {
-      mockThreadsReturn.deleteThread.mockResolvedValue(null)
+      mockThreadsReturn.deleteThread.mockResolvedValue({
+        success: true,
+        nextId: null,
+      })
       const { router } = renderChatRoute('thread-1')
       await waitFor(() =>
         expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
@@ -330,6 +336,23 @@ describe('Playground chat route (/playground/chat/$threadId)', () => {
 
       await waitFor(() =>
         expect(router.state.location.pathname).toBe('/playground')
+      )
+    })
+
+    it('stays on the current thread and keeps the draft when delete fails', async () => {
+      mockThreadsReturn.deleteThread.mockResolvedValue({ success: false })
+      localStorage.setItem('toolhive.playground.draft.thread-1', 'unsent draft')
+      const { router } = renderChatRoute('thread-1')
+      await waitFor(() =>
+        expect(screen.getByTestId('playground-sidebar')).toBeInTheDocument()
+      )
+
+      fireEvent.click(screen.getByTestId('sidebar-delete-btn'))
+
+      await new Promise((r) => setTimeout(r, 50))
+      expect(router.state.location.pathname).toBe('/playground/chat/thread-1')
+      expect(localStorage.getItem('toolhive.playground.draft.thread-1')).toBe(
+        'unsent draft'
       )
     })
 
@@ -361,7 +384,10 @@ describe('Playground chat route (/playground/chat/$threadId)', () => {
     })
 
     it('navigates to /playground when ChatInterface deletes the last thread', async () => {
-      mockThreadsReturn.deleteThread.mockResolvedValue(null)
+      mockThreadsReturn.deleteThread.mockResolvedValue({
+        success: true,
+        nextId: null,
+      })
       const { router } = renderChatRoute('thread-1')
       await waitFor(() =>
         expect(screen.getByTestId('chat-interface')).toBeInTheDocument()

--- a/renderer/src/routes/playground.chat.$threadId.tsx
+++ b/renderer/src/routes/playground.chat.$threadId.tsx
@@ -62,12 +62,16 @@ function PlaygroundChat() {
   }
 
   const handleDeleteThread = async (id: string) => {
-    const nextId = await deleteThread(id)
+    const result = await deleteThread(id)
+    if (!result.success) {
+      // Delete failed — the thread (and its draft) still exists.
+      return
+    }
     clearThreadDraft(id)
-    if (nextId) {
+    if (result.nextId) {
       void navigate({
         to: '/playground/chat/$threadId',
-        params: { threadId: nextId },
+        params: { threadId: result.nextId },
       })
     } else {
       // No threads remain — go to index which will create a new one

--- a/renderer/src/routes/playground.chat.$threadId.tsx
+++ b/renderer/src/routes/playground.chat.$threadId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { ChatInterface } from '@/features/chat/components/chat-interface'
 import { PlaygroundSidebar } from '@/features/chat/components/playground-sidebar'
 import { usePlaygroundThreads } from '@/features/chat/hooks/use-playground-threads'
+import { clearThreadDraft } from '@/features/chat/hooks/use-thread-draft'
 
 export const Route = createFileRoute('/playground/chat/$threadId')({
   component: PlaygroundChat,
@@ -62,6 +63,7 @@ function PlaygroundChat() {
 
   const handleDeleteThread = async (id: string) => {
     const nextId = await deleteThread(id)
+    clearThreadDraft(id)
     if (nextId) {
       void navigate({
         to: '/playground/chat/$threadId',


### PR DESCRIPTION
Composer text in the Playground chat was kept only in React state, so navigating away from `/playground/chat/$threadId` — or switching to another thread — silently dropped any unsent draft. This PR persists drafts per thread in `localStorage` and resets the composer cleanly when threads change.


https://github.com/user-attachments/assets/dd5eec4f-45fc-4859-9f22-f55d707ca896



- Add `useThreadDraft(threadId)` in `renderer/src/features/chat/hooks/use-thread-draft.ts`, which stores the composer text under `toolhive.playground.draft.<threadId>` and returns a `[text, setText]` tuple; also exports `clearThreadDraft(id)` for external cleanup
- Swap `ChatInputPrompt`'s `useState('')` for `useThreadDraft(threadId)` and thread the `threadId` prop down from `ChatInterface`
- Key both `ChatInputPrompt` instances by `threadId` in `ChatInterface`, so a thread switch remounts the composer and the hook's lazy `useState` initializer reads the correct stored draft — no `useEffect` needed to "adjust state on prop change" (see [React docs: You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect))
- As a side-benefit, the remount also resets the internal `usePromptInputAttachments` state, fixing a latent bug where files staged in thread A bled into thread B
- Call `clearThreadDraft(id)` from `handleDeleteThread` in `playground.chat.$threadId.tsx` so deleting a thread doesn't leave an orphan draft key
- Unit tests for `useThreadDraft` covering empty state, existing-draft load, persist-on-update, clear-on-empty, undefined-threadId in-memory fallback, remount with a different `threadId`, and `clearThreadDraft`

**Not changed in this PR (deliberate):**

- Attachments are not persisted to `localStorage` — `FileUIPart` objects aren't reliably serializable and are already ephemeral by design
- No cross-tab sync (Electron single-renderer)