### PR TITLE
fix(skills): preserve serif typography on detail page sticky header

### DIFF
--- a/renderer/src/features/skills/components/skill-detail-layout.tsx
+++ b/renderer/src/features/skills/components/skill-detail-layout.tsx
@@ -120,8 +120,8 @@ export function SkillDetailLayout({
                   </LinkViewTransition>
                 </div>
                 <h2
-                  className="text-foreground m-0 truncate p-0 text-2xl
-                    font-semibold tracking-tight"
+                  className="text-foreground m-0 truncate p-0 font-serif
+                    text-2xl font-light tracking-tight"
                 >
                   {title}
                 </h2>


### PR DESCRIPTION
On a Skills detail page, scrolling past the main header swaps the title for a sticky version in the left rail. The sticky title was rendered with the default sans-serif font and a semibold weight, while the original header uses the `.text-page-title` serif (Merriweather, weight 300). Same heading, two different typefaces — a noticeable jump every time the user scrolled.

https://github.com/user-attachments/assets/5502ce7e-2030-45f1-9a38-25d0cf639747


## Root cause

`SkillDetailLayout` rendered the sticky `<h2>` with `text-2xl font-semibold tracking-tight`, while the original heading in `registry-detail-header.tsx` uses the `.text-page-title` utility defined in `index.css`, which sets `font-family: var(--font-serif)` and `font-weight: 300`. So the sticky variant was overriding font family **and** weight, not just size.

## Changes

- [`skill-detail-layout.tsx`](renderer/src/features/skills/components/skill-detail-layout.tsx) — replace `font-semibold` with `font-serif font-light` on the sticky `<h2>`. `tracking-tight` (`-0.025em`) already approximates the `-0.85px` letter-spacing of `.text-page-title` at this size, and `text-2xl` (24px) keeps the sticky title compact.

Net effect: same Merriweather typography as the page header, just smaller — no font swap on scroll.

## How to validate

1. Open any Skills detail page (Installed, Registry, or Local Builds).
2. Scroll until the main header leaves the viewport — the title that fades into the left rail is now Merriweather (serif), not Inter, and visually feels like a continuation of the original heading.
3. Scroll back up — the transition between the full header and the sticky title is a pure size change, no font-family flicker.
4. Reduced-motion users (`motion-reduce`) get the same end state without the fade transition.

## Out of scope

- The original header (`RegistryDetailHeader`) is unchanged.
- No changes to other detail pages that don't use `SkillDetailLayout`.