### PR TITLE
feat(playground): persist MCP App UI metadata across restarts

### DIFF
--- a/main/src/chat/__tests__/mcp-tools.test.ts
+++ b/main/src/chat/__tests__/mcp-tools.test.ts
@@ -38,6 +38,12 @@ const mockCreateMCPClient = vi.hoisted(() =>
   vi.fn().mockResolvedValue(mockAiMcpClient)
 )
 
+// MCP App UI metadata DB reader/writer mocks
+const mockReadAllMcpAppUiMetadata = vi.hoisted(() =>
+  vi.fn().mockReturnValue({})
+)
+const mockReplaceAllMcpAppUiMetadata = vi.hoisted(() => vi.fn())
+
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
@@ -107,6 +113,14 @@ vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
 
 vi.mock('../../logger', () => ({
   default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../../db/readers/mcp-app-ui-metadata-reader', () => ({
+  readAllMcpAppUiMetadata: mockReadAllMcpAppUiMetadata,
+}))
+
+vi.mock('../../db/writers/mcp-app-ui-metadata-writer', () => ({
+  replaceAllMcpAppUiMetadata: mockReplaceAllMcpAppUiMetadata,
 }))
 
 // ---------------------------------------------------------------------------
@@ -180,6 +194,10 @@ beforeEach(() => {
   mockAiMcpClient.tools.mockResolvedValue({})
   mockAiMcpClient.close.mockResolvedValue(undefined)
   mockCreateMCPClient.mockResolvedValue(mockAiMcpClient)
+
+  // MCP App UI metadata DB reader/writer
+  mockReadAllMcpAppUiMetadata.mockReturnValue({})
+  mockReplaceAllMcpAppUiMetadata.mockReset().mockImplementation(() => {})
 })
 
 // ---------------------------------------------------------------------------
@@ -553,7 +571,7 @@ describe('createMcpTools', () => {
     expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
   })
 
