### PR TITLE
chore(ci): upgrade e2e Ollama model from qwen2.5:3b to qwen3:1.7b

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   OLLAMA_BASE_URL: http://localhost:11434
-  OLLAMA_MODEL: qwen2.5:3b
+  OLLAMA_MODEL: qwen3:1.7b
   OLLAMA_VERSION: 0.18.2
 
 jobs:


### PR DESCRIPTION
## Summary

Upgrades the Ollama model used in e2e tests from `qwen2.5:3b` to `qwen3:1.7b`.

## Why

The Playground e2e test (`configures Ollama provider and sends chat message`) is flaky because `qwen2.5:3b` has poor tool-calling reliability.

[Tool-calling benchmark](https://github.com/MikeVeerman/tool-calling-benchmark) results:

| Model | Agent Score | Action | Restraint | Wrong Tool | Latency |
|---|---|---|---|---|---|
| **qwen3:1.7b** | **0.960** | 0.900 | 1.000 | 0 | 10.6s |
| qwen2.5:3b (current) | 0.670 | 0.800 | 0.500 | 1 | 3.0s |

`qwen3:1.7b` is half the size, has zero wrong tool calls, and perfect restraint. Tested in the enterprise repo with 2 consecutive green e2e runs.

## Test plan

- [ ] E2E Playground test passes with qwen3:1.7b
- [ ] All other e2e tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)