### PR TITLE
feat(skills): surface original repo and tighten registry table

### DIFF
--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -35,6 +35,13 @@ const skillNoNamespace: RegistrySkill = {
   name: 'standalone',
 }
 
+const skillUnparseableRepo: RegistrySkill = {
+  name: 'weird-repo-skill',
+  namespace: 'io.github.weird',
+  description: 'Skill with an unparseable repository URL',
+  repository: { type: 'git', url: 'not-a-valid-url' },
+}
+
 function makeRouter(skills: RegistrySkill[]) {
   const rootRoute = createRootRoute({
     component: Outlet,
@@ -187,38 +194,42 @@ describe('TableRegistrySkills', () => {
     expect(router.state.location.pathname).toBe('/skills')
   })
 
-  it('renders a GitHub link for skills with a repository url', async () => {
+  it('renders a repository link with the normalized repo label for skills with a repository url', async () => {
     const router = makeRouter([ociSkill, gitSkill])
     renderRoute(router)
 
-    const links = await screen.findAllByRole('link', {
-      name: /open repository on github/i,
-    })
+    const links = await screen.findAllByRole('link', { name: /org\/repo/i })
     expect(links).toHaveLength(1)
     expect(links[0]).toHaveAttribute('href', 'https://github.com/org/repo')
     expect(links[0]).toHaveAttribute('target', '_blank')
+    expect(links[0]).toHaveAttribute('rel', expect.stringContaining('noopener'))
   })
 
-  it('does not render a GitHub link for skills without a repository', async () => {
+  it('falls back to the raw URL when the repository URL cannot be normalized', async () => {
+    const router = makeRouter([skillUnparseableRepo])
+    renderRoute(router)
+
+    const link = await screen.findByRole('link', { name: /not-a-valid-url/i })
+    expect(link).toHaveAttribute('href', 'not-a-valid-url')
+    expect(screen.getByText('not-a-valid-url')).toBeVisible()
+  })
+
+  it('does not render a repository link for skills without a repository', async () => {
     const router = makeRouter([gitSkill])
     renderRoute(router)
 
     await waitFor(() => {
       expect(screen.getByText('git-skill')).toBeVisible()
     })
-    expect(
-      screen.queryByRole('link', { name: /open repository on github/i })
-    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
 
-  it('does not navigate to the detail page when the GitHub link is clicked', async () => {
+  it('does not navigate to the detail page when the repository link is clicked', async () => {
     const user = userEvent.setup()
     const router = makeRouter([ociSkill])
     renderRoute(router)
 
-    const link = await screen.findByRole('link', {
-      name: /open repository on github/i,
-    })
+    const link = await screen.findByRole('link', { name: /org\/repo/i })
     await user.click(link)
 
     expect(router.state.location.pathname).toBe('/skills')

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -79,10 +79,14 @@ describe('TableRegistrySkills', () => {
     expect(
       screen.getByRole('columnheader', { name: /about/i })
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: /original repo/i })
+    ).toBeInTheDocument()
 
     expect(screen.getByText('io.github.user')).toBeVisible()
     expect(screen.getByText('git-skill')).toBeVisible()
     expect(screen.getByText('A helpful skill')).toBeVisible()
+    expect(screen.getByText('org/repo')).toBeVisible()
   })
 
   it('shows an empty state when skills is empty', async () => {

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -74,16 +74,15 @@ describe('TableRegistrySkills', () => {
       screen.getByRole('columnheader', { name: /skill/i })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('columnheader', { name: /registry/i })
-    ).toBeInTheDocument()
-    expect(
       screen.getByRole('columnheader', { name: /about/i })
     ).toBeInTheDocument()
     expect(
       screen.getByRole('columnheader', { name: /original repo/i })
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('columnheader', { name: /registry/i })
+    ).not.toBeInTheDocument()
 
-    expect(screen.getByText('io.github.user')).toBeVisible()
     expect(screen.getByText('git-skill')).toBeVisible()
     expect(screen.getByText('A helpful skill')).toBeVisible()
     expect(screen.getByText('org/repo')).toBeVisible()

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -35,7 +35,10 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
   const title = skill.name ?? 'Unknown skill'
   const namespace = skill.namespace
   const canNavigate = !!(namespace && skill.name)
-  const repoLabel = getDisplayRepoLabel(skill.repository?.url)
+  const repositoryUrl = skill.repository?.url
+  const displayRepoLabel = repositoryUrl
+    ? (getDisplayRepoLabel(repositoryUrl) ?? repositoryUrl)
+    : null
 
   function goToDetail() {
     if (!canNavigate) return
@@ -92,9 +95,9 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
         </TableCell>
 
         <TableCell className="text-muted-foreground py-3">
-          {skill.repository?.url ? (
+          {repositoryUrl && displayRepoLabel ? (
             <a
-              href={skill.repository.url}
+              href={repositoryUrl}
               target="_blank"
               rel="noopener noreferrer"
               onClick={(e) => {
@@ -107,21 +110,18 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
               }}
               className="text-muted-foreground hover:bg-accent inline-flex
                 items-center gap-2 rounded-md px-2 py-1 text-sm"
-              aria-label="Open repository on GitHub"
             >
-              <Github className="size-4 shrink-0" />
-              {repoLabel ? (
-                <Tooltip onlyWhenTruncated>
-                  <TooltipTrigger asChild>
-                    <span className="block max-w-[200px] truncate">
-                      {repoLabel}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-xs">
-                    {repoLabel}
-                  </TooltipContent>
-                </Tooltip>
-              ) : null}
+              <Github aria-hidden className="size-4 shrink-0" />
+              <Tooltip onlyWhenTruncated>
+                <TooltipTrigger asChild>
+                  <span className="block max-w-[200px] truncate">
+                    {displayRepoLabel}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  {displayRepoLabel}
+                </TooltipContent>
+              </Tooltip>
             </a>
           ) : (
             <span className="text-muted-foreground/60 text-sm">—</span>

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/common/components/ui/tooltip'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { getSkillInstallReference } from '../lib/skill-reference'
+import { getDisplayRepoLabel } from '../lib/get-display-repo-label'
 import { trackEvent } from '@/common/lib/analytics'
 
 function activateOnKey(e: React.KeyboardEvent, onActivate: () => void) {
@@ -34,6 +35,7 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
   const title = skill.name ?? 'Unknown skill'
   const namespace = skill.namespace
   const canNavigate = !!(namespace && skill.name)
+  const repoLabel = getDisplayRepoLabel(skill.repository?.url)
 
   function goToDetail() {
     if (!canNavigate) return
@@ -104,7 +106,7 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
           )}
         </TableCell>
 
-        <TableCell className="py-3">
+        <TableCell className="text-muted-foreground py-3">
           {skill.repository?.url ? (
             <a
               href={skill.repository.url}
@@ -119,12 +121,26 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
                 })
               }}
               className="text-muted-foreground hover:bg-accent inline-flex
-                size-8 items-center justify-center rounded-md"
+                items-center gap-2 rounded-md px-2 py-1 text-sm"
               aria-label="Open repository on GitHub"
             >
-              <Github className="size-4" />
+              <Github className="size-4 shrink-0" />
+              {repoLabel ? (
+                <Tooltip onlyWhenTruncated>
+                  <TooltipTrigger asChild>
+                    <span className="block max-w-[200px] truncate">
+                      {repoLabel}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    {repoLabel}
+                  </TooltipContent>
+                </Tooltip>
+              ) : null}
             </a>
-          ) : null}
+          ) : (
+            <span className="text-muted-foreground/60 text-sm">—</span>
+          )}
         </TableCell>
 
         <TableCell className="py-3 pr-3 text-right">
@@ -185,7 +201,9 @@ export function TableRegistrySkills({ skills }: { skills: RegistrySkill[] }) {
           >
             About
           </TableHead>
-          <TableHead className="w-12" aria-label="Repository" />
+          <TableHead className="text-muted-foreground w-[240px] font-medium">
+            Original Repo
+          </TableHead>
           <TableHead className="w-[120px] pr-3" aria-label="Actions" />
         </TableRow>
       </TableHeader>

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -71,21 +71,6 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
           </Tooltip>
         </TableCell>
 
-        <TableCell className="text-muted-foreground hidden py-3 lg:table-cell">
-          {namespace ? (
-            <Tooltip onlyWhenTruncated>
-              <TooltipTrigger asChild>
-                <span className="block max-w-[200px] truncate text-sm">
-                  {namespace}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-xs">{namespace}</TooltipContent>
-            </Tooltip>
-          ) : (
-            <span className="text-muted-foreground/60 text-sm">—</span>
-          )}
-        </TableCell>
-
         <TableCell
           className="text-muted-foreground hidden w-full max-w-0 py-3
             md:table-cell"
@@ -188,12 +173,6 @@ export function TableRegistrySkills({ skills }: { skills: RegistrySkill[] }) {
         <TableRow className="bg-muted/40 hover:bg-muted/40">
           <TableHead className="text-muted-foreground font-medium">
             Skill
-          </TableHead>
-          <TableHead
-            className="text-muted-foreground hidden w-[200px] font-medium
-              lg:table-cell"
-          >
-            Registry
           </TableHead>
           <TableHead
             className="text-muted-foreground hidden w-full max-w-0 font-medium


### PR DESCRIPTION
Follow-up table polish on top of #2102 / #2097 / #2098.

The registry table for Skills had two ergonomic issues compared to the card view:

- The Repository column was an unlabeled icon-only column — discoverable as a GitHub link but invisible at a glance unless you hover the icon.
- The Registry column showed the raw `io.github.<org>` namespace, which duplicates the upstream source already implied by the repo URL and crowds the table at lg breakpoints.

This PR aligns the table with the card by surfacing the normalized repo label (the same `org/repo` / `host/path` string produced by `getDisplayRepoLabel` and used as the card subtitle) and dropping the now-redundant namespace column.

Before:
<img width="1280" height="802" alt="Screenshot 2026-04-27 at 12 39 50" src="https://github.com/user-attachments/assets/f5ecb5b5-365e-4f5f-90a5-2c45e2e9b5f3" />

After:
<img width="1280" height="800" alt="Screenshot 2026-04-27 at 12 35 16" src="https://github.com/user-attachments/assets/ca91b2e0-b05f-41a1-a71a-b0e9acc54764" />


## Summary

- **Original Repo column** replaces the icon-only Repository column. The header is now a visible `Original Repo`, and each row renders the GitHub icon side-by-side with the normalized `org/repo` label inside the existing `<a>` link. Same `aria-label="Open repository on GitHub"`, same `target="_blank"`, same analytics event — only the visible affordance changes. Skills with no repository fall back to the standard `—` placeholder used elsewhere in the table.
- **Registry (namespace) column removed.** Its content (`io.github.<org>`) duplicated the upstream source already encoded in the repo label, and on `lg` breakpoints it competed for width with the more informative repo column.
- **Test coverage updated** in `table-registry-skills.test.tsx`: asserts the new `Original Repo` header, the rendered `org/repo` label, and that the old `Registry` columnheader is gone. All other navigation / install-dialog / GitHub-link assertions are untouched.

## How to validate

1. Skills → Registry → switch to the table view. Each row that has a repository now shows the normalized `org/repo` (or `host/path` for non-GitHub hosts) next to the GitHub icon, under a new `Original Repo` header.
2. The `Registry` column with the `io.github.…` namespace is gone; description/About now flexes into the freed space.
3. Click the repo cell → opens the upstream repository in a new tab (no row navigation).
4. Click anywhere else on the row → still navigates to `/skills/$namespace/$skillName`.
5. Click `Install` → opens the dialog with the existing reference (OCI identifier or `namespace/name`) prefilled, no navigation.
6. Skills without a repository render `—` and have no link.

## Out of scope

- The card view (`CardRegistrySkill`) is unchanged — it already used the normalized repo label as its subtitle.
- The skill detail page header is unchanged.