### PR TITLE
feat(skills): persist build dialog errors inline instead of an ephemeral toast

### DIFF
--- a/renderer/src/common/mocks/fixtures/skills_build/post.ts
+++ b/renderer/src/common/mocks/fixtures/skills_build/post.ts
@@ -10,8 +10,14 @@ export const mockedPostApiV1BetaSkillsBuild = AutoAPIMock<
   PostApiV1BetaSkillsBuildData
 >({
   reference: 'ghcr.io/org/skill-one:v1',
-}).scenario('server-error', (mock) =>
-  mock.overrideHandler(() =>
-    HttpResponse.json({ error: 'Failed to build' }, { status: 500 })
+})
+  .scenario('server-error', (mock) =>
+    mock.overrideHandler(() =>
+      HttpResponse.json({ error: 'Failed to build' }, { status: 500 })
+    )
   )
-)
+  .scenario('user-error', (mock) =>
+    mock.overrideHandler(() =>
+      HttpResponse.json({ error: 'SKILL.md missing' }, { status: 400 })
+    )
+  )

--- a/renderer/src/common/mocks/scenarioNames.ts
+++ b/renderer/src/common/mocks/scenarioNames.ts
@@ -9,6 +9,8 @@ export const MockScenarios = {
   Empty: 'empty',
   /** API returns 500 Internal Server Error */
   ServerError: 'server-error',
+  /** API returns 400 Bad Request from a user-input error */
+  UserError: 'user-error',
   /** Resource not found - API returns 404 */
   NotFound: 'not-found',
 } as const

--- a/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
@@ -157,4 +157,76 @@ describe('DialogBuildSkill', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false)
     })
   })
