### PR TITLE
feat(skills): nice empty state when search returns no results

### DIFF
--- a/renderer/src/common/components/empty-state.tsx
+++ b/renderer/src/common/components/empty-state.tsx
@@ -22,7 +22,7 @@ type EmptyStateProps = {
   body: string
 } & (
   | { actions: [ReactNode, ReactNode?]; children?: never }
-  | { actions?: never; children: ReactNode }
+  | { actions?: never; children?: ReactNode }
 )
 
 export function EmptyState({

--- a/renderer/src/features/skills/components/__tests__/grid-cards-builds.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/grid-cards-builds.test.tsx
@@ -106,7 +106,7 @@ describe('GridCardsBuilds', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('No builds found matching the current filter')
+        screen.getByRole('heading', { name: /no builds found/i })
       ).toBeInTheDocument()
     })
   })

--- a/renderer/src/features/skills/components/__tests__/grid-cards-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/grid-cards-registry-skills.test.tsx
@@ -51,7 +51,7 @@ describe('GridCardsRegistrySkills', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText('No skills found matching the current filter')
+        screen.getByRole('heading', { name: /no skills found/i })
       ).toBeInTheDocument()
     })
   })

--- a/renderer/src/features/skills/components/__tests__/grid-cards-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/grid-cards-skills.test.tsx
@@ -51,7 +51,7 @@ describe('GridCardsSkills', () => {
     renderWithProviders(<GridCardsSkills skills={[]} />)
 
     expect(
-      screen.getByText('No skills found matching the current filter')
+      screen.getByRole('heading', { name: /no skills found/i })
     ).toBeInTheDocument()
   })
 })

--- a/renderer/src/features/skills/components/__tests__/table-builds.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-builds.test.tsx
@@ -93,7 +93,7 @@ describe('TableBuilds', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/no builds found matching the current filter/i)
+        screen.getByRole('heading', { name: /no builds found/i })
       ).toBeVisible()
     })
   })

--- a/renderer/src/features/skills/components/__tests__/table-installed-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-installed-skills.test.tsx
@@ -100,7 +100,7 @@ describe('TableInstalledSkills', () => {
     renderWithProviders(<TableInstalledSkills skills={[]} />)
 
     expect(
-      screen.getByText(/no skills found matching the current filter/i)
+      screen.getByRole('heading', { name: /no skills found/i })
     ).toBeVisible()
   })
 })

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -91,7 +91,7 @@ describe('TableRegistrySkills', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/no skills found matching the current filter/i)
+        screen.getByRole('heading', { name: /no skills found/i })
       ).toBeVisible()
     })
   })

--- a/renderer/src/features/skills/components/grid-cards-builds.tsx
+++ b/renderer/src/features/skills/components/grid-cards-builds.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import { getApiV1BetaSkillsBuildsOptions } from '@common/api/generated/@tanstack/react-query.gen'
 import { EmptyState } from '@/common/components/empty-state'
 import { IllustrationPackage } from '@/common/components/illustrations/illustration-package'
+import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
 import { Button } from '@/common/components/ui/button'
 import { cn } from '@/common/lib/utils'
 import { HammerIcon } from 'lucide-react'
@@ -43,9 +44,13 @@ export function GridCardsBuilds({ filter, onBuild }: GridCardsBuildsProps) {
 
   if (filteredData.length === 0) {
     return (
-      <div className="text-muted-foreground py-12 text-center">
-        <p className="text-sm">No builds found matching the current filter</p>
-      </div>
+      <EmptyState
+        illustration={IllustrationNoSearchResults}
+        title="No builds found"
+        body="Try adjusting your search to find what you're looking for."
+      >
+        <></>
+      </EmptyState>
     )
   }
 

--- a/renderer/src/features/skills/components/grid-cards-builds.tsx
+++ b/renderer/src/features/skills/components/grid-cards-builds.tsx
@@ -48,9 +48,7 @@ export function GridCardsBuilds({ filter, onBuild }: GridCardsBuildsProps) {
         illustration={IllustrationNoSearchResults}
         title="No builds found"
         body="Try adjusting your search to find what you're looking for."
-      >
-        <></>
-      </EmptyState>
+      />
     )
   }
 

--- a/renderer/src/features/skills/components/grid-cards-registry-skills.tsx
+++ b/renderer/src/features/skills/components/grid-cards-registry-skills.tsx
@@ -1,5 +1,7 @@
 import type { RegistrySkill } from '@common/api/generated/types.gen'
 import { CardRegistrySkill } from './card-registry-skill'
