### PR TITLE
fix(ci): use GITHUB_TOKEN for issue comments in bug-fix agent

### DIFF
--- a/.github/workflows/_bug-fix-agent.yml
+++ b/.github/workflows/_bug-fix-agent.yml
@@ -270,7 +270,7 @@ jobs:
           && steps.guard.outputs.skip != 'true'
           && steps.tdd.outputs.result == 'failure'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -f bug-analysis.md ]; then
             ANALYSIS=$(cat bug-analysis.md)


### PR DESCRIPTION
## Summary

- Use `github.token` instead of the GitHub App token for the "Comment on issue" step
- The GitHub App (`toolhive-studio-ci`) doesn't have Issues write permission, causing `Resource not accessible by integration (addComment)`
- The workflow's `GITHUB_TOKEN` has `issues: write` via the caller's permissions block, so it works

## Test plan

- [ ] Add `auto-fix` label to a Bug issue, let agent run and fail, verify comment is posted on the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)