### PR TITLE
fix(skills): raise registry card Install button above navigation overlay

### DIFF
--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -67,7 +67,7 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
             ) : null}
             <Button
               variant="secondary"
-              className="rounded-full"
+              className="relative z-10 rounded-full"
               onClick={(e) => {
                 e.stopPropagation()
                 trackEvent('Skills: install dialog opened', {


### PR DESCRIPTION
On the Skills > Registry tab, clicking **Install** on a card would navigate to the skill detail page instead of opening the install dialog. The Local Builds and Installed tabs were unaffected.

## Root cause

[`card-skill-base.tsx`](renderer/src/features/skills/components/card-skill-base.tsx) renders a full-card click overlay — an absolutely-positioned `<span>` pinned to `inset-0` inside the title button — to make the whole card a navigation target. Because the overlay is absolutely positioned against the `relative` `Card`, it stacks above any statically-positioned descendant, including footer buttons. Siblings in the footer have to opt into their own stacking context (`position: relative` + a `z-index`) to receive their own clicks, otherwise the overlay captures the pointer and the card-level `onClick` runs instead.

Every other action button in the Skills cards already does this:

- [`card-build.tsx`](renderer/src/features/skills/components/card-build.tsx) — Install and Remove use `relative z-10`.
- [`card-skill.tsx`](renderer/src/features/skills/components/card-skill.tsx) — Uninstall uses `relative z-10`.
- [`card-registry-skill.tsx`](renderer/src/features/skills/components/card-registry-skill.tsx) — the sibling GitHub link uses `relative z-10`.

The Install button in `card-registry-skill.tsx` was the only one missing the escape hatch, so the overlay kept eating its clicks. The existing `e.stopPropagation()` on the handler was correct but never fired — the event never reached the button in the first place.

## Changes

- [`card-registry-skill.tsx`](renderer/src/features/skills/components/card-registry-skill.tsx): add `relative z-10` to the Install button's class list, matching the pattern used on the other Skills cards.

No logic, analytics, or markup changes beyond the class tweak.

## Verification

- On **Skills > Registry** (both grid and table views), clicking **Install** opens the install dialog. Clicking the title or any empty area of the card still navigates to the skill detail page.
- **Local Builds** and **Installed** tabs behave as before.
- Existing tests in [`card-registry-skill.test.tsx`](renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx) — `opens the install dialog when Install button is clicked` and `does not navigate when Install button is clicked` — continue to pass; they exercise the `onClick` path via userEvent and are unaffected by the z-index fix.