### PR TITLE
feat(skills): launch Skills as default landing route

### DIFF
--- a/e2e-tests/fixtures/electron.ts
+++ b/e2e-tests/fixtures/electron.ts
@@ -77,6 +77,9 @@ export function deleteTestSecretViaCli(): void {
 }
 
 async function createAndActivateTestGroup(window: Page): Promise<void> {
+  // The app now lands on /skills by default — navigate to the MCP Servers
+  // groups page where the "Add a group" affordance lives.
+  await window.getByRole('link', { name: /mcp servers/i }).click()
   await window.getByRole('button', { name: /add a group/i }).click()
   await window.getByRole('dialog').waitFor()
   await window.getByLabel(/name/i).fill(TEST_GROUP_NAME)

--- a/e2e-tests/mcp-optimizer-startup-cleanup.spec.ts
+++ b/e2e-tests/mcp-optimizer-startup-cleanup.spec.ts
@@ -46,6 +46,9 @@ async function createGroupViaUi(
   groupName: string
 ): Promise<void> {
   const { window } = launched
+  // The app now lands on /skills by default — navigate to the MCP Servers
+  // groups page where the "Add a group" affordance lives.
+  await window.getByRole('link', { name: /mcp servers/i }).click()
   await window.getByRole('button', { name: /add a group/i }).click()
   await window.getByRole('dialog').waitFor()
   await window.getByLabel(/name/i).fill(groupName)

--- a/e2e-tests/skills.spec.ts
+++ b/e2e-tests/skills.spec.ts
@@ -1,0 +1,66 @@
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+import { test as base, expect } from '@playwright/test'
+import { test } from './fixtures/electron'
+import { launchApp } from './helpers/app-relaunch'
+
+// Standalone test (does not use the shared fixture) so the assertion runs
+// against the app's true initial route, before any nav clicks happen.
+base.describe('Skills default landing route', () => {
+  base('app launches into the Skills page on /skills', async () => {
+    const userDataDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'toolhive-e2e-skills-default-')
+    )
+    const launched = await launchApp(userDataDir)
+    try {
+      // Tabs are part of the Skills page only, so their presence proves we
+      // landed on /skills rather than /group/default.
+      await expect(
+        launched.window.getByRole('tab', { name: 'Registry' })
+      ).toBeVisible()
+      await expect(
+        launched.window.getByRole('tab', { name: 'Installed' })
+      ).toBeVisible()
+      await expect(
+        launched.window.getByRole('tab', { name: 'Local Builds' })
+      ).toBeVisible()
+
+      // Installed is the default tab — empty state confirms its panel is the
+      // active one on a clean userDataDir.
+      await expect(
+        launched.window.getByRole('heading', { name: /no skills installed/i })
+      ).toBeVisible()
+    } finally {
+      await launched.close()
+      fs.rmSync(userDataDir, { recursive: true, force: true })
+    }
+  })
+})
+
+test.describe('Skills page navigation', () => {
+  test('switches between tabs and shows the right empty state', async ({
+    window,
+  }) => {
+    // The shared fixture leaves us on the test group page; navigate to Skills.
+    await window.getByRole('link', { name: /^skills$/i }).click()
+
+    // Installed (default) shows the no-skills empty state.
+    await expect(
+      window.getByRole('heading', { name: /no skills installed/i })
+    ).toBeVisible()
+
+    // Local Builds shows its own empty state with a "Build skill" CTA.
+    await window.getByRole('tab', { name: 'Local Builds' }).click()
+    await expect(
+      window.getByRole('heading', { name: /no local builds/i })
+    ).toBeVisible()
+    await expect(
+      window.getByRole('button', { name: /build skill/i })
+    ).toBeVisible()
+
+    // Registry tab renders its toolbar (search input + view toggle).
+    await window.getByRole('tab', { name: 'Registry' }).click()
+    await expect(window.getByPlaceholder(/search/i).first()).toBeVisible()
+  })
+})

