### PR TITLE
ci: skip macOS code signing on PR validation builds

### DIFF
--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -31,17 +31,11 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Setup macOS code signing
-        uses: ./.github/actions/setup-macos-codesign
-        if: runner.os == 'macOS'
-        with:
-          apple-certificate: ${{ secrets.APPLE_CERTIFICATE }}
-          apple-certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
-          apple-api-key: ${{ secrets.APPLE_API_KEY }}
-
-          apple-issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
-          apple-key-id: ${{ secrets.APPLE_KEY_ID }}
+      # This matrix runs on every PR (including forks) and only verifies the
+      # app builds. Signing/notarization secrets aren't available to forked
+      # PRs anyway, so we skip code signing here entirely — the signed and
+      # notarized builds live in on-release.yml and the opt-in /build-test
+      # flow (pr-build-test.yml).
 
       - name: Setup Flatpak (Linux only)
         uses: ./.github/actions/setup-flatpak
@@ -51,7 +45,3 @@ jobs:
         run: pnpm run make
         env:
           npm_config_target_platform: ${{ runner.os == 'Linux' && 'linux' || (runner.os == 'macOS' && 'darwin' || 'win32') }}
-          # Apple API Key method for notarization (set by composite action)
-          APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
-          APPLE_ISSUER_ID: ${{ env.APPLE_ISSUER_ID }}
-          APPLE_KEY_ID: ${{ env.APPLE_KEY_ID }}

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -81,9 +81,19 @@ const config: ForgeConfig = {
     },
 
     // MacOS Code Signing Configuration
-    osxSign: process.env.MAC_DEVELOPER_IDENTITY
-      ? { identity: process.env.MAC_DEVELOPER_IDENTITY }
-      : {}, // Auto-detect certificates
+    // Only enable signing when credentials are actually available. Without
+    // this guard, `osxSign: {}` asks electron-osx-sign to auto-detect a
+    // codesign identity, which fails on runners that don't have one
+    // imported (e.g. PR validation builds and local dev).
+    osxSign: (() => {
+      if (process.env.MAC_DEVELOPER_IDENTITY) {
+        return { identity: process.env.MAC_DEVELOPER_IDENTITY }
+      }
+      if (process.env.APPLE_API_KEY || process.env.APPLE_ID) {
+        return {} // Auto-detect certificates
+      }
+      return undefined
+    })(),
 
     // Windows Code Signing Configuration
     // Azure Trusted Signing (preferred) with DigiCert KeyLocker fallback.


### PR DESCRIPTION
## Summary

- The PR validation matrix (`on-pr.yml` → `_build-matrix.yml`) ran macOS code signing on every PR, which fails for forks because `APPLE_*` secrets aren't exposed to forked PR workflows. The `security import` step errored with `SecKeychainItemImport: One or more parameters passed to a function were not valid` ([example failing job](https://github.com/stacklok/toolhive-studio/actions/runs/24796832191/job/72573277517?pr=2080)).
- Signing belongs in release builds (`on-release.yml`) and the opt-in `/build-test` flow (`pr-build-test.yml`, which already blocks forks). A per-PR sanity build doesn't need signed artifacts.
- Drop the `setup-macos-codesign` step from `_build-matrix.yml` and guard `osxSign` in `forge.config.ts` so the build cleanly skips signing when no credentials are present, instead of asking `electron-osx-sign` to auto-detect an identity that doesn't exist on a clean runner.

## Test plan

- [ ] CI passes on this PR (macOS matrix should build without attempting to sign).
- [ ] Confirm next release build (`on-release.yml`) still signs + notarizes — `APPLE_API_KEY` set by `setup-macos-codesign` keeps `osxSign` enabled.
- [ ] Confirm `/build-test` flow still signs macOS — same path as release.
- [ ] Local `pnpm run make` without Apple creds no longer tries to auto-detect an identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)