### PR TITLE
feat(skills): registry card polish and persisted pagination state

### DIFF
--- a/main/src/ipc-handlers/ui-preferences.ts
+++ b/main/src/ipc-handlers/ui-preferences.ts
@@ -1,8 +1,12 @@
 import { ipcMain } from 'electron'
 import {
+  getPageSizePreference,
   getViewModePreference,
+  setPageSizePreference,
   setViewModePreference,
+  UI_PAGE_SIZE_PREFERENCE_KEYS,
   UI_PREFERENCE_KEYS,
+  type UiPageSizeKey,
   type UiPreferenceKey,
   type ViewMode,
 } from '../ui-preferences'
@@ -16,8 +20,19 @@ function isUiPreferenceKey(key: unknown): key is UiPreferenceKey {
   )
 }
 
+function isUiPageSizeKey(key: unknown): key is UiPageSizeKey {
+  return (
+    typeof key === 'string' &&
+    (UI_PAGE_SIZE_PREFERENCE_KEYS as readonly string[]).includes(key)
+  )
+}
+
 function isViewMode(value: unknown): value is ViewMode {
   return value === 'card' || value === 'table'
+}
+
+function isPageSize(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
 }
 
 export function register() {
@@ -32,6 +47,20 @@ export function register() {
     (_event, key: unknown, value: unknown): void => {
       if (!isUiPreferenceKey(key) || !isViewMode(value)) return
       setViewModePreference(key, value)
+    }
+  )
+
+  ipcMain.handle(
+    'ui-preferences:get-page-size',
+    (_event, key: unknown): number | undefined =>
+      isUiPageSizeKey(key) ? getPageSizePreference(key) : undefined
+  )
+
+  ipcMain.handle(
+    'ui-preferences:set-page-size',
+    (_event, key: unknown, value: unknown): void => {
+      if (!isUiPageSizeKey(key) || !isPageSize(value)) return
+      setPageSizePreference(key, value)
     }
   )
 }

