### PR TITLE
fix(main): enhance PATH when spawning thv so macOS credential helpers resolve

### DIFF
--- a/main/src/container-engine.ts
+++ b/main/src/container-engine.ts
@@ -2,6 +2,7 @@ import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
 import { platform } from 'node:os'
 import log from './logger'
+import { createEnhancedPath } from './utils/enhanced-path'
 
 const execAsync = promisify(exec)
 
@@ -9,45 +10,6 @@ interface ContainerEngineStatus {
   docker: boolean
   podman: boolean
   available: boolean
-}
-
-// Common installation paths by platform
-const getCommonPaths = (): string[] => {
-  const currentPlatform = platform()
-
-  switch (currentPlatform) {
-    case 'darwin':
-      return [
-        '/Applications/Docker.app/Contents/Resources/bin',
-        '/opt/homebrew/bin',
-        '/usr/local/bin',
-        '~/.rd/bin',
-      ]
-    case 'linux':
-      return ['/usr/local/bin', '/opt/homebrew/bin', '/snap/bin', '~/.rd/bin']
-    case 'win32':
-      return [
-        'C:\\Program Files\\Docker\\Docker\\resources\\bin',
-        'C:\\Program Files\\RedHat\\Podman',
-      ]
-    default:
-      return []
-  }
-}
-
-const expandPath = (path: string): string =>
-  path.startsWith('~')
-    ? path.replace('~', process.env.HOME || process.env.USERPROFILE || '')
-    : path
-
-const createEnhancedPath = (): string => {
-  const commonPaths = getCommonPaths().map(expandPath)
-  const currentPath = process.env.PATH || ''
-  const separator = platform() === 'win32' ? ';' : ':'
-
-  return [...commonPaths, ...currentPath.split(separator)]
-    .filter(Boolean)
-    .join(separator)
 }
 
 const tryCommand = async (command: string): Promise<boolean> => {

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -454,6 +454,49 @@ describe('toolhive-manager', () => {
       expect(spawnArgs.some((a) => a.startsWith('--sentry-'))).toBe(false)
     })
 
+    it('spawns with an enhanced PATH that includes common container-tooling dirs', async () => {
+      const originalPath = process.env.PATH
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      })
+      vi.stubEnv('PATH', '/usr/bin:/bin')
+
+      try {
+        const startPromise = startToolhive()
+        await vi.advanceTimersByTimeAsync(50)
+        await startPromise
+
+        const spawnOptions = mockSpawn.mock.calls[0]![2] as {
+          env: Record<string, string>
+        }
+        const spawnedPath = spawnOptions.env.PATH
+        expect(spawnedPath).toBeDefined()
+        const entries = spawnedPath!.split(':')
+
+        expect(entries).toContain(
+          '/Applications/Docker.app/Contents/Resources/bin'
+        )
+        expect(entries).toContain('/opt/homebrew/bin')
+        expect(entries).toContain('/usr/local/bin')
+        expect(entries).toContain('/usr/bin')
+        expect(entries).toContain('/bin')
+
+        expect(spawnOptions.env.TOOLHIVE_SKIP_DESKTOP_CHECK).toBe('true')
+      } finally {
+        Object.defineProperty(process, 'platform', {
+          value: originalPlatform,
+          configurable: true,
+        })
+        if (originalPath === undefined) {
+          delete process.env.PATH
+        } else {
+          process.env.PATH = originalPath
+        }
+      }
+    })
+
     it('omits sentry flags when telemetry is disabled', async () => {
       vi.stubEnv('VITE_SENTRY_THV_DSN', 'https://test@sentry.io/123')
       vi.mocked(readSetting).mockReturnValue('false')

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events'
 import { vol } from 'memfs'
 import { spawn } from 'node:child_process'
 import net from 'node:net'
+import { platform } from 'node:os'
 import { app } from 'electron'
 import {
   startToolhive,
@@ -29,6 +30,18 @@ vi.mock('node:child_process', async (importOriginal) => {
     default: {
       ...actual,
       spawn: mockSpawnFn,
+    },
+  }
+})
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  const platformMock = vi.fn(actual.platform)
+  return {
+    ...actual,
+    platform: platformMock,
+    default: {
+      ...actual,
+      platform: platformMock,
     },
   }
 })
