### PR TITLE
feat(skills): add analytics coverage for the Skills feature

### DIFF
--- a/renderer/src/features/skills/components/build-detail-page.tsx
+++ b/renderer/src/features/skills/components/build-detail-page.tsx
@@ -12,6 +12,7 @@ import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogDeleteBuild } from './dialog-delete-build'
 import { SkillDetailLayout } from './skill-detail-layout'
 import { SkillMarkdown } from './skill-markdown'
+import { trackEvent } from '@/common/lib/analytics'
 
 interface BuildDetailPageProps {
   build: LocalBuild
@@ -87,11 +88,27 @@ export function BuildDetailPage({ build }: BuildDetailPageProps) {
         description={description}
         actions={
           <div className="flex items-center gap-3">
-            <Button variant="secondary" onClick={() => setDeleteOpen(true)}>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                trackEvent('Skills: delete build dialog opened', {
+                  source: 'build_detail',
+                })
+                setDeleteOpen(true)
+              }}
+            >
               <Trash2Icon className="size-4" />
               Remove
             </Button>
-            <Button variant="action" onClick={() => setInstallOpen(true)}>
+            <Button
+              variant="action"
+              onClick={() => {
+                trackEvent('Skills: install dialog opened', {
+                  source: 'build_detail',
+                })
+                setInstallOpen(true)
+              }}
+            >
               Install
             </Button>
           </div>

--- a/renderer/src/features/skills/components/card-build.tsx
+++ b/renderer/src/features/skills/components/card-build.tsx
@@ -7,6 +7,7 @@ import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from 
 import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogDeleteBuild } from './dialog-delete-build'
 import { CardSkillBase } from './card-skill-base'
