### PR TITLE
feat(skills): paginate registry tab and preserve state across detail navigation

### DIFF
--- a/renderer/src/common/components/ui/__tests__/pagination.test.tsx
+++ b/renderer/src/common/components/ui/__tests__/pagination.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Pagination } from '../pagination'
+
+function setup(props: Partial<React.ComponentProps<typeof Pagination>> = {}) {
+  const onPageChange = vi.fn()
+  const onPageSizeChange = vi.fn()
+  const utils = render(
+    <Pagination
+      page={1}
+      pageSize={12}
+      total={100}
+      onPageChange={onPageChange}
+      onPageSizeChange={onPageSizeChange}
+      {...props}
+    />
+  )
+  return { onPageChange, onPageSizeChange, ...utils }
+}
+
+describe('Pagination', () => {
+  it('renders "Showing X-Y of N" info, current page and controls', () => {
+    setup({ page: 2, pageSize: 12, total: 100 })
+
+    expect(screen.getByText('Showing 13-24 of 100 results')).toBeVisible()
+    expect(screen.getByText('Page 2')).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /go to first page/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /go to previous page/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /go to next page/i })
+    ).toBeVisible()
+  })
+
+  it('uses a custom item label', () => {
+    setup({ total: 100, itemLabel: 'skills' })
+    expect(screen.getByText('Showing 1-12 of 100 skills')).toBeVisible()
+  })
+
+  it('disables first and previous on page 1', () => {
+    setup({ page: 1, pageSize: 12, total: 100 })
+
+    expect(
+      screen.getByRole('button', { name: /go to first page/i })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /go to previous page/i })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /go to next page/i })
+    ).toBeEnabled()
+  })
+
+  it('disables next on the last page', () => {
+    setup({ page: 9, pageSize: 12, total: 100 })
+
+    expect(
+      screen.getByRole('button', { name: /go to next page/i })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /go to previous page/i })
+    ).toBeEnabled()
+  })
+
+  it('invokes onPageChange when navigation buttons are clicked', async () => {
+    const user = userEvent.setup()
+    const { onPageChange } = setup({ page: 3, pageSize: 12, total: 100 })
+
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+    expect(onPageChange).toHaveBeenCalledWith(4)
+
+    await user.click(
+      screen.getByRole('button', { name: /go to previous page/i })
+    )
+    expect(onPageChange).toHaveBeenCalledWith(2)
+
+    await user.click(screen.getByRole('button', { name: /go to first page/i }))
+    expect(onPageChange).toHaveBeenCalledWith(1)
+  })
+
+  it('invokes onPageSizeChange when a new size is selected', async () => {
+    const user = userEvent.setup()
+    const { onPageSizeChange } = setup({ page: 1, pageSize: 12, total: 500 })
+
+    await user.click(screen.getByRole('combobox', { name: /items per page/i }))
+    await user.click(screen.getByRole('option', { name: '50' }))
+
+    expect(onPageSizeChange).toHaveBeenCalledWith(50)
+  })
+
+  it('renders nothing when total fits in the smallest page size option', () => {
+    const { container } = setup({ page: 1, pageSize: 12, total: 5 })
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/renderer/src/common/components/ui/pagination.tsx
+++ b/renderer/src/common/components/ui/pagination.tsx
@@ -42,11 +42,14 @@ export function Pagination({
     return null
   }
 
+  // Guard against non-positive pageSize so downstream math (ceil / multiply)
+  // can't produce Infinity or negative ranges.
+  const safePageSize = Math.max(1, Math.floor(pageSize))
   const safePage = Math.max(1, page)
-  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  const totalPages = Math.max(1, Math.ceil(total / safePageSize))
   const currentPage = Math.min(safePage, totalPages)
-  const firstItem = total === 0 ? 0 : (currentPage - 1) * pageSize + 1
-  const lastItem = Math.min(currentPage * pageSize, total)
+  const firstItem = total === 0 ? 0 : (currentPage - 1) * safePageSize + 1
+  const lastItem = Math.min(currentPage * safePageSize, total)
   const isFirstPage = currentPage <= 1
   const isLastPage = currentPage >= totalPages
 

--- a/renderer/src/common/components/ui/pagination.tsx
+++ b/renderer/src/common/components/ui/pagination.tsx
@@ -1,0 +1,125 @@
+import {
+  ChevronFirstIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from 'lucide-react'
+
+import { cn } from '@/common/lib/utils'
+import { Button } from '@/common/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/common/components/ui/select'
+
+export const DEFAULT_PAGE_SIZE_OPTIONS = [12, 24, 50, 100] as const
+
+type PaginationProps = {
+  page: number
+  pageSize: number
+  total: number
+  pageSizeOptions?: readonly number[]
+  onPageChange: (page: number) => void
+  onPageSizeChange: (size: number) => void
+  className?: string
+  itemLabel?: string
+}
+
+export function Pagination({
+  page,
+  pageSize,
+  total,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+  onPageChange,
+  onPageSizeChange,
+  className,
+  itemLabel = 'results',
+}: PaginationProps) {
+  const smallestOption = Math.min(...pageSizeOptions)
+  if (total <= 0 || total <= smallestOption) {
+    return null
+  }
+
+  const safePage = Math.max(1, page)
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  const currentPage = Math.min(safePage, totalPages)
+  const firstItem = total === 0 ? 0 : (currentPage - 1) * pageSize + 1
+  const lastItem = Math.min(currentPage * pageSize, total)
+  const isFirstPage = currentPage <= 1
+  const isLastPage = currentPage >= totalPages
+
+  return (
+    <div
+      className={cn(
+        `bg-background flex h-[52px] items-center justify-between rounded-md
+        border py-2 pr-2 pl-4`,
+        className
+      )}
+      data-slot="pagination"
+    >
+      <p className="text-muted-foreground text-sm">
+        Showing {firstItem}-{lastItem} of {total} {itemLabel}
+      </p>
+      <div className="flex items-center justify-center gap-2 opacity-80">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Go to first page"
+          disabled={isFirstPage}
+          onClick={() => onPageChange(1)}
+        >
+          <ChevronFirstIcon />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Go to previous page"
+          disabled={isFirstPage}
+          onClick={() => onPageChange(currentPage - 1)}
+        >
+          <ChevronLeftIcon />
+        </Button>
+        <p
+          className="text-foreground px-1 text-sm whitespace-nowrap"
+          aria-live="polite"
+        >
+          Page {currentPage}
+        </p>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Go to next page"
+          disabled={isLastPage}
+          onClick={() => onPageChange(currentPage + 1)}
+        >
+          <ChevronRightIcon />
+        </Button>
+      </div>
+      <div className="flex items-center gap-2">
+        <p className="text-secondary-foreground text-sm whitespace-nowrap">
+          Items per page
+        </p>
+        <Select
+          value={String(pageSize)}
+          onValueChange={(value) => onPageSizeChange(Number(value))}
+        >
+          <SelectTrigger
+            aria-label="Items per page"
+            className="h-10 border-0 shadow-none"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent align="end">
+            {pageSizeOptions.map((option) => (
+              <SelectItem key={option} value={String(option)}>
+                {option}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}

--- a/renderer/src/common/mocks/fixtures/registry_registryName_v0_1_x_dev_toolhive_skills/get.ts
+++ b/renderer/src/common/mocks/fixtures/registry_registryName_v0_1_x_dev_toolhive_skills/get.ts
@@ -1,0 +1,23 @@
+import type {
+  GetRegistryByRegistryNameV01xDevToolhiveSkillsResponse,
+  GetRegistryByRegistryNameV01xDevToolhiveSkillsData,
+} from '@common/api/generated/types.gen'
+import { AutoAPIMock } from '@mocks'
+
+export const mockedGetRegistryByRegistryNameV01XDevToolhiveSkills = AutoAPIMock<
+  GetRegistryByRegistryNameV01xDevToolhiveSkillsResponse,
+  GetRegistryByRegistryNameV01xDevToolhiveSkillsData
+>({
+  skills: [
+    {
+      name: 'sample-skill',
+      namespace: 'io.github.sample',
+      description: 'A sample registry skill used as fixture default.',
+    },
+  ],
+  metadata: {
+    page: 1,
+    limit: 12,
+    total: 1,
+  },
+})

--- a/renderer/src/common/mocks/fixtures/registry_registryName_v0_1_x_dev_toolhive_skills/get.ts
+++ b/renderer/src/common/mocks/fixtures/registry_registryName_v0_1_x_dev_toolhive_skills/get.ts
@@ -4,6 +4,11 @@ import type {
 } from '@common/api/generated/types.gen'
 import { AutoAPIMock } from '@mocks'
 
+// Name intentionally uses `V01X` (uppercase X): it must match the mock name
+// derived by `mocker.ts#toPascalCase` from the path segment `v0.1.x`, which is
+// what MSW looks up at runtime. The generated SDK types use `V01x` because
+// they come from a different codegen (`@hey-api/openapi-ts`) with its own
+// casing rules — don't align these without also updating the mocker.
 export const mockedGetRegistryByRegistryNameV01XDevToolhiveSkills = AutoAPIMock<
   GetRegistryByRegistryNameV01xDevToolhiveSkillsResponse,
   GetRegistryByRegistryNameV01xDevToolhiveSkillsData

--- a/renderer/src/features/registry-servers/components/registry-detail-header.tsx
+++ b/renderer/src/features/registry-servers/components/registry-detail-header.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@/common/components/ui/button'
 import { LinkViewTransition } from '@/common/components/link-view-transition'
 import { ChevronLeft } from 'lucide-react'
-import type { ReactNode } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
+import { useCanGoBack, useRouter } from '@tanstack/react-router'
 
 type RegistryDetailHeaderProps = {
   title: string
@@ -9,6 +10,13 @@ type RegistryDetailHeaderProps = {
   backSearch?: Record<string, unknown>
   badges?: ReactNode
   description?: string | null
+  /**
+   * When true, clicking the back button navigates using browser history
+   * (`router.history.back()`) so the previous search params (e.g. pagination)
+   * are restored. Falls back to navigating to `backTo` when there is no
+   * in-app history to go back to (direct deep-links).
+   */
+  historyBack?: boolean
 }
 
 export function RegistryDetailHeader({
@@ -17,11 +25,36 @@ export function RegistryDetailHeader({
   backSearch,
   badges,
   description,
+  historyBack = false,
 }: RegistryDetailHeaderProps) {
+  const router = useRouter()
+  const canGoBack = useCanGoBack()
+
+  const handleBackClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!historyBack || !canGoBack) return
+    // Let the browser handle modifier-clicks (open in new tab, etc.)
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return
+    }
+    event.preventDefault()
+    router.history.back()
+  }
+
   return (
     <div className="w-full">
       <div className="mb-5">
-        <LinkViewTransition to={backTo} search={backSearch}>
+        <LinkViewTransition
+          to={backTo}
+          search={backSearch}
+          onClick={handleBackClick}
+        >
           <Button variant="outline" aria-label="Back" className="rounded-full">
             <ChevronLeft className="size-4" />
             Back

--- a/renderer/src/features/skills/components/__tests__/skill-detail-layout.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/skill-detail-layout.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+  RouterProvider,
+} from '@tanstack/react-router'
+import { SkillDetailLayout } from '../skill-detail-layout'
+
+beforeAll(() => {
+  class FakeIntersectionObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return []
+    }
+    root = null
+    rootMargin = ''
+    thresholds = []
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).IntersectionObserver = FakeIntersectionObserver
+})
+
+function renderWithHistory(initialEntries: string[]) {
+  const rootRoute = createRootRoute({ component: Outlet })
+
+  const skillsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills',
+    component: () => <div data-testid="skills-page">skills page</div>,
+  })
+
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills_/$namespace/$skillName',
+    component: () => (
+      <SkillDetailLayout
+        title="Test Skill"
+        backTo="/skills"
+        backSearch={{ tab: 'registry' }}
+        actions={<div>actions</div>}
+      />
+    ),
+  })
+
+  const router = new Router({
+    routeTree: rootRoute.addChildren([skillsRoute, detailRoute]),
+    history: createMemoryHistory({ initialEntries }),
+    defaultNotFoundComponent: () => null,
+  })
+
+  render(<RouterProvider router={router} />)
+  return router
+}
+
+describe('SkillDetailLayout Back button', () => {
+  it('uses router.history.back() so the previous search params are restored', async () => {
+    const user = userEvent.setup()
+    const router = renderWithHistory([
+      '/skills?tab=registry&page=3&limit=24',
+      '/skills_/io.github.test/skill-1',
+    ])
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'Test Skill' })
+      ).toBeVisible()
+    })
+
+    await user.click(screen.getAllByRole('link', { name: /back/i })[0]!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('skills-page')).toBeVisible()
+    })
+
+    expect(router.state.location.pathname).toBe('/skills')
+    expect(router.state.location.search).toMatchObject({
+      tab: 'registry',
+      page: 3,
+      limit: 24,
+    })
+  })
+
+  it('falls back to the link target when there is no history to go back to (deep-link)', async () => {
+    const user = userEvent.setup()
+    const router = renderWithHistory(['/skills_/io.github.test/skill-1'])
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'Test Skill' })
+      ).toBeVisible()
+    })
+
+    await user.click(screen.getAllByRole('link', { name: /back/i })[0]!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('skills-page')).toBeVisible()
+    })
+
+    expect(router.state.location.pathname).toBe('/skills')
+    expect(router.state.location.search).toMatchObject({ tab: 'registry' })
+  })
+})