@@ -455,46 +468,29 @@ describe('toolhive-manager', () => {
     })
 
     it('spawns with an enhanced PATH that includes common container-tooling dirs', async () => {
-      const originalPath = process.env.PATH
-      const originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', {
-        value: 'darwin',
-        configurable: true,
-      })
+      vi.mocked(platform).mockReturnValue('darwin')
       vi.stubEnv('PATH', '/usr/bin:/bin')
 
-      try {
-        const startPromise = startToolhive()
-        await vi.advanceTimersByTimeAsync(50)
-        await startPromise
+      const startPromise = startToolhive()
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
 
-        const spawnOptions = mockSpawn.mock.calls[0]![2] as {
-          env: Record<string, string>
-        }
-        const spawnedPath = spawnOptions.env.PATH
-        expect(spawnedPath).toBeDefined()
-        const entries = spawnedPath!.split(':')
-
-        expect(entries).toContain(
-          '/Applications/Docker.app/Contents/Resources/bin'
-        )
-        expect(entries).toContain('/opt/homebrew/bin')
-        expect(entries).toContain('/usr/local/bin')
-        expect(entries).toContain('/usr/bin')
-        expect(entries).toContain('/bin')
-
-        expect(spawnOptions.env.TOOLHIVE_SKIP_DESKTOP_CHECK).toBe('true')
-      } finally {
-        Object.defineProperty(process, 'platform', {
-          value: originalPlatform,
-          configurable: true,
-        })
-        if (originalPath === undefined) {
-          delete process.env.PATH
-        } else {
-          process.env.PATH = originalPath
-        }
+      const spawnOptions = mockSpawn.mock.calls[0]![2] as {
+        env: Record<string, string>
       }
+      const spawnedPath = spawnOptions.env.PATH
+      expect(spawnedPath).toBeDefined()
+      const entries = spawnedPath!.split(':')
+
+      expect(entries).toContain(
+        '/Applications/Docker.app/Contents/Resources/bin'
+      )
+      expect(entries).toContain('/opt/homebrew/bin')
+      expect(entries).toContain('/usr/local/bin')
+      expect(entries).toContain('/usr/bin')
+      expect(entries).toContain('/bin')
+
+      expect(spawnOptions.env.TOOLHIVE_SKIP_DESKTOP_CHECK).toBe('true')
     })
 
     it('omits sentry flags when telemetry is disabled', async () => {

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -8,6 +8,7 @@ import log from './logger'
 import * as Sentry from '@sentry/electron/main'
 import { getQuittingState } from './app-state'
 import { readSetting } from './db/readers/settings-reader'
+import { createEnhancedPath } from './utils/enhanced-path'
 import {
   ALREADY_RUNNING,
   REGISTRY_AUTH_REQUIRED,
@@ -182,6 +183,7 @@ export async function startToolhive(): Promise<void> {
       windowsHide: true,
       env: {
         ...process.env,
+        PATH: createEnhancedPath(),
         TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
       },
     })

--- a/main/src/utils/__tests__/enhanced-path.test.ts
+++ b/main/src/utils/__tests__/enhanced-path.test.ts
@@ -56,6 +56,19 @@ describe('createEnhancedPath', () => {
     expect(result).not.toContain('~')
   })
 
+  it('keeps ~ verbatim when HOME and USERPROFILE are both unset', () => {
+    mockPlatform.mockReturnValue('darwin')
+    vi.stubEnv('PATH', '')
+    vi.stubEnv('HOME', '')
+    vi.stubEnv('USERPROFILE', '')
+
+    const result = createEnhancedPath()
+    const entries = result.split(':')
+
+    expect(entries).toContain('~/.rd/bin')
+    expect(entries).not.toContain('/.rd/bin')
+  })
+
   it('uses semicolon as separator on win32', () => {
     mockPlatform.mockReturnValue('win32')
     vi.stubEnv('PATH', 'C:\\Windows\\System32;C:\\Windows')

--- a/main/src/utils/__tests__/enhanced-path.test.ts
+++ b/main/src/utils/__tests__/enhanced-path.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { platform } from 'node:os'
+
+import { createEnhancedPath } from '../enhanced-path'
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  const platformMock = vi.fn(actual.platform)
+  return {
+    ...actual,
+    platform: platformMock,
+    default: {
+      ...actual,
+      platform: platformMock,
+    },
+  }
+})
+
+const mockPlatform = vi.mocked(platform)
+
+describe('createEnhancedPath', () => {
+  beforeEach(() => {
+    mockPlatform.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('prepends macOS container-tooling paths on darwin', () => {
+    mockPlatform.mockReturnValue('darwin')
+    vi.stubEnv('PATH', '/usr/bin:/bin')
+    vi.stubEnv('HOME', '/Users/test')
+
+    const result = createEnhancedPath()
+    const entries = result.split(':')
+
+    expect(entries.slice(0, 4)).toEqual([
+      '/Applications/Docker.app/Contents/Resources/bin',
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/Users/test/.rd/bin',
+    ])
+    expect(entries).toContain('/usr/bin')
+    expect(entries).toContain('/bin')
+  })
+
+  it('expands ~ using HOME', () => {
+    mockPlatform.mockReturnValue('darwin')
+    vi.stubEnv('PATH', '')
+    vi.stubEnv('HOME', '/Users/alice')
+
+    const result = createEnhancedPath()
+
+    expect(result).toContain('/Users/alice/.rd/bin')
+    expect(result).not.toContain('~')
+  })
+
+  it('uses semicolon as separator on win32', () => {
+    mockPlatform.mockReturnValue('win32')
+    vi.stubEnv('PATH', 'C:\\Windows\\System32;C:\\Windows')
+
+    const result = createEnhancedPath()
+    const entries = result.split(';')
+
+    expect(entries[0]).toBe('C:\\Program Files\\Docker\\Docker\\resources\\bin')
+    expect(entries[1]).toBe('C:\\Program Files\\RedHat\\Podman')
+    expect(entries).toContain('C:\\Windows\\System32')
+    expect(entries).toContain('C:\\Windows')
+  })
+
+  it('prepends linux container-tooling paths', () => {
+    mockPlatform.mockReturnValue('linux')
+    vi.stubEnv('PATH', '/usr/bin:/bin')
+    vi.stubEnv('HOME', '/home/test')
+
+    const result = createEnhancedPath()
+    const entries = result.split(':')
+
+    expect(entries.slice(0, 4)).toEqual([
+      '/usr/local/bin',
+      '/opt/homebrew/bin',
+      '/snap/bin',
+      '/home/test/.rd/bin',
+    ])
+  })
+
+  it('preserves existing PATH entries after the prepended paths', () => {
+    mockPlatform.mockReturnValue('darwin')
+    vi.stubEnv('PATH', '/existing/bin:/another/bin')
+    vi.stubEnv('HOME', '/Users/test')
+
+    const result = createEnhancedPath()
+    const entries = result.split(':')
+
+    const existingIndex = entries.indexOf('/existing/bin')
+    const anotherIndex = entries.indexOf('/another/bin')
+
+    expect(existingIndex).toBeGreaterThan(-1)
+    expect(anotherIndex).toBeGreaterThan(existingIndex)
+  })
+
+  it('handles empty PATH gracefully', () => {
+    mockPlatform.mockReturnValue('darwin')
+    vi.stubEnv('PATH', '')
+    vi.stubEnv('HOME', '/Users/test')
+
+    const result = createEnhancedPath()
+
+    expect(result).not.toBe('')
+    expect(result).toContain('/usr/local/bin')
+    // No trailing empty segments from the split/join
+    expect(result.endsWith(':')).toBe(false)
+  })
+})

--- a/main/src/utils/enhanced-path.ts
+++ b/main/src/utils/enhanced-path.ts
@@ -1,0 +1,39 @@
+import { platform } from 'node:os'
+
+const getCommonPaths = (): string[] => {
+  const currentPlatform = platform()
+
+  switch (currentPlatform) {
+    case 'darwin':
+      return [
+        '/Applications/Docker.app/Contents/Resources/bin',
+        '/opt/homebrew/bin',
+        '/usr/local/bin',
+        '~/.rd/bin',
+      ]
+    case 'linux':
+      return ['/usr/local/bin', '/opt/homebrew/bin', '/snap/bin', '~/.rd/bin']
+    case 'win32':
+      return [
+        'C:\\Program Files\\Docker\\Docker\\resources\\bin',
+        'C:\\Program Files\\RedHat\\Podman',
+      ]
+    default:
+      return []
+  }
+}
+
+const expandPath = (path: string): string =>
+  path.startsWith('~')
+    ? path.replace('~', process.env.HOME || process.env.USERPROFILE || '')
+    : path
+
+export const createEnhancedPath = (): string => {
+  const commonPaths = getCommonPaths().map(expandPath)
+  const currentPath = process.env.PATH || ''
+  const separator = platform() === 'win32' ? ';' : ':'
+
+  return [...commonPaths, ...currentPath.split(separator)]
+    .filter(Boolean)
+    .join(separator)
+}

--- a/main/src/utils/enhanced-path.ts
+++ b/main/src/utils/enhanced-path.ts
@@ -23,10 +23,11 @@ const getCommonPaths = (): string[] => {
   }
 }
 
-const expandPath = (path: string): string =>
-  path.startsWith('~')
-    ? path.replace('~', process.env.HOME || process.env.USERPROFILE || '')
-    : path
+const expandPath = (path: string): string => {
+  if (!path.startsWith('~')) return path
+  const homeDir = process.env.HOME || process.env.USERPROFILE
+  return homeDir ? path.replace('~', homeDir) : path
+}
 
 export const createEnhancedPath = (): string => {
   const commonPaths = getCommonPaths().map(expandPath)


### PR DESCRIPTION
On macOS, installing a skill from the registry fails with:

> pulling OCI artifact "ghcr.io/stacklok/dockyard/skills/agents-md:0.1.0": pulling from registry: failed to perform "FetchReference" on source: GET "https://ghcr.io/v2/...": exec: "docker-credential-osxkeychain": executable file not found in $PATH

The error only reproduces when Studio is launched from the Dock / Finder / Spotlight — launching `thv` from a terminal works fine.

## Root cause

GUI-launched apps on macOS inherit a minimal PATH from `launchd` (typically `/usr/bin:/bin:/usr/sbin:/sbin`) — shell rc files are never sourced. Docker's credential helpers live in `/usr/local/bin`, `/opt/homebrew/bin`, or `/Applications/Docker.app/Contents/Resources/bin`, none of which end up on that PATH.

`thv serve` is spawned from [`main/src/toolhive-manager.ts`](main/src/toolhive-manager.ts) with the main process' env passed through unchanged. When `thv` reads `~/.docker/config.json` and sees `"credsStore": "osxkeychain"`, it tries to `exec("docker-credential-osxkeychain")` against the inherited PATH and fails.

We already had the exact helper needed for this — `createEnhancedPath` — but it was private to [`main/src/container-engine.ts`](main/src/container-engine.ts) and used only for the Docker / Podman detection check.

## Changes

- **[`main/src/utils/enhanced-path.ts`](main/src/utils/enhanced-path.ts)** — extracted `createEnhancedPath` (plus `getCommonPaths` / `expandPath`) into a shared util. Behavior is identical to the previous in-`container-engine` implementation: prepends the platform's common container-tooling dirs (Docker Desktop, Homebrew, Rancher Desktop) to `process.env.PATH`, with `~` expansion and the right separator per OS.
- **[`main/src/container-engine.ts`](main/src/container-engine.ts)** — drops the local copy and imports from the shared module. Pure refactor.
- **[`main/src/toolhive-manager.ts`](main/src/toolhive-manager.ts)** — the `thv serve` spawn now sets `PATH: createEnhancedPath()` in `env` alongside `TOOLHIVE_SKIP_DESKTOP_CHECK`. This fixes the credential-helper exec and also covers any other subprocess `thv` may shell out to in the future.

## Tests

- **[`main/src/utils/__tests__/enhanced-path.test.ts`](main/src/utils/__tests__/enhanced-path.test.ts)** — covers darwin / linux / win32 prepends, `~` expansion, existing PATH preservation, win32 `;` separator, empty-PATH handling.
- **[`main/src/tests/toolhive-manager.test.ts`](main/src/tests/toolhive-manager.test.ts)** — new case asserting `spawn` is called with an `env.PATH` containing the darwin helper dirs, while still propagating `TOOLHIVE_SKIP_DESKTOP_CHECK=true`.
- `pnpm test:nonInteractive` — 167 files, 1920 tests passing.
- `pnpm type-check` — clean.

## How to validate

1. Package the app (`pnpm run package`) on macOS with `~/.docker/config.json` set to `{ "credsStore": "osxkeychain" }`.
2. Launch the packaged `.app` from Finder (not from a terminal).
3. Skills → Registry → Install `agents-md`. The install should succeed without the `docker-credential-osxkeychain` PATH error.
4. Regression check: the existing container-engine detection (used by the Docker daemon warning banner) continues to work — same helper, same behavior.

## Out of scope

- Using `fix-path` / `shell-env` to resolve arbitrary user-installed tools (nix, asdf, mise, exotic Homebrew prefixes). Can be added later if we hit issues with the hardcoded list.
- Parsing `thv` stderr to surface a friendlier credential-helper error in the UI.