### PR TITLE
fix(playground): clear composer draft synchronously on submit

### DIFF
--- a/renderer/src/features/chat/hooks/__tests__/use-thread-draft.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-thread-draft.test.ts
@@ -84,6 +84,51 @@ describe('useThreadDraft', () => {
     expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
   })
 
+  // Regression: ChatInterface swaps between the centered (empty-state) and
+  // bottom (with-messages) composer when `hasMessages` flips after the user
+  // submits. Both instances are keyed by the same `threadId`, so the new
+  // instance's `useState` lazy initializer re-reads `localStorage` before
+  // the unmounting instance's flush runs. If the clear write is debounced,
+  // the new composer re-hydrates with the just-sent draft.
+  it('clears storage synchronously when the draft is reset to empty', () => {
+    localStorage.setItem(`${STORAGE_PREFIX}t1`, 'hello')
+    const { result } = renderHook(() => useThreadDraft('t1'))
+
+    act(() => {
+      result.current[1]('')
+    })
+
+    // No timer advance — the write must have already happened so any
+    // component that remounts in the same commit reads empty.
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBeNull()
+    expect(result.current[0]).toBe('')
+  })
+
+  it('a fresh mount after clearing reads empty, not the previous draft', () => {
+    const { result, unmount } = renderHook(() => useThreadDraft('t1'))
+
+    act(() => {
+      result.current[1]('hello')
+    })
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_MS)
+    })
+    expect(localStorage.getItem(`${STORAGE_PREFIX}t1`)).toBe('hello')
+
+    // Simulates the submit handler clearing the draft.
+    act(() => {
+      result.current[1]('')
+    })
+
+    // Mount a new instance with the same threadId before the previous one
+    // unmounts (mirrors render-before-commit ordering when the empty-state
+    // and with-messages composers swap).
+    const { result: r2 } = renderHook(() => useThreadDraft('t1'))
+    expect(r2.current[0]).toBe('')
+
+    unmount()
+  })
+
   it('flushes the pending write on unmount', () => {
     const { result, unmount } = renderHook(() => useThreadDraft('t1'))
 

--- a/renderer/src/features/chat/hooks/use-thread-draft.ts
+++ b/renderer/src/features/chat/hooks/use-thread-draft.ts
@@ -76,6 +76,12 @@ export function useThreadDraft(
       setText(next)
       latestRef.current = next
       if (!threadId) return
+      // Flush clears synchronously so a sibling remount with the same
+      // threadId can't re-hydrate from a stale draft before the debounce.
+      if (next === '') {
+        flush()
+        return
+      }
       if (timerRef.current !== null) {
         clearTimeout(timerRef.current)
       }


### PR DESCRIPTION
Following #2048, the Playground composer visibly kept the user's message on screen after pressing Send. The draft persistence added in that PR debounces localStorage writes by 200 ms, which is correct for typing but breaks the submit path: by the time the debounce fires, the composer has already remounted and re-hydrated from the stale draft.

## Why the draft came back

`ChatInterface` renders two `ChatInputPrompt` instances — a centered one inside the empty-state overlay when `hasMessages === false`, and a bottom one when `hasMessages === true`. Both are keyed by `threadId`.

1. User types "hello" on an empty thread. `useChat` holds the optimistic user message as soon as `sendMessage` is called, so `hasMessages` flips to `true` in the same commit.
2. `handleSubmit` in `chat-input-prompt.tsx` calls `setText('')`. The hook sets in-memory state to `''` and schedules a 200 ms debounced `localStorage` clear.
3. React re-renders. The centered composer unmounts, the bottom composer mounts. Both carry the same `threadId`, so the key swap is a full remount.
4. React's render phase runs **before** cleanup effects. The new composer's `useState(() => readDraft(threadId))` lazy initializer reads `localStorage` while the debounced clear is still pending, picks up `"hello"`, and the bottom composer mounts with the just-sent text in it.

Regression tests
Two new tests in use-thread-draft.test.ts:

- clears storage synchronously when the draft is reset to empty — no timer advance; localStorage must already be empty after update('').
- a fresh mount after clearing reads empty, not the previous draft — mounts a new hook instance with the same threadId in between update('hello') + flush and update(''), mirroring the render-before-commit ordering of the composer swap.
- Both failed on main (expected 'hello' to be null / expected 'hello' to be '') and pass with the fix.

How to validate

- Open /playground on an empty thread, configure a provider, type a message, and send. The textarea clears immediately and stays clear after the bottom composer appears.
- Thread switching still restores the right per-thread draft (existing tests cover this).
- Typing performance is unchanged — writes are still coalesced into a single localStorage.setItem every 200 ms.