### PR TITLE
fix(ci): grant security-fix job permissions in on-main workflow

### DIFF
--- a/.github/workflows/on-main.yml
+++ b/.github/workflows/on-main.yml
@@ -30,4 +30,9 @@ jobs:
     needs: security
     if: ${{ always() && needs.security.result == 'failure' }}
     uses: ./.github/workflows/_security-fix-agent.yml
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
     secrets: inherit


### PR DESCRIPTION
## Summary

- Fix `Invalid workflow file` error on merges to `main` caused by the top-level `permissions: contents: read` in `on-main.yml` capping the permissions of the reusable `_security-fix-agent.yml` workflow.
- Grant the required permissions (`contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`) explicitly on the `security-fix` job — same pattern used for the bug-fix agent.
- Other jobs (`security`, `static-checks`, `unit-tests`, `e2e-tests`) continue to inherit the safer `contents: read` default.

The failing CI error was:

> The nested job 'remediate' is requesting 'contents: write, issues: write, pull-requests: write, id-token: write', but is only allowed 'contents: read, issues: none, pull-requests: none, id-token: none'.
