### PR TITLE
feat(skills): explain User vs Project scope in install dialog

### DIFF
--- a/renderer/src/common/components/ui/tooltip-info-icon.tsx
+++ b/renderer/src/common/components/ui/tooltip-info-icon.tsx
@@ -1,22 +1,27 @@
-import { TooltipTrigger } from '@radix-ui/react-tooltip'
-import { Tooltip, TooltipContent } from './tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip'
 import { InfoIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
 
 export function TooltipInfoIcon({
   children,
   className,
+  ariaLabel = 'More info',
 }: {
   children: ReactNode
   className?: string
+  ariaLabel?: string
 }) {
   return (
     <Tooltip>
-      <TooltipTrigger asChild autoFocus={false}>
-        <InfoIcon
-          className="text-muted-foreground size-4 rounded-full"
-          data-testid="tooltip-info-icon"
-        />
+      <TooltipTrigger
+        type="button"
+        aria-label={ariaLabel}
+        data-testid="tooltip-info-icon"
+        className="focus-visible:ring-ring inline-flex items-center
+          justify-center rounded-full outline-none focus-visible:ring-2
+          focus-visible:ring-offset-1"
+      >
+        <InfoIcon className="text-muted-foreground size-4 rounded-full" />
       </TooltipTrigger>
       <TooltipContent className={className}>{children}</TooltipContent>
     </Tooltip>

--- a/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { expect, it, vi, describe, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -36,6 +36,23 @@ describe('DialogInstallSkill', () => {
     expect(screen.getByText(/scope/i)).toBeInTheDocument()
     expect(screen.getAllByText(/clients/i).length).toBeGreaterThan(0)
     expect(screen.getByText(/version/i)).toBeInTheDocument()
+  })
+
+  it('shows a tooltip explaining User vs Project scope', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    const scopeLabel = screen.getByText(/scope/i).closest('div')
+    const tooltipIcon = within(scopeLabel!).getByTestId('tooltip-info-icon')
+    expect(tooltipIcon).toHaveAttribute('aria-label', 'More info')
+
+    await user.hover(tooltipIcon)
+
+    await waitFor(() => {
+      const tooltip = screen.getByRole('tooltip')
+      expect(tooltip).toHaveTextContent(/installed globally in your home/i)
+      expect(tooltip).toHaveTextContent(/installed in the root of a specific/i)
+    })
   })
 
   it('prefills name from defaultReference prop', () => {

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -37,6 +37,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/common/components/ui/select'
+import { TooltipInfoIcon } from '@/common/components/ui/tooltip-info-icon'
 import { ChevronDown, FolderOpenIcon, TriangleAlertIcon } from 'lucide-react'
 import { useMutationInstallSkill } from '../hooks/use-mutation-install-skill'
 
@@ -180,7 +181,19 @@ export function DialogInstallSkill({
               name="scope"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Scope</FormLabel>
+                  <div className="flex items-center gap-1">
+                    <FormLabel>Scope</FormLabel>
+                    <TooltipInfoIcon className="max-w-72">
+                      <span className="block">
+                        <strong>User</strong>: installed globally in your home
+                        directory and available across all projects.
+                      </span>
+                      <span className="mt-1 block">
+                        <strong>Project</strong>: installed in the root of a
+                        specific project folder and scoped to that project only.
+                      </span>
+                    </TooltipInfoIcon>
+                  </div>
                   <Select
                     value={field.value}
                     onValueChange={(v) => {


### PR DESCRIPTION
The install skill dialog exposes a `Scope` select with `User` / `Project` options, but never explains the difference — users have to guess where the skill will land on disk, and the extra `Project root` input only appears after they pick `Project`. This PR adds a hover hint so the choice is self-describing.

<img width="1285" height="797" alt="Screenshot 2026-04-21 at 18 33 29" src="https://github.com/user-attachments/assets/e9ba7164-9aa2-4157-9ca0-d77744197a21" />



- Add a `TooltipInfoIcon` next to the `Scope` label in `DialogInstallSkill` (`renderer/src/features/skills/components/dialog-install-skill.tsx`), reusing the same primitive already used on `form-fields-proxy.tsx`, `form-fields-base.tsx`, `form-fields-auth.tsx`, and the registry `configuration-tab-content.tsx`, so field-level help stays visually consistent across the app.
- Tooltip copy:
  - **User** — installed globally in your home directory and available across all projects.
  - **Project** — installed in the root of a specific project folder and scoped to that project only.
- Wrap the `FormLabel` + icon in a `flex items-center gap-1` container — same pattern used elsewhere — so the `(i)` icon sits inline with the label without disturbing the rest of the form layout.