--- a/main/src/feature-flags/__tests__/flags.test.ts
+++ b/main/src/feature-flags/__tests__/flags.test.ts
@@ -71,14 +71,14 @@ describe('Feature Flags', () => {
     it('should return value from SQLite when available', () => {
       vi.mocked(readFeatureFlag).mockReturnValueOnce(true)
 
-      const result = getFeatureFlag(featureFlagKeys.SKILLS)
+      const result = getFeatureFlag(featureFlagKeys.AGENTS)
       expect(result).toBe(true)
     })
 
     it('should return false (default) when SQLite returns undefined', () => {
       vi.mocked(readFeatureFlag).mockReturnValueOnce(undefined)
 
-      const result = getFeatureFlag(featureFlagKeys.SKILLS)
+      const result = getFeatureFlag(featureFlagKeys.AGENTS)
       expect(result).toBe(false)
     })
 
@@ -87,7 +87,7 @@ describe('Feature Flags', () => {
         throw new Error('DB error')
       })
 
-      const result = getFeatureFlag(featureFlagKeys.SKILLS)
+      const result = getFeatureFlag(featureFlagKeys.AGENTS)
       expect(result).toBe(false)
     })
 
@@ -136,10 +136,10 @@ describe('Feature Flags', () => {
 
   describe('enableFeatureFlag', () => {
     it('should write true to SQLite for enabled flags', () => {
-      enableFeatureFlag(featureFlagKeys.SKILLS)
+      enableFeatureFlag(featureFlagKeys.AGENTS)
 
       expect(writeFeatureFlag).toHaveBeenCalledWith(
-        `feature_flag_${featureFlagKeys.SKILLS}`,
+        `feature_flag_${featureFlagKeys.AGENTS}`,
         true
       )
     })

--- a/main/src/feature-flags/flags.ts
+++ b/main/src/feature-flags/flags.ts
@@ -15,11 +15,6 @@ const featureFlagOptions: Record<FeatureFlagKey, FeatureFlagOptions> = {
     defaultValue: false,
     isExperimental: true,
   },
-  [featureFlagKeys.SKILLS]: {
-    isDisabled: false,
-    defaultValue: false,
-    isExperimental: false,
-  },
   [featureFlagKeys.AGENTS]: {
     isDisabled: false,
     defaultValue: false,

--- a/renderer/src/common/components/layout/top-nav/__tests__/top-nav.test.tsx
+++ b/renderer/src/common/components/layout/top-nav/__tests__/top-nav.test.tsx
@@ -33,6 +33,13 @@ describe('TopNav', () => {
     return renderRoute(router, { permissions })
   }
 
+  it('renders Skills navigation link', async () => {
+    renderTopNav()
+    await waitFor(() => {
+      expect(screen.getByText('Skills')).toBeInTheDocument()
+    })
+  })
+
   it('renders MCP Servers navigation link', async () => {
     renderTopNav()
     await waitFor(() => {

--- a/renderer/src/common/components/layout/top-nav/index.tsx
+++ b/renderer/src/common/components/layout/top-nav/index.tsx
@@ -28,8 +28,6 @@ import { getOsDesignVariant } from '@/common/lib/os-design'
 import { trackEvent } from '@/common/lib/analytics'
 import { NavSeparator } from './nav-separator'
 import { NavIconButton } from './nav-icon-button'
-import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
-import { featureFlagKeys } from '@utils/feature-flags'
 import { usePermissions } from '@/common/contexts/permissions'
 import { PERMISSION_KEYS } from '@/common/contexts/permissions/permission-keys'
 import { buildOnrampDocsUrl } from '@/common/lib/onramp-url'
@@ -69,23 +67,20 @@ function useIsActive() {
 
 function TopNavLinks() {
   const isActive = useIsActive()
-  const isSkillsEnabled = useFeatureFlag(featureFlagKeys.SKILLS)
   const { canShow } = usePermissions()
 
   return (
     <NavigationMenu>
       <NavigationMenuList className="gap-2">
-        {isSkillsEnabled && (
-          <NavigationMenuItem>
-            <NavButton
-              to="/skills"
-              icon={BookOpen}
-              isActive={isActive(['/skills'])}
-            >
-              Skills
-            </NavButton>
-          </NavigationMenuItem>
-        )}
+        <NavigationMenuItem>
+          <NavButton
+            to="/skills"
+            icon={BookOpen}
+            isActive={isActive(['/skills'])}
+          >
+            Skills
+          </NavButton>
+        </NavigationMenuItem>
         <NavigationMenuItem>
           <NavButton
             to="/group/default"

--- a/renderer/src/common/hooks/use-experimental-features.tsx
+++ b/renderer/src/common/hooks/use-experimental-features.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
 import { useCallback } from 'react'
-import { featureFlagKeys } from '../../../../utils/feature-flags'
 import { trackEvent } from '../lib/analytics'
 
 interface FeatureFlag {
@@ -12,10 +11,6 @@ interface FeatureFlag {
 }
 
 function formatFeatureFlagName(key: string): string {
-  if (key === featureFlagKeys.SKILLS) {
-    return 'Skills'
-  }
-
   return key
     .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
@@ -23,10 +18,6 @@ function formatFeatureFlagName(key: string): string {
 }
 
 function formatFeatureFlagDescription(key: string): React.ReactNode {
-  if (key === featureFlagKeys.SKILLS) {
-    return 'Browse and manage AI agent skills installed via ToolHive.'
-  }
-
   return `Enable ${formatFeatureFlagName(key)} feature`
 }
 

--- a/renderer/src/routes/__tests__/index.redirect.test.tsx
+++ b/renderer/src/routes/__tests__/index.redirect.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+} from '@tanstack/react-router'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
+import { Route as IndexRoute } from '../index'
+
+function renderIndexRoute() {
+  const beforeLoad = IndexRoute.options.beforeLoad as unknown as (
+    ...args: unknown[]
+  ) => Promise<void> | void
+
+  const rootRoute = createRootRoute({
+    component: Outlet,
+  })
+
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => null,
+    beforeLoad,
+  })
+
+  const skillsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills',
+    component: () => <div data-testid="skills-route" />,
+  })
+
+  const router = new Router({
+    routeTree: rootRoute.addChildren([indexRoute, skillsRoute]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+    defaultNotFoundComponent: () => null,
+  })
+
+  const utils = renderRoute(
+    router as unknown as ReturnType<typeof createTestRouter>
+  )
+
+  return { ...utils, router }
+}
+
+describe('Index route (/)', () => {
+  it('redirects to /skills', async () => {
+    const { router } = renderIndexRoute()
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/skills')
+    })
+  })
+})

--- a/renderer/src/routes/index.tsx
+++ b/renderer/src/routes/index.tsx
@@ -2,10 +2,6 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
   beforeLoad: () => {
-    throw redirect({
-      to: '/group/$groupName',
-      params: { groupName: 'default' },
-      replace: true,
-    })
+    throw redirect({ to: '/skills', replace: true })
   },
 })

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -1,5 +1,4 @@
 export const featureFlagKeys = {
   META_OPTIMIZER: 'meta_optimizer',
-  SKILLS: 'skills',
   AGENTS: 'agents',
 } as const


### PR DESCRIPTION
Skills graduates from a flag-gated, opt-in surface to a first-class part of the app: the `SKILLS` feature flag is removed entirely, the top-nav entry is unconditional, and the app now lands on `/skills` (Installed tab) on startup.

## Summary

- **`/` now redirects to `/skills`** ([renderer/src/routes/index.tsx](renderer/src/routes/index.tsx)). The existing `validateSearch` in [renderer/src/routes/skills.tsx](renderer/src/routes/skills.tsx) already defaults `tab` to `'installed'`, so the redirect is a one-liner — no extra search params needed and the URL stays clean (`/skills`, not `/skills?tab=installed`).
- **`SKILLS` feature flag removed** from [utils/feature-flags.ts](utils/feature-flags.ts) and [main/src/feature-flags/flags.ts](main/src/feature-flags/flags.ts). Unlike `META_OPTIMIZER` (kept as `isDisabled: true` during sunset), this is a real launch, so the entry is dropped outright. Existing `feature_flag_skills` rows in SQLite become inert orphans — `getFeatureFlag` only iterates `featureFlagKeys`, so no migration is required.
- **Top-nav Skills link is unconditional** ([renderer/src/common/components/layout/top-nav/index.tsx](renderer/src/common/components/layout/top-nav/index.tsx)) and now sits first in the nav order, matching its new role as the default route. Removed the `useFeatureFlag` / `featureFlagKeys` imports.
- **Cleanup** in [renderer/src/common/hooks/use-experimental-features.tsx](renderer/src/common/hooks/use-experimental-features.tsx): the `if (key === featureFlagKeys.SKILLS)` branches in `formatFeatureFlagName` / `formatFeatureFlagDescription` were already dead (Skills had `isExperimental: false` and was filtered out of the experimental list) and would have stopped compiling once the key was gone.

## Tests

- New [renderer/src/routes/__tests__/index.redirect.test.tsx](renderer/src/routes/__tests__/index.redirect.test.tsx) — asserts `/` resolves to `/skills` via the route's `beforeLoad`, mirroring the pattern used in `playground.index.test.tsx`.
- [top-nav.test.tsx](renderer/src/common/components/layout/top-nav/__tests__/top-nav.test.tsx) — adds a test asserting the **Skills** link renders without any flag setup.
- [main/src/feature-flags/__tests__/flags.test.ts](main/src/feature-flags/__tests__/flags.test.ts) — the four SKILLS-specific assertions are rerouted onto `featureFlagKeys.AGENTS` (same shape: non-disabled, default `false`) so the SQLite read/write/default paths stay covered.
- New [e2e-tests/skills.spec.ts](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/e2e-tests/skills.spec.ts) — app launches into the Skills page on /skills (standalone, via launchApp) directly verifies the default landing route on a fresh userDataDir. A second test walks the three Skills tabs from the unconditional nav link and asserts each empty state, implicitly covering the removed flag.
- Updated [e2e-tests/fixtures/electron.ts](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/e2e-tests/fixtures/electron.ts) and [e2e-tests/mcp-optimizer-startup-cleanup.spec.ts](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/e2e-tests/mcp-optimizer-startup-cleanup.spec.ts) — both now click the MCP Servers nav link before opening the Add a group dialog, so existing specs no longer rely on / landing on the groups page.

`pnpm run type-check`, `pnpm run lint`, and `pnpm run test:nonInteractive` (2036 tests across 181 files) all pass locally.

## How to validate

1. Fresh launch → app lands on **Skills → Installed**, not on `/group/default`.
2. Top nav shows **Skills** as the first entry, regardless of any prior `feature_flag_skills` value in SQLite.
3. `Settings → Experimental features` no longer mentions Skills (it never did, but verify the section still renders correctly with only `AGENTS` left).
4. DevTools: `window.FeatureFlag.skills` is now `undefined` — that's expected; existing automation that toggled the flag should be removed.
5. `/group/default` still works when reached from the MCP Servers nav entry or any deep link — this PR only changes the `/` redirect target.

## Out of scope

- No DB migration for orphaned `feature_flag_skills` rows (harmless; never read).
- No change to `LinkViewTransition`'s `ORDERED_ROUTES` — `/skills` is already first in that list.
- No change to the unrelated `AGENTS` flag or the chat playground.