### PR TITLE
fix(ci): grant security-fix job permissions in scheduled workflow

### DIFF
--- a/.github/workflows/security-fix-cron.yml
+++ b/.github/workflows/security-fix-cron.yml
@@ -18,4 +18,9 @@ jobs:
     needs: security
     if: ${{ always() && needs.security.result == 'failure' }}
     uses: ./.github/workflows/_security-fix-agent.yml
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
     secrets: inherit


### PR DESCRIPTION
## Summary

- Fix \`Invalid workflow file\` error on the scheduled security run caused by the top-level \`permissions: contents: read\` in \`security-fix-cron.yml\` capping the permissions of the reusable \`_security-fix-agent.yml\` workflow.
- Grant the required permissions (\`contents: write\`, \`pull-requests: write\`, \`issues: write\`, \`id-token: write\`) explicitly on the \`security-fix\` job — same pattern already used in \`on-main.yml\` (#2094).
- The \`security\` job continues to inherit the safer \`contents: read\` default.

The failing workflow error was:

> The nested job 'remediate' is requesting 'contents: write, issues: write, pull-requests: write, id-token: write', but is only allowed 'contents: read,