+import { EmptyState } from '@/common/components/empty-state'
+import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
 import { cn } from '@/common/lib/utils'
 
 export function GridCardsRegistrySkills({
@@ -9,9 +11,13 @@ export function GridCardsRegistrySkills({
 }) {
   if (skills.length === 0) {
     return (
-      <div className="text-muted-foreground py-12 text-center">
-        <p className="text-sm">No skills found matching the current filter</p>
-      </div>
+      <EmptyState
+        illustration={IllustrationNoSearchResults}
+        title="No skills found"
+        body="Try adjusting your search to find what you're looking for."
+      >
+        <></>
+      </EmptyState>
     )
   }
 

--- a/renderer/src/features/skills/components/grid-cards-registry-skills.tsx
+++ b/renderer/src/features/skills/components/grid-cards-registry-skills.tsx
@@ -15,9 +15,7 @@ export function GridCardsRegistrySkills({
         illustration={IllustrationNoSearchResults}
         title="No skills found"
         body="Try adjusting your search to find what you're looking for."
-      >
-        <></>
-      </EmptyState>
+      />
     )
   }
 

--- a/renderer/src/features/skills/components/grid-cards-skills.tsx
+++ b/renderer/src/features/skills/components/grid-cards-skills.tsx
@@ -1,13 +1,19 @@
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { CardSkill } from './card-skill'
+import { EmptyState } from '@/common/components/empty-state'
+import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
 import { cn } from '@/common/lib/utils'
 
 export function GridCardsSkills({ skills }: { skills: InstalledSkill[] }) {
   if (skills.length === 0) {
     return (
-      <div className="text-muted-foreground py-12 text-center">
-        <p className="text-sm">No skills found matching the current filter</p>
-      </div>
+      <EmptyState
+        illustration={IllustrationNoSearchResults}
+        title="No skills found"
+        body="Try adjusting your search to find what you're looking for."
+      >
+        <></>
+      </EmptyState>
     )
   }
 

--- a/renderer/src/features/skills/components/grid-cards-skills.tsx
+++ b/renderer/src/features/skills/components/grid-cards-skills.tsx
@@ -11,9 +11,7 @@ export function GridCardsSkills({ skills }: { skills: InstalledSkill[] }) {
         illustration={IllustrationNoSearchResults}
         title="No skills found"
         body="Try adjusting your search to find what you're looking for."
-      >
-        <></>
-      </EmptyState>
+      />
     )
   }
 

--- a/renderer/src/features/skills/components/table-builds.tsx
+++ b/renderer/src/features/skills/components/table-builds.tsx
@@ -233,9 +233,7 @@ export function TableBuilds({ filter, onBuild }: TableBuildsProps) {
         illustration={IllustrationNoSearchResults}
         title="No builds found"
         body="Try adjusting your search to find what you're looking for."
-      >
-        <></>
-      </EmptyState>
+      />
     )
   }
 

--- a/renderer/src/features/skills/components/table-builds.tsx
+++ b/renderer/src/features/skills/components/table-builds.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/common/components/ui/button'
 import { Badge } from '@/common/components/ui/badge'
 import { EmptyState } from '@/common/components/empty-state'
 import { IllustrationPackage } from '@/common/components/illustrations/illustration-package'
+import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
 import {
   Table,
   TableBody,
@@ -228,9 +229,13 @@ export function TableBuilds({ filter, onBuild }: TableBuildsProps) {
 
   if (filteredData.length === 0) {
     return (
-      <div className="text-muted-foreground py-12 text-center">
-        <p className="text-sm">No builds found matching the current filter</p>
-      </div>
+      <EmptyState
+        illustration={IllustrationNoSearchResults}
+        title="No builds found"
+        body="Try adjusting your search to find what you're looking for."
+      >
+        <></>
+      </EmptyState>
     )
   }
 

--- a/renderer/src/features/skills/components/table-installed-skills.tsx
+++ b/renderer/src/features/skills/components/table-installed-skills.tsx
@@ -14,6 +14,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/common/components/ui/tooltip'
+import { EmptyState } from '@/common/components/empty-state'
+import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
 import { FolderGit2Icon, Trash2Icon, UserIcon } from 'lucide-react'
 import type { GithubComStacklokToolhivePkgSkillsInstalledSkill as InstalledSkill } from '@common/api/generated/types.gen'
 import { DialogUninstallSkill } from './dialog-uninstall-skill'
@@ -154,9 +156,13 @@ function SkillRow({ skill }: { skill: InstalledSkill }) {
 export function TableInstalledSkills({ skills }: { skills: InstalledSkill[] }) {
   if (skills.length === 0) {
     return (
-      <div className="text-muted-foreground py-12 text-center">
-        <p className="text-sm">No skills found matching the current filter</p>
-      </div>
+      <EmptyState
+        illustration={IllustrationNoSearchResults}
+        title="No skills found"
+        body="Try adjusting your search to find what you're looking for."
+      >
+        <></>
+      </EmptyState>
     )
   }
 

--- a/renderer/src/features/skills/components/table-installed-skills.tsx
+++ b/renderer/src/features/skills/components/table-installed-skills.tsx
@@ -160,9 +160,7 @@ export function TableInstalledSkills({ skills }: { skills: InstalledSkill[] }) {
         illustration={IllustrationNoSearchResults}
         title="No skills found"
         body="Try adjusting your search to find what you're looking for."
-      >
-        <></>
-      </EmptyState>
+      />
     )
   }
 

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -166,9 +166,7 @@ export function TableRegistrySkills({ skills }: { skills: RegistrySkill[] }) {
         illustration={IllustrationNoSearchResults}
         title="No skills found"
         body="Try adjusting your search to find what you're looking for."
-      >
-        <></>
-      </EmptyState>
+      />
     )
   }
 

--- a/renderer/src/features/skills/components/table-registry-skills.tsx
+++ b/renderer/src/features/skills/components/table-registry-skills.tsx
@@ -16,6 +16,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/common/components/ui/tooltip'
+import { EmptyState } from '@/common/components/empty-state'
+import { IllustrationNoSearchResults } from '@/common/components/illustrations/illustration-no-search-results'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { getSkillInstallReference } from '../lib/skill-reference'
 import { trackEvent } from '@/common/lib/analytics'
@@ -160,9 +162,13 @@ function RegistrySkillRow({ skill }: { skill: RegistrySkill }) {
 export function TableRegistrySkills({ skills }: { skills: RegistrySkill[] }) {
   if (skills.length === 0) {
     return (
-      <div className="text-muted-foreground py-12 text-center">
-        <p className="text-sm">No skills found matching the current filter</p>
-      </div>
+      <EmptyState
+        illustration={IllustrationNoSearchResults}
+        title="No skills found"
+        body="Try adjusting your search to find what you're looking for."
+      >
+        <></>
+      </EmptyState>
     )
   }
 


### PR DESCRIPTION
Polish follow-up on the Skills page. When a search or filter on any of the three tabs returned nothing, we rendered a single line of grey text hugging the top of the content area, while the rest of the app already uses the shared `EmptyState` component (with `IllustrationNoSearchResults`) for "skill not found", "build not found", "no skills installed", and "no local builds". Six components on the Skills page shared the old placeholder — table + grid for each tab — so the empty case felt visually out of place next to those proper empty states.

This PR swaps the placeholder for the shared `EmptyState` so the search-empty case is consistent with the rest of the app: an illustration, a `No skills found` (or `No builds found` on the builds tab) heading, and a `Try adjusting your search to find what you're looking for.` body. No actions are attached — the search input above remains the implicit call to action, mirroring how the plain text behaved.

<img width="1281" height="802" alt="Screenshot 2026-04-28 at 10 06 13" src="https://github.com/user-attachments/assets/3e246d76-dfa1-4b8a-9ec2-48036c866df9" />


## Changes

- Registry tab: [`table-registry-skills.tsx`](renderer/src/features/skills/components/table-registry-skills.tsx), [`grid-cards-registry-skills.tsx`](renderer/src/features/skills/components/grid-cards-registry-skills.tsx).
- Installed tab: [`table-installed-skills.tsx`](renderer/src/features/skills/components/table-installed-skills.tsx), [`grid-cards-skills.tsx`](renderer/src/features/skills/components/grid-cards-skills.tsx).
- Local Builds tab (filter case only): [`table-builds.tsx`](renderer/src/features/skills/components/table-builds.tsx), [`grid-cards-builds.tsx`](renderer/src/features/skills/components/grid-cards-builds.tsx).
- Tests in the matching `__tests__/` files were updated to assert the new heading instead of the old placeholder copy.

## How to validate

1. Skills → Registry → type a query that matches nothing (e.g. `zzz`). The illustration + heading + body render in place of the old one-line placeholder, in both table and grid view.
2. Skills → Installed → install at least one skill, then type a query that matches nothing — same empty state.
3. Skills → Local Builds → with builds present, type a query that matches nothing — "No builds found" empty state. With zero builds, the existing "No local builds" + Build skill CTA still renders unchanged.
4. Skill / Build / Server detail "not found" pages are unchanged.

## Out of scope

- The "No skills installed" full-empty state on the Installed tab (already a proper `EmptyState` in `skills-page.tsx`).
- The "No local builds" full-empty state on the Builds tab (already a proper `EmptyState` in `table-builds.tsx` / `grid-cards-builds.tsx`).
- Differentiating "empty registry" vs. "search has no results" — same empty state today, same behaviour after this PR.