+
+  it('shows error alert inside the dialog when build fails', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkillsBuild.activateScenario('server-error')
+    vi.mocked(window.electronAPI.selectFolder).mockResolvedValue(
+      '/home/user/my-skill'
+    )
+
+    renderWithProviders(<DialogBuildSkill open onOpenChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /browse for folder/i }))
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
+        '/home/user/my-skill'
+      )
+    })
+    await user.click(screen.getByRole('button', { name: /^build$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('surfaces the backend message verbatim for 400 packager errors', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkillsBuild.activateScenario('user-error')
+    vi.mocked(window.electronAPI.selectFolder).mockResolvedValue(
+      '/home/user/my-skill'
+    )
+
+    renderWithProviders(<DialogBuildSkill open onOpenChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /browse for folder/i }))
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
+        '/home/user/my-skill'
+      )
+    })
+    await user.click(screen.getByRole('button', { name: /^build$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('SKILL.md missing')
+    })
+  })
+
+  it('clears the error alert when the dialog is closed', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkillsBuild.activateScenario('server-error')
+    vi.mocked(window.electronAPI.selectFolder).mockResolvedValue(
+      '/home/user/my-skill'
+    )
+
+    renderWithProviders(<DialogBuildSkill open onOpenChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /browse for folder/i }))
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
+        '/home/user/my-skill'
+      )
+    })
+    await user.click(screen.getByRole('button', { name: /^build$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/renderer/src/features/skills/components/dialog-build-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-build-skill.tsx
@@ -20,7 +20,8 @@ import {
   FormLabel,
   FormMessage,
 } from '@/common/components/ui/form'
-import { FolderOpenIcon } from 'lucide-react'
+import { Alert, AlertDescription } from '@/common/components/ui/alert'
+import { FolderOpenIcon, TriangleAlertIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { useMutationBuildSkill } from '../hooks/use-mutation-build-skill'
 import { DialogInstallSkill } from './dialog-install-skill'
@@ -45,6 +46,7 @@ export function DialogBuildSkill({
   const { mutateAsync: buildSkill, isPending } = useMutationBuildSkill()
   const [installOpen, setInstallOpen] = useState(false)
   const [builtReference, setBuiltReference] = useState<string | undefined>()
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   const form = useForm<FormSchema>({
     resolver: zodV4Resolver(formSchema),
@@ -57,6 +59,7 @@ export function DialogBuildSkill({
   function handleClose() {
     trackEvent('Skills: build dialog cancelled')
     form.reset()
+    setSubmitError(null)
     onOpenChange(false)
   }
 
@@ -69,6 +72,7 @@ export function DialogBuildSkill({
   }
 
   async function onSubmit(values: FormSchema) {
+    setSubmitError(null)
     trackEvent('Skills: build dialog submitted', {
       has_tag: values.tag ? 'true' : 'false',
     })
@@ -82,6 +86,7 @@ export function DialogBuildSkill({
 
       const reference = result?.reference
       form.reset()
+      setSubmitError(null)
       onOpenChange(false)
 
       if (reference) {
@@ -100,9 +105,16 @@ export function DialogBuildSkill({
       } else {
         toast.success('Skill built successfully')
       }
-    } catch {
-      // Error toast is handled by useMutationBuildSkill onError
-      // Keep the dialog open on failure
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : typeof err === 'object' && err !== null && 'error' in err
+            ? String((err as { error: unknown }).error)
+            : typeof err === 'string'
+              ? err
+              : 'Failed to build skill'
+      setSubmitError(message)
     }
   }
 
@@ -116,6 +128,12 @@ export function DialogBuildSkill({
               Build a skill from a local directory on your computer.
             </DialogDescription>
           </DialogHeader>
+          {submitError && (
+            <Alert variant="destructive">
+              <TriangleAlertIcon className="size-4" />
+              <AlertDescription>{submitError}</AlertDescription>
+            </Alert>
+          )}
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(onSubmit)}

--- a/renderer/src/features/skills/hooks/__tests__/use-mutation-build-skill.test.ts
+++ b/renderer/src/features/skills/hooks/__tests__/use-mutation-build-skill.test.ts
@@ -73,7 +73,7 @@ describe('useMutationBuildSkill', () => {
     expect(result.current.data?.reference).toBe('ghcr.io/org/skill-one:v1')
   })
 
-  it('shows error toast on failure', async () => {
+  it('does not show an error toast on failure (dialog renders inline alert)', async () => {
     mockedPostApiV1BetaSkillsBuild.activateScenario('server-error')
 
     const { Wrapper } = createQueryClientWrapper()
@@ -90,7 +90,7 @@ describe('useMutationBuildSkill', () => {
       expect(result.current.isError).toBe(true)
     })
 
-    expect(toast.error).toHaveBeenCalledWith('Failed to build skill')
+    expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('invalidates builds list query on success', async () => {

--- a/renderer/src/features/skills/hooks/use-mutation-build-skill.ts
+++ b/renderer/src/features/skills/hooks/use-mutation-build-skill.ts
@@ -3,7 +3,6 @@ import {
   postApiV1BetaSkillsBuildMutation,
   getApiV1BetaSkillsBuildsQueryKey,
 } from '@common/api/generated/@tanstack/react-query.gen'
-import { toast } from 'sonner'
 import { trackEvent } from '@/common/lib/analytics'
 
 export function useMutationBuildSkill() {
@@ -21,7 +20,6 @@ export function useMutationBuildSkill() {
       })
     },
     onError: (_error, variables) => {
-      toast.error('Failed to build skill')
       trackEvent('Skills: build failed', {
         has_tag: variables.body?.tag ? 'true' : 'false',
       })


### PR DESCRIPTION
The skill-build dialog currently relies on `useMutationBuildSkill.onError` to fire a generic `toast.error('Failed to build skill')`. The toast disappears in seconds, hides the actual backend message, and can't be re-read while the user fixes the path or tag — exactly when they need it. With [stacklok/toolhive#5076](https://github.com/stacklok/toolhive/pull/5076) the build endpoint will return `400 Bad Request` with actionable, packager-authored messages (`SKILL.md missing`, `invalid SKILL.md frontmatter`, `skill directory too large`, symlink violations); we want those on screen, not in a four-second toast.

`DialogInstallSkill` already follows the persistent-inline pattern — this PR mirrors it on `DialogBuildSkill`.

<img width="1290" height="808" alt="Screenshot 2026-04-27 at 18 51 21" src="https://github.com/user-attachments/assets/d8eb144c-b681-4a12-b2a8-36a68a39464e" />


## Changes

- `dialog-build-skill.tsx` — add a `submitError` state, render a destructive `Alert` between the header and the form when set, clear it on `Cancel` and on every resubmit. Error extraction handles `Error.message`, the `{ error }` shape returned by the toolhive backend, and bare strings — same ladder as `DialogInstallSkill`.
- `use-mutation-build-skill.ts` — drop the generic `toast.error` (and the `toast` import). The hook keeps `trackEvent('Skills: build failed', …)` so analytics are unchanged. Aligns with `useMutationInstallSkill`, which already lets the dialog own the error surface.
- `mocks` — add a global `user-error` scenario name and wire it on the `skills_build` POST fixture as `{ error: 'SKILL.md missing' } / 400`, modelling the new toolhive#5076 shape.

## Tests

- `dialog-build-skill.test.tsx` — three new cases: alert appears on `server-error`, alert text is the verbatim 400 packager message on `user-error`, alert is cleared when the dialog is cancelled.
- `use-mutation-build-skill.test.ts` — replaces the old "shows error toast on failure" case with one asserting `toast.error` is **not** called on failure (the dialog renders the alert instead).
- `pnpm run type-check`, `pnpm run lint`, and `pnpm run test:nonInteractive run renderer/src/features/skills/...` are green locally.

## Out of scope

- No frontend reaction to specific sentinel values from toolhive#5076 — we surface whatever the backend returns, keeping the renderer decoupled from the toolhive-core sentinel list.
- Other dialogs are unchanged: `DialogInstallSkill`, local/remote MCP forms, and the registry "Run from registry" form already persist their submission errors inline.
- No API client regeneration — toolhive#5076 doesn't change the OpenAPI annotation (`@Failure 400` was already advertised on `buildSkill`).