+import { trackEvent } from '@/common/lib/analytics'
 
 export function CardBuild({ build }: { build: LocalBuild }) {
   const [installOpen, setInstallOpen] = useState(false)
@@ -48,11 +49,15 @@ export function CardBuild({ build }: { build: LocalBuild }) {
         badges={badges}
         onClick={
           tag
-            ? () =>
+            ? () => {
+                trackEvent('Skills: build card opened', {
+                  has_tag: 'true',
+                })
                 void navigate({
                   to: '/skills/builds/$tag',
                   params: { tag },
                 })
+              }
             : undefined
         }
         footer={
@@ -62,6 +67,9 @@ export function CardBuild({ build }: { build: LocalBuild }) {
               className="relative z-10 rounded-full"
               onClick={(e) => {
                 e.stopPropagation()
+                trackEvent('Skills: delete build dialog opened', {
+                  source: 'build_card',
+                })
                 setDeleteOpen(true)
               }}
               aria-label={`Remove ${title}`}
@@ -74,6 +82,9 @@ export function CardBuild({ build }: { build: LocalBuild }) {
               className="relative z-10 rounded-full"
               onClick={(e) => {
                 e.stopPropagation()
+                trackEvent('Skills: install dialog opened', {
+                  source: 'build_card',
+                })
                 setInstallOpen(true)
               }}
               aria-label={`Install ${title}`}

--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -22,6 +22,7 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
   function handleCardClick() {
     if (!canNavigate) return
     trackEvent('Skills: registry card opened', {
+      source: 'registry_card',
       name,
       namespace: namespace ?? '',
     })
@@ -47,6 +48,7 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
                 onClick={(e) => {
                   e.stopPropagation()
                   trackEvent('Skills: registry card github clicked', {
+                    source: 'registry_card',
                     name,
                     namespace: namespace ?? '',
                   })

--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -6,6 +6,7 @@ import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { CardSkillBase } from './card-skill-base'
 import { getSkillInstallReference } from '../lib/skill-reference'
+import { trackEvent } from '@/common/lib/analytics'
 
 export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
   const [installOpen, setInstallOpen] = useState(false)
@@ -20,6 +21,10 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
 
   function handleCardClick() {
     if (!canNavigate) return
+    trackEvent('Skills: registry card opened', {
+      name,
+      namespace: namespace ?? '',
+    })
     void navigate({
       to: '/skills/$namespace/$skillName',
       params: { namespace: namespace!, skillName: skill.name! },
@@ -39,7 +44,13 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
               <Button
                 variant="ghost"
                 asChild
-                onClick={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  trackEvent('Skills: registry card github clicked', {
+                    name,
+                    namespace: namespace ?? '',
+                  })
+                }}
                 className="relative z-10"
               >
                 <a
@@ -57,6 +68,11 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
               className="rounded-full"
               onClick={(e) => {
                 e.stopPropagation()
+                trackEvent('Skills: install dialog opened', {
+                  source: 'registry_card',
+                  name,
+                  namespace: namespace ?? '',
+                })
                 setInstallOpen(true)
               }}
             >

--- a/renderer/src/features/skills/components/card-skill.tsx
+++ b/renderer/src/features/skills/components/card-skill.tsx
@@ -12,6 +12,7 @@ import { DialogUninstallSkill } from './dialog-uninstall-skill'
 import { CardSkillBase } from './card-skill-base'
 import { SkillClientsBadges } from './skill-clients-badges'
 import { skillStatusVariantMap } from './skill-status'
+import { trackEvent } from '@/common/lib/analytics'
 
 export function CardSkill({ skill }: { skill: InstalledSkill }) {
   const [uninstallOpen, setUninstallOpen] = useState(false)
@@ -78,6 +79,10 @@ export function CardSkill({ skill }: { skill: InstalledSkill }) {
             className="relative z-10 rounded-full"
             onClick={(e) => {
               e.stopPropagation()
+              trackEvent('Skills: uninstall dialog opened', {
+                source: 'installed_card',
+                scope: scope ?? 'unknown',
+              })
               setUninstallOpen(true)
             }}
             aria-label={`Uninstall ${title}`}

--- a/renderer/src/features/skills/components/dialog-build-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-build-skill.tsx
@@ -24,6 +24,7 @@ import { FolderOpenIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { useMutationBuildSkill } from '../hooks/use-mutation-build-skill'
 import { DialogInstallSkill } from './dialog-install-skill'
+import { trackEvent } from '@/common/lib/analytics'
 
 const formSchema = z.object({
   path: z.string().min(1, 'Path is required'),
@@ -54,6 +55,7 @@ export function DialogBuildSkill({
   })
 
   function handleClose() {
+    trackEvent('Skills: build dialog cancelled')
     form.reset()
     onOpenChange(false)
   }
@@ -61,11 +63,15 @@ export function DialogBuildSkill({
   async function handleBrowse() {
     const selected = await window.electronAPI.selectFolder()
     if (selected) {
+      trackEvent('Skills: build path selected')
       form.setValue('path', selected, { shouldValidate: true })
     }
   }
 
   async function onSubmit(values: FormSchema) {
+    trackEvent('Skills: build dialog submitted', {
+      has_tag: values.tag ? 'true' : 'false',
+    })
     try {
       const result = await buildSkill({
         body: {
@@ -75,7 +81,8 @@ export function DialogBuildSkill({
       })
 
       const reference = result?.reference
-      handleClose()
+      form.reset()
+      onOpenChange(false)
 
       if (reference) {
         setBuiltReference(reference)
@@ -84,7 +91,10 @@ export function DialogBuildSkill({
           closeButton: true,
           action: {
             label: 'Install now',
-            onClick: () => setInstallOpen(true),
+            onClick: () => {
+              trackEvent('Skills: build install-now clicked')
+              setInstallOpen(true)
+            },
           },
         })
       } else {

--- a/renderer/src/features/skills/components/dialog-delete-build.tsx
+++ b/renderer/src/features/skills/components/dialog-delete-build.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/common/components/ui/dialog'
 import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from '@common/api/generated/types.gen'
 import { useMutationDeleteBuild } from '../hooks/use-mutation-delete-build'
+import { trackEvent } from '@/common/lib/analytics'
 
 interface DialogDeleteBuildProps {
   open: boolean
@@ -30,6 +31,7 @@ export function DialogDeleteBuild({
 
   async function handleConfirm() {
     if (!tag) return
+    trackEvent('Skills: delete build dialog confirmed', { tag })
     try {
       await deleteBuild({ path: { tag } })
       onOpenChange(false)
@@ -54,7 +56,10 @@ export function DialogDeleteBuild({
           <Button
             variant="secondary"
             className="rounded-full"
-            onClick={() => onOpenChange(false)}
+            onClick={() => {
+              trackEvent('Skills: delete build dialog cancelled')
+              onOpenChange(false)
+            }}
             disabled={isPending}
           >
             Cancel

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -40,6 +40,7 @@ import {
 import { TooltipInfoIcon } from '@/common/components/ui/tooltip-info-icon'
 import { ChevronDown, FolderOpenIcon, TriangleAlertIcon } from 'lucide-react'
 import { useMutationInstallSkill } from '../hooks/use-mutation-install-skill'
+import { trackEvent } from '@/common/lib/analytics'
 
 const formSchema = z
   .object({
@@ -100,6 +101,7 @@ export function DialogInstallSkill({
   const scope = useWatch({ control: form.control, name: 'scope' })
 
   function handleClose() {
+    trackEvent('Skills: install dialog cancelled')
     form.reset()
     setSubmitError(null)
     onOpenChange(false)
@@ -108,12 +110,18 @@ export function DialogInstallSkill({
   async function handleBrowseProjectRoot() {
     const selected = await window.electronAPI.selectFolder()
     if (selected) {
+      trackEvent('Skills: install project root selected')
       form.setValue('project_root', selected, { shouldValidate: true })
     }
   }
 
   async function onSubmit(values: FormSchema) {
     setSubmitError(null)
+    trackEvent('Skills: install dialog submitted', {
+      scope: values.scope,
+      has_version: values.version ? 'true' : 'false',
+      clients_count: values.clients?.length ?? 0,
+    })
     try {
       await installSkill({
         body: {
@@ -125,7 +133,9 @@ export function DialogInstallSkill({
           version: values.version || undefined,
         },
       })
-      handleClose()
+      form.reset()
+      setSubmitError(null)
+      onOpenChange(false)
     } catch (err) {
       const message =
         err instanceof Error
@@ -197,6 +207,7 @@ export function DialogInstallSkill({
                   <Select
                     value={field.value}
                     onValueChange={(v) => {
+                      trackEvent('Skills: install scope changed', { scope: v })
                       field.onChange(v)
                       if (v === 'user') {
                         form.setValue('project_root', '')
@@ -290,11 +301,13 @@ export function DialogInstallSkill({
                               }
                               onCheckedChange={(isChecked) => {
                                 const current = field.value ?? []
-                                field.onChange(
-                                  isChecked
-                                    ? [...current, clientType]
-                                    : current.filter((v) => v !== clientType)
-                                )
+                                const next = isChecked
+                                  ? [...current, clientType]
+                                  : current.filter((v) => v !== clientType)
+                                trackEvent('Skills: install clients changed', {
+                                  clients_count: next.length,
+                                })
+                                field.onChange(next)
                               }}
                               onSelect={(e) => e.preventDefault()}
                             >

--- a/renderer/src/features/skills/components/dialog-uninstall-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-uninstall-skill.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/common/components/ui/dialog'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { useMutationUninstallSkill } from '../hooks/use-mutation-uninstall-skill'
+import { trackEvent } from '@/common/lib/analytics'
 
 interface DialogUninstallSkillProps {
   open: boolean
@@ -27,6 +28,9 @@ export function DialogUninstallSkill({
 
   async function handleConfirm() {
     if (!skillName) return
+    trackEvent('Skills: uninstall dialog confirmed', {
+      scope: skill?.scope ?? 'unknown',
+    })
     try {
       await uninstallSkill({
         path: { name: skillName },
@@ -56,7 +60,10 @@ export function DialogUninstallSkill({
           <Button
             variant="secondary"
             className="rounded-full"
-            onClick={() => onOpenChange(false)}
+            onClick={() => {
+              trackEvent('Skills: uninstall dialog cancelled')
+              onOpenChange(false)
+            }}
             disabled={isPending}
           >
             Cancel

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -9,6 +9,7 @@ import {
   getSkillOciRef,
 } from '../lib/skill-reference'
 import { SkillMarkdown } from './skill-markdown'
+import { trackEvent } from '@/common/lib/analytics'
 
 interface SkillDetailPageProps {
   skill: RegistrySkill
@@ -69,11 +70,31 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
         description={description}
         actions={
           <div className="flex items-center gap-3">
-            <Button variant="action" onClick={() => setInstallOpen(true)}>
+            <Button
+              variant="action"
+              onClick={() => {
+                trackEvent('Skills: install dialog opened', {
+                  source: 'registry_detail',
+                  name,
+                  namespace: namespace ?? '',
+                })
+                setInstallOpen(true)
+              }}
+            >
               Install
             </Button>
             {skill.repository?.url && (
-              <Button asChild variant="outline" className="rounded-full">
+              <Button
+                asChild
+                variant="outline"
+                className="rounded-full"
+                onClick={() =>
+                  trackEvent('Skills: detail github clicked', {
+                    name,
+                    namespace: namespace ?? '',
+                  })
+                }
+              >
                 <a
                   href={skill.repository.url}
                   target="_blank"

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -28,6 +28,7 @@ import { ViewToggle } from '@/common/components/view-toggle'
 import { useViewPreference } from '@/common/hooks/use-view-preference'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { useNavigate, useSearch } from '@tanstack/react-router'
+import { trackEvent } from '@/common/lib/analytics'
 
 type Tab = 'registry' | 'installed' | 'builds'
 
@@ -37,16 +38,20 @@ export function SkillsPage() {
   const navigate = useNavigate({ from: '/skills' })
 
   function setTab(value: Tab) {
+    trackEvent('Skills: tab changed', { tab: value })
     void navigate({ search: { tab: value }, replace: true })
   }
 
   // Registry tab search (server-side, debounced)
   const [registrySearch, setRegistrySearch] = useState('')
   const [debouncedRegistrySearch, setDebouncedRegistrySearch] = useState('')
-  const debouncedSetRegistrySearch = useDebouncedCallback(
-    setDebouncedRegistrySearch,
-    300
-  )
+  const debouncedSetRegistrySearch = useDebouncedCallback((value: string) => {
+    setDebouncedRegistrySearch(value)
+    trackEvent('Skills: registry search', {
+      query_length: value.length,
+      has_query: value.length > 0 ? 'true' : 'false',
+    })
+  }, 300)
 
   function handleRegistrySearchChange(value: string) {
     setRegistrySearch(value)
@@ -117,7 +122,16 @@ export function SkillsPage() {
                   onChange={handleRegistrySearchChange}
                   placeholder="Search..."
                 />
-                <ViewToggle value={registryView} onChange={setRegistryView} />
+                <ViewToggle
+                  value={registryView}
+                  onChange={(view) => {
+                    trackEvent('Skills: view toggled', {
+                      tab: 'registry',
+                      view,
+                    })
+                    setRegistryView(view)
+                  }}
+                />
               </>
             )}
             {tab === 'installed' && hasSkills && (
@@ -127,7 +141,16 @@ export function SkillsPage() {
                   onChange={setInstalledFilter}
                   placeholder="Search..."
                 />
-                <ViewToggle value={installedView} onChange={setInstalledView} />
+                <ViewToggle
+                  value={installedView}
+                  onChange={(view) => {
+                    trackEvent('Skills: view toggled', {
+                      tab: 'installed',
+                      view,
+                    })
+                    setInstalledView(view)
+                  }}
+                />
               </>
             )}
             {tab === 'builds' && (
@@ -137,10 +160,24 @@ export function SkillsPage() {
                   onChange={setBuildsFilter}
                   placeholder="Search..."
                 />
-                <ViewToggle value={buildsView} onChange={setBuildsView} />
+                <ViewToggle
+                  value={buildsView}
+                  onChange={(view) => {
+                    trackEvent('Skills: view toggled', {
+                      tab: 'builds',
+                      view,
+                    })
+                    setBuildsView(view)
+                  }}
+                />
                 <Button
                   variant="action"
-                  onClick={() => setBuildOpen(true)}
+                  onClick={() => {
+                    trackEvent('Skills: build dialog opened', {
+                      source: 'builds_tab',
+                    })
+                    setBuildOpen(true)
+                  }}
                   className="shrink-0"
                 >
                   <HammerIcon className="size-4" />
@@ -186,12 +223,22 @@ export function SkillsPage() {
           {buildsView === 'table' ? (
             <TableBuilds
               filter={buildsFilter}
-              onBuild={() => setBuildOpen(true)}
+              onBuild={() => {
+                trackEvent('Skills: build dialog opened', {
+                  source: 'builds_empty_state',
+                })
+                setBuildOpen(true)
+              }}
             />
           ) : (
             <GridCardsBuilds
               filter={buildsFilter}
-              onBuild={() => setBuildOpen(true)}
+              onBuild={() => {
+                trackEvent('Skills: build dialog opened', {
+                  source: 'builds_empty_state',
+                })
+                setBuildOpen(true)
+              }}
             />
           )}
         </TabsContent>

--- a/renderer/src/features/skills/components/table-builds.tsx
+++ b/renderer/src/features/skills/components/table-builds.tsx
@@ -23,6 +23,7 @@ import {
 import { HammerIcon, Trash2Icon } from 'lucide-react'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogDeleteBuild } from './dialog-delete-build'
+import { trackEvent } from '@/common/lib/analytics'
 
 function getShortDigest(digest: string | undefined): string | undefined {
   if (!digest) return undefined
@@ -54,6 +55,7 @@ function BuildRow({ build }: { build: LocalBuild }) {
 
   function goToDetail() {
     if (!tag) return
+    trackEvent('Skills: build card opened', { has_tag: 'true' })
     void navigate({
       to: '/skills/builds/$tag',
       params: { tag },
@@ -148,6 +150,9 @@ function BuildRow({ build }: { build: LocalBuild }) {
               className="rounded-full"
               onClick={(e) => {
                 e.stopPropagation()
+                trackEvent('Skills: delete build dialog opened', {
+                  source: 'build_table',
+                })
                 setDeleteOpen(true)
               }}
               aria-label={`Remove ${title}`}
@@ -161,6 +166,9 @@ function BuildRow({ build }: { build: LocalBuild }) {
               className="rounded-full"
               onClick={(e) => {
                 e.stopPropagation()
+                trackEvent('Skills: install dialog opened', {
+                  source: 'build_table',
+                })
                 setInstallOpen(true)
               }}
               aria-label={`Install ${title}`}

--- a/renderer/src/features/skills/components/table-installed-skills.tsx
+++ b/renderer/src/features/skills/components/table-installed-skills.tsx
@@ -19,6 +19,7 @@ import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill
 import { DialogUninstallSkill } from './dialog-uninstall-skill'
 import { SkillClientsBadges } from './skill-clients-badges'
 import { skillStatusVariantMap } from './skill-status'
+import { trackEvent } from '@/common/lib/analytics'
 
 function SkillRow({ skill }: { skill: InstalledSkill }) {
   const [uninstallOpen, setUninstallOpen] = useState(false)
@@ -127,6 +128,10 @@ function SkillRow({ skill }: { skill: InstalledSkill }) {
             className="rounded-full"
             onClick={(e) => {
               e.stopPropagation()
+              trackEvent('Skills: uninstall dialog opened', {
+                source: 'installed_table',
+                scope: scope ?? 'unknown',
+              })
               setUninstallOpen(true)
             }}
             aria-label={`Uninstall ${title}`}

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/common/components/ui/tooltip'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { getSkillInstallReference } from '../lib/skill-reference'
+import { trackEvent } from '@/common/lib/analytics'
 
 function activateOnKey(e: React.KeyboardEvent, onActivate: () => void) {
   if (e.key === 'Enter' || e.key === ' ') {
@@ -36,6 +37,11 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
 
   function goToDetail() {
     if (!canNavigate) return
+    trackEvent('Skills: registry card opened', {
+      name: title,
+      namespace: namespace ?? '',
+      source: 'registry_table',
+    })
     void navigate({
       to: '/skills/$namespace/$skillName',
       params: { namespace: namespace!, skillName: skill.name! },
@@ -104,7 +110,14 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
               href={skill.repository.url}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation()
+                trackEvent('Skills: registry card github clicked', {
+                  name: title,
+                  namespace: namespace ?? '',
+                  source: 'registry_table',
+                })
+              }}
               className="text-muted-foreground hover:bg-accent inline-flex
                 size-8 items-center justify-center rounded-md"
               aria-label="Open repository on GitHub"
@@ -121,6 +134,11 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
             className="rounded-full"
             onClick={(e) => {
               e.stopPropagation()
+              trackEvent('Skills: install dialog opened', {
+                source: 'registry_table',
+                name: title,
+                namespace: namespace ?? '',
+              })
               setInstallOpen(true)
             }}
             aria-label={`Install ${title}`}

--- a/renderer/src/features/skills/hooks/__tests__/use-mutation-build-skill.test.ts
+++ b/renderer/src/features/skills/hooks/__tests__/use-mutation-build-skill.test.ts
@@ -1,11 +1,16 @@
 import { renderHook, waitFor } from '@testing-library/react'
-import { expect, it, vi, describe } from 'vitest'
+import { expect, it, vi, describe, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { toast } from 'sonner'
 import { useMutationBuildSkill } from '../use-mutation-build-skill'
 import { recordRequests } from '@/common/mocks/node'
 import { mockedPostApiV1BetaSkillsBuild } from '@/common/mocks/fixtures/skills_build/post'
+import { trackEvent } from '@/common/lib/analytics'
+
+vi.mock('@/common/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}))
 
 const createQueryClientWrapper = () => {
   const queryClient = new QueryClient({
@@ -22,6 +27,10 @@ const createQueryClientWrapper = () => {
 }
 
 describe('useMutationBuildSkill', () => {
+  beforeEach(() => {
+    vi.mocked(trackEvent).mockClear()
+  })
+
   it('sends POST to /api/v1beta/skills/build with correct body', async () => {
     const rec = recordRequests()
     const { Wrapper } = createQueryClientWrapper()
@@ -105,5 +114,53 @@ describe('useMutationBuildSkill', () => {
         ]),
       })
     )
+  })
+
+  it('tracks build success event without leaking source path', async () => {
+    const { Wrapper } = createQueryClientWrapper()
+
+    const { result } = renderHook(() => useMutationBuildSkill(), {
+      wrapper: Wrapper,
+    })
+
+    result.current.mutateAsync({
+      body: { path: '/home/user/my-skill', tag: 'v1.0.0' },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(trackEvent).toHaveBeenCalledWith('Skills: build succeeded', {
+      has_tag: 'true',
+      has_reference: 'true',
+    })
+    const [, payload] =
+      vi
+        .mocked(trackEvent)
+        .mock.calls.find(([name]) => name === 'Skills: build succeeded') ?? []
+    expect(JSON.stringify(payload)).not.toContain('/home/user/my-skill')
+  })
+
+  it('tracks build failure event on error', async () => {
+    mockedPostApiV1BetaSkillsBuild.activateScenario('server-error')
+
+    const { Wrapper } = createQueryClientWrapper()
+
+    const { result } = renderHook(() => useMutationBuildSkill(), {
+      wrapper: Wrapper,
+    })
+
+    result.current
+      .mutateAsync({ body: { path: '/home/user/my-skill' } })
+      .catch(() => {})
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+
+    expect(trackEvent).toHaveBeenCalledWith('Skills: build failed', {
+      has_tag: 'false',
+    })
   })
 })

--- a/renderer/src/features/skills/hooks/__tests__/use-mutation-delete-build.test.ts
+++ b/renderer/src/features/skills/hooks/__tests__/use-mutation-delete-build.test.ts
@@ -1,11 +1,16 @@
 import { renderHook, waitFor } from '@testing-library/react'
-import { expect, it, vi, describe } from 'vitest'
+import { expect, it, vi, describe, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { toast } from 'sonner'
 import { useMutationDeleteBuild } from '../use-mutation-delete-build'
 import { recordRequests } from '@/common/mocks/node'
 import { mockedDeleteApiV1BetaSkillsBuildsByTag } from '@/common/mocks/fixtures/skills_builds_tag/delete'
+import { trackEvent } from '@/common/lib/analytics'
+
+vi.mock('@/common/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}))
 
 const createQueryClientWrapper = () => {
   const queryClient = new QueryClient({
@@ -22,6 +27,10 @@ const createQueryClientWrapper = () => {
 }
 
 describe('useMutationDeleteBuild', () => {
+  beforeEach(() => {
+    vi.mocked(trackEvent).mockClear()
+  })
+
   it('sends DELETE to /api/v1beta/skills/builds/{tag} with correct path param', async () => {
     const rec = recordRequests()
     const { Wrapper } = createQueryClientWrapper()
@@ -105,5 +114,45 @@ describe('useMutationDeleteBuild', () => {
         ]),
       })
     )
+  })
+
+  it('tracks delete build success event with tag', async () => {
+    const { Wrapper } = createQueryClientWrapper()
+
+    const { result } = renderHook(() => useMutationDeleteBuild(), {
+      wrapper: Wrapper,
+    })
+
+    result.current.mutateAsync({ path: { tag: 'localhost/my-skill:v1.0.0' } })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(trackEvent).toHaveBeenCalledWith('Skills: delete build succeeded', {
+      tag: 'localhost/my-skill:v1.0.0',
+    })
+  })
+
+  it('tracks delete build failure event on error', async () => {
+    mockedDeleteApiV1BetaSkillsBuildsByTag.activateScenario('server-error')
+
+    const { Wrapper } = createQueryClientWrapper()
+
+    const { result } = renderHook(() => useMutationDeleteBuild(), {
+      wrapper: Wrapper,
+    })
+
+    result.current
+      .mutateAsync({ path: { tag: 'localhost/my-skill:v1.0.0' } })
+      .catch(() => {})
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+
+    expect(trackEvent).toHaveBeenCalledWith('Skills: delete build failed', {
+      tag: 'localhost/my-skill:v1.0.0',
+    })
   })
 })

--- a/renderer/src/features/skills/hooks/__tests__/use-mutation-install-skill.test.ts
+++ b/renderer/src/features/skills/hooks/__tests__/use-mutation-install-skill.test.ts
@@ -1,11 +1,16 @@
 import { renderHook, waitFor } from '@testing-library/react'
-import { expect, it, vi, describe } from 'vitest'
+import { expect, it, vi, describe, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { toast } from 'sonner'
 import { useMutationInstallSkill } from '../use-mutation-install-skill'
 import { recordRequests } from '@/common/mocks/node'
 import { mockedPostApiV1BetaSkills } from '@/common/mocks/fixtures/skills/post'
+import { trackEvent } from '@/common/lib/analytics'
+
+vi.mock('@/common/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}))
 
 const createQueryClientWrapper = () => {
   const queryClient = new QueryClient({
@@ -22,6 +27,10 @@ const createQueryClientWrapper = () => {
 }
 
 describe('useMutationInstallSkill', () => {
+  beforeEach(() => {
+    vi.mocked(trackEvent).mockClear()
+  })
+
   it('sends POST to /api/v1beta/skills with correct body', async () => {
     const rec = recordRequests()
     const { Wrapper } = createQueryClientWrapper()
@@ -130,5 +139,56 @@ describe('useMutationInstallSkill', () => {
         ]),
       })
     )
+  })
+
+  it('tracks install success event with skill metadata', async () => {
+    const { Wrapper } = createQueryClientWrapper()
+
+    const { result } = renderHook(() => useMutationInstallSkill(), {
+      wrapper: Wrapper,
+    })
+
+    result.current.mutateAsync({
+      body: {
+        name: 'skill-one',
+        scope: 'user',
+        version: 'v1.0.0',
+        clients: ['vscode', 'cursor'],
+      },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(trackEvent).toHaveBeenCalledWith('Skills: install succeeded', {
+      skill_name: 'skill-one',
+      scope: 'user',
+      has_version: 'true',
+      clients_count: 2,
+    })
+  })
+
+  it('tracks install failure event on error', async () => {
+    mockedPostApiV1BetaSkills.activateScenario('server-error')
+
+    const { Wrapper } = createQueryClientWrapper()
+
+    const { result } = renderHook(() => useMutationInstallSkill(), {
+      wrapper: Wrapper,
+    })
+
+    result.current
+      .mutateAsync({ body: { name: 'skill-one', scope: 'project' } })
+      .catch(() => {})
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+
+    expect(trackEvent).toHaveBeenCalledWith('Skills: install failed', {
+      skill_name: 'skill-one',
+      scope: 'project',
+    })
   })
 })

--- a/renderer/src/features/skills/hooks/__tests__/use-mutation-uninstall-skill.test.ts
+++ b/renderer/src/features/skills/hooks/__tests__/use-mutation-uninstall-skill.test.ts
@@ -1,11 +1,16 @@
 import { renderHook, waitFor } from '@testing-library/react'
-import { expect, it, vi, describe } from 'vitest'
+import { expect, it, vi, describe, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { toast } from 'sonner'
 import { useMutationUninstallSkill } from '../use-mutation-uninstall-skill'
 import { recordRequests } from '@/common/mocks/node'
 import { mockedDeleteApiV1BetaSkillsByName } from '@/common/mocks/fixtures/skills_name/delete'
+import { trackEvent } from '@/common/lib/analytics'
+
+vi.mock('@/common/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}))
 
 const createQueryClientWrapper = () => {
   const queryClient = new QueryClient({
@@ -22,6 +27,10 @@ const createQueryClientWrapper = () => {
 }
 
 describe('useMutationUninstallSkill', () => {
+  beforeEach(() => {
+    vi.mocked(trackEvent).mockClear()
+  })
+
   it('sends DELETE to /api/v1beta/skills/{name} with correct path and query params', async () => {
     const rec = recordRequests()
     const { Wrapper } = createQueryClientWrapper()
@@ -112,5 +121,51 @@ describe('useMutationUninstallSkill', () => {
         ]),
       })
     )
+  })
+
+  it('tracks uninstall success event with scope and project_root info', async () => {
+    const { Wrapper } = createQueryClientWrapper()
+
+    const { result } = renderHook(() => useMutationUninstallSkill(), {
+      wrapper: Wrapper,
+    })
+
+    result.current.mutateAsync({
+      path: { name: 'my-skill' },
+      query: { scope: 'project', project_root: '/path/to/project' },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(trackEvent).toHaveBeenCalledWith('Skills: uninstall succeeded', {
+      skill_name: 'my-skill',
+      scope: 'project',
+      has_project_root: 'true',
+    })
+  })
+
+  it('tracks uninstall failure event on error', async () => {
+    mockedDeleteApiV1BetaSkillsByName.activateScenario('server-error')
+
+    const { Wrapper } = createQueryClientWrapper()
+
+    const { result } = renderHook(() => useMutationUninstallSkill(), {
+      wrapper: Wrapper,
+    })
+
+    result.current
+      .mutateAsync({ path: { name: 'my-skill' }, query: { scope: 'user' } })
+      .catch(() => {})
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+
+    expect(trackEvent).toHaveBeenCalledWith('Skills: uninstall failed', {
+      skill_name: 'my-skill',
+      scope: 'user',
+    })
   })
 })

--- a/renderer/src/features/skills/hooks/use-mutation-build-skill.ts
+++ b/renderer/src/features/skills/hooks/use-mutation-build-skill.ts
@@ -4,19 +4,27 @@ import {
   getApiV1BetaSkillsBuildsQueryKey,
 } from '@common/api/generated/@tanstack/react-query.gen'
 import { toast } from 'sonner'
+import { trackEvent } from '@/common/lib/analytics'
 
 export function useMutationBuildSkill() {
   const queryClient = useQueryClient()
 
   return useMutation({
     ...postApiV1BetaSkillsBuildMutation(),
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
+      trackEvent('Skills: build succeeded', {
+        has_tag: variables.body?.tag ? 'true' : 'false',
+        has_reference: data?.reference ? 'true' : 'false',
+      })
       queryClient.invalidateQueries({
         queryKey: getApiV1BetaSkillsBuildsQueryKey(),
       })
     },
-    onError: () => {
+    onError: (_error, variables) => {
       toast.error('Failed to build skill')
+      trackEvent('Skills: build failed', {
+        has_tag: variables.body?.tag ? 'true' : 'false',
+      })
     },
   })
 }

--- a/renderer/src/features/skills/hooks/use-mutation-delete-build.ts
+++ b/renderer/src/features/skills/hooks/use-mutation-delete-build.ts
@@ -4,6 +4,7 @@ import {
   getApiV1BetaSkillsBuildsQueryKey,
 } from '@common/api/generated/@tanstack/react-query.gen'
 import { toast } from 'sonner'
+import { trackEvent } from '@/common/lib/analytics'
 
 export function useMutationDeleteBuild() {
   const queryClient = useQueryClient()
@@ -13,12 +14,14 @@ export function useMutationDeleteBuild() {
     onSuccess: (_data, variables) => {
       const tag = variables.path.tag
       toast.success(`${tag} removed successfully`)
+      trackEvent('Skills: delete build succeeded', { tag })
       queryClient.invalidateQueries({
         queryKey: getApiV1BetaSkillsBuildsQueryKey(),
       })
     },
-    onError: () => {
+    onError: (_error, variables) => {
       toast.error('Failed to remove build')
+      trackEvent('Skills: delete build failed', { tag: variables.path.tag })
     },
   })
 }

--- a/renderer/src/features/skills/hooks/use-mutation-install-skill.ts
+++ b/renderer/src/features/skills/hooks/use-mutation-install-skill.ts
@@ -3,6 +3,7 @@ import {
   postApiV1BetaSkillsMutation,
   getApiV1BetaSkillsQueryKey,
 } from '@common/api/generated/@tanstack/react-query.gen'
+import type { PkgApiV1InstallSkillRequest } from '@common/api/generated/types.gen'
 import { toast } from 'sonner'
 import { trackEvent } from '@/common/lib/analytics'
 
@@ -12,23 +13,25 @@ export function useMutationInstallSkill() {
   return useMutation({
     ...postApiV1BetaSkillsMutation(),
     onSuccess: (data, variables) => {
+      const body = variables.body as PkgApiV1InstallSkillRequest
       const skillName =
         data?.skill?.metadata?.name ?? data?.skill?.reference ?? 'Skill'
       toast.success(`${skillName} installed successfully`)
       trackEvent('Skills: install succeeded', {
         skill_name: skillName,
-        scope: variables.body.scope,
-        has_version: variables.body.version ? 'true' : 'false',
-        clients_count: variables.body.clients?.length ?? 0,
+        scope: body.scope ?? 'unknown',
+        has_version: body.version ? 'true' : 'false',
+        clients_count: body.clients?.length ?? 0,
       })
       queryClient.invalidateQueries({
         queryKey: getApiV1BetaSkillsQueryKey(),
       })
     },
     onError: (_error, variables) => {
+      const body = variables.body as PkgApiV1InstallSkillRequest
       trackEvent('Skills: install failed', {
-        skill_name: variables.body.name,
-        scope: variables.body.scope,
+        skill_name: body.name ?? 'unknown',
+        scope: body.scope ?? 'unknown',
       })
     },
   })

--- a/renderer/src/features/skills/hooks/use-mutation-install-skill.ts
+++ b/renderer/src/features/skills/hooks/use-mutation-install-skill.ts
@@ -4,18 +4,31 @@ import {
   getApiV1BetaSkillsQueryKey,
 } from '@common/api/generated/@tanstack/react-query.gen'
 import { toast } from 'sonner'
+import { trackEvent } from '@/common/lib/analytics'
 
 export function useMutationInstallSkill() {
   const queryClient = useQueryClient()
 
   return useMutation({
     ...postApiV1BetaSkillsMutation(),
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       const skillName =
         data?.skill?.metadata?.name ?? data?.skill?.reference ?? 'Skill'
       toast.success(`${skillName} installed successfully`)
+      trackEvent('Skills: install succeeded', {
+        skill_name: skillName,
+        scope: variables.body.scope,
+        has_version: variables.body.version ? 'true' : 'false',
+        clients_count: variables.body.clients?.length ?? 0,
+      })
       queryClient.invalidateQueries({
         queryKey: getApiV1BetaSkillsQueryKey(),
+      })
+    },
+    onError: (_error, variables) => {
+      trackEvent('Skills: install failed', {
+        skill_name: variables.body.name,
+        scope: variables.body.scope,
       })
     },
   })

--- a/renderer/src/features/skills/hooks/use-mutation-uninstall-skill.ts
+++ b/renderer/src/features/skills/hooks/use-mutation-uninstall-skill.ts
@@ -4,6 +4,7 @@ import {
   getApiV1BetaSkillsQueryKey,
 } from '@common/api/generated/@tanstack/react-query.gen'
 import { toast } from 'sonner'
+import { trackEvent } from '@/common/lib/analytics'
 
 export function useMutationUninstallSkill() {
   const queryClient = useQueryClient()
@@ -13,12 +14,21 @@ export function useMutationUninstallSkill() {
     onSuccess: (_data, variables) => {
       const skillName = variables.path.name
       toast.success(`${skillName} uninstalled successfully`)
+      trackEvent('Skills: uninstall succeeded', {
+        skill_name: skillName,
+        scope: variables.query?.scope ?? 'unknown',
+        has_project_root: variables.query?.project_root ? 'true' : 'false',
+      })
       queryClient.invalidateQueries({
         queryKey: getApiV1BetaSkillsQueryKey(),
       })
     },
-    onError: () => {
+    onError: (_error, variables) => {
       toast.error('Failed to uninstall skill')
+      trackEvent('Skills: uninstall failed', {
+        skill_name: variables.path.name,
+        scope: variables.query?.scope ?? 'unknown',
+      })
     },
   })
 }


### PR DESCRIPTION
Adds `trackEvent` calls across the Skills feature so we can measure adoption, entry points, and drop-off. Page views are already emitted by the router subscription in `renderer/src/renderer.tsx`, so this PR only covers user actions, following the existing `Feature: action` convention used by `Playground:`, `Customize Tools:`, and `Update Version:`.

## Event surface

All events use the `Skills:` prefix:

- Navigation — `tab changed`, `view toggled`, `registry search`
- Registry — `registry card opened`, `registry card github clicked`, `detail github clicked`
- Install — `install dialog opened` / `submitted` / `cancelled` / `scope changed` / `clients changed` / `project root selected`, `install succeeded` / `failed`
- Uninstall — `uninstall dialog opened` / `confirmed` / `cancelled`, `uninstall succeeded` / `failed`
- Build — `build dialog opened` / `submitted` / `cancelled`, `build path selected`, `build card opened`, `build install-now clicked`, `build succeeded` / `failed`
- Delete build — `delete build dialog opened` / `confirmed` / `cancelled`, `delete build succeeded` / `failed`

Every `*_dialog_opened` event carries a `source` attribute (`registry_card`, `registry_table`, `registry_detail`, `installed_card`, `installed_table`, `build_card`, `build_table`, `build_detail`, `builds_tab`, `builds_empty_state`) so we can attribute clicks to their entry point.

## Where the events live

- **Mutation hooks** (`use-mutation-{install,uninstall,build,delete-build}-skill.ts`) own the `succeeded` / `failed` events in their `onSuccess` / `onError` — same pattern as `use-run-custom-server.tsx` and `use-mutation-create-group.ts`.
- **`skills-page.tsx`** owns `tab changed`, `view toggled`, and the debounced `registry search`.
- **Cards, tables, and detail pages** own the click-level events (card opened, github clicked, install/uninstall/remove dialog opened) with the right `source`.
- **Dialogs** own `submitted`, `cancelled`, and field-change events. The install/build dialogs were tweaked so their success branch doesn't reuse `handleClose`, letting us distinguish "cancelled" from "successful close".

## Privacy

- Never logged: absolute filesystem paths (`project_root`, `build.path`), OCI URLs, raw search queries.
- Logged: `name`, `namespace`, `scope`, `tag`, client type, counts, and stringified booleans — matching the payload style used elsewhere.

## Tests

Added `vi.mock('@/common/lib/analytics')` and success/failure assertions to all four mutation-hook test files, including a check that the build payload doesn't leak the source path. `pnpm vitest run renderer/src/features/skills` is green (19 files, 141 tests).