--- a/main/src/ipc-handlers/ui-preferences.ts
+++ b/main/src/ipc-handlers/ui-preferences.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron'
 import {
   getPageSizePreference,
   getViewModePreference,
+  isValidPageSize,
   setPageSizePreference,
   setViewModePreference,
   UI_PAGE_SIZE_PREFERENCE_KEYS,
@@ -31,10 +32,6 @@ function isViewMode(value: unknown): value is ViewMode {
   return value === 'card' || value === 'table'
 }
 
-function isPageSize(value: unknown): value is number {
-  return typeof value === 'number' && Number.isInteger(value) && value > 0
-}
-
 export function register() {
   ipcMain.handle(
     'ui-preferences:get-view-mode',
@@ -59,7 +56,7 @@ export function register() {
   ipcMain.handle(
     'ui-preferences:set-page-size',
     (_event, key: unknown, value: unknown): void => {
-      if (!isUiPageSizeKey(key) || !isPageSize(value)) return
+      if (!isUiPageSizeKey(key) || !isValidPageSize(value)) return
       setPageSizePreference(key, value)
     }
   )

--- a/main/src/ui-preferences.ts
+++ b/main/src/ui-preferences.ts
@@ -54,3 +54,51 @@ export function setViewModePreference(
     log.error(`[DB] Failed to write UI preference "${key}":`, err)
   }
 }
+
+export const UI_PAGE_SIZE_PREFERENCE_KEYS = [
+  'ui.pageSize.skillsRegistry',
+] as const
+
+export type UiPageSizeKey = (typeof UI_PAGE_SIZE_PREFERENCE_KEYS)[number]
+
+function isValidPageSizeKey(key: string): key is UiPageSizeKey {
+  return (UI_PAGE_SIZE_PREFERENCE_KEYS as readonly string[]).includes(key)
+}
+
+function isValidPageSize(value: number): boolean {
+  return Number.isInteger(value) && value > 0 && value <= 1000
+}
+
+/**
+ * Reads a persisted page-size preference. Returns `undefined` when no
+ * preference has been stored yet or when the persisted value is malformed,
+ * so callers can fall back to a hardcoded default or URL param.
+ */
+export function getPageSizePreference(key: UiPageSizeKey): number | undefined {
+  try {
+    const raw = readSetting(key)
+    if (!raw) return undefined
+    const parsed = Number(raw)
+    if (!isValidPageSize(parsed)) return undefined
+    return parsed
+  } catch (err) {
+    log.error(`[DB] Failed to read page size preference "${key}":`, err)
+    return undefined
+  }
+}
+
+export function setPageSizePreference(key: UiPageSizeKey, value: number): void {
+  if (!isValidPageSizeKey(key)) {
+    log.warn(`[DB] Refusing to write unknown page size key: ${key}`)
+    return
+  }
+  if (!isValidPageSize(value)) {
+    log.warn(`[DB] Refusing to write invalid page size: ${value}`)
+    return
+  }
+  try {
+    writeSetting(key, String(value))
+  } catch (err) {
+    log.error(`[DB] Failed to write page size preference "${key}":`, err)
+  }
+}

--- a/main/src/ui-preferences.ts
+++ b/main/src/ui-preferences.ts
@@ -65,8 +65,13 @@ function isValidPageSizeKey(key: string): key is UiPageSizeKey {
   return (UI_PAGE_SIZE_PREFERENCE_KEYS as readonly string[]).includes(key)
 }
 
-function isValidPageSize(value: number): boolean {
-  return Number.isInteger(value) && value > 0 && value <= 1000
+export function isValidPageSize(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value > 0 &&
+    value <= 1000
+  )
 }
 
 /**

--- a/preload/src/api/ui-preferences.ts
+++ b/preload/src/api/ui-preferences.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron'
 import type {
+  UiPageSizeKey,
   UiPreferenceKey,
   ViewMode,
 } from '../../../main/src/ui-preferences'
@@ -10,6 +11,10 @@ export const uiPreferencesApi = {
       ipcRenderer.invoke('ui-preferences:get-view-mode', key),
     setViewMode: (key: UiPreferenceKey, value: ViewMode): Promise<void> =>
       ipcRenderer.invoke('ui-preferences:set-view-mode', key, value),
+    getPageSize: (key: UiPageSizeKey): Promise<number | undefined> =>
+      ipcRenderer.invoke('ui-preferences:get-page-size', key),
+    setPageSize: (key: UiPageSizeKey, value: number): Promise<void> =>
+      ipcRenderer.invoke('ui-preferences:set-page-size', key, value),
   },
 }
 
@@ -17,5 +22,7 @@ export interface UiPreferencesAPI {
   uiPreferences: {
     getViewMode: (key: UiPreferenceKey) => Promise<ViewMode>
     setViewMode: (key: UiPreferenceKey, value: ViewMode) => Promise<void>
+    getPageSize: (key: UiPageSizeKey) => Promise<number | undefined>
+    setPageSize: (key: UiPageSizeKey, value: number) => Promise<void>
   }
 }

--- a/renderer/src/common/components/ui/__tests__/pagination.test.tsx
+++ b/renderer/src/common/components/ui/__tests__/pagination.test.tsx
@@ -34,6 +34,9 @@ describe('Pagination', () => {
     expect(
       screen.getByRole('button', { name: /go to next page/i })
     ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /go to last page/i })
+    ).toBeVisible()
   })
 
   it('uses a custom item label', () => {
@@ -53,13 +56,19 @@ describe('Pagination', () => {
     expect(
       screen.getByRole('button', { name: /go to next page/i })
     ).toBeEnabled()
+    expect(
+      screen.getByRole('button', { name: /go to last page/i })
+    ).toBeEnabled()
   })
 
-  it('disables next on the last page', () => {
+  it('disables next and last on the last page', () => {
     setup({ page: 9, pageSize: 12, total: 100 })
 
     expect(
       screen.getByRole('button', { name: /go to next page/i })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /go to last page/i })
     ).toBeDisabled()
     expect(
       screen.getByRole('button', { name: /go to previous page/i })
@@ -80,6 +89,9 @@ describe('Pagination', () => {
 
     await user.click(screen.getByRole('button', { name: /go to first page/i }))
     expect(onPageChange).toHaveBeenCalledWith(1)
+
+    await user.click(screen.getByRole('button', { name: /go to last page/i }))
+    expect(onPageChange).toHaveBeenCalledWith(9)
   })
 
   it('invokes onPageSizeChange when a new size is selected', async () => {

--- a/renderer/src/common/components/ui/pagination.tsx
+++ b/renderer/src/common/components/ui/pagination.tsx
@@ -1,5 +1,6 @@
 import {
   ChevronFirstIcon,
+  ChevronLastIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
 } from 'lucide-react'
@@ -98,6 +99,15 @@ export function Pagination({
           onClick={() => onPageChange(currentPage + 1)}
         >
           <ChevronRightIcon />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Go to last page"
+          disabled={isLastPage}
+          onClick={() => onPageChange(totalPages)}
+        >
+          <ChevronLastIcon />
         </Button>
       </div>
       <div className="flex items-center gap-2">

--- a/renderer/src/common/hooks/__tests__/use-page-size-preference.test.tsx
+++ b/renderer/src/common/hooks/__tests__/use-page-size-preference.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { usePageSizePreference } from '../use-page-size-preference'
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('usePageSizePreference', () => {
+  beforeEach(() => {
+    window.electronAPI.uiPreferences.getPageSize = vi
+      .fn()
+      .mockResolvedValue(undefined)
+    window.electronAPI.uiPreferences.setPageSize = vi
+      .fn()
+      .mockResolvedValue(undefined)
+  })
+
+  it('returns undefined while the initial read is in flight', () => {
+    const { result } = renderHook(
+      () => usePageSizePreference('ui.pageSize.skillsRegistry'),
+      { wrapper: makeWrapper() }
+    )
+
+    expect(result.current.pageSize).toBeUndefined()
+  })
+
+  it('reads the persisted page size from the main process', async () => {
+    window.electronAPI.uiPreferences.getPageSize = vi.fn().mockResolvedValue(50)
+
+    const { result } = renderHook(
+      () => usePageSizePreference('ui.pageSize.skillsRegistry'),
+      { wrapper: makeWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.pageSize).toBe(50)
+    })
+    expect(window.electronAPI.uiPreferences.getPageSize).toHaveBeenCalledWith(
+      'ui.pageSize.skillsRegistry'
+    )
+  })
+
+  it('leaves pageSize undefined when nothing is persisted', async () => {
+    const { result } = renderHook(
+      () => usePageSizePreference('ui.pageSize.skillsRegistry'),
+      { wrapper: makeWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.pageSize).toBeUndefined()
+  })
+
+  it('persists the new page size via IPC and updates state optimistically', async () => {
+    const { result } = renderHook(
+      () => usePageSizePreference('ui.pageSize.skillsRegistry'),
+      { wrapper: makeWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    act(() => {
+      result.current.setPageSize(24)
+    })
+
+    await waitFor(() => {
+      expect(result.current.pageSize).toBe(24)
+    })
+
+    await waitFor(() => {
+      expect(window.electronAPI.uiPreferences.setPageSize).toHaveBeenCalledWith(
+        'ui.pageSize.skillsRegistry',
+        24
+      )
+    })
+  })
+})

--- a/renderer/src/common/hooks/use-page-size-preference.ts
+++ b/renderer/src/common/hooks/use-page-size-preference.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import log from 'electron-log/renderer'
+import { useCallback } from 'react'
+import type { UiPageSizeKey } from '../../../../main/src/ui-preferences'
+
+function pageSizePreferenceQueryKey(key: UiPageSizeKey) {
+  return ['ui-preference', 'page-size', key] as const
+}
+
+/**
+ * Reads and writes a persisted paginated-list page-size preference backed by
+ * the main-process SQLite `settings` table via IPC. Mirrors `useViewPreference`.
+ *
+ * Returns `undefined` until the initial read resolves so callers can fall
+ * back to a URL search param or a hardcoded default without flashing the
+ * wrong size.
+ */
+export function usePageSizePreference(key: UiPageSizeKey) {
+  const queryClient = useQueryClient()
+
+  const { data, isPending } = useQuery({
+    queryKey: pageSizePreferenceQueryKey(key),
+    queryFn: async (): Promise<number | null> => {
+      try {
+        const value = await window.electronAPI.uiPreferences.getPageSize(key)
+        return typeof value === 'number' ? value : null
+      } catch (error) {
+        log.error(`Failed to read page size preference "${key}":`, error)
+        return null
+      }
+    },
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  })
+
+  const { mutate } = useMutation({
+    mutationFn: async (value: number) => {
+      await window.electronAPI.uiPreferences.setPageSize(key, value)
+      return value
+    },
+    onMutate: async (value: number) => {
+      await queryClient.cancelQueries({
+        queryKey: pageSizePreferenceQueryKey(key),
+      })
+      const previous = queryClient.getQueryData<number | null>(
+        pageSizePreferenceQueryKey(key)
+      )
+      queryClient.setQueryData(pageSizePreferenceQueryKey(key), value)
+      return { previous }
+    },
+    onError: (error, _value, context) => {
+      log.error(`Failed to persist page size preference "${key}":`, error)
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(
+          pageSizePreferenceQueryKey(key),
+          context.previous
+        )
+      }
+    },
+  })
+
+  const setPageSize = useCallback(
+    (value: number) => {
+      mutate(value)
+    },
+    [mutate]
+  )
+
+  return {
+    pageSize: data ?? undefined,
+    isLoading: isPending,
+    setPageSize,
+  }
+}

--- a/renderer/src/common/mocks/electronAPI.ts
+++ b/renderer/src/common/mocks/electronAPI.ts
@@ -43,6 +43,8 @@ function createElectronStub(): Partial<ElectronAPI> {
     uiPreferences: {
       getViewMode: vi.fn().mockResolvedValue('card'),
       setViewMode: vi.fn().mockResolvedValue(undefined),
+      getPageSize: vi.fn().mockResolvedValue(undefined),
+      setPageSize: vi.fn().mockResolvedValue(undefined),
     } as ElectronAPI['uiPreferences'],
     chat: {
       stream: vi.fn(),

--- a/renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx
@@ -61,9 +61,23 @@ describe('CardRegistrySkill', () => {
       expect(screen.getByText('my-skill')).toBeVisible()
     })
 
-    it('renders the namespace', () => {
+    it('does not render the namespace as a subtitle', () => {
       renderRoute(router)
-      expect(screen.getByText('io.github.user')).toBeVisible()
+      expect(screen.queryByText('io.github.user')).not.toBeInTheDocument()
+    })
+
+    it('renders the normalized repo label when repository.url is set', async () => {
+      const skillRouter = createCardTestRouter({
+        ...baseSkill,
+        repository: {
+          type: 'git',
+          url: 'https://github.com/example/skills.git',
+        },
+      }) as unknown as ReturnType<typeof createTestRouter>
+      await skillRouter.navigate({ to: '/skills' })
+      renderRoute(skillRouter)
+      expect(screen.getByText('example/skills')).toBeVisible()
+      expect(screen.queryByText('io.github.user')).not.toBeInTheDocument()
     })
 
     it('renders the description', () => {
@@ -78,15 +92,6 @@ describe('CardRegistrySkill', () => {
       await skillRouter.navigate({ to: '/skills' })
       renderRoute(skillRouter)
       expect(screen.getByText('Unknown skill')).toBeVisible()
-    })
-
-    it('does not render namespace row when namespace is absent', async () => {
-      const skillRouter = createCardTestRouter({
-        name: 'my-skill',
-      }) as unknown as ReturnType<typeof createTestRouter>
-      await skillRouter.navigate({ to: '/skills' })
-      renderRoute(skillRouter)
-      expect(screen.queryByText('io.github.user')).not.toBeInTheDocument()
     })
 
     it('does not render description when absent', async () => {

--- a/renderer/src/features/skills/components/__tests__/skills-page.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/skills-page.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { StrictMode } from 'react'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 import { renderRoute } from '@/common/test/render-route'
@@ -273,6 +273,66 @@ describe('SkillsPage registry pagination', () => {
 
     const { search } = router.state.location
     expect(search).toMatchObject({ tab: 'registry', page: 3 })
+  })
+
+  it('persists the selected page size via the uiPreferences IPC', async () => {
+    const user = userEvent.setup()
+    const setPageSize = vi.fn().mockResolvedValue(undefined)
+    window.electronAPI.uiPreferences.setPageSize = setPageSize
+    setupRegistryMock(200)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('skill-1')).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('combobox', { name: /items per page/i }))
+    await user.click(screen.getByRole('option', { name: '50' }))
+
+    await waitFor(() => {
+      expect(setPageSize).toHaveBeenCalledWith('ui.pageSize.skillsRegistry', 50)
+    })
+  })
+
+  it('hydrates the initial page size from the persisted preference', async () => {
+    window.electronAPI.uiPreferences.getPageSize = vi.fn().mockResolvedValue(50)
+    setupRegistryMock(200)
+
+    renderSkillsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 1-50 of 200 skills')).toBeVisible()
+    })
+    expect(screen.getByText('skill-50')).toBeVisible()
+  })
+
+  it('prefers the URL limit over the persisted preference', async () => {
+    window.electronAPI.uiPreferences.getPageSize = vi.fn().mockResolvedValue(50)
+    setupRegistryMock(200)
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const router = createFileRouteTestRouter(
+      SkillsRouteImport,
+      '/skills',
+      '/skills?tab=registry&limit=24',
+      queryClient
+    )
+
+    render(
+      <PermissionsProvider>
+        <PromptProvider>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </PromptProvider>
+      </PermissionsProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 1-24 of 200 skills')).toBeVisible()
+    })
   })
 
   it('returns to the first page via the First button', async () => {

--- a/renderer/src/features/skills/components/card-registry-skill.tsx
+++ b/renderer/src/features/skills/components/card-registry-skill.tsx
@@ -6,6 +6,7 @@ import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { CardSkillBase } from './card-skill-base'
 import { getSkillInstallReference } from '../lib/skill-reference'
+import { getDisplayRepoLabel } from '../lib/get-display-repo-label'
 import { trackEvent } from '@/common/lib/analytics'
 
 export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
@@ -15,6 +16,7 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
   const name = skill.name ?? 'Unknown skill'
   const namespace = skill.namespace
   const description = skill.description
+  const repoLabel = getDisplayRepoLabel(skill.repository?.url)
   const defaultReference = getSkillInstallReference(skill)
 
   const canNavigate = !!(namespace && skill.name)
@@ -36,7 +38,7 @@ export function CardRegistrySkill({ skill }: { skill: RegistrySkill }) {
     <>
       <CardSkillBase
         title={name}
-        subtitle={namespace}
+        subtitle={repoLabel ?? undefined}
         description={description}
         onClick={canNavigate ? handleCardClick : undefined}
         footer={

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Button } from '@/common/components/ui/button'
-import { TagIcon, GitForkIcon, GithubIcon, ScaleIcon } from 'lucide-react'
+import { TagIcon, GithubIcon, ScaleIcon } from 'lucide-react'
 import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { SkillDetailLayout } from './skill-detail-layout'
@@ -8,6 +8,7 @@ import {
   getSkillInstallReference,
   getSkillOciRef,
 } from '../lib/skill-reference'
+import { getDisplayRepoLabel } from '../lib/get-display-repo-label'
 import { SkillMarkdown } from './skill-markdown'
 import { trackEvent } from '@/common/lib/analytics'
 
@@ -23,10 +24,11 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
   const description = skill.description
   const version = skill.version
   const license = skill.license
+  const repoLabel = getDisplayRepoLabel(skill.repository?.url)
   const defaultReference = getSkillInstallReference(skill)
   const ociRef = getSkillOciRef(skill)
 
-  const hasBadges = !!(version || namespace || license)
+  const hasBadges = !!(version || repoLabel || license)
 
   return (
     <>
@@ -46,13 +48,13 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
                   {version}
                 </span>
               )}
-              {namespace && (
+              {repoLabel && (
                 <span
                   className="text-muted-foreground flex items-center gap-1
                     text-sm"
                 >
-                  <GitForkIcon className="size-4" />
-                  {namespace}
+                  <GithubIcon className="size-4" />
+                  {repoLabel}
                 </span>
               )}
               {license && (

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Button } from '@/common/components/ui/button'
-import { TagIcon, GithubIcon, ScaleIcon } from 'lucide-react'
+import { TagIcon, GitForkIcon, GithubIcon, ScaleIcon } from 'lucide-react'
 import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { SkillDetailLayout } from './skill-detail-layout'
@@ -53,7 +53,7 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
                   className="text-muted-foreground flex items-center gap-1
                     text-sm"
                 >
-                  <GithubIcon className="size-4" />
+                  <GitForkIcon className="size-4" />
                   {repoLabel}
                 </span>
               )}

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -50,14 +50,33 @@ export function SkillsPage() {
 
   const {
     pageSize: persistedRegistryLimit,
+    isLoading: isRegistryLimitPreferenceLoading,
     setPageSize: persistRegistryLimit,
   } = usePageSizePreference('ui.pageSize.skillsRegistry')
 
+  // Ignore persisted values that fall outside the current set of options (e.g.
+  // left over from an older app version or a manual DB edit) so the selector
+  // never renders with an unmatched value.
+  const validatedPersistedRegistryLimit =
+    persistedRegistryLimit !== undefined &&
+    (REGISTRY_PAGE_SIZE_OPTIONS as readonly number[]).includes(
+      persistedRegistryLimit
+    )
+      ? persistedRegistryLimit
+      : undefined
+
   // URL wins over persisted preference so a bookmarked `?limit=24` is honored.
-  // When neither is present we fall back to the hardcoded default; the
-  // persisted value (if any) will apply once the IPC read resolves.
+  // When neither is present we fall back to the hardcoded default.
   const registryLimit =
-    urlRegistryLimit ?? persistedRegistryLimit ?? DEFAULT_REGISTRY_PAGE_SIZE
+    urlRegistryLimit ??
+    validatedPersistedRegistryLimit ??
+    DEFAULT_REGISTRY_PAGE_SIZE
+
+  // Avoid an initial fetch at the default size followed by a refetch at the
+  // persisted size: when no URL limit is present, wait for the IPC read to
+  // settle before enabling the registry query.
+  const isRegistryQueryEnabled =
+    urlRegistryLimit !== undefined || !isRegistryLimitPreferenceLoading
 
   function setTab(value: Tab) {
     trackEvent('Skills: tab changed', { tab: value })
@@ -113,6 +132,7 @@ export function SkillsPage() {
         ...(debouncedRegistrySearch ? { q: debouncedRegistrySearch } : {}),
       },
     }),
+    enabled: isRegistryQueryEnabled,
     placeholderData: (prev) => prev,
   })
   const registrySkills = registryData?.skills ?? []

--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -27,11 +27,15 @@ import { DialogBuildSkill } from './dialog-build-skill'
 import { HammerIcon } from 'lucide-react'
 import { ViewToggle } from '@/common/components/view-toggle'
 import { useViewPreference } from '@/common/hooks/use-view-preference'
+import { usePageSizePreference } from '@/common/hooks/use-page-size-preference'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import type { SkillsSearch } from '@/routes/skills'
 import { trackEvent } from '@/common/lib/analytics'
-import { REGISTRY_PAGE_SIZE_OPTIONS } from '../lib/registry-pagination'
+import {
+  DEFAULT_REGISTRY_PAGE_SIZE,
+  REGISTRY_PAGE_SIZE_OPTIONS,
+} from '../lib/registry-pagination'
 
 type Tab = 'registry' | 'installed' | 'builds'
 
@@ -40,9 +44,20 @@ export function SkillsPage() {
   const {
     tab,
     page: registryPage,
-    limit: registryLimit,
+    limit: urlRegistryLimit,
   } = useSearch({ from: '/skills' })
   const navigate = useNavigate({ from: '/skills' })
+
+  const {
+    pageSize: persistedRegistryLimit,
+    setPageSize: persistRegistryLimit,
+  } = usePageSizePreference('ui.pageSize.skillsRegistry')
+
+  // URL wins over persisted preference so a bookmarked `?limit=24` is honored.
+  // When neither is present we fall back to the hardcoded default; the
+  // persisted value (if any) will apply once the IPC read resolves.
+  const registryLimit =
+    urlRegistryLimit ?? persistedRegistryLimit ?? DEFAULT_REGISTRY_PAGE_SIZE
 
   function setTab(value: Tab) {
     trackEvent('Skills: tab changed', { tab: value })
@@ -60,6 +75,7 @@ export function SkillsPage() {
   }
 
   function setRegistryLimit(limit: number) {
+    persistRegistryLimit(limit)
     void navigate({
       search: (prev: SkillsSearch) => ({ ...prev, limit, page: 1 }),
       replace: true,
@@ -140,7 +156,7 @@ export function SkillsPage() {
       <Tabs
         value={tab}
         onValueChange={(v) => setTab(v as Tab)}
-        className="gap-4"
+        className="min-h-0 flex-1 gap-4"
       >
         <div className="flex items-center justify-between gap-4">
           <TabsList variant="pill">
@@ -229,6 +245,7 @@ export function SkillsPage() {
             <GridCardsRegistrySkills skills={registrySkills} />
           )}
           <Pagination
+            className="mt-auto"
             page={registryMetadata?.page ?? registryPage}
             pageSize={registryMetadata?.limit ?? registryLimit}
             total={registryMetadata?.total ?? 0}

--- a/renderer/src/features/skills/lib/__tests__/get-display-repo-label.test.ts
+++ b/renderer/src/features/skills/lib/__tests__/get-display-repo-label.test.ts
@@ -1,0 +1,64 @@
+import { expect, it, describe } from 'vitest'
+import { getDisplayRepoLabel } from '../get-display-repo-label'
+
+describe('getDisplayRepoLabel', () => {
+  it('returns org/repo for a plain GitHub URL', () => {
+    expect(getDisplayRepoLabel('https://github.com/stacklok/skills')).toBe(
+      'stacklok/skills'
+    )
+  })
+
+  it('strips a trailing .git suffix from GitHub URLs', () => {
+    expect(getDisplayRepoLabel('https://github.com/stacklok/skills.git')).toBe(
+      'stacklok/skills'
+    )
+  })
+
+  it('strips www. and trailing slashes from GitHub URLs', () => {
+    expect(getDisplayRepoLabel('https://www.github.com/stacklok/skills/')).toBe(
+      'stacklok/skills'
+    )
+  })
+
+  it('ignores any extra path segments on GitHub URLs', () => {
+    expect(
+      getDisplayRepoLabel('https://github.com/stacklok/skills/tree/main')
+    ).toBe('stacklok/skills')
+  })
+
+  it('returns host/path for non-GitHub hosts', () => {
+    expect(getDisplayRepoLabel('https://gitlab.com/group/sub/repo')).toBe(
+      'gitlab.com/group/sub/repo'
+    )
+  })
+
+  it('strips .git and trailing slashes for non-GitHub hosts', () => {
+    expect(getDisplayRepoLabel('https://gitlab.com/group/repo.git/')).toBe(
+      'gitlab.com/group/repo'
+    )
+  })
+
+  it('returns null for undefined', () => {
+    expect(getDisplayRepoLabel(undefined)).toBeNull()
+  })
+
+  it('returns null for null', () => {
+    expect(getDisplayRepoLabel(null)).toBeNull()
+  })
+
+  it('returns null for an empty string', () => {
+    expect(getDisplayRepoLabel('')).toBeNull()
+  })
+
+  it('returns null for an unparseable URL', () => {
+    expect(getDisplayRepoLabel('not a url')).toBeNull()
+  })
+
+  it('returns null when GitHub URL has no repo segment', () => {
+    expect(getDisplayRepoLabel('https://github.com/stacklok')).toBeNull()
+  })
+
+  it('returns null when there is no path at all', () => {
+    expect(getDisplayRepoLabel('https://github.com')).toBeNull()
+  })
+})

--- a/renderer/src/features/skills/lib/get-display-repo-label.ts
+++ b/renderer/src/features/skills/lib/get-display-repo-label.ts
@@ -1,0 +1,33 @@
+/**
+ * Produces a human-readable label for a repository URL intended for UI
+ * surfaces like card subheadings or detail-page badges.
+ *
+ * - GitHub URLs collapse to `org/repo`.
+ * - Other hosts collapse to `host/path` with `www.` and `.git`/trailing
+ *   slashes stripped.
+ * - Returns `null` when the URL is missing or unparseable so callers can
+ *   omit the element entirely.
+ */
+export function getDisplayRepoLabel(
+  url: string | undefined | null
+): string | null {
+  if (!url) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+
+  const host = parsed.hostname.replace(/^www\./, '')
+  const path = parsed.pathname.replace(/^\/+|\/+$/g, '').replace(/\.git$/, '')
+  if (!path) return null
+
+  if (host === 'github.com') {
+    const [org, repo] = path.split('/')
+    return org && repo ? `${org}/${repo}` : null
+  }
+
+  return `${host}/${path}`
+}

--- a/renderer/src/routes/skills.tsx
+++ b/renderer/src/routes/skills.tsx
@@ -16,7 +16,7 @@ type SkillsTab = (typeof VALID_TABS)[number]
 export type SkillsSearch = {
   tab: SkillsTab
   page: number
-  limit: number
+  limit: number | undefined
 }
 
 export const Route = createFileRoute('/skills')({
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/skills')({
       limitNum
     )
       ? limitNum
-      : DEFAULT_REGISTRY_PAGE_SIZE
+      : undefined
 
     return { tab, page, limit }
   },
@@ -46,7 +46,7 @@ export const Route = createFileRoute('/skills')({
       queryClient.ensureQueryData(
         getRegistryByRegistryNameV01xDevToolhiveSkillsOptions({
           path: { registryName: 'default' },
-          query: { page, limit },
+          query: { page, limit: limit ?? DEFAULT_REGISTRY_PAGE_SIZE },
         })
       ),
     ]),


### PR DESCRIPTION
Follow-up polish to the Skills → Registry tab on top of #2097 / #2098.

https://github.com/user-attachments/assets/100c6ae8-57ba-4270-8635-9037ebd2d646


Summary

- Normalized repo label replaces the io.github.stacklok subheading on registry cards and the namespace badge on the skill detail page. GitHub URLs render as org/repo, other hosts as host/path. The namespace stays on props — only hidden from the UI. Table view is untouched.
- Pagination bar pinned to the viewport bottom so it stays anchored with 3 cards or 30. Overflowing grids still scroll as before.
- Last-page button (>|) added to the shared Pagination component, next to the existing next/first/prev controls.
- Items-per-page is remembered across sessions via a new ui.pageSize.skillsRegistry preference, wired through the same uiPreferences IPC path used for view-mode. URL ?limit= still wins over the stored value.
