### PR TITLE
refactor(telemetry): migrate Sentry main-process telemetry gate to SQLite

### DIFF
--- a/main/src/ipc-handlers/telemetry.ts
+++ b/main/src/ipc-handlers/telemetry.ts
@@ -1,30 +1,17 @@
 import { ipcMain } from 'electron'
-import { telemetryStore } from '../telemetry-store'
 import { writeSetting } from '../db/writers/settings-writer'
-import log from '../logger'
+import { getIsTelemetryEnabled } from '../telemetry-settings'
 
 export function register() {
-  ipcMain.handle('sentry.is-enabled', () => {
-    return telemetryStore.get('isTelemetryEnabled', true)
-  })
+  ipcMain.handle('sentry.is-enabled', () => getIsTelemetryEnabled())
 
   ipcMain.handle('sentry.opt-out', (): boolean => {
-    telemetryStore.set('isTelemetryEnabled', false)
-    try {
-      writeSetting('isTelemetryEnabled', 'false')
-    } catch (err) {
-      log.error('[DB] Failed to dual-write isTelemetryEnabled:', err)
-    }
-    return telemetryStore.get('isTelemetryEnabled', false)
+    writeSetting('isTelemetryEnabled', 'false')
+    return false
   })
 
   ipcMain.handle('sentry.opt-in', (): boolean => {
-    telemetryStore.set('isTelemetryEnabled', true)
-    try {
-      writeSetting('isTelemetryEnabled', 'true')
-    } catch (err) {
-      log.error('[DB] Failed to dual-write isTelemetryEnabled:', err)
-    }
+    writeSetting('isTelemetryEnabled', 'true')
     return true
   })
 }

--- a/main/src/sentry.ts
+++ b/main/src/sentry.ts
@@ -1,11 +1,9 @@
 import * as Sentry from '@sentry/electron/main'
-import { telemetryStore } from './telemetry-store'
 import { getInstanceId } from './util'
 import { getAutoLaunchStatus } from './auto-launch'
+import { getIsTelemetryEnabled } from './telemetry-settings'
 
 const isE2E = process.env.TOOLHIVE_E2E === 'true'
-
-const store = telemetryStore
 
 export function initSentry() {
   Sentry.init({
@@ -14,10 +12,9 @@ export function initSentry() {
     propagateTraceparent: true,
     tracePropagationTargets: ['localhost', /^https?:\/\/127\.0\.0\.1/],
     tracesSampleRate: 1.0,
-    beforeSend: (event) =>
-      store.get('isTelemetryEnabled', true) ? event : null,
+    beforeSend: (event) => (getIsTelemetryEnabled() ? event : null),
     beforeSendTransaction: async (transaction) => {
-      if (!store.get('isTelemetryEnabled', true)) {
+      if (!getIsTelemetryEnabled()) {
         return null
       }
       if (!transaction?.contexts?.trace) return null

--- a/main/src/telemetry-settings.ts
+++ b/main/src/telemetry-settings.ts
@@ -1,0 +1,12 @@
+import { readSetting } from './db/readers/settings-reader'
+import log from './logger'
+
+export function getIsTelemetryEnabled(): boolean {
+  try {
+    const value = readSetting('isTelemetryEnabled')
+    if (value !== undefined) return value === 'true'
+  } catch (err) {
+    log.error('[DB] SQLite read failed (isTelemetryEnabled):', err)
+  }
+  return true
+}


### PR DESCRIPTION
`main/src/sentry.ts` and the `sentry.is-enabled` / `sentry.opt-in` / `sentry.opt-out` IPC handlers were still reading `isTelemetryEnabled` from `electron-store` and dual-writing to SQLite. This PR flips main-process reads/writes for that key onto SQLite only, as a scoped first step toward the broader electron-store removal — no changes to other stores and no change to the one-time migration in `reconcile-from-store.ts`.

- Add `main/src/telemetry-settings.ts` exporting a synchronous `getIsTelemetryEnabled()` helper that reads via `readSetting('isTelemetryEnabled')` and defaults to `true` when the key is absent or the read throws. Mirrors the convention used by `getIsAutoUpdateEnabled` in `main/src/auto-update.ts`.
- Wire `beforeSend` and `beforeSendTransaction` in `main/src/sentry.ts` through the helper instead of `telemetryStore.get(...)`. The read stays synchronous so Sentry can call it from `beforeSend`; `getDb()` lazily opens the DB and `app.getPath('userData')` is safe pre-`whenReady`, so early Sentry events are handled correctly. On read failure the helper returns `true`, matching the existing fail-open convention.
- Simplify `main/src/ipc-handlers/telemetry.ts`: `sentry.is-enabled` delegates to the helper; `sentry.opt-in` / `sentry.opt-out` write exclusively via `writeSetting` and return the boolean directly. The old `telemetryStore.set(...)` + `try/catch` dual-write is removed.
- `main/src/telemetry-store.ts` is intentionally kept — its sole consumer now is `main/src/db/reconcile-from-store.ts`, which still uses it for the one-time electron-store → SQLite migration, just like `autoUpdateStore`, `quitConfirmationStore`, and the other legacy stores.

### How to validate

- `pnpm run type-check` and `pnpm run lint` pass.
- `pnpm test main/src/db/__tests__/reconcile-from-store.test.ts` still passes (migration path unchanged).
- In a fresh profile: toggle telemetry off in Settings → General, relaunch, and confirm `sentry.is-enabled` returns `false` and no Sentry events are sent. Inspect `desktop.db`'s `settings` table — `isTelemetryEnabled` should be `'false'`.
- Opt back in, relaunch, and confirm events resume.

### Not changed in this PR (deliberate)

- No other electron-store backed settings are migrated. `autoUpdateStore`, `quitConfirmationStore`, `newsletterStore`, `expertConsultationStore`, `chatSettingsStore`, `threadsStore`, `shutdownStore`, and `featureFlagStore` are untouched.
- `reconcile-from-store.ts` still seeds `isTelemetryEnabled` from `telemetryStore` on first launch for users upgrading from a pre-migration version — no data loss.
- E2E: `telemetryStore`'s `!isE2E` default is no longer in play, but `main/src/sentry.ts` already sets `dsn: isE2E ? undefined : import.meta.env.VITE_SENTRY_DSN`, so Sentry never transmits in E2E regardless.