### PR TITLE
feat(ci): add visual bug-fix agent with live-app access

### DIFF
--- a/.claude/agents/toolhive-studio-driver.md
+++ b/.claude/agents/toolhive-studio-driver.md
@@ -23,10 +23,19 @@ and keep its rules in mind throughout the session.
 
 ## Operating principles
 
-- **Drive only via `bash scripts/agent.sh` subcommands** (`shot`, `xdo`,
+- **Drive only via `bash .claude/skills/devcontainer-dev/scripts/agent.sh` subcommands** (`shot`, `xdo`,
   `tail`, `health`). These are pre-approved on a narrow surface. Use
   raw `docker exec` only if a task genuinely needs something the
   wrappers don't cover, and expect a permission prompt.
+- **Never prepend `cd ...` to the wrapper invocation.** The script uses
+  `git rev-parse --show-toplevel` to locate the repo root from any cwd
+  inside the repo, so a `cd` adds nothing. It also breaks pre-approval:
+  `Bash(bash .claude/...)` is a literal-prefix match against the
+  *whole* command string, and the form `cd ... && bash ...` doesn't
+  start with `bash`. Additionally, the compound `cd /x 2>/dev/null && ...`
+  shape trips a hardcoded Claude Code security guard ("path resolution
+  bypass") that no allowlist can override. Just call the script with
+  its full path: `bash .claude/skills/devcontainer-dev/scripts/agent.sh <verb>`.
 - **Always start with a health check.** If the devcontainer isn't up,
   launch it via `pnpm devContainer:dev` (long-running — run in
   background). Don't try to drive a non-running stack.

--- a/.claude/agents/toolhive-studio-driver.md
+++ b/.claude/agents/toolhive-studio-driver.md
@@ -1,0 +1,59 @@
+---
+name: toolhive-studio-driver
+description: >-
+  Drive the toolhive-studio devcontainer for live UI exploration: launch
+  the dev environment, take screenshots, click and type via xdotool, tail
+  dev-server logs, and report observations back to the parent. Use when
+  the parent needs to delegate visual / interactive testing of the
+  ToolHive Studio Electron app — e.g. verifying a UI change, reproducing
+  a UI bug, or capturing screenshots for a PR. NOT for backend-only work
+  or for the standard host-side `pnpm start` flow.
+skills:
+  - devcontainer-dev
+tools: Bash, Read, Grep, Glob
+---
+
+# ToolHive Studio Driver
+
+You drive toolhive-studio's containerized dev environment to explore,
+test, or reproduce issues against the live Electron app. The
+`devcontainer-dev` skill is preloaded — it documents the launch flow,
+the wrapper recipes, and known gotchas. **Read it once at the start**
+and keep its rules in mind throughout the session.
+
+## Operating principles
+
+- **Drive only via `bash scripts/agent.sh` subcommands** (`shot`, `xdo`,
+  `tail`, `health`). These are pre-approved on a narrow surface. Use
+  raw `docker exec` only if a task genuinely needs something the
+  wrappers don't cover, and expect a permission prompt.
+- **Always start with a health check.** If the devcontainer isn't up,
+  launch it via `pnpm devContainer:dev` (long-running — run in
+  background). Don't try to drive a non-running stack.
+- **Screenshot before and after every action.** Pixel-coordinate
+  driving is brittle; modal/CSS changes invalidate prior coordinates.
+  Verify state-by-state instead of chaining many actions.
+- **Use cropped screenshots when zooming on a region** — vision models
+  perform meaningfully better on a focused crop than on the full
+  1920×1200 framebuffer. The wrapper takes `--crop WxH+X+Y`.
+- **HMR settle delay.** After editing renderer code, `sleep 2` before
+  re-screenshotting. If your edit touches anything under `main/`, the
+  live app will not pick it up without an Electron restart — call that
+  out and rely on unit tests for main-process changes.
+- **Save artifacts to `/tmp/<task-slug>-<step>.png`** so they survive
+  past your exit and the parent can read them. Reference them by
+  absolute path in your final report.
+
+## Reporting back
+
+When you finish a task, report concisely:
+
+- What you did, step by step (action → observation).
+- Paths to the screenshots that ground each observation.
+- Any unexpected app behavior, errors in `entrypoint`/`xvfb`/`fluxbox`
+  logs, or rough edges in the wrapper itself.
+- If the devcontainer was already up at the start, mention it (so the
+  parent knows nothing was launched on its behalf).
+
+Keep the report tight — under 400 words unless the parent asked for a
+deep dive. The screenshots are the evidence; the prose is the index.

--- a/.claude/skills/devcontainer-dev/SKILL.md
+++ b/.claude/skills/devcontainer-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: devcontainer-dev
 description: Spin up and interact with ToolHive Studio's containerized dev environment (Xvfb + noVNC + DinD). Use when running, testing, or debugging the app in isolation — locally, in a git worktree, or in GitHub Codespaces; when touching `.devcontainer/*`, `scripts/devcontainer-*.sh`, or the `devContainer:dev` npm script; or when debugging "blank white window", "Docker daemon failed to start", or "Missing X server" errors in the devcontainer. The container is fully isolated: no host pnpm install, no host Docker socket, no host X11/GPU — experiment freely without contaminating the host.
-allowed-tools: Read, Grep, Glob, Bash
+allowed-tools: Read, Grep, Glob, Bash(bash scripts/agent.sh:*), Bash(pnpm devContainer:dev)
 ---
 
 # Containerized Dev Environment
@@ -142,20 +142,40 @@ docker exec "$CONTAINER" bash -c '
 
 The container has enough tools for an AI agent to both **see** and **interact with** the running Electron window without going through the browser / noVNC. Useful for headless testing, reproducing user-reported UI bugs, or validating a feature end-to-end.
 
-All commands run via `docker exec` against the container with `DISPLAY=:99` set (matches Xvfb's display).
+The recipes below are wrapped in `scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
 
 ### See the screen (screenshots)
 
 ```bash
-# Take a PNG of the whole virtual framebuffer
+# Wrapped (recommended): screenshot to /tmp/shot.png on the host
+bash scripts/agent.sh shot
+
+# With an output path
+bash scripts/agent.sh shot ./shot.png
+
+# Cropped — vision models perform much better on a focused region than on
+# the full 1920×1200 framebuffer. Format is ImageMagick's WxH+X+Y.
+bash scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
+```
+
+Fallback (raw docker exec):
+
+```bash
 docker exec "$CONTAINER" bash -c 'DISPLAY=:99 import -window root /tmp/shot.png'
-# Copy it to the host for viewing / feeding to a vision model
 docker cp "$CONTAINER:/tmp/shot.png" /tmp/shot.png
 ```
 
 `import` is from ImageMagick. For a specific window only, use `xwininfo` to get the WID then `import -window <WID>`.
 
 ### See the window tree (what's there, where, which is focused)
+
+```bash
+# Wrapped: xdotool passthrough
+bash scripts/agent.sh xdo search --class ToolHive
+bash scripts/agent.sh xdo getactivewindow getwindowname
+```
+
+Fallback (raw docker exec):
 
 ```bash
 docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xwininfo -root -tree'
@@ -167,23 +187,61 @@ The main app window has `WM_CLASS=ToolHive` (see gotcha below). Its geometry is 
 
 ### Interact with the UI (mouse, keyboard)
 
+`xdo` is a passthrough to `xdotool` inside the container — its argument surface is intentionally narrow (X events only, no shell, no file access) so a single wrapper covers click / key / type / mousemove without per-verb validation cost.
+
 ```bash
-# Move the mouse and click
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool mousemove 400 300 click 1'
+# Click at coordinates
+bash scripts/agent.sh xdo mousemove --sync 400 300 click 1
 
 # Type into whatever has focus
+bash scripts/agent.sh xdo type --delay 20 'hello world'
+
+# Send a keystroke (DevTools)
+bash scripts/agent.sh xdo key ctrl+shift+i
+
+# Focus the main window by class
+bash scripts/agent.sh xdo search --class ToolHive windowactivate
+```
+
+Fallback (raw docker exec):
+
+```bash
+docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool mousemove 400 300 click 1'
 docker exec "$CONTAINER" bash -c "DISPLAY=:99 xdotool type --delay 20 'hello world'"
+docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool key ctrl+shift+i'
+```
 
-# Send a keystroke
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool key ctrl+shift+i'   # DevTools
+### Tail a log
 
-# Focus the main window by name
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool search --name ToolHive windowactivate'
+The dev-stack writes canonical logs under `/tmp/*.log` (see [Log files](#log-files-written-by-the-entrypoint)).
+
+```bash
+# Last 50 lines (default)
+bash scripts/agent.sh tail entrypoint
+
+# Last N lines
+bash scripts/agent.sh tail xvfb 200
+```
+
+Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entrypoint`.
+
+### Health check
+
+One-call readiness check — Electron running, `thv serve` running, the ToolHive X window mapped, and noVNC reachable. Exits non-zero if anything is down.
+
+```bash
+bash scripts/agent.sh health
 ```
 
 ### Typical agent loop
 
-Screenshot → feed to vision model → decide next action → `xdotool` → screenshot again. The usual caveats apply: pixel-coordinate automation is fragile, and CSS changes or modal dialogs can throw it off. For robust long-term automation, prefer a DOM-level approach (e.g. Chrome DevTools Protocol against Electron's remote debugging port — not currently wired in, see [Future: CDP access](#future-cdp-access)).
+Screenshot → Read it with the Read tool → reason about what you see → act via `xdo` → screenshot again. Pixel-coordinate driving is brittle (modal/CSS changes invalidate prior coordinates), so verify state-by-state instead of chaining many actions. Use cropped screenshots when zooming on a region — vision models perform meaningfully better on a focused crop than on the full 1920×1200 framebuffer.
+
+For robust DOM-level automation (querying / clicking by selector, scraping state), prefer a CDP-based approach once it's wired in — see [Future: CDP access](#future-cdp-access). Pixel ops via `xdo` and `shot` remain the right tool for OS-level interactions, multi-window coordination, and visual-regression checks.
+
+### After editing renderer code
+
+Vite HMR applies the change in-place — `sleep 2` before re-screenshotting so the UI has time to repaint. If your edit touches `main/`, a manual Electron restart is needed (~15s); rely on unit tests for main-process changes when driving the live app.
 
 ### Future: CDP access
 

--- a/.claude/skills/devcontainer-dev/SKILL.md
+++ b/.claude/skills/devcontainer-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: devcontainer-dev
 description: Spin up and interact with ToolHive Studio's containerized dev environment (Xvfb + noVNC + DinD). Use when running, testing, or debugging the app in isolation — locally, in a git worktree, or in GitHub Codespaces; when touching `.devcontainer/*`, `scripts/devcontainer-*.sh`, or the `devContainer:dev` npm script; or when debugging "blank white window", "Docker daemon failed to start", or "Missing X server" errors in the devcontainer. The container is fully isolated: no host pnpm install, no host Docker socket, no host X11/GPU — experiment freely without contaminating the host.
-allowed-tools: Read, Grep, Glob, Bash(bash scripts/agent.sh:*), Bash(pnpm devContainer:dev)
+allowed-tools: Read, Grep, Glob, Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*), Bash(pnpm devContainer:dev)
 ---
 
 # Containerized Dev Environment
@@ -142,20 +142,20 @@ docker exec "$CONTAINER" bash -c '
 
 The container has enough tools for an AI agent to both **see** and **interact with** the running Electron window without going through the browser / noVNC. Useful for headless testing, reproducing user-reported UI bugs, or validating a feature end-to-end.
 
-The recipes below are wrapped in `scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
+The recipes below are wrapped in `.claude/skills/devcontainer-dev/scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
 
 ### See the screen (screenshots)
 
 ```bash
 # Wrapped (recommended): screenshot to /tmp/shot.png on the host
-bash scripts/agent.sh shot
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot
 
 # With an output path
-bash scripts/agent.sh shot ./shot.png
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot ./shot.png
 
 # Cropped — vision models perform much better on a focused region than on
 # the full 1920×1200 framebuffer. Format is ImageMagick's WxH+X+Y.
-bash scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
 ```
 
 Fallback (raw docker exec):
@@ -171,8 +171,8 @@ docker cp "$CONTAINER:/tmp/shot.png" /tmp/shot.png
 
 ```bash
 # Wrapped: xdotool passthrough
-bash scripts/agent.sh xdo search --class ToolHive
-bash scripts/agent.sh xdo getactivewindow getwindowname
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo search --class ToolHive
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo getactivewindow getwindowname
 ```
 
 Fallback (raw docker exec):
@@ -191,16 +191,16 @@ The main app window has `WM_CLASS=ToolHive` (see gotcha below). Its geometry is 
 
 ```bash
 # Click at coordinates
-bash scripts/agent.sh xdo mousemove --sync 400 300 click 1
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo mousemove --sync 400 300 click 1
 
 # Type into whatever has focus
-bash scripts/agent.sh xdo type --delay 20 'hello world'
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo type --delay 20 'hello world'
 
 # Send a keystroke (DevTools)
-bash scripts/agent.sh xdo key ctrl+shift+i
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo key ctrl+shift+i
 
 # Focus the main window by class
-bash scripts/agent.sh xdo search --class ToolHive windowactivate
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo search --class ToolHive windowactivate
 ```
 
 Fallback (raw docker exec):
@@ -217,10 +217,10 @@ The dev-stack writes canonical logs under `/tmp/*.log` (see [Log files](#log-fil
 
 ```bash
 # Last 50 lines (default)
-bash scripts/agent.sh tail entrypoint
+bash .claude/skills/devcontainer-dev/scripts/agent.sh tail entrypoint
 
 # Last N lines
-bash scripts/agent.sh tail xvfb 200
+bash .claude/skills/devcontainer-dev/scripts/agent.sh tail xvfb 200
 ```
 
 Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entrypoint`.
@@ -230,7 +230,7 @@ Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entryp
 One-call readiness check — Electron running, `thv serve` running, the ToolHive X window mapped, and noVNC reachable. Exits non-zero if anything is down.
 
 ```bash
-bash scripts/agent.sh health
+bash .claude/skills/devcontainer-dev/scripts/agent.sh health
 ```
 
 ### Typical agent loop

--- a/.claude/skills/devcontainer-dev/scripts/agent.sh
+++ b/.claude/skills/devcontainer-dev/scripts/agent.sh
@@ -5,18 +5,21 @@
 # only the documented commands — so the allowlist can target this single
 # script instead of broad `Bash(docker exec *)`.
 #
-# Usage (run from the repo root, or any cwd — paths resolve from the
-# script's own location):
+# Usage (run from anywhere inside the repo — uses `git rev-parse` to
+# locate the repo root):
 #
-#   scripts/agent.sh shot [--crop WxH+X+Y] [PATH]   # screenshot to host
-#   scripts/agent.sh xdo  <args...>                  # xdotool passthrough
-#   scripts/agent.sh tail LOG [N]                    # tail one of /tmp/*.log
-#   scripts/agent.sh health                          # readiness check
+#   bash .claude/skills/devcontainer-dev/scripts/agent.sh shot [--crop WxH+X+Y] [PATH]
+#   bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo  <args...>
+#   bash .claude/skills/devcontainer-dev/scripts/agent.sh tail LOG [N]
+#   bash .claude/skills/devcontainer-dev/scripts/agent.sh health
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$REPO_ROOT" ]; then
+  echo "agent.sh: must be run from inside the repo (git rev-parse failed)" >&2
+  exit 1
+fi
 
 DISPLAY_NAME=":99"
 URL_CACHE_FILE="$HOME/.cache/toolhive-studio-url"

--- a/.codex/skills/devcontainer-dev/SKILL.md
+++ b/.codex/skills/devcontainer-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: devcontainer-dev
 description: Spin up and interact with ToolHive Studio's containerized dev environment (Xvfb + noVNC + DinD). Use when running, testing, or debugging the app in isolation — locally, in a git worktree, or in GitHub Codespaces; when touching `.devcontainer/*`, `scripts/devcontainer-*.sh`, or the `devContainer:dev` npm script; or when debugging "blank white window", "Docker daemon failed to start", or "Missing X server" errors in the devcontainer. The container is fully isolated: no host pnpm install, no host Docker socket, no host X11/GPU — experiment freely without contaminating the host.
-allowed-tools: Read, Grep, Glob, Bash
+allowed-tools: Read, Grep, Glob, Bash(bash scripts/agent.sh:*), Bash(pnpm devContainer:dev)
 ---
 
 # Containerized Dev Environment
@@ -142,20 +142,40 @@ docker exec "$CONTAINER" bash -c '
 
 The container has enough tools for an AI agent to both **see** and **interact with** the running Electron window without going through the browser / noVNC. Useful for headless testing, reproducing user-reported UI bugs, or validating a feature end-to-end.
 
-All commands run via `docker exec` against the container with `DISPLAY=:99` set (matches Xvfb's display).
+The recipes below are wrapped in `scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
 
 ### See the screen (screenshots)
 
 ```bash
-# Take a PNG of the whole virtual framebuffer
+# Wrapped (recommended): screenshot to /tmp/shot.png on the host
+bash scripts/agent.sh shot
+
+# With an output path
+bash scripts/agent.sh shot ./shot.png
+
+# Cropped — vision models perform much better on a focused region than on
+# the full 1920×1200 framebuffer. Format is ImageMagick's WxH+X+Y.
+bash scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
+```
+
+Fallback (raw docker exec):
+
+```bash
 docker exec "$CONTAINER" bash -c 'DISPLAY=:99 import -window root /tmp/shot.png'
-# Copy it to the host for viewing / feeding to a vision model
 docker cp "$CONTAINER:/tmp/shot.png" /tmp/shot.png
 ```
 
 `import` is from ImageMagick. For a specific window only, use `xwininfo` to get the WID then `import -window <WID>`.
 
 ### See the window tree (what's there, where, which is focused)
+
+```bash
+# Wrapped: xdotool passthrough
+bash scripts/agent.sh xdo search --class ToolHive
+bash scripts/agent.sh xdo getactivewindow getwindowname
+```
+
+Fallback (raw docker exec):
 
 ```bash
 docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xwininfo -root -tree'
@@ -167,23 +187,61 @@ The main app window has `WM_CLASS=ToolHive` (see gotcha below). Its geometry is 
 
 ### Interact with the UI (mouse, keyboard)
 
+`xdo` is a passthrough to `xdotool` inside the container — its argument surface is intentionally narrow (X events only, no shell, no file access) so a single wrapper covers click / key / type / mousemove without per-verb validation cost.
+
 ```bash
-# Move the mouse and click
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool mousemove 400 300 click 1'
+# Click at coordinates
+bash scripts/agent.sh xdo mousemove --sync 400 300 click 1
 
 # Type into whatever has focus
+bash scripts/agent.sh xdo type --delay 20 'hello world'
+
+# Send a keystroke (DevTools)
+bash scripts/agent.sh xdo key ctrl+shift+i
+
+# Focus the main window by class
+bash scripts/agent.sh xdo search --class ToolHive windowactivate
+```
+
+Fallback (raw docker exec):
+
+```bash
+docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool mousemove 400 300 click 1'
 docker exec "$CONTAINER" bash -c "DISPLAY=:99 xdotool type --delay 20 'hello world'"
+docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool key ctrl+shift+i'
+```
 
-# Send a keystroke
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool key ctrl+shift+i'   # DevTools
+### Tail a log
 
-# Focus the main window by name
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool search --name ToolHive windowactivate'
+The dev-stack writes canonical logs under `/tmp/*.log` (see [Log files](#log-files-written-by-the-entrypoint)).
+
+```bash
+# Last 50 lines (default)
+bash scripts/agent.sh tail entrypoint
+
+# Last N lines
+bash scripts/agent.sh tail xvfb 200
+```
+
+Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entrypoint`.
+
+### Health check
+
+One-call readiness check — Electron running, `thv serve` running, the ToolHive X window mapped, and noVNC reachable. Exits non-zero if anything is down.
+
+```bash
+bash scripts/agent.sh health
 ```
 
 ### Typical agent loop
 
-Screenshot → feed to vision model → decide next action → `xdotool` → screenshot again. The usual caveats apply: pixel-coordinate automation is fragile, and CSS changes or modal dialogs can throw it off. For robust long-term automation, prefer a DOM-level approach (e.g. Chrome DevTools Protocol against Electron's remote debugging port — not currently wired in, see [Future: CDP access](#future-cdp-access)).
+Screenshot → Read it with the Read tool → reason about what you see → act via `xdo` → screenshot again. Pixel-coordinate driving is brittle (modal/CSS changes invalidate prior coordinates), so verify state-by-state instead of chaining many actions. Use cropped screenshots when zooming on a region — vision models perform meaningfully better on a focused crop than on the full 1920×1200 framebuffer.
+
+For robust DOM-level automation (querying / clicking by selector, scraping state), prefer a CDP-based approach once it's wired in — see [Future: CDP access](#future-cdp-access). Pixel ops via `xdo` and `shot` remain the right tool for OS-level interactions, multi-window coordination, and visual-regression checks.
+
+### After editing renderer code
+
+Vite HMR applies the change in-place — `sleep 2` before re-screenshotting so the UI has time to repaint. If your edit touches `main/`, a manual Electron restart is needed (~15s); rely on unit tests for main-process changes when driving the live app.
 
 ### Future: CDP access
 

--- a/.codex/skills/devcontainer-dev/SKILL.md
+++ b/.codex/skills/devcontainer-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: devcontainer-dev
 description: Spin up and interact with ToolHive Studio's containerized dev environment (Xvfb + noVNC + DinD). Use when running, testing, or debugging the app in isolation — locally, in a git worktree, or in GitHub Codespaces; when touching `.devcontainer/*`, `scripts/devcontainer-*.sh`, or the `devContainer:dev` npm script; or when debugging "blank white window", "Docker daemon failed to start", or "Missing X server" errors in the devcontainer. The container is fully isolated: no host pnpm install, no host Docker socket, no host X11/GPU — experiment freely without contaminating the host.
-allowed-tools: Read, Grep, Glob, Bash(bash scripts/agent.sh:*), Bash(pnpm devContainer:dev)
+allowed-tools: Read, Grep, Glob, Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*), Bash(pnpm devContainer:dev)
 ---
 
 # Containerized Dev Environment
@@ -142,20 +142,20 @@ docker exec "$CONTAINER" bash -c '
 
 The container has enough tools for an AI agent to both **see** and **interact with** the running Electron window without going through the browser / noVNC. Useful for headless testing, reproducing user-reported UI bugs, or validating a feature end-to-end.
 
-The recipes below are wrapped in `scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
+The recipes below are wrapped in `.claude/skills/devcontainer-dev/scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
 
 ### See the screen (screenshots)
 
 ```bash
 # Wrapped (recommended): screenshot to /tmp/shot.png on the host
-bash scripts/agent.sh shot
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot
 
 # With an output path
-bash scripts/agent.sh shot ./shot.png
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot ./shot.png
 
 # Cropped — vision models perform much better on a focused region than on
 # the full 1920×1200 framebuffer. Format is ImageMagick's WxH+X+Y.
-bash scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
 ```
 
 Fallback (raw docker exec):
@@ -171,8 +171,8 @@ docker cp "$CONTAINER:/tmp/shot.png" /tmp/shot.png
 
 ```bash
 # Wrapped: xdotool passthrough
-bash scripts/agent.sh xdo search --class ToolHive
-bash scripts/agent.sh xdo getactivewindow getwindowname
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo search --class ToolHive
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo getactivewindow getwindowname
 ```
 
 Fallback (raw docker exec):
@@ -191,16 +191,16 @@ The main app window has `WM_CLASS=ToolHive` (see gotcha below). Its geometry is 
 
 ```bash
 # Click at coordinates
-bash scripts/agent.sh xdo mousemove --sync 400 300 click 1
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo mousemove --sync 400 300 click 1
 
 # Type into whatever has focus
-bash scripts/agent.sh xdo type --delay 20 'hello world'
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo type --delay 20 'hello world'
 
 # Send a keystroke (DevTools)
-bash scripts/agent.sh xdo key ctrl+shift+i
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo key ctrl+shift+i
 
 # Focus the main window by class
-bash scripts/agent.sh xdo search --class ToolHive windowactivate
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo search --class ToolHive windowactivate
 ```
 
 Fallback (raw docker exec):
@@ -217,10 +217,10 @@ The dev-stack writes canonical logs under `/tmp/*.log` (see [Log files](#log-fil
 
 ```bash
 # Last 50 lines (default)
-bash scripts/agent.sh tail entrypoint
+bash .claude/skills/devcontainer-dev/scripts/agent.sh tail entrypoint
 
 # Last N lines
-bash scripts/agent.sh tail xvfb 200
+bash .claude/skills/devcontainer-dev/scripts/agent.sh tail xvfb 200
 ```
 
 Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entrypoint`.
@@ -230,7 +230,7 @@ Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entryp
 One-call readiness check — Electron running, `thv serve` running, the ToolHive X window mapped, and noVNC reachable. Exits non-zero if anything is down.
 
 ```bash
-bash scripts/agent.sh health
+bash .claude/skills/devcontainer-dev/scripts/agent.sh health
 ```
 
 ### Typical agent loop

--- a/.cursor/skills/devcontainer-dev/SKILL.md
+++ b/.cursor/skills/devcontainer-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: devcontainer-dev
 description: Spin up and interact with ToolHive Studio's containerized dev environment (Xvfb + noVNC + DinD). Use when running, testing, or debugging the app in isolation — locally, in a git worktree, or in GitHub Codespaces; when touching `.devcontainer/*`, `scripts/devcontainer-*.sh`, or the `devContainer:dev` npm script; or when debugging "blank white window", "Docker daemon failed to start", or "Missing X server" errors in the devcontainer. The container is fully isolated: no host pnpm install, no host Docker socket, no host X11/GPU — experiment freely without contaminating the host.
-allowed-tools: Read, Grep, Glob, Bash
+allowed-tools: Read, Grep, Glob, Bash(bash scripts/agent.sh:*), Bash(pnpm devContainer:dev)
 ---
 
 # Containerized Dev Environment
@@ -142,20 +142,40 @@ docker exec "$CONTAINER" bash -c '
 
 The container has enough tools for an AI agent to both **see** and **interact with** the running Electron window without going through the browser / noVNC. Useful for headless testing, reproducing user-reported UI bugs, or validating a feature end-to-end.
 
-All commands run via `docker exec` against the container with `DISPLAY=:99` set (matches Xvfb's display).
+The recipes below are wrapped in `scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
 
 ### See the screen (screenshots)
 
 ```bash
-# Take a PNG of the whole virtual framebuffer
+# Wrapped (recommended): screenshot to /tmp/shot.png on the host
+bash scripts/agent.sh shot
+
+# With an output path
+bash scripts/agent.sh shot ./shot.png
+
+# Cropped — vision models perform much better on a focused region than on
+# the full 1920×1200 framebuffer. Format is ImageMagick's WxH+X+Y.
+bash scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
+```
+
+Fallback (raw docker exec):
+
+```bash
 docker exec "$CONTAINER" bash -c 'DISPLAY=:99 import -window root /tmp/shot.png'
-# Copy it to the host for viewing / feeding to a vision model
 docker cp "$CONTAINER:/tmp/shot.png" /tmp/shot.png
 ```
 
 `import` is from ImageMagick. For a specific window only, use `xwininfo` to get the WID then `import -window <WID>`.
 
 ### See the window tree (what's there, where, which is focused)
+
+```bash
+# Wrapped: xdotool passthrough
+bash scripts/agent.sh xdo search --class ToolHive
+bash scripts/agent.sh xdo getactivewindow getwindowname
+```
+
+Fallback (raw docker exec):
 
 ```bash
 docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xwininfo -root -tree'
@@ -167,23 +187,61 @@ The main app window has `WM_CLASS=ToolHive` (see gotcha below). Its geometry is 
 
 ### Interact with the UI (mouse, keyboard)
 
+`xdo` is a passthrough to `xdotool` inside the container — its argument surface is intentionally narrow (X events only, no shell, no file access) so a single wrapper covers click / key / type / mousemove without per-verb validation cost.
+
 ```bash
-# Move the mouse and click
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool mousemove 400 300 click 1'
+# Click at coordinates
+bash scripts/agent.sh xdo mousemove --sync 400 300 click 1
 
 # Type into whatever has focus
+bash scripts/agent.sh xdo type --delay 20 'hello world'
+
+# Send a keystroke (DevTools)
+bash scripts/agent.sh xdo key ctrl+shift+i
+
+# Focus the main window by class
+bash scripts/agent.sh xdo search --class ToolHive windowactivate
+```
+
+Fallback (raw docker exec):
+
+```bash
+docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool mousemove 400 300 click 1'
 docker exec "$CONTAINER" bash -c "DISPLAY=:99 xdotool type --delay 20 'hello world'"
+docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool key ctrl+shift+i'
+```
 
-# Send a keystroke
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool key ctrl+shift+i'   # DevTools
+### Tail a log
 
-# Focus the main window by name
-docker exec "$CONTAINER" bash -c 'DISPLAY=:99 xdotool search --name ToolHive windowactivate'
+The dev-stack writes canonical logs under `/tmp/*.log` (see [Log files](#log-files-written-by-the-entrypoint)).
+
+```bash
+# Last 50 lines (default)
+bash scripts/agent.sh tail entrypoint
+
+# Last N lines
+bash scripts/agent.sh tail xvfb 200
+```
+
+Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entrypoint`.
+
+### Health check
+
+One-call readiness check — Electron running, `thv serve` running, the ToolHive X window mapped, and noVNC reachable. Exits non-zero if anything is down.
+
+```bash
+bash scripts/agent.sh health
 ```
 
 ### Typical agent loop
 
-Screenshot → feed to vision model → decide next action → `xdotool` → screenshot again. The usual caveats apply: pixel-coordinate automation is fragile, and CSS changes or modal dialogs can throw it off. For robust long-term automation, prefer a DOM-level approach (e.g. Chrome DevTools Protocol against Electron's remote debugging port — not currently wired in, see [Future: CDP access](#future-cdp-access)).
+Screenshot → Read it with the Read tool → reason about what you see → act via `xdo` → screenshot again. Pixel-coordinate driving is brittle (modal/CSS changes invalidate prior coordinates), so verify state-by-state instead of chaining many actions. Use cropped screenshots when zooming on a region — vision models perform meaningfully better on a focused crop than on the full 1920×1200 framebuffer.
+
+For robust DOM-level automation (querying / clicking by selector, scraping state), prefer a CDP-based approach once it's wired in — see [Future: CDP access](#future-cdp-access). Pixel ops via `xdo` and `shot` remain the right tool for OS-level interactions, multi-window coordination, and visual-regression checks.
+
+### After editing renderer code
+
+Vite HMR applies the change in-place — `sleep 2` before re-screenshotting so the UI has time to repaint. If your edit touches `main/`, a manual Electron restart is needed (~15s); rely on unit tests for main-process changes when driving the live app.
 
 ### Future: CDP access
 

--- a/.cursor/skills/devcontainer-dev/SKILL.md
+++ b/.cursor/skills/devcontainer-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: devcontainer-dev
 description: Spin up and interact with ToolHive Studio's containerized dev environment (Xvfb + noVNC + DinD). Use when running, testing, or debugging the app in isolation — locally, in a git worktree, or in GitHub Codespaces; when touching `.devcontainer/*`, `scripts/devcontainer-*.sh`, or the `devContainer:dev` npm script; or when debugging "blank white window", "Docker daemon failed to start", or "Missing X server" errors in the devcontainer. The container is fully isolated: no host pnpm install, no host Docker socket, no host X11/GPU — experiment freely without contaminating the host.
-allowed-tools: Read, Grep, Glob, Bash(bash scripts/agent.sh:*), Bash(pnpm devContainer:dev)
+allowed-tools: Read, Grep, Glob, Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*), Bash(pnpm devContainer:dev)
 ---
 
 # Containerized Dev Environment
@@ -142,20 +142,20 @@ docker exec "$CONTAINER" bash -c '
 
 The container has enough tools for an AI agent to both **see** and **interact with** the running Electron window without going through the browser / noVNC. Useful for headless testing, reproducing user-reported UI bugs, or validating a feature end-to-end.
 
-The recipes below are wrapped in `scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
+The recipes below are wrapped in `.claude/skills/devcontainer-dev/scripts/agent.sh`, which finds the devcontainer for *this* worktree by label, validates inputs, and execs only the documented commands. Pre-approving `Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*)` gives an agent the full driving surface without granting broad `Bash(docker exec *)` (which would let it run arbitrary commands in any container on the host). The raw `docker exec` recipes still work and are listed below as the explicit-approval fallback for ad-hoc cases the wrapper doesn't cover.
 
 ### See the screen (screenshots)
 
 ```bash
 # Wrapped (recommended): screenshot to /tmp/shot.png on the host
-bash scripts/agent.sh shot
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot
 
 # With an output path
-bash scripts/agent.sh shot ./shot.png
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot ./shot.png
 
 # Cropped — vision models perform much better on a focused region than on
 # the full 1920×1200 framebuffer. Format is ImageMagick's WxH+X+Y.
-bash scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
+bash .claude/skills/devcontainer-dev/scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
 ```
 
 Fallback (raw docker exec):
@@ -171,8 +171,8 @@ docker cp "$CONTAINER:/tmp/shot.png" /tmp/shot.png
 
 ```bash
 # Wrapped: xdotool passthrough
-bash scripts/agent.sh xdo search --class ToolHive
-bash scripts/agent.sh xdo getactivewindow getwindowname
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo search --class ToolHive
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo getactivewindow getwindowname
 ```
 
 Fallback (raw docker exec):
@@ -191,16 +191,16 @@ The main app window has `WM_CLASS=ToolHive` (see gotcha below). Its geometry is 
 
 ```bash
 # Click at coordinates
-bash scripts/agent.sh xdo mousemove --sync 400 300 click 1
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo mousemove --sync 400 300 click 1
 
 # Type into whatever has focus
-bash scripts/agent.sh xdo type --delay 20 'hello world'
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo type --delay 20 'hello world'
 
 # Send a keystroke (DevTools)
-bash scripts/agent.sh xdo key ctrl+shift+i
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo key ctrl+shift+i
 
 # Focus the main window by class
-bash scripts/agent.sh xdo search --class ToolHive windowactivate
+bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo search --class ToolHive windowactivate
 ```
 
 Fallback (raw docker exec):
@@ -217,10 +217,10 @@ The dev-stack writes canonical logs under `/tmp/*.log` (see [Log files](#log-fil
 
 ```bash
 # Last 50 lines (default)
-bash scripts/agent.sh tail entrypoint
+bash .claude/skills/devcontainer-dev/scripts/agent.sh tail entrypoint
 
 # Last N lines
-bash scripts/agent.sh tail xvfb 200
+bash .claude/skills/devcontainer-dev/scripts/agent.sh tail xvfb 200
 ```
 
 Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entrypoint`.
@@ -230,7 +230,7 @@ Allowed log names: `xvfb`, `fluxbox`, `x11vnc`, `websockify`, `keyring`, `entryp
 One-call readiness check — Electron running, `thv serve` running, the ToolHive X window mapped, and noVNC reachable. Exits non-zero if anything is down.
 
 ```bash
-bash scripts/agent.sh health
+bash .claude/skills/devcontainer-dev/scripts/agent.sh health
 ```
 
 ### Typical agent loop

--- a/.github/workflows/_visual-bug-fix-agent.yml
+++ b/.github/workflows/_visual-bug-fix-agent.yml
@@ -66,6 +66,7 @@ jobs:
             exit 0
           fi
 
+          # Check if the agent already gave up on this issue (final comment exists)
           GAVE_UP=$(gh api "repos/${{ github.repository }}/issues/${{ inputs.issue-number }}/comments" \
             --paginate --jq '[.[] | select(.body | contains("Visual Bug Fix Agent"))] | length' 2>/dev/null || echo "0")
           if [ "$GAVE_UP" -gt "0" ]; then
@@ -194,20 +195,33 @@ jobs:
 
             LIVE APP AVAILABLE:
             A running ToolHive Studio is available inside the project's devcontainer.
-            The container ID is in the environment variable DEVCONTAINER_ID.
-            The workspace is bind-mounted at /workspaces/toolhive-studio inside the
-            container, so source edits on the runner propagate to the container via
-            Vite HMR (renderer changes only — main-process edits would need an
-            Electron restart, see the devcontainer-dev skill).
+            The container ID is in the environment variable DEVCONTAINER_ID. The
+            workspace is bind-mounted at /workspaces/toolhive-studio inside the
+            container, so renderer source edits on the runner propagate via Vite HMR.
+
+            Two important constraints:
+              - After editing renderer code, `sleep 2` before re-screenshotting so
+                HMR has time to apply. Otherwise you will see stale UI.
+              - If your fix touches anything under `main/`, visual verification
+                will NOT work in this run — Electron would need a manual restart
+                that costs ~15s and breaks the loop. Rely on unit tests for
+                main-process changes.
+
+            The agent loop is: capture screen → Read it with the Read tool →
+            reason about what you see → act → capture again.
 
             Useful commands:
-              scripts/devcontainer-screenshot.sh /tmp/shot.png   # captures the screen, prints absolute path
-              scripts/devcontainer-steal.sh "$DEVCONTAINER_ID" /tmp/foo ./foo   # extract any file from /tmp
+              # Capture screen to a runner-side path (NOT a container path), then Read it:
+              scripts/devcontainer-screenshot.sh ./shot.png
+              # Extract any other tmpfs file (logs, generated artifacts):
+              scripts/devcontainer-steal.sh "$DEVCONTAINER_ID" /tmp/foo ./foo
+              # Inspect the X11 window tree — the main app window has WM_CLASS=ToolHive:
               docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xwininfo -root -tree'
-              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool search --name ToolHive'
-              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool mousemove X Y click 1'
+              # Drive input — keyboard is more reliable than mouse-coordinate clicks:
               docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool key Tab'
-              # Read /tmp/shot.png with the Read tool to view captured screenshots.
+              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool key Return'
+              # Mouse coordinates are fragile (modals shift the layout); use sparingly:
+              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool mousemove X Y click 1'
 
             WHEN TO USE THE LIVE APP:
             Default to a unit-test reproduction. Reach for the live app only when

--- a/.github/workflows/_visual-bug-fix-agent.yml
+++ b/.github/workflows/_visual-bug-fix-agent.yml
@@ -2,12 +2,15 @@ name: Visual Bug Fix Agent
 
 # Mirror of `_bug-fix-agent.yml` with one key difference: a live ToolHive
 # Studio is booted inside the project's devcontainer (Xvfb + Electron + thv)
-# alongside the agent, and the agent gets `docker exec` access to drive it
-# (xdotool, screenshots, in-container test runs). Aimed at bugs that resist
-# a pure unit-test reproduction — UI/routing side-effects, async backend
-# lifecycle, real IPC.
+# alongside the agent, and the agent drives it through `scripts/agent.sh`
+# (xdotool, screenshots, log tails, readiness check). Aimed at bugs that
+# resist a pure unit-test reproduction — UI/routing side-effects, async
+# backend lifecycle, real IPC.
 #
-# Substrate proven in PR #2120; helper scripts and skill doc landed there.
+# The agent's allowlist scopes `Bash(bash scripts/agent.sh:*)` rather than
+# raw `docker exec`, so the driving surface stays narrow. See
+# .claude/skills/devcontainer-dev/SKILL.md for the full wrapper recipe.
+#
 # Same `claude-code-action` workflow-validation constraint applies as
 # production: a triggering run will only succeed once this file is on
 # `main` (or its content matches `main` byte-for-byte at the head ref).
@@ -195,9 +198,12 @@ jobs:
 
             LIVE APP AVAILABLE:
             A running ToolHive Studio is available inside the project's devcontainer.
-            The container ID is in the environment variable DEVCONTAINER_ID. The
-            workspace is bind-mounted at /workspaces/toolhive-studio inside the
-            container, so renderer source edits on the runner propagate via Vite HMR.
+            All driving goes through `bash scripts/agent.sh` — a tightly-scoped
+            wrapper that finds the worktree's container by label and execs only
+            the documented commands. See .claude/skills/devcontainer-dev/SKILL.md
+            for the full surface. The workspace is bind-mounted at
+            /workspaces/toolhive-studio inside the container, so renderer source
+            edits on the runner propagate via Vite HMR.
 
             Two important constraints:
               - After editing renderer code, `sleep 2` before re-screenshotting so
@@ -211,17 +217,22 @@ jobs:
             reason about what you see → act → capture again.
 
             Useful commands:
-              # Capture screen to a runner-side path (NOT a container path), then Read it:
-              scripts/devcontainer-screenshot.sh ./shot.png
-              # Extract any other tmpfs file (logs, generated artifacts):
-              scripts/devcontainer-steal.sh "$DEVCONTAINER_ID" /tmp/foo ./foo
-              # Inspect the X11 window tree — the main app window has WM_CLASS=ToolHive:
-              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xwininfo -root -tree'
+              # Capture screen to a runner-side path, then Read it:
+              bash scripts/agent.sh shot ./shot.png
+              # Cropped screenshot for vision-model focus (WxH+X+Y):
+              bash scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
+              # Tail one of the in-container logs (xvfb, fluxbox, x11vnc,
+              # websockify, keyring, entrypoint):
+              bash scripts/agent.sh tail entrypoint
+              # Find the main window — its WM_CLASS is ToolHive:
+              bash scripts/agent.sh xdo search --class ToolHive
               # Drive input — keyboard is more reliable than mouse-coordinate clicks:
-              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool key Tab'
-              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool key Return'
+              bash scripts/agent.sh xdo key Tab
+              bash scripts/agent.sh xdo key Return
               # Mouse coordinates are fragile (modals shift the layout); use sparingly:
-              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool mousemove X Y click 1'
+              bash scripts/agent.sh xdo mousemove X Y click 1
+              # One-call readiness check (electron, thv serve, window, noVNC):
+              bash scripts/agent.sh health
 
             WHEN TO USE THE LIVE APP:
             Default to a unit-test reproduction. Reach for the live app only when
@@ -250,7 +261,7 @@ jobs:
           claude_args: >-
             --model opus
             --max-turns 75
-            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(cat *),Bash(ls *),Bash(docker exec *),Bash(docker cp *),Bash(docker ps *),Bash(scripts/devcontainer-screenshot.sh *),Bash(scripts/devcontainer-steal.sh *)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash scripts/agent.sh:*)"
 
       - name: 'Hard gate — Verify test fails'
         id: gate
@@ -313,7 +324,7 @@ jobs:
           claude_args: >-
             --model sonnet
             --max-turns 150
-            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(docker exec *),Bash(docker cp *),Bash(scripts/devcontainer-screenshot.sh *),Bash(scripts/devcontainer-steal.sh *)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash scripts/agent.sh:*)"
 
       - name: 'Phase 2b — Direct Fix without TDD (Sonnet)'
         id: phase2b
@@ -354,7 +365,7 @@ jobs:
           claude_args: >-
             --model sonnet
             --max-turns 150
-            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(docker exec *),Bash(docker cp *),Bash(scripts/devcontainer-screenshot.sh *),Bash(scripts/devcontainer-steal.sh *)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash scripts/agent.sh:*)"
 
       - name: 'Hard gate — Verify all checks pass'
         id: verify

--- a/.github/workflows/_visual-bug-fix-agent.yml
+++ b/.github/workflows/_visual-bug-fix-agent.yml
@@ -1,0 +1,462 @@
+name: Visual Bug Fix Agent
+
+# Mirror of `_bug-fix-agent.yml` with one key difference: a live ToolHive
+# Studio is booted inside the project's devcontainer (Xvfb + Electron + thv)
+# alongside the agent, and the agent gets `docker exec` access to drive it
+# (xdotool, screenshots, in-container test runs). Aimed at bugs that resist
+# a pure unit-test reproduction — UI/routing side-effects, async backend
+# lifecycle, real IPC.
+#
+# Substrate proven in PR #2120; helper scripts and skill doc landed there.
+# Same `claude-code-action` workflow-validation constraint applies as
+# production: a triggering run will only succeed once this file is on
+# `main` (or its content matches `main` byte-for-byte at the head ref).
+
+on:
+  workflow_call:
+    inputs:
+      issue-number:
+        required: true
+        type: number
+
+concurrency:
+  group: visual-bug-fix-${{ inputs.issue-number }}
+  cancel-in-progress: true
+
+jobs:
+  fix:
+    name: Visual Bug Fix
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    env:
+      # Required by .devcontainer/devcontainer.json runArgs port mapping.
+      # In CI we don't expose noVNC off-runner; just pick a valid port.
+      NOVNC_HOST_PORT: 6080
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.TOOLHIVE_STUDIO_CI_APP_ID }}
+          private-key: ${{ secrets.TOOLHIVE_STUDIO_CI_APP_KEY }}
+
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Check for existing PR or previous failure
+        id: guard
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="fix/auto-${{ inputs.issue-number }}-visual"
+          BASE="${{ github.event.repository.default_branch }}"
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --base "$BASE" --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "::notice::Open PR #${EXISTING_PR} already exists for issue #${{ inputs.issue-number }} — skipping"
+            exit 0
+          fi
+
+          GAVE_UP=$(gh api "repos/${{ github.repository }}/issues/${{ inputs.issue-number }}/comments" \
+            --paginate --jq '[.[] | select(.body | contains("Visual Bug Fix Agent"))] | length' 2>/dev/null || echo "0")
+          if [ "$GAVE_UP" -gt "0" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "::notice::Visual agent already exhausted all attempts for issue #${{ inputs.issue-number }} — skipping"
+            exit 0
+          fi
+
+          echo "skip=false" >> $GITHUB_OUTPUT
+
+      - name: Fetch issue body
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh issue view ${{ inputs.issue-number }} --json title,body,labels \
+            --template '# {{.title}}{{"\n\n"}}{{.body}}' > issue-body.md
+
+      - name: Setup
+        if: steps.guard.outputs.skip != 'true'
+        uses: ./.github/actions/setup
+
+      # ---------- Devcontainer substrate (additions over `_bug-fix-agent.yml`) ----------
+
+      - name: Set up Docker Buildx
+        # Required so BuildKit's `gha` cache backend is available.
+        # See PR #2120 for context — without this, `cacheFrom: type=gha` fails
+        # silently with "unknown cache importer: gha".
+        if: steps.guard.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache devcontainer node_modules
+        # Image-layer caching alone is not enough — the named `node_modules`
+        # volume is fresh on every CI run, so postCreateCommand's pnpm install
+        # would dominate. Caching the volume's contents keyed on pnpm-lock.yaml
+        # drops that step from ~100s to ~9s.
+        if: steps.guard.outputs.skip != 'true'
+        id: nm-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: nm-cache
+          key: dc-nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Pre-populate devcontainer node_modules volume
+        if: steps.guard.outputs.skip != 'true' && steps.nm-cache.outputs.cache-hit == 'true'
+        run: |
+          VOLUME=toolhive-node-modules-toolhive-studio
+          docker volume create "$VOLUME" >/dev/null
+          docker run --rm \
+            -v "$PWD/nm-cache:/src:ro" \
+            -v "$VOLUME:/dst" \
+            alpine:3 sh -c 'cp -a /src/. /dst/'
+
+      - name: Build & start devcontainer
+        if: steps.guard.outputs.skip != 'true'
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: toolhive-studio-devcontainer
+          cacheFrom: type=gha
+          push: never
+          runCmd: |
+            echo "Devcontainer up. Workspace: $(pwd)"
+
+      - name: Find container ID
+        if: steps.guard.outputs.skip != 'true'
+        id: container
+        run: |
+          C=$(docker ps \
+            --filter "label=devcontainer.local_folder=$GITHUB_WORKSPACE" \
+            --format '{{.ID}}' | head -1)
+          if [ -z "$C" ]; then
+            echo "::error::No devcontainer found for $GITHUB_WORKSPACE"
+            docker ps
+            exit 1
+          fi
+          echo "id=$C" >> $GITHUB_OUTPUT
+          echo "::notice::Devcontainer ID: $C"
+
+      - name: Launch app inside devcontainer (background)
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          docker exec -d -u node ${{ steps.container.outputs.id }} \
+            bash -c 'cd /workspaces/toolhive-studio && \
+              nohup bash scripts/devcontainer-entrypoint.sh \
+                > /tmp/entrypoint.log 2>&1 &'
+
+      - name: Wait for app readiness
+        if: steps.guard.outputs.skip != 'true'
+        timeout-minutes: 10
+        run: |
+          C=${{ steps.container.outputs.id }}
+          for i in $(seq 1 120); do
+            # Process gates AND a window-mapped check via xdotool. Process
+            # presence is not the same as "UI rendered" — see PR #2120.
+            if docker exec -u node "$C" bash -c '
+                curl -fsS http://localhost:6080/ >/dev/null 2>&1 \
+                && pgrep -f "[e]lectron/dist/electron" >/dev/null \
+                && pgrep -f "[t]hv serve" >/dev/null \
+                && DISPLAY=:99 xdotool search --class ToolHive >/dev/null 2>&1
+              '; then
+              sleep 2
+              echo "::notice::App ready in ${i} attempts"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::App did not become ready within 10 minutes"
+          docker exec "$C" tail -200 /tmp/entrypoint.log || true
+          exit 1
+
+      # ---------- /Devcontainer substrate ----------
+
+      - name: 'Phase 1 — Analyze & Write Failing Test (Opus)'
+        id: phase1
+        if: steps.guard.outputs.skip != 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1
+        env:
+          DEVCONTAINER_ID: ${{ steps.container.outputs.id }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read .claude/skills/bug-fix-tdd/SKILL.md and follow it.
+            Read .claude/skills/devcontainer-dev/SKILL.md for live-app context.
+            Read issue-body.md for the bug report.
+
+            LIVE APP AVAILABLE:
+            A running ToolHive Studio is available inside the project's devcontainer.
+            The container ID is in the environment variable DEVCONTAINER_ID.
+            The workspace is bind-mounted at /workspaces/toolhive-studio inside the
+            container, so source edits on the runner propagate to the container via
+            Vite HMR (renderer changes only — main-process edits would need an
+            Electron restart, see the devcontainer-dev skill).
+
+            Useful commands:
+              scripts/devcontainer-screenshot.sh /tmp/shot.png   # captures the screen, prints absolute path
+              scripts/devcontainer-steal.sh "$DEVCONTAINER_ID" /tmp/foo ./foo   # extract any file from /tmp
+              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xwininfo -root -tree'
+              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool search --name ToolHive'
+              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool mousemove X Y click 1'
+              docker exec -u node "$DEVCONTAINER_ID" bash -c 'DISPLAY=:99 xdotool key Tab'
+              # Read /tmp/shot.png with the Read tool to view captured screenshots.
+
+            WHEN TO USE THE LIVE APP:
+            Default to a unit-test reproduction. Reach for the live app only when
+            the bug genuinely requires it: cross-route side effects, async backend
+            lifecycle (`thv` workload events), real IPC. Pixel-driving is fragile
+            and slow — even when you use the live app for repro, your eventual
+            FAILING TEST should be a unit test that captures the underlying
+            invariant (e.g. mock the IPC event and assert the router behavior).
+            The unit test is what gates Phase 2.
+
+            Your task (Phase 1 — Analysis & Test):
+            1. Analyze the bug report: understand description, steps to reproduce, expected vs actual behavior.
+            2. Search the codebase to find the relevant source code.
+            3. Reproduce the bug. Use the live app if a unit test alone is not enough.
+            4. Write a unit test that captures the bug — it MUST FAIL when you run it.
+            5. Run the test with: pnpm run test:nonInteractive -- <test-file-path>
+            6. Verify the test fails FOR THE RIGHT REASON (not import errors or unrelated failures).
+            7. If the test passes (bug not reproduced), try a different approach (max 3 attempts).
+
+            Output:
+            - The test file in the correct __tests__/ directory.
+            - bug-analysis.md with your findings (follow the format in the skill).
+              Include a "Visual repro:" section if you used the live app.
+
+            Do NOT modify any source files. Only create/edit test files and bug-analysis.md.
+          claude_args: >-
+            --model opus
+            --max-turns 75
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(cat *),Bash(ls *),Bash(docker exec *),Bash(docker cp *),Bash(docker ps *),Bash(scripts/devcontainer-screenshot.sh *),Bash(scripts/devcontainer-steal.sh *)"
+
+      - name: 'Hard gate — Verify test fails'
+        id: gate
+        if: steps.guard.outputs.skip != 'true' && steps.phase1.outcome == 'success'
+        run: |
+          if [ ! -f bug-analysis.md ]; then
+            echo "::warning::bug-analysis.md not found"
+            echo "test_fails=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          TEST_FILE=$(grep "^Test file:" bug-analysis.md | sed 's/^Test file: //' || true)
+          if [ -z "$TEST_FILE" ]; then
+            echo "::warning::No 'Test file:' line found in bug-analysis.md"
+            echo "test_fails=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "test_file=$TEST_FILE" >> $GITHUB_OUTPUT
+
+          if pnpm run test:nonInteractive -- "$TEST_FILE" 2>&1; then
+            echo "::warning::Test passed (bug not reproduced)"
+            echo "test_fails=false" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::Test fails as expected"
+            echo "test_fails=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: 'Phase 2 — TDD Fix (Sonnet)'
+        id: phase2
+        if: >-
+          steps.guard.outputs.skip != 'true'
+          && steps.gate.outputs.test_fails == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1
+        env:
+          BUG_TEST_FILE: ${{ steps.gate.outputs.test_file }}
+          BUG_ISSUE_NUMBER: ${{ inputs.issue-number }}
+          DEVCONTAINER_ID: ${{ steps.container.outputs.id }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read .claude/skills/bug-fix-tdd/SKILL.md and bug-analysis.md.
+
+            The live app from Phase 1 is still running in the devcontainer
+            (ID: $DEVCONTAINER_ID). You may use it to sanity-check your fix
+            visually, but the gate is still: pnpm run test:nonInteractive passes.
+
+            Your task (Phase 2 — Fix):
+            1. Read the failing test and understand what it expects.
+            2. Apply the MINIMUM fix to make the test pass.
+            3. Run the test to verify it passes: pnpm run test:nonInteractive -- ${{ steps.gate.outputs.test_file }}
+            4. Run the full test suite: pnpm run test:nonInteractive
+            5. Run pnpm run lint and pnpm run type-check.
+            6. If any check fails, adjust the fix (max 5 attempts).
+            7. Write pr-body.md (include 'Fixes #${{ inputs.issue-number }}') and fix-title.txt.
+
+            Do NOT run git, gh, or modify .env files.
+            Do NOT over-engineer — apply the smallest change that fixes the bug.
+          claude_args: >-
+            --model sonnet
+            --max-turns 150
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(docker exec *),Bash(docker cp *),Bash(scripts/devcontainer-screenshot.sh *),Bash(scripts/devcontainer-steal.sh *)"
+
+      - name: 'Phase 2b — Direct Fix without TDD (Sonnet)'
+        id: phase2b
+        if: >-
+          steps.guard.outputs.skip != 'true'
+          && steps.phase1.outcome == 'success'
+          && steps.gate.outputs.test_fails != 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1
+        env:
+          BUG_ISSUE_NUMBER: ${{ inputs.issue-number }}
+          DEVCONTAINER_ID: ${{ steps.container.outputs.id }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read .claude/skills/bug-fix-tdd/SKILL.md and bug-analysis.md.
+            Read issue-body.md for the original bug report.
+
+            The bug could NOT be reproduced in a unit test, even with live-app access.
+            bug-analysis.md contains the analysis of the bug from Phase 1.
+
+            The live app from Phase 1 is still running in the devcontainer
+            (ID: $DEVCONTAINER_ID). You may use it to sanity-check your fix.
+
+            Your task (Phase 2b — Direct Fix):
+            1. Read the analysis and understand the root cause.
+            2. Apply the MINIMUM fix to resolve the bug.
+            3. If you CAN write a regression test, do so — but it is not required.
+            4. Run the full test suite: pnpm run test:nonInteractive
+            5. Run pnpm run lint and pnpm run type-check.
+            6. If any check fails, adjust the fix (max 5 attempts).
+            7. Write pr-body.md (include 'Fixes #${{ inputs.issue-number }}').
+               Note in the PR body that no regression test was possible.
+            8. Write fix-title.txt.
+
+            Do NOT run git, gh, or modify .env files.
+            Do NOT over-engineer — apply the smallest change that fixes the bug.
+          claude_args: >-
+            --model sonnet
+            --max-turns 150
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(docker exec *),Bash(docker cp *),Bash(scripts/devcontainer-screenshot.sh *),Bash(scripts/devcontainer-steal.sh *)"
+
+      - name: 'Hard gate — Verify all checks pass'
+        id: verify
+        if: >-
+          steps.guard.outputs.skip != 'true'
+          && (steps.phase2.outcome == 'success' || steps.phase2b.outcome == 'success')
+        run: |
+          if pnpm run test:nonInteractive && pnpm run lint && pnpm run type-check; then
+            echo "::notice::All checks pass"
+            echo "result=success" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Verification failed"
+            echo "result=failure" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create branch and commit
+        if: steps.guard.outputs.skip != 'true' && steps.verify.outputs.result == 'success'
+        id: push
+        run: |
+          ISSUE_NUM="${{ inputs.issue-number }}"
+          BRANCH="fix/auto-${ISSUE_NUM}-visual"
+          TITLE=$(cat fix-title.txt 2>/dev/null || echo "fix: auto-fix for #${ISSUE_NUM}")
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+
+          git add -A -- '*.ts' '*.tsx' '**/*.ts' '**/*.tsx'
+
+          if git diff --cached --quiet; then
+            echo "::warning::No source changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "$TITLE"
+            git push -u origin "$BRANCH"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.guard.outputs.skip != 'true' && steps.verify.outputs.result == 'success' && steps.push.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="${{ steps.push.outputs.branch }}"
+          BASE="${{ github.event.repository.default_branch }}"
+          TITLE=$(cat fix-title.txt 2>/dev/null || echo "fix: auto-fix for #${{ inputs.issue-number }}")
+
+          if [ ! -f pr-body.md ]; then
+            echo "Automated fix for #${{ inputs.issue-number }} (visual flow)." > pr-body.md
+          fi
+
+          printf '\n\n---\n_Generated by the Visual Bug Fix Agent (with live-app access)._\n' \
+            >> pr-body.md
+
+          gh label create auto-fix-visual --description "Automated bug fix by Visual Bug Fix Agent" --color FBCA04 2>/dev/null || true
+          gh pr create \
+            --title "$TITLE" \
+            --body-file pr-body.md \
+            --base "$BASE" \
+            --head "$BRANCH" \
+            --label "auto-fix-visual"
+
+      - name: Comment on issue (all attempts failed)
+        if: >-
+          always()
+          && steps.guard.outputs.skip != 'true'
+          && steps.verify.outputs.result != 'success'
+          && steps.phase1.outcome != 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f bug-analysis.md ]; then
+            ANALYSIS=$(cat bug-analysis.md)
+          else
+            ANALYSIS="The Visual Bug Fix Agent could not analyze this bug. The issue may involve behavior that cannot be captured in a unit test even with live-app access."
+          fi
+
+          printf '## Visual Bug Fix Agent — Automated Analysis\n\n%s\n\n---\n*Automated analysis by the Visual Bug Fix Agent (live-app access). A developer will review this issue manually.*\n' \
+            "$ANALYSIS" > /tmp/comment-body.md
+
+          gh issue comment "${{ inputs.issue-number }}" --body-file /tmp/comment-body.md
+          gh issue edit "${{ inputs.issue-number }}" --remove-label "auto-fix-visual" 2>/dev/null || true
+
+      - name: Diagnostics on failure
+        if: >-
+          always()
+          && steps.guard.outputs.skip != 'true'
+          && steps.verify.outputs.result != 'success'
+        run: |
+          C=${{ steps.container.outputs.id }}
+          if [ -n "$C" ]; then
+            echo '=== Container processes ==='
+            docker exec "$C" ps auxf || true
+            echo '=== entrypoint.log ==='
+            docker exec "$C" tail -300 /tmp/entrypoint.log || true
+            echo '=== xvfb.log ==='
+            docker exec "$C" tail -100 /tmp/xvfb.log || true
+            echo '=== fluxbox.log ==='
+            docker exec "$C" tail -100 /tmp/fluxbox.log || true
+            echo '=== keyring.log ==='
+            docker exec "$C" tail -50 /tmp/keyring.log || true
+          fi
+
+      - name: Dump devcontainer node_modules for cache
+        # Cache miss only — populates nm-cache/ for actions/cache's post-step
+        # to save. Multiple containers can mount the same volume, so this
+        # doesn't disturb the running app.
+        if: >-
+          always()
+          && steps.guard.outputs.skip != 'true'
+          && steps.nm-cache.outputs.cache-hit != 'true'
+        run: |
+          VOLUME=toolhive-node-modules-toolhive-studio
+          rm -rf nm-cache && mkdir -p nm-cache
+          docker run --rm \
+            -v "$VOLUME:/src:ro" \
+            -v "$PWD/nm-cache:/dst" \
+            alpine:3 sh -c 'cp -a /src/. /dst/' || true

--- a/.github/workflows/_visual-bug-fix-agent.yml
+++ b/.github/workflows/_visual-bug-fix-agent.yml
@@ -2,12 +2,12 @@ name: Visual Bug Fix Agent
 
 # Mirror of `_bug-fix-agent.yml` with one key difference: a live ToolHive
 # Studio is booted inside the project's devcontainer (Xvfb + Electron + thv)
-# alongside the agent, and the agent drives it through `scripts/agent.sh`
+# alongside the agent, and the agent drives it through `.claude/skills/devcontainer-dev/scripts/agent.sh`
 # (xdotool, screenshots, log tails, readiness check). Aimed at bugs that
 # resist a pure unit-test reproduction — UI/routing side-effects, async
 # backend lifecycle, real IPC.
 #
-# The agent's allowlist scopes `Bash(bash scripts/agent.sh:*)` rather than
+# The agent's allowlist scopes `Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*)` rather than
 # raw `docker exec`, so the driving surface stays narrow. See
 # .claude/skills/devcontainer-dev/SKILL.md for the full wrapper recipe.
 #
@@ -198,7 +198,7 @@ jobs:
 
             LIVE APP AVAILABLE:
             A running ToolHive Studio is available inside the project's devcontainer.
-            All driving goes through `bash scripts/agent.sh` — a tightly-scoped
+            All driving goes through `bash .claude/skills/devcontainer-dev/scripts/agent.sh` — a tightly-scoped
             wrapper that finds the worktree's container by label and execs only
             the documented commands. See .claude/skills/devcontainer-dev/SKILL.md
             for the full surface. The workspace is bind-mounted at
@@ -218,21 +218,21 @@ jobs:
 
             Useful commands:
               # Capture screen to a runner-side path, then Read it:
-              bash scripts/agent.sh shot ./shot.png
+              bash .claude/skills/devcontainer-dev/scripts/agent.sh shot ./shot.png
               # Cropped screenshot for vision-model focus (WxH+X+Y):
-              bash scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
+              bash .claude/skills/devcontainer-dev/scripts/agent.sh shot --crop 800x600+560+300 ./dialog.png
               # Tail one of the in-container logs (xvfb, fluxbox, x11vnc,
               # websockify, keyring, entrypoint):
-              bash scripts/agent.sh tail entrypoint
+              bash .claude/skills/devcontainer-dev/scripts/agent.sh tail entrypoint
               # Find the main window — its WM_CLASS is ToolHive:
-              bash scripts/agent.sh xdo search --class ToolHive
+              bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo search --class ToolHive
               # Drive input — keyboard is more reliable than mouse-coordinate clicks:
-              bash scripts/agent.sh xdo key Tab
-              bash scripts/agent.sh xdo key Return
+              bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo key Tab
+              bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo key Return
               # Mouse coordinates are fragile (modals shift the layout); use sparingly:
-              bash scripts/agent.sh xdo mousemove X Y click 1
+              bash .claude/skills/devcontainer-dev/scripts/agent.sh xdo mousemove X Y click 1
               # One-call readiness check (electron, thv serve, window, noVNC):
-              bash scripts/agent.sh health
+              bash .claude/skills/devcontainer-dev/scripts/agent.sh health
 
             WHEN TO USE THE LIVE APP:
             Default to a unit-test reproduction. Reach for the live app only when
@@ -261,7 +261,7 @@ jobs:
           claude_args: >-
             --model opus
             --max-turns 75
-            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash scripts/agent.sh:*)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*)"
 
       - name: 'Hard gate — Verify test fails'
         id: gate
@@ -324,7 +324,7 @@ jobs:
           claude_args: >-
             --model sonnet
             --max-turns 150
-            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash scripts/agent.sh:*)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*)"
 
       - name: 'Phase 2b — Direct Fix without TDD (Sonnet)'
         id: phase2b
@@ -365,7 +365,7 @@ jobs:
           claude_args: >-
             --model sonnet
             --max-turns 150
-            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash scripts/agent.sh:*)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check),Bash(cat *),Bash(ls *),Bash(sleep *),Bash(bash .claude/skills/devcontainer-dev/scripts/agent.sh:*)"
 
       - name: 'Hard gate — Verify all checks pass'
         id: verify

--- a/.github/workflows/visual-bug-fix-on-label.yml
+++ b/.github/workflows/visual-bug-fix-on-label.yml
@@ -1,0 +1,28 @@
+name: Visual Bug Fix (On Label)
+
+# Trigger for the Visual Bug Fix Agent. Mirrors `bug-fix-on-label.yml` but
+# fires on a different label (`auto-fix-visual`) so it runs in parallel
+# with — and never instead of — the production agent. An issue can carry
+# both labels to compare outcomes side by side; in practice you'd usually
+# pick one.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  bug-fix:
+    name: Visual Bug Fix Agent
+    if: >-
+      github.event.label.name == 'auto-fix-visual'
+      && contains(github.event.issue.labels.*.name, 'Bug')
+    uses: ./.github/workflows/_visual-bug-fix-agent.yml
+    with:
+      issue-number: ${{ github.event.issue.number }}
+    secrets: inherit

--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Tightly-scoped wrapper around the agent-driving recipes documented in
+# .claude/skills/devcontainer-dev/SKILL.md. Each subcommand finds the
+# devcontainer for *this* worktree by label, validates inputs, and execs
+# only the documented commands — so the allowlist can target this single
+# script instead of broad `Bash(docker exec *)`.
+#
+# Usage (run from the repo root, or any cwd — paths resolve from the
+# script's own location):
+#
+#   scripts/agent.sh shot [--crop WxH+X+Y] [PATH]   # screenshot to host
+#   scripts/agent.sh xdo  <args...>                  # xdotool passthrough
+#   scripts/agent.sh tail LOG [N]                    # tail one of /tmp/*.log
+#   scripts/agent.sh health                          # readiness check
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+DISPLAY_NAME=":99"
+URL_CACHE_FILE="$HOME/.cache/toolhive-studio-url"
+
+find_container() {
+  local container
+  container=$(docker ps \
+    --filter "label=devcontainer.local_folder=$REPO_ROOT" \
+    --format '{{.ID}}' | head -1)
+  if [ -z "$container" ]; then
+    echo "agent.sh: no devcontainer running for $REPO_ROOT" >&2
+    echo "          start one with: pnpm devContainer:dev" >&2
+    exit 1
+  fi
+  printf '%s' "$container"
+}
+
+# Allowlist of log basenames the `tail` subcommand will read. Keeps the
+# subcommand from being a generic `cat /any/path` in disguise.
+ALLOWED_LOGS=(
+  xvfb
+  fluxbox
+  x11vnc
+  websockify
+  keyring
+  entrypoint
+)
+
+is_allowed_log() {
+  local name="$1" allowed
+  for allowed in "${ALLOWED_LOGS[@]}"; do
+    [ "$name" = "$allowed" ] && return 0
+  done
+  return 1
+}
+
+cmd_shot() {
+  local crop="" out_path=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --crop)
+        crop="${2:-}"
+        if ! [[ "$crop" =~ ^[0-9]+x[0-9]+\+[0-9]+\+[0-9]+$ ]]; then
+          echo "agent.sh shot: --crop expects WxH+X+Y (integers), got: $crop" >&2
+          exit 2
+        fi
+        shift 2
+        ;;
+      -*)
+        echo "agent.sh shot: unknown flag: $1" >&2
+        exit 2
+        ;;
+      *)
+        out_path="$1"
+        shift
+        ;;
+    esac
+  done
+  [ -z "$out_path" ] && out_path="/tmp/shot.png"
+
+  local container in_path import_args
+  container=$(find_container)
+  in_path="/tmp/agent-shot-$$.png"
+  if [ -n "$crop" ]; then
+    import_args="-window root -crop $crop +repage"
+  else
+    import_args="-window root"
+  fi
+
+  # shellcheck disable=SC2086
+  docker exec "$container" bash -c \
+    "DISPLAY=$DISPLAY_NAME import $import_args $in_path"
+  docker cp "$container:$in_path" "$out_path"
+  docker exec "$container" rm -f "$in_path" >/dev/null 2>&1 || true
+
+  local abs_out
+  abs_out=$(readlink -f "$out_path" 2>/dev/null || echo "$out_path")
+  echo "wrote: $abs_out"
+}
+
+cmd_xdo() {
+  if [ $# -eq 0 ]; then
+    echo "agent.sh xdo: requires xdotool args (e.g., 'mousemove 100 200 click 1')" >&2
+    exit 2
+  fi
+  local container
+  container=$(find_container)
+  # Pass argv through positionally so quoted strings (e.g. 'type "hello world"')
+  # survive without going through a shell -c.
+  docker exec -e "DISPLAY=$DISPLAY_NAME" "$container" xdotool "$@"
+}
+
+cmd_tail() {
+  if [ $# -lt 1 ]; then
+    echo "agent.sh tail: usage: tail LOG [N]" >&2
+    echo "  LOG ∈ {${ALLOWED_LOGS[*]}}" >&2
+    exit 2
+  fi
+  local log="$1" n="${2:-50}"
+  if ! is_allowed_log "$log"; then
+    echo "agent.sh tail: unknown log '$log'" >&2
+    echo "  allowed: ${ALLOWED_LOGS[*]}" >&2
+    exit 2
+  fi
+  if ! [[ "$n" =~ ^[0-9]+$ ]]; then
+    echo "agent.sh tail: N must be a positive integer, got: $n" >&2
+    exit 2
+  fi
+  local container
+  container=$(find_container)
+  docker exec "$container" tail -n "$n" "/tmp/${log}.log"
+}
+
+cmd_health() {
+  local container fail=0
+  container=$(find_container) || exit 1
+  echo "container: $container"
+
+  if docker exec "$container" pgrep -f '[e]lectron/dist/electron' >/dev/null 2>&1; then
+    echo "electron:   running"
+  else
+    echo "electron:   NOT running"
+    fail=1
+  fi
+
+  if docker exec "$container" pgrep -f '[t]hv serve' >/dev/null 2>&1; then
+    echo "thv serve:  running"
+  else
+    echo "thv serve:  NOT running"
+    fail=1
+  fi
+
+  if docker exec "$container" bash -c "DISPLAY=$DISPLAY_NAME xdotool search --class ToolHive >/dev/null 2>&1"; then
+    echo "window:     ToolHive present"
+  else
+    echo "window:     ToolHive NOT mapped"
+    fail=1
+  fi
+
+  if docker exec "$container" curl -sf -o /dev/null -m 3 http://localhost:6080/; then
+    echo "noVNC:6080: ok (in-container)"
+  else
+    echo "noVNC:6080: NOT responding (in-container)"
+    fail=1
+  fi
+
+  if [ -f "$URL_CACHE_FILE" ]; then
+    local url
+    url=$(cat "$URL_CACHE_FILE")
+    if curl -sf -o /dev/null -m 3 "$url"; then
+      echo "noVNC host: ok ($url)"
+    else
+      echo "noVNC host: NOT responding ($url)"
+      fail=1
+    fi
+  else
+    echo "noVNC host: unknown (no $URL_CACHE_FILE)"
+  fi
+
+  exit "$fail"
+}
+
+usage() {
+  local fd="${1:-2}"
+  cat >&"$fd" <<EOF
+Usage: $0 <subcommand> [args...]
+
+Subcommands:
+  shot [--crop WxH+X+Y] [PATH]   Screenshot the in-container display to
+                                 PATH on the host (default: /tmp/shot.png).
+                                 --crop forwards to ImageMagick \`import\`.
+  xdo  <args...>                 Run \`xdotool <args>\` against DISPLAY=:99
+                                 inside the devcontainer. Covers click,
+                                 key, type, mousemove, search, etc.
+  tail LOG [N]                   Tail /tmp/<LOG>.log (last N lines, default
+                                 50). LOG ∈ {${ALLOWED_LOGS[*]}}.
+  health                         Print readiness of electron, thv serve,
+                                 the ToolHive X window, and noVNC. Exit 0
+                                 if all green.
+
+Each subcommand finds the devcontainer for this worktree by label
+(devcontainer.local_folder=$REPO_ROOT) — never accepts a container ID.
+EOF
+}
+
+main() {
+  local sub="${1:-}"
+  [ $# -gt 0 ] && shift
+  case "$sub" in
+    shot)         cmd_shot "$@" ;;
+    xdo)          cmd_xdo "$@" ;;
+    tail)         cmd_tail "$@" ;;
+    health)       cmd_health "$@" ;;
+    -h|--help|help) usage 1; exit 0 ;;
+    "")           usage; exit 1 ;;
+    *) echo "agent.sh: unknown subcommand: $sub" >&2; usage; exit 1 ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a parallel "Visual Bug Fix Agent" — a label-gated copy of the production bug-fix agent (`_bug-fix-agent.yml`) with one structural addition: the project's devcontainer is booted alongside the agent and exposed via `docker exec`, so the agent can drive the live app (xdotool, screenshots, in-container test runs) for bugs that resist a pure unit-test reproduction.

**Production behavior is unchanged.** This adds two new files; nothing existing is modified.

## Depends on PR #2120

The agent's prompt references `scripts/devcontainer-screenshot.sh` and `scripts/devcontainer-steal.sh`, plus the corrected `devcontainer-dev` skill. All three land in #2120. **#2120 should merge first**; otherwise this agent's first run would fail when invoking missing scripts.

## What changes

| File | Mirrors | Differences |
|---|---|---|
| `_visual-bug-fix-agent.yml` | `_bug-fix-agent.yml` | + buildx setup, `node_modules` cache + populate, `devcontainers/ci` build/start, find container, launch entrypoint, readiness gate (process + `xdotool search --class ToolHive` + 2s settle); + `DEVCONTAINER_ID` env on each phase; + live-app paragraph in Phase 1 / 2 / 2b prompts; + `--allowedTools` extended with `docker exec/cp/ps` and the two helper scripts; + nm-cache dump step; + diagnostics-on-failure step; concurrency `visual-bug-fix-*`; branch suffix `-visual`; PR label `auto-fix-visual`; failure-comment marker `Visual Bug Fix Agent`; `timeout-minutes` 45→60; Phase 1 `--max-turns` 50→75 |
| `visual-bug-fix-on-label.yml` | `bug-fix-on-label.yml` | Triggers on label `auto-fix-visual` (still requires `Bug` label) |

The structural shape, gating, phases, hard gates, branch/PR creation, and failure handling are byte-equivalent to the production agent modulo the renames required for parallel runs.

## Cost expectations

> Rough estimates, sample of 2 production runs.

| | Production agent today | + visual variant (current) | + #2136 (prebuilt image) |
|---|---|---|---|
| Per-fix wall time | ~18 min | ~22 min (+22%) | ~19 min (+5%) |

Phase 1 (5–9 min agent thinking) dominates regardless of substrate. The +4 min is the devcontainer build + boot. Once #2136 lands, that drops to ~30s.

## Activation

The trigger is the `auto-fix-visual` label on a `Bug`-labeled issue. To test:
1. Merge #2120 (helper scripts + skill update).
2. Merge this PR.
3. Apply the `auto-fix-visual` label to a candidate bug. The natural first candidate is **#663** (server deletion focuses MCP Servers tab), chosen earlier in the experiment for its async-IPC-driven cross-route behavior.

Both labels (`auto-fix` and `auto-fix-visual`) can be applied to the same issue if you want a head-to-head comparison.

## What this PR does NOT prove

That live-app access actually improves the agent's success rate. The substrate is proven (in #2120). The agent integration is mechanical. Whether the +22% (or +5% post-#2136) wall-time tax is worth it depends entirely on how Phase 1 performs on bugs that resist unit-test repro — and that can only be measured by labeling real issues and observing outcomes.

## Risk surface

- Production agent is untouched; worst case rollback is `git rm` of two files.
- If the agent misbehaves on a labeled issue, the label is trivially removed and the workflow has a "give-up" guard (final comment marker) that prevents repeat retries.
- `claude-code-action`'s workflow validation means the FIRST real run happens after merge — there is no pre-merge dry run available.