### PR TITLE
feat(skills): surface source repository and tighten registry metadata

### DIFF
--- a/renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx
@@ -105,6 +105,32 @@ describe('CardRegistrySkill', () => {
       renderRoute(router)
       expect(screen.getByRole('button', { name: /install/i })).toBeVisible()
     })
+
+    it('does not render a GitHub link when repository is absent', () => {
+      renderRoute(router)
+      expect(
+        screen.queryByRole('link', { name: /open repository on github/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders a GitHub link when repository.url is set', async () => {
+      const skillRouter = createCardTestRouter({
+        ...baseSkill,
+        repository: {
+          type: 'git',
+          url: 'https://github.com/example/skills',
+        },
+      }) as unknown as ReturnType<typeof createTestRouter>
+      await skillRouter.navigate({ to: '/skills' })
+      renderRoute(skillRouter)
+
+      const link = screen.getByRole('link', {
+        name: /open repository on github/i,
+      })
+      expect(link).toBeVisible()
+      expect(link).toHaveAttribute('href', 'https://github.com/example/skills')
+      expect(link).toHaveAttribute('target', '_blank')
+    })
   })
 
   describe('navigation', () => {
@@ -128,6 +154,26 @@ describe('CardRegistrySkill', () => {
       await user.click(screen.getByRole('button', { name: /install/i }))
 
       expect(router.state.location.pathname).toBe('/skills')
+    })
+
+    it('does not navigate to the detail page when the GitHub link is clicked', async () => {
+      const user = userEvent.setup()
+      const skillRouter = createCardTestRouter({
+        ...baseSkill,
+        repository: {
+          type: 'git',
+          url: 'https://github.com/example/skills',
+        },
+      }) as unknown as ReturnType<typeof createTestRouter>
+      await skillRouter.navigate({ to: '/skills' })
+      renderRoute(skillRouter)
+
+      const link = screen.getByRole('link', {
+        name: /open repository on github/i,
+      })
+      await user.click(link)
+
+      expect(skillRouter.state.location.pathname).toBe('/skills')
     })
   })
 

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -20,6 +20,7 @@ const ociSkill: RegistrySkill = {
   description: 'A helpful skill',
   version: 'v1.0.0',
   packages: [{ registryType: 'oci', identifier: 'ghcr.io/org/my-skill' }],
+  repository: { type: 'git', url: 'https://github.com/org/repo' },
 }
 
 const gitSkill: RegistrySkill = {
@@ -73,7 +74,7 @@ describe('TableRegistrySkills', () => {
       screen.getByRole('columnheader', { name: /skill/i })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('columnheader', { name: /author/i })
+      screen.getByRole('columnheader', { name: /registry/i })
     ).toBeInTheDocument()
     expect(
       screen.getByRole('columnheader', { name: /about/i })
@@ -179,6 +180,43 @@ describe('TableRegistrySkills', () => {
       name: /install my-skill/i,
     })
     await user.click(install)
+
+    expect(router.state.location.pathname).toBe('/skills')
+  })
+
+  it('renders a GitHub link for skills with a repository url', async () => {
+    const router = makeRouter([ociSkill, gitSkill])
+    renderRoute(router)
+
+    const links = await screen.findAllByRole('link', {
+      name: /open repository on github/i,
+    })
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveAttribute('href', 'https://github.com/org/repo')
+    expect(links[0]).toHaveAttribute('target', '_blank')
+  })
+
+  it('does not render a GitHub link for skills without a repository', async () => {
+    const router = makeRouter([gitSkill])
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('git-skill')).toBeVisible()
+    })
+    expect(
+      screen.queryByRole('link', { name: /open repository on github/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not navigate to the detail page when the GitHub link is clicked', async () => {
+    const user = userEvent.setup()
+    const router = makeRouter([ociSkill])
+    renderRoute(router)
+
+    const link = await screen.findByRole('link', {
+      name: /open repository on github/i,
+    })
+    await user.click(link)
 
     expect(router.state.location.pathname).toBe('/skills')
   })

--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Github } from 'lucide-react'
 import { Button } from '@/common/components/ui/button'
 import { useNavigate } from '@tanstack/react-router'
 import type { RegistrySkill } from '@common/api/generated/types.gen'
@@ -36,16 +37,35 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
         description={description}
         onClick={canNavigate ? handleCardClick : undefined}
         footer={
-          <Button
-            variant="secondary"
-            className="rounded-full"
-            onClick={(e) => {
-              e.stopPropagation()
-              setInstallOpen(true)
-            }}
-          >
-            Install
-          </Button>
+          <>
+            {skill.repository?.url ? (
+              <Button
+                variant="ghost"
+                asChild
+                onClick={(e) => e.stopPropagation()}
+                className="relative z-10"
+              >
+                <a
+                  href={skill.repository.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Open repository on GitHub"
+                >
+                  <Github className="text-muted-foreground size-4" />
+                </a>
+              </Button>
+            ) : null}
+            <Button
+              variant="secondary"
+              className="rounded-full"
+              onClick={(e) => {
+                e.stopPropagation()
+                setInstallOpen(true)
+              }}
+            >
+              Install
+            </Button>
+          </>
         }
       />
 

--- a/renderer/src/features/skills/components/skill-detail-layout.tsx
+++ b/renderer/src/features/skills/components/skill-detail-layout.tsx
@@ -112,7 +112,7 @@ export function SkillDetailLayout({
         </div>
 
         {rightPanel && (
-          <div className="flex flex-1 flex-col gap-3">{rightPanel}</div>
+          <div className="flex min-w-0 flex-1 flex-col gap-3">{rightPanel}</div>
         )}
       </div>
     </div>

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Button } from '@/common/components/ui/button'
-import { TagIcon, GitForkIcon, ScaleIcon } from 'lucide-react'
+import { TagIcon, GitForkIcon, GithubIcon, ScaleIcon } from 'lucide-react'
 import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { SkillDetailLayout } from './skill-detail-layout'
@@ -72,6 +72,18 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
             <Button variant="action" onClick={() => setInstallOpen(true)}>
               Install
             </Button>
+            {skill.repository?.url && (
+              <a
+                href={skill.repository.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button variant="outline" className="rounded-full">
+                  <GithubIcon className="size-4" />
+                  GitHub
+                </Button>
+              </a>
+            )}
           </div>
         }
         rightPanel={
@@ -84,7 +96,7 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
                 dark:bg-transparent"
             >
               {ociRef ? (
-                <SkillMarkdown skillRef={ociRef} />
+                <SkillMarkdown skillRef={ociRef} stripFrontmatter />
               ) : (
                 <p className="text-muted-foreground text-sm">
                   No SKILL.md available for this skill.

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -73,16 +73,16 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
               Install
             </Button>
             {skill.repository?.url && (
-              <a
-                href={skill.repository.url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Button variant="outline" className="rounded-full">
+              <Button asChild variant="outline" className="rounded-full">
+                <a
+                  href={skill.repository.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <GithubIcon className="size-4" />
                   GitHub
-                </Button>
-              </a>
+                </a>
+              </Button>
             )}
           </div>
         }

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
+import { Github } from 'lucide-react'
 import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { Button } from '@/common/components/ui/button'
 import {
@@ -105,6 +106,22 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
           )}
         </TableCell>
 
+        <TableCell className="py-3">
+          {skill.repository?.url ? (
+            <a
+              href={skill.repository.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="text-muted-foreground hover:bg-accent inline-flex
+                size-8 items-center justify-center rounded-md"
+              aria-label="Open repository on GitHub"
+            >
+              <Github className="size-4" />
+            </a>
+          ) : null}
+        </TableCell>
+
         <TableCell className="py-3 pr-3 text-right">
           <Button
             variant="secondary"
@@ -150,7 +167,7 @@ export function TableRegistrySkills({ skills }: { skills: RegistrySkill[] }) {
             className="text-muted-foreground hidden w-[200px] font-medium
               lg:table-cell"
           >
-            Author
+            Registry
           </TableHead>
           <TableHead
             className="text-muted-foreground hidden w-full max-w-0 font-medium
@@ -158,6 +175,7 @@ export function TableRegistrySkills({ skills }: { skills: RegistrySkill[] }) {
           >
             About
           </TableHead>
+          <TableHead className="w-12" aria-label="Repository" />
           <TableHead className="w-[120px] pr-3" aria-label="Actions" />
         </TableRow>
       </TableHeader>


### PR DESCRIPTION
Following [#2045](https://github.com/stacklok/toolhive-studio/pull/2045), this PR brings the skills registry closer to parity with MCP servers: the upstream repo is one click away from every view, the `SKILL.md` preview drops the metadata we already render as badges, and the detail page stops resizing between skills.

The registry response distinguishes between `namespace` (packager, e.g. `io.github.stacklok`) and `repository.url` (upstream source, e.g. `github.com/trailofbits/skills`). Today only `namespace` is visible — it's not obvious the skill was authored elsewhere and packaged downstream. MCP servers already solve this via `repository_url`; this PR lines the two up.

## Changes

- **Card / table / detail** — link `skill.repository.url` with the same GitHub-icon pattern used for MCP servers: ghost icon on the card footer, an icon-only trailing column on the registry table, and an outline `GitHub` button next to `Install` on the detail page. All three render nothing when `repository` is absent, and their click handlers stop propagation so card/row navigation isn't triggered.
- **Table column rename** — `Author` → `Registry`. The column holds the reverse-DNS namespace (the packager/registry), not the author.
- **SKILL.md preview** — enable `stripFrontmatter` on the registry detail. `SkillMarkdown` already supported it; only the build detail was passing it. Preview now starts at the first heading instead of the YAML block duplicating `name` / `description` / `license` / `version`.
- **Detail layout** — the right panel was `flex-1` without `min-w-0`, so wide SKILL.md content (code blocks, tables) pushed the column past its 7/12 allotment and varied between skills. Adding `min-w-0` lets the flex child shrink; overflow now scrolls inside the card. Applies to both registry and build detail pages (shared layout).

## How to validate

1. Registry tab — card footer has a GitHub icon; opens the upstream repo in a new tab, card stays in place.
2. Table view — `Registry` header (previously `Author`); GitHub icon sits between `About` and `Install`.
3. Skill detail (e.g. `io.github.stacklok/agentic-actions-auditor`) — `GitHub` button next to `Install`; SKILL.md starts at the first heading; card width is identical across skills.