### PR TITLE
feat(playground): preload thread in the route loader and delegate scroll restoration to router

### DIFF
--- a/renderer/src/features/chat/components/__tests__/chat-interface.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/chat-interface.test.tsx
@@ -8,6 +8,14 @@ import type { ChatUIMessage } from '../../types'
 // Module mocks
 // ---------------------------------------------------------------------------
 
+// `useAutoScroll` consumes TanStack Router's element-level scroll
+// restoration entry. We don't mount a Router in this component test, so
+// stub the hook to "no saved position" which makes the hook default to
+// scroll-to-bottom (the pre-refactor behaviour the suite was written for).
+vi.mock('@tanstack/react-router', () => ({
+  useElementScrollRestoration: () => undefined,
+}))
+
 vi.mock('../thread-title-bar', () => ({
   ThreadTitleBar: (props: Record<string, unknown>) => (
     <div
@@ -52,6 +60,7 @@ const mockScrollToBottom = vi.fn()
 const mockContainerRef = createRef<HTMLDivElement>()
 
 vi.mock('../../hooks/use-auto-scroll', () => ({
+  CHAT_SCROLL_RESTORATION_ID: 'chat-messages',
   useAutoScroll: () => ({
     containerRef: mockContainerRef,
     showScrollToBottom: mockShowScrollToBottom,
@@ -69,7 +78,6 @@ const mockStreamingReturn = {
   updateSettings: vi.fn(),
   sendMessage: vi.fn(),
   cancelRequest: vi.fn(),
-  isPersistentLoading: false,
   loadPersistedSettings: vi.fn(),
   clearMessages: vi.fn(),
   currentThreadId: null as string | null,
@@ -106,7 +114,6 @@ function resetMock() {
   mockStreamingReturn.status = 'idle'
   mockStreamingReturn.messages = []
   mockStreamingReturn.isLoading = false
-  mockStreamingReturn.isPersistentLoading = false
   mockStreamingReturn.error = null
   mockStreamingReturn.settings = { provider: '', model: '' }
   mockShowScrollToBottom = false
@@ -170,24 +177,12 @@ describe('ChatInterface', () => {
     })
   })
 
-  describe('loading state', () => {
-    it('shows "Loading chat history..." when isPersistentLoading is true', () => {
-      mockStreamingReturn.isPersistentLoading = true
-      renderInterface()
-      expect(screen.getByText('Loading chat history...')).toBeInTheDocument()
-    })
+  // Loading state is now owned by the TSR route loader via
+  // `pendingComponent` in `playground.chat.$threadId.tsx`, not by this
+  // component. There is no in-component "Loading chat history..." overlay
+  // any more; see the route tests for the pending-state behaviour.
 
-    it('hides messages while loading (loading overlay covers the scroll container)', () => {
-      mockStreamingReturn.isPersistentLoading = true
-      // Messages are only rendered inside the scroll container when hasMessages is true.
-      // While isPersistentLoading, messages haven't loaded yet so the array is empty.
-      renderInterface()
-      expect(screen.queryByTestId('message-msg-1')).not.toBeInTheDocument()
-      expect(screen.getByText('Loading chat history...')).toBeInTheDocument()
-    })
-  })
-
-  describe('empty state (no messages, not loading)', () => {
+  describe('empty state (no messages)', () => {
     it('shows "Configure your providers" button when no provider is configured', () => {
       mockStreamingReturn.settings = { provider: '', model: '' }
       renderInterface()

--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -10,7 +10,10 @@ import { ChatMessage } from './chat-message'
 import { DialogProviderSettings } from './dialog-provider-settings'
 import { ErrorAlert } from './error-alert'
 import { useChatStreaming } from '../hooks/use-chat-streaming'
-import { useAutoScroll } from '../hooks/use-auto-scroll'
+import {
+  useAutoScroll,
+  CHAT_SCROLL_RESTORATION_ID,
+} from '../hooks/use-auto-scroll'
 import { useMcpAppMetadata } from '../hooks/use-mcp-app-metadata'
 import { ChatInputPrompt } from './chat-input-prompt'
 import { Separator } from '@/common/components/ui/separator'
@@ -43,15 +46,17 @@ export function ChatInterface({
     updateSettings,
     sendMessage,
     cancelRequest,
-    isPersistentLoading,
     loadPersistedSettings,
   } = useChatStreaming(threadId)
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const toolUiMetadata = useMcpAppMetadata()
 
+  const isStreaming = status === 'streaming' || status === 'submitted'
+
   const { containerRef, showScrollToBottom, scrollToBottom } = useAutoScroll({
-    resetDep: threadId,
+    threadId,
+    isStreaming,
     hasContent: messages.length > 0,
   })
 
@@ -81,38 +86,15 @@ export function ChatInterface({
       <div className="bg-background flex min-h-0 flex-1 flex-col px-4">
         {/* Messages Area */}
         <div className="relative min-h-0 flex-1 overflow-hidden">
-          {/* Loading overlay — sits above scroll container so ref stays stable */}
-          {isPersistentLoading && (
-            <div
-              className="bg-background absolute inset-0 z-10 flex items-center
-                justify-center [view-transition-name:chat-loading-state]
-                motion-safe:transition-all motion-safe:duration-300"
-            >
-              <div className="flex items-center space-x-3">
-                <div className="flex space-x-1">
-                  <div
-                    className="bg-muted-foreground h-2 w-2 animate-bounce
-                      rounded-full [animation-delay:-0.3s]"
-                  ></div>
-                  <div
-                    className="bg-muted-foreground h-2 w-2 animate-bounce
-                      rounded-full [animation-delay:-0.15s]"
-                  ></div>
-                  <div
-                    className="bg-muted-foreground h-2 w-2 animate-bounce
-                      rounded-full"
-                  ></div>
-                </div>
-                <span className="text-muted-foreground text-sm">
-                  Loading chat history...
-                </span>
-              </div>
-            </div>
-          )}
-
-          {/* Scroll container — always in DOM so containerRef is never null */}
+          {/* Scroll container — always in DOM so containerRef is never null.
+              `data-scroll-restoration-id` registers this nested scrollable
+              area with TanStack Router's scroll restoration. `overflowAnchor`
+              keeps async content (MCP iframes, images, code blocks) from
+              jolting the viewport when their height changes. */}
           <div
             ref={containerRef}
+            data-scroll-restoration-id={CHAT_SCROLL_RESTORATION_ID}
+            style={{ overflowAnchor: 'auto' }}
             className="h-full w-full overflow-y-auto scroll-smooth
               [view-transition-name:chat-messages-view]
               motion-safe:transition-all motion-safe:duration-300"
@@ -177,7 +159,7 @@ export function ChatInterface({
           </div>
 
           {/* Empty state overlay */}
-          {!isPersistentLoading && !hasMessages && (
+          {!hasMessages && (
             <div
               className="absolute inset-0 flex items-center justify-center px-6
                 [view-transition-name:chat-empty-state]

--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -88,13 +88,13 @@ export function ChatInterface({
         <div className="relative min-h-0 flex-1 overflow-hidden">
           {/* Scroll container — always in DOM so containerRef is never null.
               `data-scroll-restoration-id` registers this nested scrollable
-              area with TanStack Router's scroll restoration. `overflowAnchor`
-              keeps async content (MCP iframes, images, code blocks) from
-              jolting the viewport when their height changes. */}
+              area with TanStack Router's scroll restoration. Native scroll
+              anchoring (`overflow-anchor: auto`, the CSS default) keeps
+              async content (MCP iframes, images, code blocks) from jolting
+              the viewport when their height changes. */}
           <div
             ref={containerRef}
             data-scroll-restoration-id={CHAT_SCROLL_RESTORATION_ID}
-            style={{ overflowAnchor: 'auto' }}
             className="h-full w-full overflow-y-auto scroll-smooth
               [view-transition-name:chat-messages-view]
               motion-safe:transition-all motion-safe:duration-300"

--- a/renderer/src/features/chat/components/mcp-app-view.tsx
+++ b/renderer/src/features/chat/components/mcp-app-view.tsx
@@ -408,7 +408,12 @@ export function McpAppView({
           ? 'bg-background mt-2 overflow-hidden rounded-lg border'
           : 'mt-2 overflow-hidden'
       }
-      style={{ width: '100%' }}
+      // `overflowAnchor: auto` lets the browser keep the surrounding chat
+      // messages glued in place when the iframe asynchronously resizes
+      // itself (e.g. `bridge.onsizechange` grows `iframeHeight`). Without
+      // this, a growing iframe would push content downward and the
+      // viewport would effectively "fall" to the top of the iframe.
+      style={{ width: '100%', overflowAnchor: 'auto' }}
     >
       {toolbar}
       {iframeEl}

--- a/renderer/src/features/chat/components/mcp-app-view.tsx
+++ b/renderer/src/features/chat/components/mcp-app-view.tsx
@@ -405,15 +405,9 @@ export function McpAppView({
     <div
       className={
         prefersBorder
-          ? 'bg-background mt-2 overflow-hidden rounded-lg border'
-          : 'mt-2 overflow-hidden'
+          ? 'bg-background mt-2 w-full overflow-hidden rounded-lg border'
+          : 'mt-2 w-full overflow-hidden'
       }
-      // `overflowAnchor: auto` lets the browser keep the surrounding chat
-      // messages glued in place when the iframe asynchronously resizes
-      // itself (e.g. `bridge.onsizechange` grows `iframeHeight`). Without
-      // this, a growing iframe would push content downward and the
-      // viewport would effectively "fall" to the top of the iframe.
-      style={{ width: '100%', overflowAnchor: 'auto' }}
     >
       {toolbar}
       {iframeEl}

--- a/renderer/src/features/chat/hooks/__tests__/use-auto-scroll.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-auto-scroll.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
+
+// The hook reads TanStack Router's element-level scroll restoration entry.
+// In isolation we don't have a router in the test tree, so stub the entry
+// to undefined (simulating "no saved position"). Individual tests can
+// override via `mockSavedScroll.value`.
+const mockSavedScroll = { value: undefined as undefined | { scrollY: number } }
+vi.mock('@tanstack/react-router', () => ({
+  useElementScrollRestoration: () => mockSavedScroll.value,
+}))
+
 import { useAutoScroll } from '../use-auto-scroll'
 
-// Use unique thread IDs per test so the module-level scrollPositions Map never has key collisions.
-
-// JSDOM stubs scrollTo — override it to actually update scrollTop and fire scroll events.
+// JSDOM stubs scrollTo — override it to actually update scrollTop and fire
+// scroll events. Use unique thread IDs per test so the module-level
+// "first-mount-per-thread" Set never collides.
 function makeScrollContainer(
   scrollHeight = 1000,
   clientHeight = 300,
@@ -13,8 +23,16 @@ function makeScrollContainer(
   const el = document.createElement('div')
 
   let _scrollTop = initialScrollTop
+  let _scrollHeight = scrollHeight
   Object.defineProperties(el, {
-    scrollHeight: { get: () => scrollHeight, configurable: true },
+    scrollHeight: {
+      get: () => _scrollHeight,
+      // Tests simulate async iframe-size-handshake growth by writing to this.
+      set: (v) => {
+        _scrollHeight = v
+      },
+      configurable: true,
+    },
     clientHeight: { get: () => clientHeight, configurable: true },
     scrollTop: {
       get: () => _scrollTop,
@@ -27,14 +45,44 @@ function makeScrollContainer(
 
   el.scrollTo = vi.fn((...args: [ScrollToOptions] | [number, number]) => {
     const top = typeof args[0] === 'object' ? args[0].top : args[1]
-    if (top !== undefined) _scrollTop = top
+    if (top !== undefined) {
+      // Match real-browser clamping so the hook's landing check matches.
+      const max = Math.max(0, _scrollHeight - clientHeight)
+      _scrollTop = Math.min(max, Math.max(0, top))
+    }
     el.dispatchEvent(new Event('scroll'))
   }) as HTMLDivElement['scrollTo']
+
+  // The ResizeObserver branch observes the firstElementChild — give the
+  // container one so the hook can hook into it.
+  const inner = document.createElement('div')
+  el.appendChild(inner)
 
   return el
 }
 
-// Attach a container to the hook's ref after renderHook returns.
+// Capture ResizeObserver callbacks so tests can trigger a "content grew"
+// event synchronously.
+type ResizeCallback = ConstructorParameters<typeof ResizeObserver>[0]
+let resizeCallbacks: ResizeCallback[] = []
+beforeEach(() => {
+  resizeCallbacks = []
+  mockSavedScroll.value = undefined
+  // jsdom lacks ResizeObserver — supply a minimal spy.
+  globalThis.ResizeObserver = class {
+    cb: ResizeCallback
+    constructor(cb: ResizeCallback) {
+      this.cb = cb
+      resizeCallbacks.push(cb)
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {
+      resizeCallbacks = resizeCallbacks.filter((c) => c !== this.cb)
+    }
+  } as unknown as typeof ResizeObserver
+})
+
 function attachContainer(
   ref: React.RefObject<HTMLDivElement | null>,
   container: HTMLDivElement
@@ -46,29 +94,44 @@ function attachContainer(
   })
 }
 
+// `scrollHeight` is typed as read-only on HTMLElement, but our stub exposes
+// it as a getter/setter so tests can simulate async iframe-driven growth.
+function setScrollHeight(container: HTMLDivElement, value: number) {
+  ;(container as unknown as { scrollHeight: number }).scrollHeight = value
+}
+
+// Simulate a genuine user scroll: the hook requires a recent user input
+// event (wheel/touch/key/pointer) to differentiate real scrolls from
+// `overflow-anchor`-driven ones during the placement settling window.
+function fireUserScroll(container: HTMLDivElement) {
+  container.dispatchEvent(new Event('wheel'))
+  container.dispatchEvent(new Event('scroll'))
+}
+
 describe('useAutoScroll', () => {
   describe('basic return shape', () => {
     it('returns containerRef, showScrollToBottom, and scrollToBottom', () => {
       const { result } = renderHook(() =>
-        useAutoScroll({ resetDep: 'thread-basic', hasContent: false })
+        useAutoScroll({
+          threadId: 'thread-basic',
+          isStreaming: false,
+          hasContent: false,
+        })
       )
       expect(result.current.containerRef).toBeDefined()
       expect(result.current.showScrollToBottom).toBe(false)
       expect(typeof result.current.scrollToBottom).toBe('function')
-    })
-
-    it('showScrollToBottom starts as false', () => {
-      const { result } = renderHook(() =>
-        useAutoScroll({ resetDep: null, hasContent: false })
-      )
-      expect(result.current.showScrollToBottom).toBe(false)
     })
   })
 
   describe('scrollToBottom public method', () => {
     it('calls scrollTo on the container', () => {
       const { result } = renderHook(() =>
-        useAutoScroll({ resetDep: 'thread-stb', hasContent: true })
+        useAutoScroll({
+          threadId: 'thread-stb',
+          isStreaming: false,
+          hasContent: true,
+        })
       )
       const container = makeScrollContainer()
       attachContainer(result.current.containerRef, container)
@@ -90,15 +153,22 @@ describe('useAutoScroll', () => {
       // then attach the ref and flip to true to re-register with the real element.
       const { result, rerender } = renderHook(
         ({ hasContent }: { hasContent: boolean }) =>
-          useAutoScroll({ resetDep: 'thread-scroll-up', hasContent }),
+          useAutoScroll({
+            threadId: 'thread-scroll-up',
+            isStreaming: false,
+            hasContent,
+          }),
         { initialProps: { hasContent: false } }
       )
 
       attachContainer(result.current.containerRef, container)
       rerender({ hasContent: true })
 
+      // Placement effect lands us at the bottom (no saved scroll); simulate
+      // the user scrolling back up, then fire the scroll listener.
+      container.scrollTop = 0
       act(() => {
-        container.dispatchEvent(new Event('scroll'))
+        fireUserScroll(container)
       })
 
       expect(result.current.showScrollToBottom).toBe(true)
@@ -106,7 +176,11 @@ describe('useAutoScroll', () => {
 
     it('keeps showScrollToBottom false when hasContent is false even if scrolled up', () => {
       const { result } = renderHook(() =>
-        useAutoScroll({ resetDep: 'thread-no-content', hasContent: false })
+        useAutoScroll({
+          threadId: 'thread-no-content',
+          isStreaming: false,
+          hasContent: false,
+        })
       )
       const container = makeScrollContainer(1000, 300, 0)
       attachContainer(result.current.containerRef, container)
@@ -120,7 +194,11 @@ describe('useAutoScroll', () => {
 
     it('hides scroll button when user scrolls near bottom', () => {
       const { result } = renderHook(() =>
-        useAutoScroll({ resetDep: 'thread-near-bottom', hasContent: true })
+        useAutoScroll({
+          threadId: 'thread-near-bottom',
+          isStreaming: false,
+          hasContent: true,
+        })
       )
       // 1000 - 650 - 300 = 50 ≤ 50, so nearBottom = true
       const container = makeScrollContainer(1000, 300, 650)
@@ -134,57 +212,383 @@ describe('useAutoScroll', () => {
     })
   })
 
-  describe('thread switch — scroll position persistence', () => {
-    it('scrolls to bottom on new thread (no saved position)', () => {
-      const container = makeScrollContainer()
+  describe('follow-bottom while streaming', () => {
+    it('scrolls to bottom when content grows and user is near the bottom', () => {
+      const container = makeScrollContainer(1000, 300, 650)
 
+      // Start with both effects short-circuited (no container yet), attach,
+      // then flip deps so both the scroll listener and the ResizeObserver
+      // re-register against the now-attached element.
       const { result, rerender } = renderHook(
-        ({ threadId }) =>
-          useAutoScroll({ resetDep: threadId, hasContent: true }),
-        { initialProps: { threadId: 'thread-initial' } }
-      )
-
-      attachContainer(result.current.containerRef, container)
-      rerender({ threadId: 'thread-new-A' })
-
-      expect(container.scrollTo).toHaveBeenCalled()
-    })
-
-    it('restores saved scroll position when switching back to a scrolled-up thread', () => {
-      const container = makeScrollContainer(1000, 300, 200)
-
-      const { result, rerender } = renderHook(
-        ({ threadId }) =>
-          useAutoScroll({ resetDep: threadId, hasContent: true }),
-        { initialProps: { threadId: 'thread-persist-A' } }
+        (props: { isStreaming: boolean; hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-follow-near',
+            ...props,
+          }),
+        { initialProps: { isStreaming: false, hasContent: false } }
       )
       attachContainer(result.current.containerRef, container)
+      rerender({ isStreaming: true, hasContent: true })
+      ;(container.scrollTo as ReturnType<typeof vi.fn>).mockClear()
 
-      rerender({ threadId: 'thread-persist-B' })
-      rerender({ threadId: 'thread-persist-A' })
-
-      expect(container.scrollTo).toHaveBeenCalled()
-    })
-
-    it('resets showScrollToBottom to false when switching to a new thread', () => {
-      const container = makeScrollContainer(1000, 300, 0)
-
-      const { result, rerender } = renderHook(
-        ({ threadId, hasContent }: { threadId: string; hasContent: boolean }) =>
-          useAutoScroll({ resetDep: threadId, hasContent }),
-        { initialProps: { threadId: 'thread-reset-A', hasContent: false } }
-      )
-
-      attachContainer(result.current.containerRef, container)
-      rerender({ threadId: 'thread-reset-A', hasContent: true })
-
+      // Sync userIsNearBottomRef to near-bottom via the scroll listener
       act(() => {
         container.dispatchEvent(new Event('scroll'))
       })
-      expect(result.current.showScrollToBottom).toBe(true)
 
-      rerender({ threadId: 'thread-reset-B', hasContent: true })
-      expect(result.current.showScrollToBottom).toBe(false)
+      act(() => {
+        resizeCallbacks.forEach((cb) =>
+          cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+        )
+      })
+
+      expect(container.scrollTo).toHaveBeenCalled()
+    })
+
+    it('does NOT scroll to bottom when user has scrolled up', () => {
+      const container = makeScrollContainer(1000, 300, 0)
+
+      const { result, rerender } = renderHook(
+        (props: { isStreaming: boolean; hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-follow-away',
+            ...props,
+          }),
+        { initialProps: { isStreaming: false, hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ isStreaming: true, hasContent: true })
+
+      // Placement lands us at the bottom; simulate the user scrolling up
+      // so userIsNearBottomRef flips to false via the scroll listener.
+      container.scrollTop = 0
+      act(() => {
+        fireUserScroll(container)
+      })
+      ;(container.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+
+      act(() => {
+        resizeCallbacks.forEach((cb) =>
+          cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+        )
+      })
+
+      expect(container.scrollTo).not.toHaveBeenCalled()
+    })
+
+    it('does NOT observe content when isStreaming is false', () => {
+      const container = makeScrollContainer(1000, 300, 650)
+
+      const { result } = renderHook(() =>
+        useAutoScroll({
+          threadId: 'thread-no-stream',
+          isStreaming: false,
+          hasContent: true,
+        })
+      )
+      attachContainer(result.current.containerRef, container)
+
+      // Scroll listener should run, but ResizeObserver should NOT be attached
+      expect(resizeCallbacks.length).toBe(0)
+    })
+  })
+
+  describe('initial placement', () => {
+    it('restores the TSR-saved scroll position on re-visit', () => {
+      mockSavedScroll.value = { scrollY: 450 }
+      const container = makeScrollContainer(1000, 300, 0)
+
+      // Mount with no container → effect short-circuits, then attach +
+      // flip hasContent to trigger the placement effect.
+      const { result, rerender } = renderHook(
+        ({ hasContent }: { hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-revisit',
+            isStreaming: false,
+            hasContent,
+          }),
+        { initialProps: { hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ hasContent: true })
+
+      expect(container.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 450, behavior: 'instant' })
+      )
+    })
+
+    it('scrolls to bottom when no saved scroll entry exists (first visit)', () => {
+      mockSavedScroll.value = undefined
+      const container = makeScrollContainer(1000, 300, 0)
+
+      const { result, rerender } = renderHook(
+        ({ hasContent }: { hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-first-visit',
+            isStreaming: false,
+            hasContent,
+          }),
+        { initialProps: { hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ hasContent: true })
+
+      expect(container.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 1000 })
+      )
+    })
+
+    it('treats scrollY=0 saved entry as "no saved position" (goes to bottom)', () => {
+      mockSavedScroll.value = { scrollY: 0 }
+      const container = makeScrollContainer(1000, 300, 0)
+
+      const { result, rerender } = renderHook(
+        ({ hasContent }: { hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-zero-y',
+            isStreaming: false,
+            hasContent,
+          }),
+        { initialProps: { hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ hasContent: true })
+
+      expect(container.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 1000 })
+      )
+    })
+
+    it('does not re-place on later re-renders for the same thread', () => {
+      mockSavedScroll.value = { scrollY: 450 }
+      const container = makeScrollContainer(1000, 300, 0)
+
+      const { result, rerender } = renderHook(
+        ({ hasContent }: { hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-stable',
+            isStreaming: false,
+            hasContent,
+          }),
+        { initialProps: { hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ hasContent: true })
+
+      const callsAfterPlacement = (
+        container.scrollTo as ReturnType<typeof vi.fn>
+      ).mock.calls.length
+
+      // A subsequent re-render (e.g. new message arriving) must not
+      // re-apply the saved position or yank the user around.
+      rerender({ hasContent: true })
+
+      expect(
+        (container.scrollTo as ReturnType<typeof vi.fn>).mock.calls.length
+      ).toBe(callsAfterPlacement)
+    })
+  })
+
+  describe('settling window (async iframe size handshake)', () => {
+    it('chases the growing bottom while saved scroll still clamps, then snaps and clears once it fits', () => {
+      // Saved scroll was captured when the thread's full (iframe-expanded)
+      // height was ~2500. On return, scrollHeight starts at 1000 (iframes
+      // haven't loaded yet) so saved=2000 > max=700 → clamps.
+      mockSavedScroll.value = { scrollY: 2000 }
+      const container = makeScrollContainer(1000, 300, 0)
+
+      const { result, rerender } = renderHook(
+        ({ hasContent }: { hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-settle-chase',
+            isStreaming: false,
+            hasContent,
+          }),
+        { initialProps: { hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ hasContent: true })
+
+      const scrollTo = container.scrollTo as ReturnType<typeof vi.fn>
+
+      // Placement: target clamps → chase current bottom (scrollHeight=1000).
+      expect(scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 1000, behavior: 'instant' })
+      )
+
+      // First iframe finishes its handshake — scrollHeight grows to 1500
+      // but saved=2000 still exceeds new max=1200 → keep chasing bottom.
+      scrollTo.mockClear()
+      setScrollHeight(container, 1500)
+      act(() => {
+        resizeCallbacks.forEach((cb) =>
+          cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+        )
+      })
+      expect(scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 1500, behavior: 'instant' })
+      )
+
+      // Remaining iframes finish — scrollHeight=2800, max=2500, saved=2000
+      // now fits → snap to saved position and clear the target.
+      scrollTo.mockClear()
+      setScrollHeight(container, 2800)
+      act(() => {
+        resizeCallbacks.forEach((cb) =>
+          cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+        )
+      })
+      expect(scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 2000, behavior: 'instant' })
+      )
+
+      // Target is now cleared; a later resize must not yank the user.
+      scrollTo.mockClear()
+      setScrollHeight(container, 3500)
+      act(() => {
+        resizeCallbacks.forEach((cb) =>
+          cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+        )
+      })
+      expect(scrollTo).not.toHaveBeenCalled()
+    })
+
+    it('re-applies saved scroll on first resize when it fits but clears it afterwards', () => {
+      mockSavedScroll.value = { scrollY: 450 }
+      const container = makeScrollContainer(1000, 300, 0)
+
+      const { result, rerender } = renderHook(
+        ({ hasContent }: { hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-settle-saved-fits',
+            isStreaming: false,
+            hasContent,
+          }),
+        { initialProps: { hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ hasContent: true })
+
+      const scrollTo = container.scrollTo as ReturnType<typeof vi.fn>
+
+      // Saved=450 ≤ max=700 → fits on first apply, target cleared.
+      expect(scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 450, behavior: 'instant' })
+      )
+
+      scrollTo.mockClear()
+      act(() => {
+        resizeCallbacks.forEach((cb) =>
+          cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+        )
+      })
+      expect(scrollTo).not.toHaveBeenCalled()
+    })
+
+    it('re-applies bottom target on first visit when content grows', () => {
+      mockSavedScroll.value = undefined
+      const container = makeScrollContainer(1000, 300, 0)
+
+      const { result, rerender } = renderHook(
+        ({ hasContent }: { hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-settle-bottom',
+            isStreaming: false,
+            hasContent,
+          }),
+        { initialProps: { hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ hasContent: true })
+
+      const scrollTo = container.scrollTo as ReturnType<typeof vi.fn>
+      scrollTo.mockClear()
+
+      // Iframe loads and grows the content — bottom target must follow.
+      setScrollHeight(container, 1800)
+      act(() => {
+        resizeCallbacks.forEach((cb) =>
+          cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+        )
+      })
+      expect(scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 1800, behavior: 'instant' })
+      )
+    })
+
+    it('cancels the settling window when the user scrolls', () => {
+      // Use a saved position that clamps so the target is kept after
+      // placement — that's the case where user cancellation matters.
+      mockSavedScroll.value = { scrollY: 2000 }
+      const container = makeScrollContainer(1000, 300, 0)
+
+      const { result, rerender } = renderHook(
+        ({ hasContent }: { hasContent: boolean }) =>
+          useAutoScroll({
+            threadId: 'thread-settle-cancel',
+            isStreaming: false,
+            hasContent,
+          }),
+        { initialProps: { hasContent: false } }
+      )
+      attachContainer(result.current.containerRef, container)
+      rerender({ hasContent: true })
+
+      // User scrolls away from the placed position.
+      container.scrollTop = 100
+      act(() => {
+        fireUserScroll(container)
+      })
+
+      const scrollTo = container.scrollTo as ReturnType<typeof vi.fn>
+      scrollTo.mockClear()
+
+      // Iframe would have grown the content further, but user took over.
+      setScrollHeight(container, 3000)
+      act(() => {
+        resizeCallbacks.forEach((cb) =>
+          cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+        )
+      })
+
+      expect(scrollTo).not.toHaveBeenCalled()
+    })
+
+    it('stops re-applying after the settling window expires', () => {
+      vi.useFakeTimers()
+      try {
+        // Bottom target never self-clears, so only the deadline stops it.
+        mockSavedScroll.value = undefined
+        const container = makeScrollContainer(1000, 300, 0)
+
+        const { result, rerender } = renderHook(
+          ({ hasContent }: { hasContent: boolean }) =>
+            useAutoScroll({
+              threadId: 'thread-settle-expire',
+              isStreaming: false,
+              hasContent,
+            }),
+          { initialProps: { hasContent: false } }
+        )
+        attachContainer(result.current.containerRef, container)
+        rerender({ hasContent: true })
+
+        // Advance past the 5000ms settling deadline.
+        vi.advanceTimersByTime(6000)
+
+        const scrollTo = container.scrollTo as ReturnType<typeof vi.fn>
+        scrollTo.mockClear()
+
+        act(() => {
+          resizeCallbacks.forEach((cb) =>
+            cb([] as unknown as ResizeObserverEntry[], {} as ResizeObserver)
+          )
+        })
+
+        expect(scrollTo).not.toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 })

--- a/renderer/src/features/chat/hooks/__tests__/use-auto-scroll.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-auto-scroll.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
 // The hook reads TanStack Router's element-level scroll restoration entry.
@@ -13,8 +13,9 @@ vi.mock('@tanstack/react-router', () => ({
 import { useAutoScroll } from '../use-auto-scroll'
 
 // JSDOM stubs scrollTo — override it to actually update scrollTop and fire
-// scroll events. Use unique thread IDs per test so the module-level
-// "first-mount-per-thread" Set never collides.
+// scroll events. Use unique thread IDs per test so `placedForThreadRef`
+// inside the hook (per-instance, keyed by threadId) never collides between
+// test cases.
 function makeScrollContainer(
   scrollHeight = 1000,
   clientHeight = 300,
@@ -68,19 +69,28 @@ let resizeCallbacks: ResizeCallback[] = []
 beforeEach(() => {
   resizeCallbacks = []
   mockSavedScroll.value = undefined
-  // jsdom lacks ResizeObserver — supply a minimal spy.
-  globalThis.ResizeObserver = class {
-    cb: ResizeCallback
-    constructor(cb: ResizeCallback) {
-      this.cb = cb
-      resizeCallbacks.push(cb)
-    }
-    observe() {}
-    unobserve() {}
-    disconnect() {
-      resizeCallbacks = resizeCallbacks.filter((c) => c !== this.cb)
-    }
-  } as unknown as typeof ResizeObserver
+  // jsdom lacks ResizeObserver — stub via `vi.stubGlobal` so the original
+  // value (if any) is restored by `unstubAllGlobals` in afterEach, keeping
+  // the stub from leaking into other test files in the same worker.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      cb: ResizeCallback
+      constructor(cb: ResizeCallback) {
+        this.cb = cb
+        resizeCallbacks.push(cb)
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        resizeCallbacks = resizeCallbacks.filter((c) => c !== this.cb)
+      }
+    } as unknown as typeof ResizeObserver
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
 })
 
 function attachContainer(
@@ -338,9 +348,11 @@ describe('useAutoScroll', () => {
       )
     })
 
-    it('treats scrollY=0 saved entry as "no saved position" (goes to bottom)', () => {
+    it('restores scrollY=0 (user was scrolled to the top) instead of forcing bottom', () => {
       mockSavedScroll.value = { scrollY: 0 }
-      const container = makeScrollContainer(1000, 300, 0)
+      // Pre-scroll the container so we can tell "placement explicitly set
+      // scrollTop to 0" apart from "no placement happened".
+      const container = makeScrollContainer(1000, 300, 500)
 
       const { result, rerender } = renderHook(
         ({ hasContent }: { hasContent: boolean }) =>
@@ -355,7 +367,7 @@ describe('useAutoScroll', () => {
       rerender({ hasContent: true })
 
       expect(container.scrollTo).toHaveBeenCalledWith(
-        expect.objectContaining({ top: 1000 })
+        expect.objectContaining({ top: 0, behavior: 'instant' })
       )
     })
 

--- a/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -520,6 +520,21 @@ describe('useChatStreaming', () => {
         expect(result.current.error).toBe('An unknown error occurred')
       })
     })
+
+    it('surfaces persistent-load failures from the thread query', async () => {
+      mockChatAPI.getThreadMessagesForTransport.mockRejectedValueOnce(
+        new Error('IPC boom')
+      )
+
+      const { Wrapper } = createTestUtils()
+      const { result } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.error).toBe('IPC boom')
+      })
+    })
   })
 
   describe('settings integration', () => {

--- a/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -49,7 +49,6 @@ vi.mock('../use-thread-management', () => ({
     currentThreadId: 'toolhive-chat',
     isLoading: false,
     error: null,
-    loadMessages: vi.fn().mockResolvedValue([]),
     clearMessages: vi.fn().mockResolvedValue(undefined),
   })),
 }))
@@ -67,6 +66,7 @@ const mockChatAPI = {
   getAllThreads: vi.fn(),
   setActiveThreadId: vi.fn(),
   createChatThread: vi.fn(),
+  getThread: vi.fn(),
   getThreadMessagesForTransport: vi.fn(),
   updateThreadMessages: vi.fn(),
 }
@@ -130,6 +130,7 @@ describe('useChatStreaming', () => {
       success: true,
       threadId: 'toolhive-chat',
     })
+    mockChatAPI.getThread.mockResolvedValue(null)
     mockChatAPI.getThreadMessagesForTransport.mockResolvedValue([])
     mockChatAPI.updateThreadMessages.mockResolvedValue({ success: true })
 

--- a/renderer/src/features/chat/hooks/use-auto-scroll.ts
+++ b/renderer/src/features/chat/hooks/use-auto-scroll.ts
@@ -148,8 +148,9 @@ export function useAutoScroll({
     if (placedForThreadRef.current === threadId) return
     placedForThreadRef.current = threadId
 
-    placementTargetRef.current =
-      savedScroll && savedScroll.scrollY > 0 ? savedScroll.scrollY : 'bottom'
+    // An entry with `scrollY: 0` is a legitimate restore (user was at the
+    // top); only the absence of an entry falls back to 'bottom'.
+    placementTargetRef.current = savedScroll ? savedScroll.scrollY : 'bottom'
     settlingDeadlineRef.current = performance.now() + PLACEMENT_SETTLING_MS
 
     applyPlacementTarget(el)

--- a/renderer/src/features/chat/hooks/use-auto-scroll.ts
+++ b/renderer/src/features/chat/hooks/use-auto-scroll.ts
@@ -1,9 +1,11 @@
 import { useRef, useState, useCallback, useLayoutEffect } from 'react'
+import { useElementScrollRestoration } from '@tanstack/react-router'
+
+export const CHAT_SCROLL_RESTORATION_ID = 'chat-messages'
 
 interface UseAutoScrollOptions {
-  /** Thread ID — when this changes, save the outgoing position and restore the incoming one */
-  resetDep: string | null | undefined
-  /** Whether there is any scrollable content */
+  threadId: string | null | undefined
+  isStreaming: boolean
   hasContent: boolean
 }
 
@@ -13,116 +15,174 @@ interface UseAutoScrollReturn {
   scrollToBottom: () => void
 }
 
-/** Module-level map so positions persist across re-renders and thread switches for the session. */
-const scrollPositions = new Map<
-  string,
-  { scrollTop: number; atBottom: boolean }
->()
+const NEAR_BOTTOM_THRESHOLD_PX = 50
+
+// Safety cap for re-applying the placement target while MCP iframes / images
+// finish their async size handshake. Pathologically slow content falls out
+// of settling and the user can scroll manually.
+const PLACEMENT_SETTLING_MS = 5000
+
+type PlacementTarget = number | 'bottom' | null
+
+function isNearBottom(el: HTMLDivElement) {
+  return (
+    el.scrollHeight - el.scrollTop - el.clientHeight <= NEAR_BOTTOM_THRESHOLD_PX
+  )
+}
 
 export function useAutoScroll({
-  resetDep,
+  threadId,
+  isStreaming,
   hasContent,
 }: UseAutoScrollOptions): UseAutoScrollReturn {
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const userScrolledRef = useRef(false)
   const isProgrammaticScrollRef = useRef(false)
-  const [showScrollToBottom, setShowScrollToBottom] = useState(false)
 
-  /** Tracks the outgoing thread ID so we can save its position on switch. */
-  const prevResetDepRef = useRef<string | null | undefined>(resetDep)
+  const userIsNearBottomRef = useRef(true)
+  const [userIsNearBottom, setUserIsNearBottom] = useState(true)
 
-  const scrollToBottom = useCallback((instant = false) => {
-    const el = containerRef.current
-    if (!el) return
-    userScrolledRef.current = false
+  const showScrollToBottom = !userIsNearBottom && hasContent
+
+  const savedScroll = useElementScrollRestoration({
+    id: CHAT_SCROLL_RESTORATION_ID,
+    getKey: (location) => location.pathname,
+  })
+
+  const placementTargetRef = useRef<PlacementTarget>(null)
+  const settlingDeadlineRef = useRef<number>(0)
+  // Timestamp of the last genuine user input — used to tell real scrolls
+  // apart from `overflow-anchor`-driven ones during the settling window.
+  const lastUserInputAtRef = useRef<number>(0)
+
+  const applyPlacementTarget = useCallback((el: HTMLDivElement) => {
+    const target = placementTargetRef.current
+    if (target === null) return
+
+    // If the saved scrollY doesn't fit yet (iframes still loading), pin to
+    // the current bottom and keep the target so the next resize re-tries.
+    // Once it fits, snap exactly and clear so later resizes don't yank us.
+    const maxScrollY = Math.max(0, el.scrollHeight - el.clientHeight)
+    const fits = target !== 'bottom' && target <= maxScrollY
+    const top = fits ? target : el.scrollHeight
+
     isProgrammaticScrollRef.current = true
-    el.scrollTo({
-      top: el.scrollHeight,
-      behavior: instant ? 'auto' : 'smooth',
-    })
+    el.scrollTo({ top, behavior: 'instant' })
+    isProgrammaticScrollRef.current = false
+
+    if (fits) placementTargetRef.current = null
   }, [])
 
-  // Effect 1: Thread switch — save outgoing position, restore or scroll-to-bottom for incoming.
-  // The scroll container is always in the DOM (never conditionally unmounted), so
-  // containerRef.current is valid and the restore can happen immediately with no deferred logic.
-  useLayoutEffect(() => {
+  const scrollToBottom = useCallback(() => {
     const el = containerRef.current
+    if (!el) return
+    userIsNearBottomRef.current = true
+    setUserIsNearBottom(true)
+    isProgrammaticScrollRef.current = true
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+    // Unlocks in the scroll listener when we arrive near the bottom.
+  }, [])
 
-    // Save outgoing thread's scroll position
-    if (el && prevResetDepRef.current != null) {
-      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 50
-      scrollPositions.set(String(prevResetDepRef.current), {
-        scrollTop: el.scrollTop,
-        atBottom,
-      })
-    }
-    prevResetDepRef.current = resetDep
-
-    // Restore incoming thread or scroll to bottom
-    const saved =
-      resetDep != null ? scrollPositions.get(String(resetDep)) : undefined
-
-    if (saved && !saved.atBottom && el) {
-      userScrolledRef.current = true
-      el.scrollTo({ top: saved.scrollTop, behavior: 'auto' })
-      // Measuring the DOM to set state before paint is the intended use of useLayoutEffect.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setShowScrollToBottom(true)
-    } else {
-      userScrolledRef.current = false
-      setShowScrollToBottom(false)
-      scrollToBottom(true)
-    }
-  }, [resetDep, scrollToBottom])
-
-  // Effect 2: Scroll listener + ResizeObserver.
-  // Re-registers when hasContent changes (scroll container may have new inner content node).
-  // onScroll drives the show/hide of the scroll-to-bottom button.
-  // ResizeObserver drives auto-scroll during streaming and after images/code blocks load.
+  // Registered before the placement effect so our programmatic scrolls hit
+  // this listener and don't get misread as user scrolls.
   useLayoutEffect(() => {
     const container = containerRef.current
     if (!container) return
 
-    const onScroll = () => {
-      const { scrollTop, scrollHeight, clientHeight } = container
-      const nearBottom = scrollHeight - scrollTop - clientHeight <= 50
+    const markUserInput = () => {
+      lastUserInputAtRef.current = performance.now()
+    }
 
-      if (nearBottom) {
-        // Smooth scroll animation settled at bottom — clear programmatic flag
-        isProgrammaticScrollRef.current = false
+    const onScroll = () => {
+      const nearBottom = isNearBottom(container)
+
+      if (isProgrammaticScrollRef.current) {
+        if (nearBottom) isProgrammaticScrollRef.current = false
+        return
       }
 
-      // Ignore scroll events from our own programmatic scrollTo calls to avoid
-      // falsely setting userScrolledRef=true mid-animation
-      if (isProgrammaticScrollRef.current) return
+      // Ignore `overflow-anchor`-driven scrolls during settling; otherwise
+      // the first iframe resize would cancel placement.
+      const now = performance.now()
+      const settlingActive =
+        placementTargetRef.current !== null &&
+        now <= settlingDeadlineRef.current
+      const recentUserInput = now - lastUserInputAtRef.current < 500
+      if (settlingActive && !recentUserInput) return
 
-      userScrolledRef.current = !nearBottom
-      setShowScrollToBottom(!nearBottom && hasContent)
+      settlingDeadlineRef.current = 0
+      placementTargetRef.current = null
+
+      userIsNearBottomRef.current = nearBottom
+      if (hasContent) setUserIsNearBottom(nearBottom)
     }
 
     container.addEventListener('scroll', onScroll, { passive: true })
-
-    // Re-scroll when content height grows (streaming tokens, images, code blocks).
-    const innerContent = container.firstElementChild
-    let resizeObserver: ResizeObserver | null = null
-    if (innerContent) {
-      resizeObserver = new ResizeObserver(() => {
-        if (!userScrolledRef.current) {
-          scrollToBottom()
-        }
-      })
-      resizeObserver.observe(innerContent)
-    }
-
+    container.addEventListener('wheel', markUserInput, { passive: true })
+    container.addEventListener('touchstart', markUserInput, { passive: true })
+    container.addEventListener('keydown', markUserInput)
+    container.addEventListener('pointerdown', markUserInput)
     return () => {
       container.removeEventListener('scroll', onScroll)
-      resizeObserver?.disconnect()
+      container.removeEventListener('wheel', markUserInput)
+      container.removeEventListener('touchstart', markUserInput)
+      container.removeEventListener('keydown', markUserInput)
+      container.removeEventListener('pointerdown', markUserInput)
     }
-  }, [hasContent, scrollToBottom])
+  }, [hasContent])
+
+  // Initial placement per thread. `useChat` briefly resets messages on
+  // thread switch, flipping `hasContent` false — clear the guard so the
+  // re-hydrated render re-runs placement.
+  const placedForThreadRef = useRef<string | null>(null)
+  useLayoutEffect(() => {
+    if (!threadId) return
+    if (!hasContent) {
+      if (placedForThreadRef.current === threadId) {
+        placedForThreadRef.current = null
+      }
+      return
+    }
+
+    const el = containerRef.current
+    if (!el) return
+    if (placedForThreadRef.current === threadId) return
+    placedForThreadRef.current = threadId
+
+    placementTargetRef.current =
+      savedScroll && savedScroll.scrollY > 0 ? savedScroll.scrollY : 'bottom'
+    settlingDeadlineRef.current = performance.now() + PLACEMENT_SETTLING_MS
+
+    applyPlacementTarget(el)
+    const nearBottom = isNearBottom(el)
+    userIsNearBottomRef.current = nearBottom
+    setUserIsNearBottom(nearBottom)
+  }, [threadId, hasContent, savedScroll, applyPlacementTarget])
+
+  // One ResizeObserver, two modes:
+  // - streaming: follow the bottom if user was already near it;
+  // - placement window: re-apply the target as MCP iframes grow the DOM.
+  useLayoutEffect(() => {
+    if (!threadId || !hasContent) return
+    const container = containerRef.current
+    if (!container) return
+    const inner = container.firstElementChild
+    if (!inner) return
+
+    const observer = new ResizeObserver(() => {
+      if (isStreaming) {
+        if (userIsNearBottomRef.current) scrollToBottom()
+        return
+      }
+      if (performance.now() > settlingDeadlineRef.current) return
+      applyPlacementTarget(container)
+    })
+    observer.observe(inner)
+    return () => observer.disconnect()
+  }, [threadId, hasContent, isStreaming, applyPlacementTarget, scrollToBottom])
 
   return {
     containerRef,
     showScrollToBottom,
-    scrollToBottom: () => scrollToBottom(false),
+    scrollToBottom,
   }
 }

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -35,9 +35,23 @@ export function useChatStreaming(externalThreadId?: string | null) {
   // hook runs the data is already available — no loading flash on thread
   // switch. `usePlaygroundThreads` invalidates this key on streaming
   // completion to refresh titles/messages.
-  const { data: threadData, isPending: isThreadDataPending } = useQuery(
-    chatThreadQueryOptions(currentThreadId)
-  )
+  const {
+    data: threadData,
+    isPending: isThreadDataPending,
+    error: threadDataError,
+  } = useQuery(chatThreadQueryOptions(currentThreadId))
+
+  // Surface IPC/query failures via `persistentError` so they flow into
+  // `processedError` below (matches the pre-refactor try/catch behaviour).
+  useEffect(() => {
+    if (!threadDataError) return
+    const message =
+      threadDataError instanceof Error
+        ? threadDataError.message
+        : 'Failed to load chat history'
+    setPersistentError(message)
+    log.error('Failed to load persistent chat messages:', threadDataError)
+  }, [threadDataError])
 
   const ipcTransport = useMemo(
     () =>

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useEffect, useState, useRef } from 'react'
 import { useChat } from '@ai-sdk/react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
 import type { ChatUIMessage } from '../types'
 import { ElectronIPCChatTransport } from '../transport/electron-ipc-chat-transport'
@@ -9,10 +9,10 @@ import { useThreadManagement } from './use-thread-management'
 import type { FileUIPart } from 'ai'
 import { trackEvent } from '@/common/lib/analytics'
 import { hasValidCredentials } from '../lib/utils'
+import { chatThreadQueryOptions } from '../lib/thread-query'
 
 export function useChatStreaming(externalThreadId?: string | null) {
   const queryClient = useQueryClient()
-  const [isPersistentLoading, setIsPersistentLoading] = useState(true)
   const [persistentError, setPersistentError] = useState<string | null>(null)
 
   const {
@@ -27,9 +27,17 @@ export function useChatStreaming(externalThreadId?: string | null) {
     currentThreadId,
     isLoading: isThreadLoading,
     error: threadError,
-    loadMessages: loadThreadMessages,
     clearMessages: clearThreadMessages,
   } = useThreadManagement(externalThreadId)
+
+  // Messages come from React Query. The `/playground/chat/$threadId` route
+  // loader primes the cache via `ensureQueryData`, so by the time this
+  // hook runs the data is already available — no loading flash on thread
+  // switch. `usePlaygroundThreads` invalidates this key on streaming
+  // completion to refresh titles/messages.
+  const { data: threadData, isPending: isThreadDataPending } = useQuery(
+    chatThreadQueryOptions(currentThreadId)
+  )
 
   const ipcTransport = useMemo(
     () =>
@@ -54,28 +62,22 @@ export function useChatStreaming(externalThreadId?: string | null) {
     experimental_throttle: 200,
   })
 
+  // Hydrate the `useChat` instance from cached loader data whenever the
+  // thread identity changes. We guard with a ref so streaming-in-progress
+  // token updates inside `useChat` are never overwritten by a stale loader
+  // payload for the same thread — subsequent refetches (e.g. after
+  // `invalidateQueries` on streaming complete) are a no-op here because
+  // `useChat` already holds the canonical message list at that point.
+  const hydratedThreadRef = useRef<string | null>(null)
   useEffect(() => {
-    async function loadInitialMessages() {
-      if (!currentThreadId) return
+    if (!currentThreadId || !threadData) return
+    if (hydratedThreadRef.current === currentThreadId) return
+    hydratedThreadRef.current = currentThreadId
+    setPersistentError(null)
+    setMessages(threadData.messages)
+  }, [currentThreadId, threadData, setMessages])
 
-      try {
-        setIsPersistentLoading(true)
-        setPersistentError(null)
-
-        const persistedMessages = await loadThreadMessages()
-        setMessages(persistedMessages)
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to load chat history'
-        setPersistentError(errorMessage)
-        log.error('Failed to load persistent chat messages:', err)
-      } finally {
-        setIsPersistentLoading(false)
-      }
-    }
-
-    loadInitialMessages()
-  }, [currentThreadId, loadThreadMessages, setMessages])
+  const isPersistentLoading = !!currentThreadId && isThreadDataPending
 
   const isLoading =
     status === 'submitted' ||

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -211,6 +211,11 @@ export function usePlaygroundThreads(activeThreadId: string) {
           refreshThread(data.threadId).catch((err) =>
             log.error('[usePlaygroundThreads] refreshThread failed:', err)
           )
+          // Invalidate the loader-primed thread query so the next
+          // navigation (or preload) sees fresh messages/title.
+          queryClient.invalidateQueries({
+            queryKey: ['chat', 'thread', data.threadId],
+          })
         }
       }
     })

--- a/renderer/src/features/chat/hooks/use-thread-management.ts
+++ b/renderer/src/features/chat/hooks/use-thread-management.ts
@@ -1,7 +1,16 @@
 import { useState, useEffect, useCallback } from 'react'
 import log from 'electron-log/renderer'
-import type { ChatUIMessage } from '../types'
 
+/**
+ * Small hook that resolves the "current" thread id.
+ *
+ * Historically this hook also loaded messages from IPC, but that is now
+ * owned by the `/playground/chat/$threadId` route loader + React Query
+ * (see `chatThreadQueryOptions`). Here we just mirror the prop-provided
+ * thread id and, if none is provided, fall back to the most-recent thread
+ * or create a new one (legacy callers that render `ChatInterface` outside
+ * the route).
+ */
 export function useThreadManagement(externalThreadId?: string | null) {
   const [currentThreadId, setCurrentThreadId] = useState<string | null>(
     externalThreadId ?? null
@@ -56,23 +65,6 @@ export function useThreadManagement(externalThreadId?: string | null) {
     getCurrentThread()
   }, [externalThreadId])
 
-  const loadMessages = useCallback(async (): Promise<ChatUIMessage[]> => {
-    if (!currentThreadId) {
-      return []
-    }
-
-    try {
-      const messages =
-        await window.electronAPI.chat.getThreadMessagesForTransport(
-          currentThreadId
-        )
-      return messages || []
-    } catch (err) {
-      log.error('Failed to load messages:', err)
-      return []
-    }
-  }, [currentThreadId])
-
   const clearMessages = useCallback(async () => {
     if (!currentThreadId) return
 
@@ -95,7 +87,6 @@ export function useThreadManagement(externalThreadId?: string | null) {
     currentThreadId,
     isLoading,
     error,
-    loadMessages,
     clearMessages,
   }
 }

--- a/renderer/src/features/chat/lib/thread-query.ts
+++ b/renderer/src/features/chat/lib/thread-query.ts
@@ -1,0 +1,33 @@
+import { queryOptions } from '@tanstack/react-query'
+import type { ChatUIMessage } from '../types'
+
+/**
+ * Query factory that loads a thread's messages and metadata in one shot.
+ * Used by the `/playground/chat/$threadId` route loader so messages are
+ * warm in the React Query cache before the component renders, and is
+ * re-consumed by `useChatStreaming` via `useQuery` to hydrate the
+ * `useChat` instance without a flash of loading UI.
+ */
+export function chatThreadQueryOptions(threadId: string | null | undefined) {
+  return queryOptions({
+    queryKey: ['chat', 'thread', threadId ?? null] as const,
+    enabled: !!threadId,
+    queryFn: async () => {
+      if (!threadId) {
+        return { thread: null, messages: [] as ChatUIMessage[] }
+      }
+      const [thread, messages] = await Promise.all([
+        window.electronAPI.chat.getThread(threadId),
+        window.electronAPI.chat.getThreadMessagesForTransport(threadId),
+      ])
+      return {
+        thread,
+        messages: (messages ?? []) as ChatUIMessage[],
+      }
+    },
+    // Messages mutate during streaming via React Query cache invalidation
+    // from `usePlaygroundThreads`; a 0 staleTime guarantees the loader sees
+    // fresh data on revisit right after a completion signal fires.
+    staleTime: 0,
+  })
+}

--- a/renderer/src/renderer.tsx
+++ b/renderer/src/renderer.tsx
@@ -33,6 +33,11 @@ if (!window.electronAPI || !window.electronAPI.getToolhivePort) {
     context: { queryClient },
     defaultViewTransition: true,
     history: hashHistory,
+    scrollRestoration: true,
+    scrollRestorationBehavior: 'instant',
+    // Key by pathname so /playground/chat/<id> always restores the same
+    // position regardless of how we arrived (back/forward vs. sidebar click).
+    getScrollRestorationKey: (location) => location.pathname,
   })
 
   router.subscribe('onLoad', (data) => {

--- a/renderer/src/routes/__tests__/playground.index.test.tsx
+++ b/renderer/src/routes/__tests__/playground.index.test.tsx
@@ -64,6 +64,14 @@ const makeDbThread = (overrides: Record<string, unknown> = {}) => ({
 
 function renderIndexRoute() {
   const IndexComponent = PlaygroundIndexRoute.options.component as () => null
+  // Redirect resolution now lives in `beforeLoad`; wire it into the test
+  // router so the redirect fires during navigation, not on mount. The real
+  // `beforeLoad` is typed against the generated route tree and cannot be
+  // statically assigned to this ad-hoc test route — the `as` cast is only
+  // about shape, the underlying function is unchanged.
+  const beforeLoad = PlaygroundIndexRoute.options.beforeLoad as unknown as (
+    ...args: unknown[]
+  ) => Promise<void> | void
 
   const rootRoute = createRootRoute({
     component: Outlet,
@@ -73,6 +81,7 @@ function renderIndexRoute() {
     getParentRoute: () => rootRoute,
     path: '/playground/',
     component: IndexComponent,
+    beforeLoad,
   })
 
   // Catch-all for the redirect target — renders the threadId for assertion

--- a/renderer/src/routes/playground.chat.$threadId.tsx
+++ b/renderer/src/routes/playground.chat.$threadId.tsx
@@ -3,8 +3,30 @@ import { ChatInterface } from '@/features/chat/components/chat-interface'
 import { PlaygroundSidebar } from '@/features/chat/components/playground-sidebar'
 import { usePlaygroundThreads } from '@/features/chat/hooks/use-playground-threads'
 import { clearThreadDraft } from '@/features/chat/hooks/use-thread-draft'
+import { chatThreadQueryOptions } from '@/features/chat/lib/thread-query'
+
+function ChatLoadingDots() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="flex space-x-1">
+        <div
+          className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full
+            [animation-delay:-0.3s]"
+        />
+        <div
+          className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full
+            [animation-delay:-0.15s]"
+        />
+        <div className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full" />
+      </div>
+    </div>
+  )
+}
 
 export const Route = createFileRoute('/playground/chat/$threadId')({
+  loader: ({ context: { queryClient }, params }) =>
+    queryClient.ensureQueryData(chatThreadQueryOptions(params.threadId)),
+  pendingComponent: ChatLoadingDots,
   component: PlaygroundChat,
 })
 
@@ -23,23 +45,7 @@ function PlaygroundChat() {
   } = usePlaygroundThreads(threadId)
 
   if (isLoading) {
-    return (
-      <div className="absolute inset-0 flex items-center justify-center">
-        <div className="flex space-x-1">
-          <div
-            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full
-              [animation-delay:-0.3s]"
-          />
-          <div
-            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full
-              [animation-delay:-0.15s]"
-          />
-          <div
-            className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full"
-          />
-        </div>
-      </div>
-    )
+    return <ChatLoadingDots />
   }
 
   const activeThread = threads.find((t) => t.id === threadId)

--- a/renderer/src/routes/playground.index.tsx
+++ b/renderer/src/routes/playground.index.tsx
@@ -1,72 +1,52 @@
-import { useEffect } from 'react'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import log from 'electron-log/renderer'
 
-function PlaygroundIndexRedirect() {
-  const navigate = useNavigate()
+async function resolveInitialThreadId(): Promise<string | null> {
+  const [allThreads, activeId] = await Promise.all([
+    window.electronAPI.chat.getAllThreads(),
+    window.electronAPI.chat.getActiveThreadId(),
+  ])
 
-  useEffect(() => {
-    let cancelled = false
+  const sorted = [...allThreads].sort(
+    (a, b) => b.lastEditTimestamp - a.lastEditTimestamp
+  )
 
-    async function resolveThreadAndRedirect() {
-      try {
-        const [allThreads, activeId] = await Promise.all([
-          window.electronAPI.chat.getAllThreads(),
-          window.electronAPI.chat.getActiveThreadId(),
-        ])
+  const activeThread = activeId
+    ? sorted.find((t) => t.id === activeId)
+    : undefined
 
-        if (cancelled) return
+  const target = activeThread ?? sorted[0]
+  if (target) return target.id
 
-        const sorted = [...allThreads].sort(
-          (a, b) => b.lastEditTimestamp - a.lastEditTimestamp
-        )
+  const result = await window.electronAPI.chat.createChatThread()
+  if (result.success && result.threadId) return result.threadId
 
-        const activeThread = activeId
-          ? sorted.find((t) => t.id === activeId)
-          : undefined
-
-        const target = activeThread ?? sorted[0]
-
-        if (target) {
-          void navigate({
-            to: '/playground/chat/$threadId',
-            params: { threadId: target.id },
-            replace: true,
-          })
-          return
-        }
-
-        const result = await window.electronAPI.chat.createChatThread()
-        if (cancelled) return
-
-        if (result.success && result.threadId) {
-          void navigate({
-            to: '/playground/chat/$threadId',
-            params: { threadId: result.threadId },
-            replace: true,
-          })
-          return
-        }
-
-        log.error(
-          '[PlaygroundIndexRedirect] Failed to create initial thread:',
-          result.error
-        )
-      } catch (err) {
-        log.error('[PlaygroundIndexRedirect] Failed to resolve thread:', err)
-      }
-    }
-
-    void resolveThreadAndRedirect()
-
-    return () => {
-      cancelled = true
-    }
-  }, [navigate])
-
+  log.error(
+    '[PlaygroundIndexRedirect] Failed to create initial thread:',
+    result.error
+  )
   return null
 }
 
 export const Route = createFileRoute('/playground/')({
-  component: PlaygroundIndexRedirect,
+  // Resolve the target thread in the router itself so we never render a
+  // blank page during the mount-then-redirect bounce.
+  beforeLoad: async () => {
+    let threadId: string | null
+    try {
+      threadId = await resolveInitialThreadId()
+    } catch (err) {
+      log.error('[PlaygroundIndexRedirect] Failed to resolve thread:', err)
+      return
+    }
+
+    if (!threadId) return
+
+    throw redirect({
+      to: '/playground/chat/$threadId',
+      params: { threadId },
+      replace: true,
+    })
+  },
+  component: () => null,
 })


### PR DESCRIPTION
Two issues compounded whenever the user opened a chat thread:

1. **Double loading flash.** `useChatStreaming` fetched the message history in a `useEffect` after mount, so every thread switch bounced through an in-component "Loading chat history…" overlay even when the data was trivially small.
2. **Scroll position fought the DOM.** `useAutoScroll` owned its own save/restore via `sessionStorage` and chased the bottom on every re-render. It lost track across back/forward navigation, collided with MCP iframes (`bridge.onsizechange` grows the iframe async, which shoved the viewport), and animated smoothly through long threads on restore.

This PR moves both concerns onto primitives we already have. Thread data is preloaded in the TanStack Router route loader and cached in React Query; scroll position is owned by TanStack Router's native element-level scroll restoration. `useAutoScroll` shrinks to the things only the chat actually needs (follow-the-bottom while streaming, the scroll-to-bottom button, and a brief "settling window" so MCP iframes finishing their size handshake don't strand the user on the wrong content).

https://github.com/user-attachments/assets/a955b232-154f-4817-8dae-12ba5ccabbcd


### Route layer

- New `renderer/src/features/chat/lib/thread-query.ts` exposing `chatThreadQueryOptions(threadId)` — a `queryOptions` factory that loads `getThread` + `getThreadMessagesForTransport` in parallel with `staleTime: 0` so invalidations fire cleanly on stream completion.
- `/playground/chat/$threadId`: `loader: ({ context, params }) => context.queryClient.ensureQueryData(chatThreadQueryOptions(params.threadId))` + `pendingComponent: ChatLoadingDots`. The in-component "Loading chat history…" overlay goes away; the route owns the pending state now.
- `/playground/` (index): redirect logic moves into `beforeLoad` using `throw redirect(...)`, so the bounce from `/playground` to the active/most-recent thread never renders a blank frame.

### Consuming the cache

- `useChatStreaming` gains a `useQuery(chatThreadQueryOptions(currentThreadId))` and hydrates the `useChat` instance exactly once per thread id via a ref guard (`hydratedThreadRef`). Streaming-in-progress token updates inside `useChat` are never overwritten by a cache refetch of the same thread.
- `useThreadManagement` loses its `loadMessages` IPC path — it now only owns the "resolve current thread id" responsibility.
- `usePlaygroundThreads` invalidates `['chat', 'thread', threadId]` in addition to the existing per-thread refresh when the streaming-complete / thread-started cache signal fires, so the loader sees fresh data on the next navigation.

### Scroll restoration

- `router` gets `scrollRestoration: true`, `scrollRestorationBehavior: 'instant'`, and `getScrollRestorationKey: (location) => location.pathname`. Keying by pathname (not by TSR's default per-location state id) means the same `/playground/chat/<id>` URL restores to the same position regardless of whether the user arrived via back/forward, sidebar click, or deep link.
- The chat messages container is tagged with `data-scroll-restoration-id="chat-messages"` and `overflow-anchor: auto`. The MCP app iframe wrapper in `mcp-app-view.tsx` also gets `overflow-anchor: auto` so `bridge.onsizechange` growing `iframeHeight` doesn't push surrounding messages downward.
- `useAutoScroll` is rewritten against that contract:
  - Reads the saved scrollY via `useElementScrollRestoration({ id: 'chat-messages', getKey: location.pathname })`.
  - On first render per thread (or a `useChat`-driven `hasContent` flip, which happens on thread switch), records a placement target (saved `scrollY` or `'bottom'`) and runs a 5s **settling window**: a `ResizeObserver` on the inner content re-applies the target as MCP iframes report their final size. Long-thread restores land `behavior: 'instant'`, not smooth, so there's no long animation.
  - Distinguishes `overflow-anchor`-driven scroll events from genuine user input by tracking the timestamp of the last `wheel` / `touchstart` / `keydown` / `pointerdown` and requiring it to be within 500 ms. Without this, the first iframe resize fires a non-programmatic scroll event that would otherwise look like a user scroll and cancel placement.
  - Merges the previously-separate "settling" and "follow-bottom-while-streaming" `ResizeObserver`s into one effect that branches on `isStreaming`.

### How to validate

1. Open a long thread with multiple MCP iframes, scroll to the bottom, then navigate to Servers (or any unrelated route) and back. The thread should restore to the bottom once iframes have finished their size handshake — not to the top and not to an intermediate position.
2. From the same thread, switch to another thread via the sidebar and back. Scroll position is preserved per-thread without the loading-dots flicker.
3. Go back to a thread that's in the middle (saved scrollY landing mid-content); start scrolling up manually while iframes are still loading. The settling window should yield immediately — you stay where you scrolled.
4. Navigate to `/playground` directly (deep link, new window, or `history.pushState`). The redirect resolves in `beforeLoad` and the page never paints a blank frame.
5. `pnpm test:nonInteractive` — the full suite (1942 tests) is green.

### Not changed in this PR (deliberate)

- No change to IPC shape or thread storage — `getThread` / `getThreadMessagesForTransport` / `updateThreadMessages` all behave as before; the migration is renderer-side only.
- No eviction policy for the React Query thread cache. TanStack Router preload / warmup will drive cache lifecycle, and `staleTime: 0` guarantees fresh loads on re-entry; real cache-size tuning can be a follow-up if memory pressure from very long threads shows up.
- No removal of the `isPersistentLoading` flag from `useChatStreaming`'s return — other callers still read it via `useChat` to gate the composer, and it cleanly derives from the new query state now.
- `usePlaygroundThreads` still owns the flat thread list via `useState` rather than React Query. A similar migration is straightforward but out of scope here.