### PR TITLE
fix(api): unblock openapi-ts client generation under v0.96.1

### DIFF
--- a/common/api/openapi-ts.config.ts
+++ b/common/api/openapi-ts.config.ts
@@ -5,8 +5,7 @@ export default defineConfig({
   output: {
     case: undefined,
     path: './generated',
-    format: 'prettier',
-    lint: 'eslint',
+    postProcess: ['prettier'],
   },
   plugins: [
     ...defaultPlugins,

--- a/common/api/openapi-ts.config.ts
+++ b/common/api/openapi-ts.config.ts
@@ -8,11 +8,11 @@ export default defineConfig({
     postProcess: ['prettier'],
   },
   plugins: [
-    ...defaultPlugins,
-    '@tanstack/react-query',
+    ...defaultPlugins.filter((p) => p !== '@hey-api/typescript'),
     {
       name: '@hey-api/typescript',
       enums: false,
     },
+    '@tanstack/react-query',
   ],
 })


### PR DESCRIPTION
`@hey-api/openapi-ts@0.96.1` added [#3683](https://github.com/hey-api/openapi-ts/pull/3683) ("surface postprocess errors"), which turns a long-silent ESLint failure in `pnpm generate-client` into a fatal CI error. It showed up on the Renovate bump #2090 and the Regenerate Artifacts workflow.

## Root cause

`common/api/openapi-ts.config.ts` registered ESLint as a post-processor via the deprecated `output.lint: 'eslint'`. That pointed ESLint at `./common/api/generated`, but our flat `eslint.config.mjs` puts the same path in its global `ignores` list. Under ESLint 9, a glob that matches only ignored files exits with code 2; under openapi-ts 0.96.0 that exit code was swallowed, so generation appeared to succeed. 0.96.1 now propagates the error and aborts.

The config also tripped the new "Plugin configured multiple times" warning from [#3753](https://github.com/hey-api/openapi-ts/pull/3753) because `defaultPlugins` already contains `@hey-api/typescript` and we were appending an override on top of the spread.

## Changes

- Migrate `output.format` / `output.lint` to `output.postProcess: ['prettier']`. Drops ESLint from the pipeline — it was a no-op anyway, since `./common/api/generated/**` is globally ignored in `eslint.config.mjs`, and also silences the two deprecation warnings from hey-api.
- Filter `@hey-api/typescript` out of `defaultPlugins` before re-adding the `enums: false` override, so the plugin is registered exactly once.

## Verification

- `cd common/api && pnpm generate-client:nofetch` runs clean: no deprecation warnings, no "configured multiple times" warning, no ESLint crash, `🧹 Running Prettier` appears in the output.
- `git diff --stat common/api/generated` after regeneration is empty — the final output is byte-identical to what's committed on `main`, confirming ESLint was never actually formatting generated code (only Prettier was).
- Unblocks #2090 (Renovate bump to 0.96.1) and the Regenerate Artifacts workflow.