--- a/renderer/src/features/skills/components/__tests__/skills-page.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/skills-page.test.tsx
@@ -1,0 +1,305 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { StrictMode } from 'react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider } from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
+import { createFileRouteTestRouter } from '@/common/test/create-file-route-test-router'
+import { Route as SkillsRouteImport } from '@/routes/skills'
+import { PromptProvider } from '@/common/contexts/prompt/provider'
+import { PermissionsProvider } from '@/common/contexts/permissions/permissions-provider'
+import { SkillsPage } from '../skills-page'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { mockedGetApiV1BetaDiscoveryClients } from '@mocks/fixtures/discovery_clients/get'
+import { mockedGetApiV1BetaSkills } from '@mocks/fixtures/skills/get'
+import { mockedGetRegistryByRegistryNameV01XDevToolhiveSkills } from '@mocks/fixtures/registry_registryName_v0_1_x_dev_toolhive_skills/get'
+import { HttpResponse } from 'msw'
+
+function skillsFor(
+  page: number,
+  limit: number,
+  total: number
+): RegistrySkill[] {
+  const firstIndex = (page - 1) * limit
+  const lastIndex = Math.min(total, firstIndex + limit)
+  const size = Math.max(0, lastIndex - firstIndex)
+  return Array.from({ length: size }, (_, i) => {
+    const n = firstIndex + i + 1
+    return {
+      name: `skill-${n}`,
+      namespace: 'io.github.test',
+      description: `Skill number ${n}`,
+    }
+  })
+}
+
+function setupRegistryMock(total: number) {
+  mockedGetRegistryByRegistryNameV01XDevToolhiveSkills.overrideHandler(
+    (_data, info) => {
+      const url = new URL(info.request.url)
+      const page = Number(url.searchParams.get('page') ?? 1)
+      const limit = Number(url.searchParams.get('limit') ?? 12)
+      const search = url.searchParams.get('q') ?? ''
+      const effectiveTotal = search ? Math.min(total, 25) : total
+      return HttpResponse.json({
+        skills: skillsFor(page, limit, effectiveTotal),
+        metadata: { page, limit, total: effectiveTotal },
+      })
+    }
+  )
+}
+
+function renderSkillsPage() {
+  const router = createTestRouter(SkillsPage, '/skills')
+  router.history.replace('/skills?tab=registry')
+  return renderRoute(router)
+}
+
+beforeEach(() => {
+  mockedGetApiV1BetaDiscoveryClients.activateScenario('empty')
+  mockedGetApiV1BetaSkills.activateScenario('empty')
+})
+
+describe('SkillsPage registry pagination', () => {
+  it('renders the first page with default limit of 12', async () => {
+    setupRegistryMock(100)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-1')).toBeVisible()
+      expect(screen.getByText('skill-12')).toBeVisible()
+    })
+
+    expect(screen.queryByText('skill-13')).not.toBeInTheDocument()
+    expect(screen.getByText('Page 1')).toBeVisible()
+    expect(screen.getByText('Showing 1-12 of 100 skills')).toBeVisible()
+  })
+
+  it('advances to the next page when Next is clicked', async () => {
+    const user = userEvent.setup()
+    setupRegistryMock(100)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-1')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-13')).toBeVisible()
+      expect(screen.getByText('skill-24')).toBeVisible()
+    })
+    expect(screen.getByText('Page 2')).toBeVisible()
+    expect(screen.queryByText('skill-1')).not.toBeInTheDocument()
+  })
+
+  it('resets to page 1 when the page size changes', async () => {
+    const user = userEvent.setup()
+    setupRegistryMock(200)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-1')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Page 2')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('combobox', { name: /items per page/i }))
+    await user.click(screen.getByRole('option', { name: '50' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 1-50 of 200 skills')).toBeVisible()
+    })
+    expect(screen.getByText('Page 1')).toBeVisible()
+    expect(screen.getByText('skill-1')).toBeVisible()
+    expect(screen.getByText('skill-50')).toBeVisible()
+  })
+
+  it('resets to page 1 when the search query changes', async () => {
+    const user = userEvent.setup()
+    setupRegistryMock(100)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-1')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Page 2')).toBeVisible()
+    })
+
+    const search = screen.getByPlaceholderText('Search...')
+    await user.type(search, 'foo')
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 1-12 of 25 skills')).toBeVisible()
+    })
+    expect(screen.getByText('Page 1')).toBeVisible()
+  })
+
+  it('hides the pagination bar when the total fits in the smallest page size', async () => {
+    setupRegistryMock(10)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-1')).toBeVisible()
+    })
+
+    expect(
+      screen.queryByRole('button', { name: /go to next page/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('disables Next when on the last page of a larger result set', async () => {
+    const user = userEvent.setup()
+    setupRegistryMock(20)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 1-12 of 20 skills')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 13-20 of 20 skills')).toBeVisible()
+    })
+    expect(screen.getByText('Page 2')).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /go to next page/i })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /go to previous page/i })
+    ).toBeEnabled()
+  })
+
+  it('reads page and limit from the URL so back-navigation restores them', async () => {
+    setupRegistryMock(200)
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const router = createFileRouteTestRouter(
+      SkillsRouteImport,
+      '/skills',
+      '/skills?tab=registry&page=3&limit=24',
+      queryClient
+    )
+
+    render(
+      <PermissionsProvider>
+        <PromptProvider>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </PromptProvider>
+      </PermissionsProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 49-72 of 200 skills')).toBeVisible()
+    })
+    expect(screen.getByText('Page 3')).toBeVisible()
+    expect(screen.getByText('skill-49')).toBeVisible()
+    expect(screen.getByText('skill-72')).toBeVisible()
+  })
+
+  it('preserves the URL page under React StrictMode double-effect invocation', async () => {
+    // Regression guard: a boolean "first-run" ref guard on the search-reset
+    // effect broke under StrictMode dev, silently resetting page=1 on mount.
+    setupRegistryMock(200)
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const router = createFileRouteTestRouter(
+      SkillsRouteImport,
+      '/skills',
+      '/skills?tab=registry&page=3&limit=24',
+      queryClient
+    )
+
+    render(
+      <StrictMode>
+        <PermissionsProvider>
+          <PromptProvider>
+            <QueryClientProvider client={queryClient}>
+              <RouterProvider router={router} />
+            </QueryClientProvider>
+          </PromptProvider>
+        </PermissionsProvider>
+      </StrictMode>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Page 3')).toBeVisible()
+    })
+    expect(router.state.location.search).toMatchObject({
+      tab: 'registry',
+      page: 3,
+      limit: 24,
+    })
+  })
+
+  it('updates the URL when the page changes so navigating back works', async () => {
+    const user = userEvent.setup()
+    setupRegistryMock(100)
+    const router = createTestRouter(SkillsPage, '/skills')
+    router.history.replace('/skills?tab=registry')
+
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-1')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Page 3')).toBeVisible()
+    })
+
+    const { search } = router.state.location
+    expect(search).toMatchObject({ tab: 'registry', page: 3 })
+  })
+
+  it('returns to the first page via the First button', async () => {
+    const user = userEvent.setup()
+    setupRegistryMock(100)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-1')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Page 3')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('button', { name: /go to first page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Page 1')).toBeVisible()
+    })
+
+    // sanity: there is no "skill-25" on page 1
+    const grid = screen.getByRole('tabpanel', { name: /registry/i })
+    expect(within(grid).queryByText('skill-25')).not.toBeInTheDocument()
+  })
+})

