### PR TITLE
fix(security): pin fast-xml-parser to 5.5.8 to unblock S3 release publish

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -23,3 +23,26 @@ exclude:
   - '**/test-videos/**'
   - '**/.vite/**'
   - '**/.cache/**'
+
+ignore:
+  # Scoped to version 5.5.8 so the ignore stops applying automatically as soon
+  # as the pin in pnpm.overrides is bumped to a non-regressing upstream release.
+  - vulnerability: GHSA-gh4j-gqv2-49f6
+    package:
+      name: fast-xml-parser
+      version: 5.5.8
+      type: npm
+    reason: >-
+      Pinned to 5.5.8 because 5.7.0/5.7.1 break @aws-sdk/xml-builder
+      (see https://github.com/NaturalIntelligence/fast-xml-parser/issues/823),
+      which in turn breaks @electron-forge/publisher-s3 during release.
+      The advisory only affects XMLBuilder.buildComment / buildCdata with
+      unescaped user input; this repo does not use those APIs. Revisit once
+      upstream ships a non-regressing patch (>=5.7.2).
+  - vulnerability: CVE-2026-41650
+    package:
+      name: fast-xml-parser
+      version: 5.5.8
+      type: npm
+    reason: >-
+      Same advisory as GHSA-gh4j-gqv2-49f6. See note above.

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "overrides": {
       "@hono/node-server": ">=1.19.13",
       "@xmldom/xmldom": ">=0.9.10",
-      "fast-xml-parser": ">=5.7.0",
+      "fast-xml-parser": "5.5.8",
       "dompurify": ">=3.4.0",
       "hono": ">=4.12.14",
       "lodash": ">=4.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@hono/node-server': '>=1.19.13'
   '@xmldom/xmldom': '>=0.9.10'
-  fast-xml-parser: '>=5.7.0'
+  fast-xml-parser: 5.5.8
   dompurify: '>=3.4.0'
   hono: '>=4.12.14'
   lodash: '>=4.18.0'
@@ -1686,9 +1686,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
-
-  '@nodable/entities@2.1.0':
-    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5269,8 +5266,8 @@ packages:
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@5.7.1:
-    resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
 
   fastq@1.20.1:
@@ -9122,7 +9119,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.4':
     dependencies:
       '@smithy/types': 4.12.0
-      fast-xml-parser: 5.7.1
+      fast-xml-parser: 5.5.8
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -10423,8 +10420,6 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
-
-  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -14355,9 +14350,8 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.7.1:
+  fast-xml-parser@5.5.8:
     dependencies:
-      '@nodable/entities': 2.1.0
       fast-xml-builder: 1.1.5
       path-expression-matcher: 1.5.0
       strnum: 2.2.3


### PR DESCRIPTION
`v0.32.0-rc.0` failed to publish because the release workflow's `publish` step exploded inside `@electron-forge/publisher-s3` the moment AWS parsed its first S3 response:

> `[EntityReplacer] Invalid character '#' in entity name: "#xD"`

CI run: https://github.com/stacklok/toolhive-studio/actions/runs/24844174681/job/72728039467

## Root cause

`fast-xml-parser@5.7.0` (published 2026-04-23) introduced a new `EntityReplacer` that rejects `#` in entity names. `@aws-sdk/xml-builder` registers numeric XML entities via `parser.addEntity("#xD", "\r")` and `parser.addEntity("#10", "\n")` before parsing any S3 response, so every `publisher-s3` call now throws before a single byte is read.

Upstream is tracking this regression in:
- [fast-xml-parser#823](https://github.com/NaturalIntelligence/fast-xml-parser/issues/823) — confirmed breaking change introduced in `5.7.0`.
- [aws-sdk-js-v3#7949](https://github.com/aws/aws-sdk-js-v3/issues/7949) / [#7955](https://github.com/aws/aws-sdk-js-v3/issues/7955) — AWS acknowledges pinning `>=5.7.x` breaks the SDK.

No patched `5.7.x` exists yet.

## Why we were on 5.7.1

#2082 added a `pnpm.overrides` entry `"fast-xml-parser": ">=5.7.0"` to silence [GHSA-gh4j-gqv2-49f6](https://github.com/advisories/GHSA-gh4j-gqv2-49f6) (CVE-2026-41650). That advisory is scoped to `XMLBuilder.buildComment` / `buildCdata` when callers pass unescaped user input into comments or CDATA sections. Nothing in this repo or in the AWS SDK path uses the *builder* that way — the SDK only *parses* responses — so rolling the override back is safe for runtime code.

## Changes

- **[`package.json`](package.json)** — flip the `fast-xml-parser` override from `">=5.7.0"` to an exact pin `"5.5.8"` (the last known-good release, and the version `@aws-sdk/xml-builder` itself depends on). Exact pin, not `>=`, so the security-fix agent can't casually bump us back into 5.7.x on the next run.
- **[`pnpm-lock.yaml`](pnpm-lock.yaml)** — regenerated. `@aws-sdk/xml-builder` now consumes `fast-xml-parser@5.5.8`; the `5.7.1` entry and its `@nodable/entities@2.1.0` sub-tree are dropped.
- **[`.grype.yaml`](.grype.yaml)** — add ignores for `GHSA-gh4j-gqv2-49f6` and its CVE alias `CVE-2026-41650` with a `reason:` string that explains the rollback and references upstream #823. Prevents grype from flagging the downgrade and leaves an audit trail for future reviewers.

All other overrides in `pnpm.overrides` stay as-is — I verified each is still dragging transitive resolution up to exactly its floor; dropping any would let pnpm walk back into CVE-flagged versions.


## Follow-up (not in this PR)

Once fast-xml-parser ships `>=5.7.2` with `addEntity('#xD', ...)` support restored, flip the override back to `">=5.7.2"` and remove the two ignores in `.grype.yaml`.