-  it('resets cachedUiMetadata at the start of each call', async () => {
+  it('replaces cachedUiMetadata after each successful discovery', async () => {
     // First call: populate cache
     const toolWithUi = {
       ...makeToolDef(),
@@ -568,6 +586,90 @@ describe('createMcpTools', () => {
     mockGetEnabledMcpTools.mockResolvedValue({})
     await createMcpTools()
     expect(getCachedUiMetadata()).toEqual({})
+  })
+
+  it('persists UI metadata to SQLite after successful discovery', async () => {
+    const uiTool = {
+      ...makeToolDef(),
+      _meta: {
+        ui: { resourceUri: 'res://persist-tool', visibility: ['model'] },
+      },
+    }
+    const workload = makeWorkload()
+    mockGetApiV1BetaWorkloads.mockResolvedValue({
+      data: { workloads: [workload] },
+    })
+    mockGetEnabledMcpTools.mockResolvedValue({
+      'test-server': ['persist-tool'],
+    })
+    mockAiMcpClient.tools.mockResolvedValue({ 'persist-tool': uiTool })
+
+    await createMcpTools()
+
+    expect(mockReplaceAllMcpAppUiMetadata).toHaveBeenCalledTimes(1)
+    expect(mockReplaceAllMcpAppUiMetadata).toHaveBeenCalledWith({
+      'persist-tool': {
+        resourceUri: 'res://persist-tool',
+        serverName: 'test-server',
+      },
+    })
+  })
+
+  it('persists an empty map when discovery succeeds with no UI tools', async () => {
+    mockGetEnabledMcpTools.mockResolvedValue({})
+
+    await createMcpTools()
+
+    // Discovery succeeded (workloads: [], enabledTools: {}), so the empty
+    // map is persisted to prune any stale rows from previous streams.
+    expect(mockReplaceAllMcpAppUiMetadata).toHaveBeenCalledTimes(1)
+    expect(mockReplaceAllMcpAppUiMetadata).toHaveBeenCalledWith({})
+  })
+
+  it('does not overwrite the DB or swap the cache when fetchWorkloads rejects', async () => {
+    // First stream: populate the cache with a known UI tool.
+    const uiTool = {
+      ...makeToolDef(),
+      _meta: {
+        ui: { resourceUri: 'res://survivor', visibility: ['model'] },
+      },
+    }
+    const workload = makeWorkload()
+    mockGetApiV1BetaWorkloads.mockResolvedValueOnce({
+      data: { workloads: [workload] },
+    })
+    mockGetEnabledMcpTools.mockResolvedValueOnce({
+      'test-server': ['survivor-tool'],
+    })
+    mockAiMcpClient.tools.mockResolvedValueOnce({ 'survivor-tool': uiTool })
+
+    await createMcpTools()
+    expect(getCachedUiMetadata()).toHaveProperty('survivor-tool')
+    expect(mockReplaceAllMcpAppUiMetadata).toHaveBeenCalledTimes(1)
+    mockReplaceAllMcpAppUiMetadata.mockClear()
+
+    // Second stream: fetchWorkloads rejects (e.g. ToolHive daemon hiccup).
+    mockGetApiV1BetaWorkloads.mockRejectedValueOnce(new Error('boom'))
+
+    await createMcpTools()
+
+    // Cache must still hold the last-good snapshot and the DB must NOT be
+    // replaced with an empty map.
+    expect(getCachedUiMetadata()).toHaveProperty('survivor-tool')
+    expect(mockReplaceAllMcpAppUiMetadata).not.toHaveBeenCalled()
+    expect(log.error).toHaveBeenCalledWith(
+      'Failed to create MCP tools:',
+      expect.any(Error)
+    )
+  })
+
+  it('does not overwrite the DB when getEnabledMcpTools rejects', async () => {
+    mockGetApiV1BetaWorkloads.mockResolvedValue({ data: { workloads: [] } })
+    mockGetEnabledMcpTools.mockRejectedValue(new Error('settings unavailable'))
+
+    await createMcpTools()
+
+    expect(mockReplaceAllMcpAppUiMetadata).not.toHaveBeenCalled()
   })
 
   it('skips servers with empty tool lists', async () => {

--- a/main/src/chat/__tests__/mcp-tools.test.ts
+++ b/main/src/chat/__tests__/mcp-tools.test.ts
@@ -209,6 +209,38 @@ describe('getCachedUiMetadata', () => {
     expect(getCachedUiMetadata()).toEqual({})
   })
 
+  it('retries loading from SQLite after a transient DB read failure', async () => {
+    // Reset the module so the `uiMetadataLoaded` latch is back to its
+    // initial false state regardless of what prior tests in this file did.
+    vi.resetModules()
+    const { getCachedUiMetadata: freshGetCached } = await import('../mcp-tools')
+
+    // First call: DB throws — the latch must stay unlocked so a later call
+    // can retry.
+    mockReadAllMcpAppUiMetadata.mockImplementationOnce(() => {
+      throw new Error('database is locked')
+    })
+    expect(freshGetCached()).toEqual({})
+    expect(log.error).toHaveBeenCalledWith(
+      '[MCP Apps] Failed to load UI metadata from DB:',
+      expect.any(Error)
+    )
+    expect(mockReadAllMcpAppUiMetadata).toHaveBeenCalledTimes(1)
+
+    // Second call: DB succeeds with persisted rows — should be returned
+    // (proving the latch did not disable retries after the first failure).
+    mockReadAllMcpAppUiMetadata.mockReturnValueOnce({
+      'persisted-tool': {
+        serverName: 'srv',
+        resourceUri: 'res://persisted',
+      },
+    })
+    expect(freshGetCached()).toEqual({
+      'persisted-tool': { serverName: 'srv', resourceUri: 'res://persisted' },
+    })
+    expect(mockReadAllMcpAppUiMetadata).toHaveBeenCalledTimes(2)
+  })
+
   it('returns a shallow copy — mutating it does not affect the cache', async () => {
     const toolWithUi = {
       ...makeToolDef(),

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -27,6 +27,8 @@ import {
 } from '../utils/mcp-tools'
 import { TOOLHIVE_MCP_SERVER_NAME } from '../utils/constants'
 import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
+import { readAllMcpAppUiMetadata } from '../db/readers/mcp-app-ui-metadata-reader'
+import { replaceAllMcpAppUiMetadata } from '../db/writers/mcp-app-ui-metadata-writer'
 
 // Advertised to MCP servers during initialize so they expose UI-enabled tools
 const MCP_UI_EXTENSION_CAPABILITY = {
@@ -45,10 +47,24 @@ interface UiResourceMetadata {
   prefersBorder?: boolean
 }
 
-// Module-level cache populated by createMcpTools() on each chat stream
+// Module-level cache populated by createMcpTools() on each chat stream.
+// Seeded lazily from SQLite on first access so historical MCP App tool
+// calls can render after an app restart without waiting for a new stream.
 let cachedUiMetadata: Record<string, ToolUiMetadataEntry> = {}
+let uiMetadataLoaded = false
+
+function ensureUiMetadataLoaded(): void {
+  if (uiMetadataLoaded) return
+  uiMetadataLoaded = true
+  try {
+    cachedUiMetadata = readAllMcpAppUiMetadata()
+  } catch (error) {
+    log.error('[MCP Apps] Failed to load UI metadata from DB:', error)
+  }
+}
 
 export function getCachedUiMetadata(): Record<string, ToolUiMetadataEntry> {
+  ensureUiMetadataLoaded()
   return { ...cachedUiMetadata }
 }
 
@@ -307,8 +323,10 @@ export async function createMcpTools(): Promise<{
   const mcpTools: ToolSet = {}
   const mcpClients: Awaited<ReturnType<typeof createMCPClient>>[] = []
   let enabledTools: Record<string, string[]> = {}
-  // Reset the UI metadata cache for this stream session
+  // Reset the UI metadata cache for this stream session. Mark as loaded so
+  // subsequent getCachedUiMetadata() calls don't re-read stale DB rows.
   cachedUiMetadata = {}
+  uiMetadataLoaded = true
 
   /** Registers a validated tool and caches its UI metadata if present. */
   const registerTool = (
@@ -408,6 +426,14 @@ export async function createMcpTools(): Promise<{
       level: 'info',
       data: { tools: Object.keys(cachedUiMetadata) },
     })
+  }
+
+  // Persist the freshly built cache (even when empty — a server that lost
+  // all UI tools should have its stale entries removed).
+  try {
+    replaceAllMcpAppUiMetadata(cachedUiMetadata)
+  } catch (error) {
+    log.error('[MCP Apps] Failed to persist UI metadata to DB:', error)
   }
 
   return { tools: mcpTools, clients: mcpClients, enabledTools }

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -323,10 +323,13 @@ export async function createMcpTools(): Promise<{
   const mcpTools: ToolSet = {}
   const mcpClients: Awaited<ReturnType<typeof createMCPClient>>[] = []
   let enabledTools: Record<string, string[]> = {}
-  // Reset the UI metadata cache for this stream session. Mark as loaded so
-  // subsequent getCachedUiMetadata() calls don't re-read stale DB rows.
-  cachedUiMetadata = {}
-  uiMetadataLoaded = true
+  // Build the UI metadata map for this stream session into a local object
+  // and only swap it into the module-level cache (and persist it to SQLite)
+  // once discovery has completed successfully. A transient fetchWorkloads()
+  // or getEnabledMcpTools() failure must not wipe the previously persisted
+  // snapshot — historical MCP App iframes rely on it.
+  const nextCachedUiMetadata: Record<string, ToolUiMetadataEntry> = {}
+  let discoverySucceeded = false
 
   /** Registers a validated tool and caches its UI metadata if present. */
   const registerTool = (
@@ -339,7 +342,10 @@ export async function createMcpTools(): Promise<{
     if (shouldSkipAppOnlyTool(ui)) return false
     mcpTools[toolName] = toolDef
     if (ui?.resourceUri) {
-      cachedUiMetadata[toolName] = { resourceUri: ui.resourceUri, serverName }
+      nextCachedUiMetadata[toolName] = {
+        resourceUri: ui.resourceUri,
+        serverName,
+      }
     }
     return true
   }
@@ -368,6 +374,9 @@ export async function createMcpTools(): Promise<{
       getEnabledMcpTools(),
     ])
     enabledTools = resolvedEnabledTools
+    // Flag is set here, AFTER the two required calls resolved, so any
+    // rejection above propagates into the catch below without flipping it.
+    discoverySucceeded = true
 
     for (const [serverName, toolNames] of Object.entries(enabledTools)) {
       if (toolNames.length === 0) continue
@@ -418,22 +427,29 @@ export async function createMcpTools(): Promise<{
     log.error('Failed to create MCP tools:', error)
   }
 
-  const uiToolCount = Object.keys(cachedUiMetadata).length
-  if (uiToolCount > 0) {
-    Sentry.addBreadcrumb({
-      category: 'mcp-apps',
-      message: `Discovered ${uiToolCount} UI-enabled tool(s)`,
-      level: 'info',
-      data: { tools: Object.keys(cachedUiMetadata) },
-    })
-  }
+  if (discoverySucceeded) {
+    // Swap the module-level cache in and persist it. Empty maps are
+    // persisted too — a server that lost all UI tools should have its
+    // stale entries removed. When discovery failed we skip both, keeping
+    // the previously hydrated cache and DB rows intact.
+    cachedUiMetadata = nextCachedUiMetadata
+    uiMetadataLoaded = true
 
-  // Persist the freshly built cache (even when empty — a server that lost
-  // all UI tools should have its stale entries removed).
-  try {
-    replaceAllMcpAppUiMetadata(cachedUiMetadata)
-  } catch (error) {
-    log.error('[MCP Apps] Failed to persist UI metadata to DB:', error)
+    const uiToolCount = Object.keys(nextCachedUiMetadata).length
+    if (uiToolCount > 0) {
+      Sentry.addBreadcrumb({
+        category: 'mcp-apps',
+        message: `Discovered ${uiToolCount} UI-enabled tool(s)`,
+        level: 'info',
+        data: { tools: Object.keys(nextCachedUiMetadata) },
+      })
+    }
+
+    try {
+      replaceAllMcpAppUiMetadata(nextCachedUiMetadata)
+    } catch (error) {
+      log.error('[MCP Apps] Failed to persist UI metadata to DB:', error)
+    }
   }
 
   return { tools: mcpTools, clients: mcpClients, enabledTools }

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -55,9 +55,12 @@ let uiMetadataLoaded = false
 
 function ensureUiMetadataLoaded(): void {
   if (uiMetadataLoaded) return
-  uiMetadataLoaded = true
   try {
     cachedUiMetadata = readAllMcpAppUiMetadata()
+    // Only latch after a successful load — a transient DB read error
+    // (e.g. locked DB at startup) should not disable retries for the rest
+    // of the session.
+    uiMetadataLoaded = true
   } catch (error) {
     log.error('[MCP Apps] Failed to load UI metadata from DB:', error)
   }

--- a/main/src/db/__tests__/test-helpers.ts
+++ b/main/src/db/__tests__/test-helpers.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3'
 import { up as applyInitialSchema } from '../migrations/001-initial-schema'
 import { up as applyMigration002 } from '../migrations/002-thread-title-flag'
 import { up as applyMigration003 } from '../migrations/003-thread-starred'
+import { up as applyMigration004 } from '../migrations/004-mcp-app-ui-metadata'
 
 /**
  * Creates a fresh in-memory SQLite database with the full schema applied,
@@ -13,5 +14,6 @@ export function createTestDb(): Database.Database {
   applyInitialSchema(db)
   applyMigration002(db)
   applyMigration003(db)
+  applyMigration004(db)
   return db
 }

--- a/main/src/db/__tests__/writers-readers.test.ts
+++ b/main/src/db/__tests__/writers-readers.test.ts
@@ -67,6 +67,11 @@ import {
   clearShutdownServersFromDb,
 } from '../writers/shutdown-writer'
 import { readShutdownServers } from '../readers/shutdown-reader'
+import {
+  replaceAllMcpAppUiMetadata,
+  clearAllMcpAppUiMetadata,
+} from '../writers/mcp-app-ui-metadata-writer'
+import { readAllMcpAppUiMetadata } from '../readers/mcp-app-ui-metadata-reader'
 
 beforeEach(() => {
   testDb = createTestDb()
@@ -355,5 +360,83 @@ describe('shutdown writer/reader', () => {
     const result = readShutdownServers()
     expect(result).toHaveLength(2)
     expect(result[0]!.name).toBe('s2')
+  })
+})
+
+describe('mcp app ui metadata writer/reader', () => {
+  it('returns an empty object when the table is empty', () => {
+    expect(readAllMcpAppUiMetadata()).toEqual({})
+  })
+
+  it('round-trips a map of tool UI metadata entries', () => {
+    replaceAllMcpAppUiMetadata({
+      server1_toolA: {
+        serverName: 'server1',
+        resourceUri: 'ui://server1/toolA',
+      },
+      server2_toolB: {
+        serverName: 'server2',
+        resourceUri: 'ui://server2/toolB',
+      },
+    })
+    const result = readAllMcpAppUiMetadata()
+    expect(result).toEqual({
+      server1_toolA: {
+        serverName: 'server1',
+        resourceUri: 'ui://server1/toolA',
+      },
+      server2_toolB: {
+        serverName: 'server2',
+        resourceUri: 'ui://server2/toolB',
+      },
+    })
+  })
+
+  it('replaces existing entries on each write (no accumulation)', () => {
+    replaceAllMcpAppUiMetadata({
+      server1_toolA: {
+        serverName: 'server1',
+        resourceUri: 'ui://server1/toolA',
+      },
+      server1_toolB: {
+        serverName: 'server1',
+        resourceUri: 'ui://server1/toolB',
+      },
+    })
+    replaceAllMcpAppUiMetadata({
+      server1_toolA: {
+        serverName: 'server1',
+        resourceUri: 'ui://server1/toolA-v2',
+      },
+    })
+    const result = readAllMcpAppUiMetadata()
+    expect(Object.keys(result)).toEqual(['server1_toolA'])
+    expect(result['server1_toolA']!.resourceUri).toBe('ui://server1/toolA-v2')
+  })
+
+  it('clears the table when replace is called with an empty map', () => {
+    replaceAllMcpAppUiMetadata({
+      server1_toolA: {
+        serverName: 'server1',
+        resourceUri: 'ui://server1/toolA',
+      },
+    })
+    replaceAllMcpAppUiMetadata({})
+    expect(readAllMcpAppUiMetadata()).toEqual({})
+  })
+
+  it('clearAllMcpAppUiMetadata removes every entry', () => {
+    replaceAllMcpAppUiMetadata({
+      server1_toolA: {
+        serverName: 'server1',
+        resourceUri: 'ui://server1/toolA',
+      },
+      server2_toolB: {
+        serverName: 'server2',
+        resourceUri: 'ui://server2/toolB',
+      },
+    })
+    clearAllMcpAppUiMetadata()
+    expect(readAllMcpAppUiMetadata()).toEqual({})
   })
 })

--- a/main/src/db/migrations/004-mcp-app-ui-metadata.ts
+++ b/main/src/db/migrations/004-mcp-app-ui-metadata.ts
@@ -1,0 +1,18 @@
+import type Database from 'better-sqlite3'
+
+export function up(db: Database.Database): void {
+  db.exec(`
+    -- Tool UI metadata cache for MCP Apps (tool name -> server + resource URI).
+    -- Mirrors the in-memory cache built by createMcpTools() so historical
+    -- tool calls can render their MCP App iframes after an app restart
+    -- without first requiring a new chat stream to repopulate the cache.
+    CREATE TABLE mcp_app_ui_metadata (
+      tool_name    TEXT PRIMARY KEY,
+      server_name  TEXT NOT NULL,
+      resource_uri TEXT NOT NULL,
+      updated_at   INTEGER NOT NULL
+    );
+    CREATE INDEX idx_mcp_app_ui_metadata_server
+      ON mcp_app_ui_metadata(server_name);
+  `)
+}

--- a/main/src/db/migrator.ts
+++ b/main/src/db/migrator.ts
@@ -12,11 +12,13 @@ interface Migration {
 import * as m001 from './migrations/001-initial-schema'
 import * as m002 from './migrations/002-thread-title-flag'
 import * as m003 from './migrations/003-thread-starred'
+import * as m004 from './migrations/004-mcp-app-ui-metadata'
 
 const migrations: Migration[] = [
   { id: 1, name: '001-initial-schema', up: m001.up },
   { id: 2, name: '002-thread-title-flag', up: m002.up },
   { id: 3, name: '003-thread-starred', up: m003.up },
+  { id: 4, name: '004-mcp-app-ui-metadata', up: m004.up },
 ]
 
 export function runMigrations(): void {

--- a/main/src/db/readers/mcp-app-ui-metadata-reader.ts
+++ b/main/src/db/readers/mcp-app-ui-metadata-reader.ts
@@ -1,0 +1,29 @@
+import { getDb } from '../database'
+import { withDbSpan } from '../telemetry'
+import type { McpAppUiMetadataEntry } from '../writers/mcp-app-ui-metadata-writer'
+
+export function readAllMcpAppUiMetadata(): Record<
+  string,
+  McpAppUiMetadataEntry
+> {
+  return withDbSpan('DB read MCP App UI metadata', 'db.read', {}, () => {
+    const db = getDb()
+    const rows = db
+      .prepare(
+        'SELECT tool_name, server_name, resource_uri FROM mcp_app_ui_metadata'
+      )
+      .all() as {
+      tool_name: string
+      server_name: string
+      resource_uri: string
+    }[]
+    const result: Record<string, McpAppUiMetadataEntry> = {}
+    for (const row of rows) {
+      result[row.tool_name] = {
+        serverName: row.server_name,
+        resourceUri: row.resource_uri,
+      }
+    }
+    return result
+  })
+}

--- a/main/src/db/writers/mcp-app-ui-metadata-writer.ts
+++ b/main/src/db/writers/mcp-app-ui-metadata-writer.ts
@@ -1,0 +1,42 @@
+import { getDb, isDbWritable } from '../database'
+import { withDbSpan } from '../telemetry'
+
+export interface McpAppUiMetadataEntry {
+  resourceUri: string
+  serverName: string
+}
+
+export function replaceAllMcpAppUiMetadata(
+  entries: Record<string, McpAppUiMetadataEntry>
+): void {
+  if (!isDbWritable()) return
+  const toolNames = Object.keys(entries)
+  withDbSpan(
+    'DB replace MCP App UI metadata',
+    'db.write',
+    { 'db.entry_count': toolNames.length },
+    () => {
+      const db = getDb()
+      const now = Date.now()
+      db.transaction(() => {
+        db.prepare('DELETE FROM mcp_app_ui_metadata').run()
+        const insert = db.prepare(
+          `INSERT INTO mcp_app_ui_metadata (tool_name, server_name, resource_uri, updated_at)
+           VALUES (?, ?, ?, ?)`
+        )
+        for (const toolName of toolNames) {
+          const entry = entries[toolName]!
+          insert.run(toolName, entry.serverName, entry.resourceUri, now)
+        }
+      })()
+    }
+  )
+}
+
+export function clearAllMcpAppUiMetadata(): void {
+  if (!isDbWritable()) return
+  withDbSpan('DB clear MCP App UI metadata', 'db.write', {}, () => {
+    const db = getDb()
+    db.prepare('DELETE FROM mcp_app_ui_metadata').run()
+  })
+}


### PR DESCRIPTION
The Playground's MCP App iframe map (tool name → `{ serverName, resourceUri }`) lived only in a module-level variable in `main/src/chat/mcp-tools.ts` (`cachedUiMetadata`) that was cleared and rebuilt on every `createMcpTools()` call. That meant on a fresh app launch the cache was empty until the user kicked off a new chat stream — so any historical message in `main/src/chat/threads-storage.ts` whose tool parts had a `_meta.ui` resource silently rendered as a plain tool output instead of its `McpAppView` iframe, because [`chat-message.tsx`](renderer/src/features/chat/components/chat-message.tsx) gates `McpAppView` on the tool name being present in the metadata map consumed by [`useMcpAppMetadata`](renderer/src/features/chat/hooks/use-mcp-app-metadata.ts).

This PR mirrors the cache into SQLite (same DB that already backs chat threads, settings, and feature flags) and seeds the in-memory map lazily from the DB on the first `getCachedUiMetadata()` call, so historical MCP App iframes show up immediately after a restart. The renderer and IPC surface are unchanged.


https://github.com/user-attachments/assets/a5e152fe-06dd-4bf5-8dea-a0fff35aca17



### DB layer (`main/src/db/`)

- New migration `004-mcp-app-ui-metadata.ts` — `mcp_app_ui_metadata(tool_name TEXT PRIMARY KEY, server_name TEXT NOT NULL, resource_uri TEXT NOT NULL, updated_at INTEGER NOT NULL)` plus `idx_mcp_app_ui_metadata_server` for possible future per-server cleanup. Registered as id 4 in `migrator.ts` and applied in the in-memory test DB helper.
- New `writers/mcp-app-ui-metadata-writer.ts` — `replaceAllMcpAppUiMetadata(map)` runs `DELETE` + bulk `INSERT` inside a single `db.transaction()`, so the row set is atomically swapped on each stream and stale entries are pruned in the same operation. `clearAllMcpAppUiMetadata()` is exposed for symmetry with other writers. No encryption: `tool_name` and `resource_uri` are not secrets (unlike the `ai_providers` table).
- New `readers/mcp-app-ui-metadata-reader.ts` — `readAllMcpAppUiMetadata()` returns a `Record<string, { serverName; resourceUri }>` shaped exactly like the existing in-memory `cachedUiMetadata`, so the cache can be seeded without an adapter.

### Cache plumbing (`main/src/chat/mcp-tools.ts`)

- Add a `uiMetadataLoaded` latch and an `ensureUiMetadataLoaded()` helper that calls `readAllMcpAppUiMetadata()` exactly once and populates the in-memory map. Failures are logged and swallowed — the cache is advisory, and the next chat stream will rebuild it anyway.
- `getCachedUiMetadata()` calls `ensureUiMetadataLoaded()` before returning, so the first renderer IPC (`chat:get-tool-ui-metadata`) after startup returns the persisted map.
- `createMcpTools()` keeps its existing reset-and-rebuild semantics, marks the cache as "loaded" when it resets (so a concurrent read doesn't trigger a redundant DB fetch), and calls `replaceAllMcpAppUiMetadata(cachedUiMetadata)` after the Sentry breadcrumb — including when the map is empty, so uninstalling an MCP workload with UI tools cleans the table on the next stream.

### How to validate

1. Open a Playground chat that invokes a UI-enabled MCP tool and confirm the iframe renders.
2. Fully quit and relaunch the app. Navigate to the same thread **without** sending a new message. The historical tool part now mounts `McpAppView` immediately (the metadata map is hydrated from SQLite on the first `getToolUiMetadata` IPC).
3. Uninstall the MCP workload that provided the tool, start a new chat stream. The removed tool's row is pruned from `mcp_app_ui_metadata` by the transactional replace in `createMcpTools()`.

### Tests

- 5 new unit tests in `main/src/db/__tests__/writers-readers.test.ts` covering empty-table read, round-trip, replace-without-accumulation (second call prunes entries not in the new map), empty-map replace clearing the table, and `clearAllMcpAppUiMetadata`.
- `pnpm run type-check` and the full `main/src/db` + `main/src/chat` Vitest suites are green (71 + 56 tests).

### Not changed in this PR (deliberate)

- The renderer flow is unchanged. `useMcpAppMetadata` still calls `chat:get-tool-ui-metadata` and listens to `chat:stream:tool-ui-metadata`; seeding from SQLite happens transparently inside `getCachedUiMetadata()`.
- No electron-store migration: this cache was never persisted before, so there is nothing to reconcile.
- Stale rows across uninstalls are pruned lazily on the next `createMcpTools()` call rather than reactively on workload delete. If a user reopens a thread that referenced an uninstalled server before any new stream runs, the iframe will render and fail through the existing error path in `fetchUiResource` + `McpAppView` — same behavior as today when a workload is merely stopped.
- `_meta.ui.csp` / `permissions` / `prefersBorder` from `resources/read` are not persisted. They are re-fetched per resource load inside `McpAppView` and aren't part of the tool→server map.