### PR TITLE
feat(analytics): add UTM suite and instance id to on-ramp outbound links

### DIFF
--- a/renderer/src/common/components/layout/top-nav/__tests__/top-nav.test.tsx
+++ b/renderer/src/common/components/layout/top-nav/__tests__/top-nav.test.tsx
@@ -108,7 +108,7 @@ describe('TopNav', () => {
         })
         expect(link).toHaveAttribute(
           'href',
-          `${DOCS_BASE_URL}/enterprise?utm_source=${APP_IDENTIFIER}`
+          `${DOCS_BASE_URL}/enterprise?utm_source=${APP_IDENTIFIER}&utm_medium=app&utm_campaign=enterprise-upgrade&utm_content=app-header&tdi=test-instance-id`
         )
       })
     })

--- a/renderer/src/common/components/layout/top-nav/index.tsx
+++ b/renderer/src/common/components/layout/top-nav/index.tsx
@@ -32,7 +32,8 @@ import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
 import { featureFlagKeys } from '@utils/feature-flags'
 import { usePermissions } from '@/common/contexts/permissions'
 import { PERMISSION_KEYS } from '@/common/contexts/permissions/permission-keys'
-import { APP_IDENTIFIER, DOCS_BASE_URL } from '@common/app-info'
+import { buildOnrampDocsUrl } from '@/common/lib/onramp-url'
+import { useInstanceId } from '@/common/hooks/use-instance-id'
 
 interface NavButtonProps {
   to: string
@@ -128,7 +129,14 @@ export function TopNav({ isEnterprise = false, ...props }: TopNavProps) {
   const isProduction = import.meta.env.MODE === 'production'
   const isActive = useIsActive()
   const { canShow } = usePermissions()
+  const { instanceId } = useInstanceId()
   const showUpdateBadge = !!(appVersion?.isNewVersionAvailable && isProduction)
+
+  const enterpriseUpgradeUrl = buildOnrampDocsUrl('/enterprise', {
+    campaign: 'enterprise-upgrade',
+    content: 'app-header',
+    instanceId,
+  })
 
   useEffect(() => {
     const cleanup = window.electronAPI.onUpdateDownloaded(() => {
@@ -174,7 +182,7 @@ export function TopNav({ isEnterprise = false, ...props }: TopNavProps) {
             asChild
           >
             <a
-              href={`${DOCS_BASE_URL}/enterprise?utm_source=${APP_IDENTIFIER}`}
+              href={enterpriseUpgradeUrl}
               target="_blank"
               rel="noopener noreferrer"
               onClick={() =>

--- a/renderer/src/common/components/layout/top-nav/index.tsx
+++ b/renderer/src/common/components/layout/top-nav/index.tsx
@@ -120,6 +120,34 @@ function TopNavLinks() {
   )
 }
 
+function EnterpriseUpgradeButton() {
+  const { instanceId } = useInstanceId()
+  const href = buildOnrampDocsUrl('/enterprise', {
+    campaign: 'enterprise-upgrade',
+    content: 'app-header',
+    instanceId,
+  })
+
+  return (
+    <Button
+      variant="success"
+      className="app-region-no-drag rounded-full font-normal"
+      size="sm"
+      asChild
+    >
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() => trackEvent('Onramp: Upgrade to Enterprise clicked')}
+      >
+        <PackageOpen className="size-4" />
+        Upgrade to Enterprise
+      </a>
+    </Button>
+  )
+}
+
 interface TopNavProps extends HTMLProps<HTMLElement> {
   isEnterprise?: boolean
 }
@@ -129,14 +157,7 @@ export function TopNav({ isEnterprise = false, ...props }: TopNavProps) {
   const isProduction = import.meta.env.MODE === 'production'
   const isActive = useIsActive()
   const { canShow } = usePermissions()
-  const { instanceId } = useInstanceId()
   const showUpdateBadge = !!(appVersion?.isNewVersionAvailable && isProduction)
-
-  const enterpriseUpgradeUrl = buildOnrampDocsUrl('/enterprise', {
-    campaign: 'enterprise-upgrade',
-    content: 'app-header',
-    instanceId,
-  })
 
   useEffect(() => {
     const cleanup = window.electronAPI.onUpdateDownloaded(() => {
@@ -174,26 +195,7 @@ export function TopNav({ isEnterprise = false, ...props }: TopNavProps) {
       <div
         className="app-region-no-drag flex h-full items-center justify-self-end"
       >
-        {!isEnterprise && (
-          <Button
-            variant="success"
-            className="app-region-no-drag rounded-full font-normal"
-            size="sm"
-            asChild
-          >
-            <a
-              href={enterpriseUpgradeUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() =>
-                trackEvent('Onramp: Upgrade to Enterprise clicked')
-              }
-            >
-              <PackageOpen className="size-4" />
-              Upgrade to Enterprise
-            </a>
-          </Button>
-        )}
+        {!isEnterprise && <EnterpriseUpgradeButton />}
         <div className="flex h-full items-center gap-1 pl-2">
           {canShow(PERMISSION_KEYS.HELP_MENU) && (
             <HelpDropdown

--- a/renderer/src/common/hooks/use-hubspot-form.ts
+++ b/renderer/src/common/hooks/use-hubspot-form.ts
@@ -1,14 +1,11 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
 import { submitToHubSpot } from '../lib/hubspot'
+import { useInstanceId } from './use-instance-id'
 
 export function useHubSpotForm(formId: string, pageName: string) {
   const [consentToProcess, setConsentToProcess] = useState(false)
 
-  const { data: instanceId, isFetched } = useQuery({
-    queryKey: ['instance-id'],
-    queryFn: () => window.electronAPI.getInstanceId(),
-  })
+  const { instanceId, isFetched } = useInstanceId()
 
   const isReady = isFetched && !!instanceId
 

--- a/renderer/src/common/hooks/use-instance-id.ts
+++ b/renderer/src/common/hooks/use-instance-id.ts
@@ -1,9 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 
+const THREE_DAYS_MS = 1000 * 60 * 60 * 24 * 3
+
 export function useInstanceId() {
   const { data: instanceId, isFetched } = useQuery({
     queryKey: ['instance-id'],
     queryFn: () => window.electronAPI.getInstanceId(),
+    staleTime: THREE_DAYS_MS,
   })
 
   return { instanceId, isFetched }

--- a/renderer/src/common/hooks/use-instance-id.ts
+++ b/renderer/src/common/hooks/use-instance-id.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+export function useInstanceId() {
+  const { data: instanceId, isFetched } = useQuery({
+    queryKey: ['instance-id'],
+    queryFn: () => window.electronAPI.getInstanceId(),
+  })
+
+  return { instanceId, isFetched }
+}

--- a/renderer/src/common/lib/__tests__/onramp-url.test.ts
+++ b/renderer/src/common/lib/__tests__/onramp-url.test.ts
@@ -37,15 +37,15 @@ describe('buildOnrampDocsUrl', () => {
     expect(url).not.toContain('tdi=')
   })
 
-  it('url-encodes param values', () => {
+  it('url-encodes param values using application/x-www-form-urlencoded', () => {
     const url = buildOnrampDocsUrl('/enterprise', {
       campaign: 'enterprise upgrade',
       content: 'app/header',
       instanceId: 'id with space',
     })
 
-    expect(url).toContain('utm_campaign=enterprise%20upgrade')
+    expect(url).toContain('utm_campaign=enterprise+upgrade')
     expect(url).toContain('utm_content=app%2Fheader')
-    expect(url).toContain('tdi=id%20with%20space')
+    expect(url).toContain('tdi=id+with+space')
   })
 })

--- a/renderer/src/common/lib/__tests__/onramp-url.test.ts
+++ b/renderer/src/common/lib/__tests__/onramp-url.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { APP_IDENTIFIER, DOCS_BASE_URL } from '@common/app-info'
+import { buildOnrampDocsUrl } from '../onramp-url'
+
+describe('buildOnrampDocsUrl', () => {
+  it('emits utm params in the documented order with tdi when instanceId is provided', () => {
+    const url = buildOnrampDocsUrl('/enterprise', {
+      campaign: 'enterprise-upgrade',
+      content: 'app-header',
+      instanceId: 'abc-123',
+    })
+
+    expect(url).toBe(
+      `${DOCS_BASE_URL}/enterprise?utm_source=${APP_IDENTIFIER}&utm_medium=app&utm_campaign=enterprise-upgrade&utm_content=app-header&tdi=abc-123`
+    )
+  })
+
+  it('omits the tdi param when instanceId is undefined', () => {
+    const url = buildOnrampDocsUrl('/guides-registry/', {
+      campaign: 'custom-registry',
+      content: 'registry-view-tile',
+    })
+
+    expect(url).toBe(
+      `${DOCS_BASE_URL}/guides-registry/?utm_source=${APP_IDENTIFIER}&utm_medium=app&utm_campaign=custom-registry&utm_content=registry-view-tile`
+    )
+    expect(url).not.toContain('tdi=')
+  })
+
+  it('omits the tdi param when instanceId is an empty string', () => {
+    const url = buildOnrampDocsUrl('/enterprise', {
+      campaign: 'enterprise-upgrade',
+      content: 'app-header',
+      instanceId: '',
+    })
+
+    expect(url).not.toContain('tdi=')
+  })
+
+  it('url-encodes param values', () => {
+    const url = buildOnrampDocsUrl('/enterprise', {
+      campaign: 'enterprise upgrade',
+      content: 'app/header',
+      instanceId: 'id with space',
+    })
+
+    expect(url).toContain('utm_campaign=enterprise%20upgrade')
+    expect(url).toContain('utm_content=app%2Fheader')
+    expect(url).toContain('tdi=id%20with%20space')
+  })
+})

--- a/renderer/src/common/lib/onramp-url.ts
+++ b/renderer/src/common/lib/onramp-url.ts
@@ -1,0 +1,29 @@
+import { APP_IDENTIFIER, DOCS_BASE_URL } from '@common/app-info'
+
+type OnrampUrlOptions = {
+  campaign: string
+  content: string
+  instanceId?: string
+}
+
+export function buildOnrampDocsUrl(
+  path: string,
+  { campaign, content, instanceId }: OnrampUrlOptions
+): string {
+  const params: Array<[string, string]> = [
+    ['utm_source', APP_IDENTIFIER],
+    ['utm_medium', 'app'],
+    ['utm_campaign', campaign],
+    ['utm_content', content],
+  ]
+
+  if (instanceId) {
+    params.push(['tdi', instanceId])
+  }
+
+  const query = params
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join('&')
+
+  return `${DOCS_BASE_URL}${path}?${query}`
+}

--- a/renderer/src/common/lib/onramp-url.ts
+++ b/renderer/src/common/lib/onramp-url.ts
@@ -10,20 +10,16 @@ export function buildOnrampDocsUrl(
   path: string,
   { campaign, content, instanceId }: OnrampUrlOptions
 ): string {
-  const params: Array<[string, string]> = [
+  const params = new URLSearchParams([
     ['utm_source', APP_IDENTIFIER],
     ['utm_medium', 'app'],
     ['utm_campaign', campaign],
     ['utm_content', content],
-  ]
+  ])
 
   if (instanceId) {
-    params.push(['tdi', instanceId])
+    params.append('tdi', instanceId)
   }
 
-  const query = params
-    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
-    .join('&')
-
-  return `${DOCS_BASE_URL}${path}?${query}`
+  return `${DOCS_BASE_URL}${path}?${params.toString()}`
 }

--- a/renderer/src/features/registry-servers/components/card-registry-promo.tsx
+++ b/renderer/src/features/registry-servers/components/card-registry-promo.tsx
@@ -7,11 +7,17 @@ import {
 } from '@/common/components/ui/card'
 import { Button } from '@/common/components/ui/button'
 import { trackEvent } from '@/common/lib/analytics'
-import { APP_IDENTIFIER, DOCS_BASE_URL } from '@common/app-info'
-
-const REGISTRY_DOCS_URL = `${DOCS_BASE_URL}/guides-registry/?utm_source=${APP_IDENTIFIER}`
+import { buildOnrampDocsUrl } from '@/common/lib/onramp-url'
+import { useInstanceId } from '@/common/hooks/use-instance-id'
 
 export function CardRegistryPromo() {
+  const { instanceId } = useInstanceId()
+  const registryDocsUrl = buildOnrampDocsUrl('/guides-registry/', {
+    campaign: 'custom-registry',
+    content: 'registry-view-tile',
+    instanceId,
+  })
+
   return (
     <Card className="bg-brand-green-mid gap-0 border-none p-4">
       <CardHeader className="px-0">
@@ -36,7 +42,7 @@ export function CardRegistryPromo() {
             hover:bg-brand-green-dark/90 rounded-full p-4 font-medium"
         >
           <a
-            href={REGISTRY_DOCS_URL}
+            href={registryDocsUrl}
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => trackEvent('Onramp: custom registry docs clicked')}

--- a/renderer/src/routes/__tests__/registry.test.tsx
+++ b/renderer/src/routes/__tests__/registry.test.tsx
@@ -108,11 +108,13 @@ describe('Promo Card', () => {
       expect(screen.getByText('Build a custom registry')).toBeVisible()
     })
 
-    const link = screen.getByRole('link', { name: /learn how/i })
-    expect(link).toHaveAttribute(
-      'href',
-      `${DOCS_BASE_URL}/guides-registry/?utm_source=${APP_IDENTIFIER}`
-    )
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /learn how/i })
+      expect(link).toHaveAttribute(
+        'href',
+        `${DOCS_BASE_URL}/guides-registry/?utm_source=${APP_IDENTIFIER}&utm_medium=app&utm_campaign=custom-registry&utm_content=registry-view-tile&tdi=test-instance-id`
+      )
+    })
   })
 
   it('tracks event when CTA is clicked', async () => {


### PR DESCRIPTION
Our two in-app on-ramps to `docs.stacklok.com` — the "Upgrade to Enterprise" button in the top nav and the "Build a custom registry" promo tile on the Registry page — only attached `utm_source=toolhive-studio`. Marketing can't tell which surface a click came from or correlate it back to the install. This PR extends both links with the full UTM suite plus a `tdi` (telemetry distinct instance) param populated from the existing instance id.

### Target URLs

- Enterprise: `…/enterprise?utm_source=toolhive-studio&utm_medium=app&utm_campaign=enterprise-upgrade&utm_content=app-header&tdi=<instance id>`
- Custom registry: `…/guides-registry/?utm_source=toolhive-studio&utm_medium=app&utm_campaign=custom-registry&utm_content=registry-view-tile&tdi=<instance id>`

### Changes

- Extract `useInstanceId` into `renderer/src/common/hooks/use-instance-id.ts` so the `['instance-id']` react-query key isn't duplicated across features; `useHubSpotForm` now consumes it (behavior unchanged).
- Add `buildOnrampDocsUrl(path, { campaign, content, instanceId })` in `renderer/src/common/lib/onramp-url.ts`. Emits params in a stable order and omits `tdi` when the id query hasn't resolved yet, so the link stays clickable on first render.
- Wire the top-nav Enterprise button and the custom registry promo tile through the new builder with their respective `campaign` / `content` values.

### Not changed in this PR (deliberate)

- No other docs links are touched (`HelpDropdown`, README, MCP Optimizer sunset blog).
- No change to the main-process `getInstanceId` or its IPC handler.