### PR TITLE
feat(skills): allow pasting and validating folder paths in build dialog

### DIFF
--- a/main/src/ipc-handlers/dialogs.ts
+++ b/main/src/ipc-handlers/dialogs.ts
@@ -1,4 +1,5 @@
 import { ipcMain, dialog } from 'electron'
+import fs from 'node:fs'
 import { getMainWindow } from '../main-window'
 import log from '../logger'
 
@@ -32,6 +33,16 @@ export function register() {
     } catch (error) {
       log.error('Failed to show folder dialog:', error)
       return null
+    }
+  })
+
+  ipcMain.handle('dialog:is-directory', async (_event, path: unknown) => {
+    if (typeof path !== 'string' || path.length === 0) return false
+    try {
+      const stat = await fs.promises.stat(path)
+      return stat.isDirectory()
+    } catch {
+      return false
     }
   })
 }

--- a/preload/src/api/dialogs.ts
+++ b/preload/src/api/dialogs.ts
@@ -5,9 +5,12 @@ export const dialogsApi = {
     ipcRenderer.invoke('dialog:select-file'),
   selectFolder: (): Promise<string | null> =>
     ipcRenderer.invoke('dialog:select-folder'),
+  isDirectory: (path: string): Promise<boolean> =>
+    ipcRenderer.invoke('dialog:is-directory', path),
 }
 
 export interface DialogsAPI {
   selectFile: () => Promise<string | null>
   selectFolder: () => Promise<string | null>
+  isDirectory: (path: string) => Promise<boolean>
 }

--- a/renderer/src/common/mocks/electronAPI.ts
+++ b/renderer/src/common/mocks/electronAPI.ts
@@ -50,6 +50,7 @@ function createElectronStub(): Partial<ElectronAPI> {
       stream: vi.fn(),
     } as unknown as ElectronAPI['chat'],
     selectFolder: vi.fn().mockResolvedValue(null),
+    isDirectory: vi.fn().mockResolvedValue(true),
     on: vi.fn(),
     removeListener: vi.fn(),
   }

--- a/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
@@ -50,9 +50,9 @@ describe('DialogBuildSkill', () => {
     await user.click(screen.getByRole('button', { name: /browse for folder/i }))
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
-        '/home/user/my-skill'
-      )
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
     })
   })
 
@@ -67,9 +67,9 @@ describe('DialogBuildSkill', () => {
 
     await user.click(screen.getByRole('button', { name: /browse for folder/i }))
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
-        '/home/user/my-skill'
-      )
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
     })
 
     await user.type(screen.getByPlaceholderText(/e\.g\. v1\.0\.0/i), 'v1.0.0')
@@ -100,9 +100,9 @@ describe('DialogBuildSkill', () => {
 
     await user.click(screen.getByRole('button', { name: /browse for folder/i }))
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
-        '/home/user/my-skill'
-      )
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
     })
     await user.click(screen.getByRole('button', { name: /^build$/i }))
 
@@ -125,9 +125,9 @@ describe('DialogBuildSkill', () => {
 
     await user.click(screen.getByRole('button', { name: /browse for folder/i }))
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
-        '/home/user/my-skill'
-      )
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
     })
     await user.click(screen.getByRole('button', { name: /^build$/i }))
 
@@ -147,9 +147,9 @@ describe('DialogBuildSkill', () => {
 
     await user.click(screen.getByRole('button', { name: /browse for folder/i }))
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
-        '/home/user/my-skill'
-      )
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
     })
     await user.click(screen.getByRole('button', { name: /^build$/i }))
 
@@ -169,9 +169,9 @@ describe('DialogBuildSkill', () => {
 
     await user.click(screen.getByRole('button', { name: /browse for folder/i }))
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
-        '/home/user/my-skill'
-      )
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
     })
     await user.click(screen.getByRole('button', { name: /^build$/i }))
 
@@ -191,9 +191,9 @@ describe('DialogBuildSkill', () => {
 
     await user.click(screen.getByRole('button', { name: /browse for folder/i }))
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
-        '/home/user/my-skill'
-      )
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
     })
     await user.click(screen.getByRole('button', { name: /^build$/i }))
 
@@ -213,9 +213,9 @@ describe('DialogBuildSkill', () => {
 
     await user.click(screen.getByRole('button', { name: /browse for folder/i }))
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/select a directory/i)).toHaveValue(
-        '/home/user/my-skill'
-      )
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
     })
     await user.click(screen.getByRole('button', { name: /^build$/i }))
 