--- a/renderer/src/features/skills/components/skill-detail-layout.tsx
+++ b/renderer/src/features/skills/components/skill-detail-layout.tsx
@@ -1,9 +1,16 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from 'react'
 import { ChevronLeft } from 'lucide-react'
 import { Button } from '@/common/components/ui/button'
 import { LinkViewTransition } from '@/common/components/link-view-transition'
 import { RegistryDetailHeader } from '@/features/registry-servers/components/registry-detail-header'
 import { cn } from '@/common/lib/utils'
+import { useCanGoBack, useRouter } from '@tanstack/react-router'
 
 interface SkillDetailLayoutProps {
   title: string
@@ -26,6 +33,24 @@ export function SkillDetailLayout({
 }: SkillDetailLayoutProps) {
   const headerRef = useRef<HTMLDivElement>(null)
   const [isHeaderVisible, setIsHeaderVisible] = useState(true)
+  const router = useRouter()
+  const canGoBack = useCanGoBack()
+
+  const handleBackClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!canGoBack) return
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return
+    }
+    event.preventDefault()
+    router.history.back()
+  }
 
   useEffect(() => {
     const target = headerRef.current
@@ -50,6 +75,7 @@ export function SkillDetailLayout({
           backTo={backTo}
           backSearch={backSearch}
           badges={badges}
+          historyBack
         />
       </div>
 
@@ -69,7 +95,11 @@ export function SkillDetailLayout({
             <div className="overflow-hidden">
               <div className="flex flex-col gap-3 pb-1">
                 <div>
-                  <LinkViewTransition to={backTo} search={backSearch}>
+                  <LinkViewTransition
+                    to={backTo}
+                    search={backSearch}
+                    onClick={handleBackClick}
+                  >
                     <Button
                       variant="outline"
                       aria-label="Back"

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -16,6 +16,7 @@ import {
   TabsTrigger,
   TabsContent,
 } from '@/common/components/ui/tabs'
+import { Pagination } from '@/common/components/ui/pagination'
 import { GridCardsSkills } from './grid-cards-skills'
 import { GridCardsBuilds } from './grid-cards-builds'
 import { GridCardsRegistrySkills } from './grid-cards-registry-skills'
@@ -28,25 +29,54 @@ import { ViewToggle } from '@/common/components/view-toggle'
 import { useViewPreference } from '@/common/hooks/use-view-preference'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { useNavigate, useSearch } from '@tanstack/react-router'
+import type { SkillsSearch } from '@/routes/skills'
 import { trackEvent } from '@/common/lib/analytics'
+import { REGISTRY_PAGE_SIZE_OPTIONS } from '../lib/registry-pagination'
 
 type Tab = 'registry' | 'installed' | 'builds'
 
 export function SkillsPage() {
   const [buildOpen, setBuildOpen] = useState(false)
-  const { tab } = useSearch({ from: '/skills' })
+  const {
+    tab,
+    page: registryPage,
+    limit: registryLimit,
+  } = useSearch({ from: '/skills' })
   const navigate = useNavigate({ from: '/skills' })
 
   function setTab(value: Tab) {
     trackEvent('Skills: tab changed', { tab: value })
-    void navigate({ search: { tab: value }, replace: true })
+    void navigate({
+      search: (prev: SkillsSearch) => ({ ...prev, tab: value }),
+      replace: true,
+    })
   }
 
-  // Registry tab search (server-side, debounced)
+  function setRegistryPage(page: number) {
+    void navigate({
+      search: (prev: SkillsSearch) => ({ ...prev, page }),
+      replace: true,
+    })
+  }
+
+  function setRegistryLimit(limit: number) {
+    void navigate({
+      search: (prev: SkillsSearch) => ({ ...prev, limit, page: 1 }),
+      replace: true,
+    })
+  }
+
+  // Registry tab search (server-side, debounced). The debounced callback only
+  // fires as a result of user input, so resetting the page to 1 here is a
+  // regular event handler — no effect required.
   const [registrySearch, setRegistrySearch] = useState('')
   const [debouncedRegistrySearch, setDebouncedRegistrySearch] = useState('')
   const debouncedSetRegistrySearch = useDebouncedCallback((value: string) => {
     setDebouncedRegistrySearch(value)
+    void navigate({
+      search: (prev: SkillsSearch) => ({ ...prev, page: 1 }),
+      replace: true,
+    })
     trackEvent('Skills: registry search', {
       query_length: value.length,
       has_query: value.length > 0 ? 'true' : 'false',
@@ -58,15 +88,19 @@ export function SkillsPage() {
     debouncedSetRegistrySearch(value)
   }
 
-  const { data: registryData } = useQuery(
-    getRegistryByRegistryNameV01xDevToolhiveSkillsOptions({
+  const { data: registryData } = useQuery({
+    ...getRegistryByRegistryNameV01xDevToolhiveSkillsOptions({
       path: { registryName: 'default' },
-      query: debouncedRegistrySearch
-        ? { q: debouncedRegistrySearch }
-        : undefined,
-    })
-  )
+      query: {
+        page: registryPage,
+        limit: registryLimit,
+        ...(debouncedRegistrySearch ? { q: debouncedRegistrySearch } : {}),
+      },
+    }),
+    placeholderData: (prev) => prev,
+  })
   const registrySkills = registryData?.skills ?? []
+  const registryMetadata = registryData?.metadata
 
   // Installed tab
   const { data } = useSuspenseQuery(getApiV1BetaSkillsOptions())
@@ -188,12 +222,32 @@ export function SkillsPage() {
           </div>
         </div>
 
-        <TabsContent value="registry">
+        <TabsContent value="registry" className="flex flex-col gap-4">
           {registryView === 'table' ? (
             <TableRegistrySkills skills={registrySkills} />
           ) : (
             <GridCardsRegistrySkills skills={registrySkills} />
           )}
+          <Pagination
+            page={registryMetadata?.page ?? registryPage}
+            pageSize={registryMetadata?.limit ?? registryLimit}
+            total={registryMetadata?.total ?? 0}
+            pageSizeOptions={REGISTRY_PAGE_SIZE_OPTIONS}
+            itemLabel="skills"
+            onPageChange={(page) => {
+              trackEvent('Skills: registry page changed', {
+                page,
+                limit: registryLimit,
+              })
+              setRegistryPage(page)
+            }}
+            onPageSizeChange={(limit) => {
+              trackEvent('Skills: registry page size changed', {
+                limit,
+              })
+              setRegistryLimit(limit)
+            }}
+          />
         </TabsContent>
 
         <TabsContent value="installed">

--- a/renderer/src/features/skills/lib/registry-pagination.ts
+++ b/renderer/src/features/skills/lib/registry-pagination.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_REGISTRY_PAGE_SIZE = 12
+export const REGISTRY_PAGE_SIZE_OPTIONS = [12, 24, 50, 100] as const

--- a/renderer/src/features/skills/lib/registry-pagination.ts
+++ b/renderer/src/features/skills/lib/registry-pagination.ts
@@ -1,2 +1,4 @@
-export const DEFAULT_REGISTRY_PAGE_SIZE = 12
-export const REGISTRY_PAGE_SIZE_OPTIONS = [12, 24, 50, 100] as const
+import { DEFAULT_PAGE_SIZE_OPTIONS } from '@/common/components/ui/pagination'
+
+export const REGISTRY_PAGE_SIZE_OPTIONS = DEFAULT_PAGE_SIZE_OPTIONS
+export const DEFAULT_REGISTRY_PAGE_SIZE = REGISTRY_PAGE_SIZE_OPTIONS[0]

--- a/renderer/src/routes/skills.tsx
+++ b/renderer/src/routes/skills.tsx
@@ -5,23 +5,48 @@ import {
   getRegistryByRegistryNameV01xDevToolhiveSkillsOptions,
 } from '@common/api/generated/@tanstack/react-query.gen'
 import { SkillsPage } from '@/features/skills/components/skills-page'
+import {
+  DEFAULT_REGISTRY_PAGE_SIZE,
+  REGISTRY_PAGE_SIZE_OPTIONS,
+} from '@/features/skills/lib/registry-pagination'
 
 const VALID_TABS = ['registry', 'installed', 'builds'] as const
 type SkillsTab = (typeof VALID_TABS)[number]
 
+export type SkillsSearch = {
+  tab: SkillsTab
+  page: number
+  limit: number
+}
+
 export const Route = createFileRoute('/skills')({
-  validateSearch: (search: Record<string, unknown>): { tab: SkillsTab } => ({
-    tab: VALID_TABS.includes(search.tab as SkillsTab)
+  validateSearch: (search: Record<string, unknown>): SkillsSearch => {
+    const tab = VALID_TABS.includes(search.tab as SkillsTab)
       ? (search.tab as SkillsTab)
-      : 'installed',
-  }),
-  loader: ({ context: { queryClient } }) =>
+      : 'installed'
+
+    const pageNum = Number(search.page)
+    const page =
+      Number.isFinite(pageNum) && pageNum >= 1 ? Math.floor(pageNum) : 1
+
+    const limitNum = Number(search.limit)
+    const limit = (REGISTRY_PAGE_SIZE_OPTIONS as readonly number[]).includes(
+      limitNum
+    )
+      ? limitNum
+      : DEFAULT_REGISTRY_PAGE_SIZE
+
+    return { tab, page, limit }
+  },
+  loaderDeps: ({ search: { page, limit } }) => ({ page, limit }),
+  loader: ({ context: { queryClient }, deps: { page, limit } }) =>
     Promise.all([
       queryClient.ensureQueryData(getApiV1BetaSkillsOptions()),
       queryClient.ensureQueryData(getApiV1BetaSkillsBuildsOptions()),
       queryClient.ensureQueryData(
         getRegistryByRegistryNameV01xDevToolhiveSkillsOptions({
           path: { registryName: 'default' },
+          query: { page, limit },
         })
       ),
     ]),


### PR DESCRIPTION
The skills registry API exposes `page` / `limit` and a total count, but the Registry tab always asked for page 1 and client-rendered everything. This PR wires up real server-side pagination, persists `page` / `limit` in the URL so they survive navigating into a skill detail and back, and extracts the controls into a reusable component.


https://github.com/user-attachments/assets/49991109-4363-4624-a93d-35878ac2763d



## Summary

- Reusable `Pagination` component (results counter, first / prev / next, current page, items-per-page selector). Hides itself when the total fits in the smallest page size.
- Skills → Registry tab paginates server-side, defaulting to 12 with options `[12, 24, 50, 100]`.
- `page` and `limit` live in the `/skills` route search params, so refresh and back-navigation from the skill detail restore the exact page.
- Back button on the skill detail now pops history (`router.history.back()`) instead of issuing a fresh navigation that stripped `page` / `limit`.
- Moved the "reset to page 1 on new search" logic out of a `useEffect` and into the debounced event handler — per [React – You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect) — which also fixes a StrictMode dev bug where the double-invoked effect clobbered the URL's `page` on every mount.

## How to validate

1. Skills → Registry shows a pagination bar with "Showing 1–12 of N skills".
2. Click Next / change page size / type a search — URL updates in place (`replace`), search resets to page 1.
3. Open a skill card → Back. You land on the page / size you left, not page 1.
4. Deep-link to `/skills_/ns/name` → Back falls through to `/skills?tab=registry`.
5. Registries with ≤ 12 skills don't show the pagination bar.

## Tests

- `pnpm test:nonInteractive` — 1913 passing. New coverage: `Pagination` unit tests, `SkillsPage` pagination integration tests (incl. StrictMode regression + URL round-trip), `SkillDetailLayout` back-button tests.
- `pnpm type-check` clean.