### PR TITLE
chore: remove unused exports

### DIFF
--- a/renderer/src/common/contexts/permissions/index.ts
+++ b/renderer/src/common/contexts/permissions/index.ts
@@ -1,7 +1,6 @@
 import { createContext, useCallback, useContext } from 'react'
 import { PERMISSION_KEYS, type PermissionKey } from './permission-keys'
 
-export type { PermissionKey } from './permission-keys'
 export { PERMISSION_KEYS } from './permission-keys'
 
 export type Permissions = Record<PermissionKey, boolean>

--- a/renderer/src/features/mcp-servers/lib/get-env-vars-drift.ts
+++ b/renderer/src/features/mcp-servers/lib/get-env-vars-drift.ts
@@ -1,7 +1,7 @@
 import type { PkgApiV1CreateRequest as V1CreateRequest } from '@common/api/generated/types.gen'
 import type { RegistryEnvVar } from '@common/api/registry-types'
 
-export interface EnvVarDriftItem {
+interface EnvVarDriftItem {
   name: string
   required: boolean
   secret: boolean


### PR DESCRIPTION
The new version of Knip caught two unused exports [here](https://github.com/stacklok/toolhive-studio/actions/runs/25055859210/job/73395837139?pr=2114)
Merging this before the upgrade to fix it.