@@ -228,5 +228,51 @@ describe('DialogBuildSkill', () => {
     await waitFor(() => {
       expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
+  })
+
+  it('accepts a manually typed path and submits when isDirectory returns true', async () => {
+    const user = userEvent.setup()
+    const rec = recordRequests()
+
+    renderWithProviders(<DialogBuildSkill open onOpenChange={vi.fn()} />)
+
+    const pathInput = screen.getByPlaceholderText(/paste or type a folder/i)
+    await user.type(pathInput, '/home/user/.agents/my-skill')
+    await user.click(screen.getByRole('button', { name: /^build$/i }))
+
+    await waitFor(() => {
+      const postCall = rec.recordedRequests.find(
+        (r) => r.method === 'POST' && r.pathname === '/api/v1beta/skills/build'
+      )
+      expect(postCall).toBeDefined()
+      expect(postCall?.payload).toMatchObject({
+        path: '/home/user/.agents/my-skill',
+      })
+    })
+
+    expect(window.electronAPI.isDirectory).toHaveBeenCalledWith(
+      '/home/user/.agents/my-skill'
+    )
+  })
+
+  it('blocks submit and shows validation error when typed path is not a directory', async () => {
+    const user = userEvent.setup()
+    const rec = recordRequests()
+    vi.mocked(window.electronAPI.isDirectory).mockResolvedValue(false)
+
+    renderWithProviders(<DialogBuildSkill open onOpenChange={vi.fn()} />)
+
+    const pathInput = screen.getByPlaceholderText(/paste or type a folder/i)
+    await user.type(pathInput, '/does/not/exist')
+    await user.click(screen.getByRole('button', { name: /^build$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/folder does not exist/i)).toBeInTheDocument()
+    })
+
+    const postCall = rec.recordedRequests.find(
+      (r) => r.method === 'POST' && r.pathname === '/api/v1beta/skills/build'
+    )
+    expect(postCall).toBeUndefined()
   })
 })

--- a/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
@@ -267,7 +267,9 @@ describe('DialogBuildSkill', () => {
     await user.click(screen.getByRole('button', { name: /^build$/i }))
 
     await waitFor(() => {
-      expect(screen.getByText(/folder does not exist/i)).toBeInTheDocument()
+      expect(
+        screen.getByText(/path is not a valid folder/i)
+      ).toBeInTheDocument()
     })
 
     const postCall = rec.recordedRequests.find(

--- a/renderer/src/features/skills/components/dialog-build-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-build-skill.tsx
@@ -28,7 +28,16 @@ import { DialogInstallSkill } from './dialog-install-skill'
 import { trackEvent } from '@/common/lib/analytics'
 
 const formSchema = z.object({
-  path: z.string().min(1, 'Path is required'),
+  path: z
+    .string()
+    .min(1, 'Path is required')
+    .refine(
+      async (value) => {
+        if (!value) return true
+        return window.electronAPI.isDirectory(value)
+      },
+      { message: 'Folder does not exist' }
+    ),
   tag: z.string().optional(),
 })
 
@@ -50,6 +59,7 @@ export function DialogBuildSkill({
 
   const form = useForm<FormSchema>({
     resolver: zodV4Resolver(formSchema),
+    mode: 'onBlur',
     defaultValues: {
       path: '',
       tag: '',
@@ -149,9 +159,9 @@ export function DialogBuildSkill({
                       <FormControl>
                         <Input
                           {...field}
-                          placeholder="Select a directory..."
-                          readOnly
-                          className="cursor-default"
+                          placeholder="Paste or type a folder path..."
+                          autoComplete="off"
+                          spellCheck={false}
                         />
                       </FormControl>
                       <Button

--- a/renderer/src/features/skills/components/dialog-build-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-build-skill.tsx
@@ -36,7 +36,7 @@ const formSchema = z.object({
         if (!value) return true
         return window.electronAPI.isDirectory(value)
       },
-      { message: 'Folder does not exist' }
+      { message: 'Path is not a valid folder' }
     ),
   tag: z.string().optional(),
 })
@@ -60,6 +60,7 @@ export function DialogBuildSkill({
   const form = useForm<FormSchema>({
     resolver: zodV4Resolver(formSchema),
     mode: 'onBlur',
+    reValidateMode: 'onBlur',
     defaultValues: {
       path: '',
       tag: '',


### PR DESCRIPTION
The Build skill dialog only let you set a path through the native OS folder picker, which on macOS/Windows hides dot-folders (e.g. `.agents`, `.claude`) unless the user toggles hidden files in the OS. This PR makes the path field editable so users can paste/type a path, and validates it against the file system through a new IPC call before the build is dispatched.


https://github.com/user-attachments/assets/3e3c9596-f3ee-4019-85ca-096a3f8edd61


## Summary

- New `dialog:is-directory` IPC handler in the main process. Calls `fs.promises.stat(path).isDirectory()` and returns `false` for any error (ENOENT, EACCES, non-string input).
- Exposed on the preload bridge as `window.electronAPI.isDirectory(path)`.
- Build skill dialog path input is now editable, with an updated placeholder (`Paste or type a folder path...`), `autoComplete="off"`, and `spellCheck={false}`. The folder picker button is unchanged.
- Form validation switched to async via a `zod` `.refine` that calls `isDirectory`, with `mode: 'onBlur'` so users get feedback on tab-out as well as on submit. Error message: `Folder does not exist`. Empty input is short-circuited so the existing `Path is required` message still wins.

## How to validate

1. Skills → Build skill. The Path input now accepts manual edits.
2. Paste an absolute path that includes a hidden segment (e.g. `/Users/me/.agents/my-skill`) — the build runs as before.
3. Paste a non-existent path and tab out / click Build — `Folder does not exist` appears under the field and the build is not dispatched.
4. Click the folder icon — the native picker still works and the picked path is treated as valid.