### PR TITLE
fix(skills): preserve bottom spacing for registry pagination on short viewports

### DIFF
--- a/renderer/src/features/skills/components/skills-page.tsx
+++ b/renderer/src/features/skills/components/skills-page.tsx
@@ -265,7 +265,7 @@ export function SkillsPage() {
             <GridCardsRegistrySkills skills={registrySkills} />
           )}
           <Pagination
-            className="mt-auto"
+            className="mt-auto mb-5"
             page={registryMetadata?.page ?? registryPage}
             pageSize={registryMetadata?.limit ?? registryLimit}
             total={registryMetadata?.total ?? 0}


### PR DESCRIPTION
On the Skills > Registry tab, the pagination bar sat flush against the bottom edge of the window when the viewport was short enough that the table/grid plus pagination overflowed the scroll container. No breathing room below the bar, so the border looked tight against the OS chrome.

## Root cause

`Main` ([renderer/src/common/components/layout/main.tsx](renderer/src/common/components/layout/main.tsx)) is the scroll container and relies on `overflow-y-auto` + `py-5` for the 20px gap below page content:

```ts
'h-[calc(100dvh-calc(var(--spacing)_*_16))] overflow-y-auto',
'px-8 py-5',
```

Chromium does not honor the `padding-bottom` of an `overflow-y-auto` container at the end of scrolled content — a long-standing engine quirk. The `py-5` only paints when content fits without scrolling.

This only manifested on the Registry tab because it is the only screen rendering a `Pagination` pinned to the bottom of its `TabsContent` via `mt-auto` (verified — `Pagination` is only used in [skills-page.tsx](renderer/src/features/skills/components/skills-page.tsx)). The pagination has a visible border (`bg-background ... rounded-md border` from [pagination.tsx](renderer/src/common/components/ui/pagination.tsx)) which made the missing gap obvious.

## Changes

- [`skills-page.tsx`](renderer/src/features/skills/components/skills-page.tsx): add `mb-5` to the registry tab `Pagination` so the bottom spacing comes from inside the scroll content (where it is honored) instead of from `Main`'s `padding-bottom`. The 20px matches `Main`'s `py-5`.

`mt-auto` continues to push the pagination to the bottom of `TabsContent` on tall viewports, so there is no visible regression there.

## How to validate

1. Skills > Registry → resize the window short enough that the table/grid + pagination overflow `Main`. Scroll to the bottom: the bar now keeps a 20px gap below it instead of touching the window edge.
2. Tall viewport: pagination is still pinned to the bottom of `TabsContent`, no double spacing.
3. Installed and Local Builds tabs are unchanged — they do not render `Pagination`.
