### PR TITLE
fix(skills): prefill version field in install dialog for every entry point

### DIFF
--- a/renderer/src/features/chat/components/tool-results/__tests__/skill-build-result-card.test.tsx
+++ b/renderer/src/features/chat/components/tool-results/__tests__/skill-build-result-card.test.tsx
@@ -143,7 +143,7 @@ describe('SkillBuildResultCard', () => {
     )
   })
 
-  it('passes an empty version to the install dialog when no explicit version exists', async () => {
+  it('falls back to the tag suffix when no explicit build.version exists', async () => {
     const result: SkillBuildResult = {
       reference: 'my-skill',
       apiReference: 'ghcr.io/example/my-skill:latest',
@@ -156,10 +156,30 @@ describe('SkillBuildResultCard', () => {
     render(<SkillBuildResultCard result={result} />)
     await userEvent.click(screen.getByTestId('chat-build-install'))
 
-    expect(screen.getByTestId('install-default-version')).toHaveTextContent('')
     expect(screen.getByTestId('install-default-reference')).toHaveTextContent(
       'my-skill'
     )
+    expect(screen.getByTestId('install-default-version')).toHaveTextContent(
+      'latest'
+    )
+  })
+
+  it('passes an empty version to the install dialog when no version info exists anywhere', async () => {
+    const result: SkillBuildResult = {
+      reference: 'my-skill',
+      build: {
+        name: 'my-skill',
+      },
+    }
+
+    render(<SkillBuildResultCard result={result} />)
+    await userEvent.click(screen.getByTestId('chat-build-install'))
+
+    expect(screen.getByTestId('install-default-reference')).toHaveTextContent(
+      'my-skill'
+    )
+    // installVersion is undefined and the JSX coerces it to '' via `?? ''`.
+    expect(screen.getByTestId('install-default-version').textContent).toBe('')
   })
 
   it('shows an error toast when copying to the clipboard fails', async () => {

--- a/renderer/src/features/chat/components/tool-results/skill-build-result-card.tsx
+++ b/renderer/src/features/chat/components/tool-results/skill-build-result-card.tsx
@@ -18,6 +18,8 @@ import {
   TooltipTrigger,
 } from '@/common/components/ui/tooltip'
 import { DialogInstallSkill } from '@/features/skills/components/dialog-install-skill'
+import { getBuildInstallDefaults } from '@/features/skills/lib/build-reference'
+import { parseSkillReference } from '@/features/skills/lib/skill-reference'
 import { trackEvent } from '@/common/lib/analytics'
 import type { SkillBuildResult } from '../../lib/parse-skill-build-result'
 
@@ -87,8 +89,14 @@ export function SkillBuildResultCard({ result }: { result: SkillBuildResult }) {
     !!v && (v.includes('/') || v.includes(':'))
   const navTag = apiReference ?? (isRegistryRef(tag) ? tag : undefined)
   const canViewDetails = !!navTag
-  const installName = build.name ?? reference
-  const installVersion = version
+  // Mirror the local-build install defaults logic: prefer build.name +
+  // build.version, then split build.tag, then split the canonical
+  // reference. This keeps the version field prefilled even when only
+  // `result.reference` (in `name:tag` form) is available.
+  const buildDefaults = getBuildInstallDefaults(build)
+  const referenceFallback = parseSkillReference(reference)
+  const installName = buildDefaults.reference ?? referenceFallback.reference
+  const installVersion = buildDefaults.version ?? referenceFallback.version
   const copyValue = build.name ?? reference
 
   const handleCopyReference = async () => {

--- a/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { expect, it, vi, describe } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -253,6 +253,91 @@ describe('DialogBuildSkill', () => {
     expect(window.electronAPI.isDirectory).toHaveBeenCalledWith(
       '/home/user/.agents/my-skill'
     )
+  })
+
+  it('opens install dialog with reference and version split out of the built name:tag', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkillsBuild.override(() => ({
+      reference: 'ghcr.io/org/skill:v2.0.0',
+    }))
+    vi.mocked(window.electronAPI.selectFolder).mockResolvedValue(
+      '/home/user/my-skill'
+    )
+
+    renderWithProviders(<DialogBuildSkill open onOpenChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /browse for folder/i }))
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
+    })
+    await user.click(screen.getByRole('button', { name: /^build$/i }))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+    })
+
+    // Sonner is globally mocked, so the action button is never rendered.
+    // Trigger the "Install now" handler captured by the toast call directly.
+    const lastCall = vi.mocked(toast.success).mock.calls.at(-1)
+    const opts = lastCall?.[1] as
+      | { action?: { onClick?: () => void } }
+      | undefined
+    opts?.action?.onClick?.()
+
+    const nameInput = await screen.findByLabelText(/name or reference/i)
+    expect(nameInput).toHaveValue('ghcr.io/org/skill')
+
+    const installDialog = nameInput.closest(
+      '[role="dialog"]'
+    ) as HTMLElement | null
+    expect(installDialog).not.toBeNull()
+    expect(
+      within(installDialog!).getByPlaceholderText('e.g. v1.0.0')
+    ).toHaveValue('v2.0.0')
+  })
+
+  it('falls back to the user-supplied tag as version when the built reference has none', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkillsBuild.override(() => ({
+      reference: 'ghcr.io/org/skill',
+    }))
+    vi.mocked(window.electronAPI.selectFolder).mockResolvedValue(
+      '/home/user/my-skill'
+    )
+
+    renderWithProviders(<DialogBuildSkill open onOpenChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /browse for folder/i }))
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
+    })
+    await user.type(screen.getByPlaceholderText(/e\.g\. v1\.0\.0/i), 'v3.4.5')
+    await user.click(screen.getByRole('button', { name: /^build$/i }))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+    })
+
+    const lastCall = vi.mocked(toast.success).mock.calls.at(-1)
+    const opts = lastCall?.[1] as
+      | { action?: { onClick?: () => void } }
+      | undefined
+    opts?.action?.onClick?.()
+
+    const nameInput = await screen.findByLabelText(/name or reference/i)
+    expect(nameInput).toHaveValue('ghcr.io/org/skill')
+
+    const installDialog = nameInput.closest(
+      '[role="dialog"]'
+    ) as HTMLElement | null
+    expect(installDialog).not.toBeNull()
+    expect(
+      within(installDialog!).getByPlaceholderText('e.g. v1.0.0')
+    ).toHaveValue('v3.4.5')
   })
 
   it('blocks submit and shows validation error when typed path is not a directory', async () => {

--- a/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-build-skill.test.tsx
@@ -340,6 +340,54 @@ describe('DialogBuildSkill', () => {
     ).toHaveValue('v3.4.5')
   })
 
+  it('parses the user-supplied tag before using it as the version fallback', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkillsBuild.override(() => ({
+      reference: 'ghcr.io/org/skill',
+    }))
+    vi.mocked(window.electronAPI.selectFolder).mockResolvedValue(
+      '/home/user/my-skill'
+    )
+
+    renderWithProviders(<DialogBuildSkill open onOpenChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /browse for folder/i }))
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(/paste or type a folder/i)
+      ).toHaveValue('/home/user/my-skill')
+    })
+    // User typed a full OCI ref into the build form's Tag field. Only
+    // the version portion should land in the install dialog's Version
+    // field, never the whole conjoined string.
+    await user.type(
+      screen.getByPlaceholderText(/e\.g\. v1\.0\.0/i),
+      'ghcr.io/org/skill:v3.4.5'
+    )
+    await user.click(screen.getByRole('button', { name: /^build$/i }))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+    })
+
+    const lastCall = vi.mocked(toast.success).mock.calls.at(-1)
+    const opts = lastCall?.[1] as
+      | { action?: { onClick?: () => void } }
+      | undefined
+    opts?.action?.onClick?.()
+
+    const nameInput = await screen.findByLabelText(/name or reference/i)
+    expect(nameInput).toHaveValue('ghcr.io/org/skill')
+
+    const installDialog = nameInput.closest(
+      '[role="dialog"]'
+    ) as HTMLElement | null
+    expect(installDialog).not.toBeNull()
+    expect(
+      within(installDialog!).getByPlaceholderText('e.g. v1.0.0')
+    ).toHaveValue('v3.4.5')
+  })
+
   it('blocks submit and shows validation error when typed path is not a directory', async () => {
     const user = userEvent.setup()
     const rec = recordRequests()

--- a/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
@@ -420,4 +420,57 @@ describe('DialogInstallSkill', () => {
       expect(versionInput).toHaveValue('')
     })
   })
+
+  it('overwrites a prefilled (non-dirty) version when a new tagged reference is pasted', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <DialogInstallSkill
+        open
+        onOpenChange={vi.fn()}
+        defaultReference="ghcr.io/org/skill"
+        defaultVersion="v1.0.0"
+      />
+    )
+
+    const nameInput = screen.getByLabelText(/name or reference/i)
+    const versionInput = screen.getByPlaceholderText('e.g. v1.0.0')
+    expect(versionInput).toHaveValue('v1.0.0')
+
+    await user.clear(nameInput)
+    await user.type(nameInput, 'ghcr.io/org/skill:v9.9.9')
+    await user.tab()
+
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('ghcr.io/org/skill')
+      // Prefilled v1.0.0 is non-dirty, so it must be replaced by the
+      // version parsed from the freshly pasted reference.
+      expect(versionInput).toHaveValue('v9.9.9')
+    })
+  })
+
+  it('preserves a user-edited version even when it equals the prefilled default', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <DialogInstallSkill
+        open
+        onOpenChange={vi.fn()}
+        defaultReference="ghcr.io/org/skill"
+        defaultVersion=""
+      />
+    )
+
+    const nameInput = screen.getByLabelText(/name or reference/i)
+    const versionInput = screen.getByPlaceholderText('e.g. v1.0.0')
+
+    await user.type(versionInput, 'v8.8.8')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'ghcr.io/org/skill:v9.9.9')
+    await user.tab()
+
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('ghcr.io/org/skill')
+      // User actively typed v8.8.8, so the blur split must not clobber it.
+      expect(versionInput).toHaveValue('v8.8.8')
+    })
+  })
 })

--- a/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
@@ -88,6 +88,8 @@ describe('DialogInstallSkill', () => {
 
     renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
 
+    // The name field auto-splits a tagged reference into name + version on
+    // blur, so submitting "ghcr.io/org/skill:v1" should send them separately.
     await user.type(
       screen.getByLabelText(/name or reference/i),
       'ghcr.io/org/skill:v1'
@@ -100,8 +102,9 @@ describe('DialogInstallSkill', () => {
       )
       expect(postCall).toBeDefined()
       expect(postCall?.payload).toMatchObject({
-        name: 'ghcr.io/org/skill:v1',
+        name: 'ghcr.io/org/skill',
         scope: 'user',
+        version: 'v1',
       })
       expect(postCall?.payload).not.toHaveProperty('clients')
     })
@@ -350,6 +353,71 @@ describe('DialogInstallSkill', () => {
 
     await waitFor(() => {
       expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('splits a tagged reference into name + version on blur', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    const nameInput = screen.getByLabelText(/name or reference/i)
+    const versionInput = screen.getByPlaceholderText('e.g. v1.0.0')
+
+    await user.type(nameInput, 'ghcr.io/org/skill:v1.2.3')
+    await user.tab()
+
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('ghcr.io/org/skill')
+      expect(versionInput).toHaveValue('v1.2.3')
+    })
+  })
+
+  it('splits a digested reference into name + sha256 version on blur', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    const nameInput = screen.getByLabelText(/name or reference/i)
+    const versionInput = screen.getByPlaceholderText('e.g. v1.0.0')
+
+    await user.type(nameInput, 'ghcr.io/org/skill@sha256:deadbeef')
+    await user.tab()
+
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('ghcr.io/org/skill')
+      expect(versionInput).toHaveValue('sha256:deadbeef')
+    })
+  })
+
+  it('does not overwrite a version the user already typed', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    const nameInput = screen.getByLabelText(/name or reference/i)
+    const versionInput = screen.getByPlaceholderText('e.g. v1.0.0')
+
+    await user.type(versionInput, 'v9.9.9')
+    await user.type(nameInput, 'ghcr.io/org/skill:v1.2.3')
+    await user.tab()
+
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('ghcr.io/org/skill')
+      expect(versionInput).toHaveValue('v9.9.9')
+    })
+  })
+
+  it('leaves a bare reference (no tag/digest) untouched on blur', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    const nameInput = screen.getByLabelText(/name or reference/i)
+    const versionInput = screen.getByPlaceholderText('e.g. v1.0.0')
+
+    await user.type(nameInput, 'ghcr.io/org/skill')
+    await user.tab()
+
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('ghcr.io/org/skill')
+      expect(versionInput).toHaveValue('')
     })
   })
 })

--- a/renderer/src/features/skills/components/__tests__/table-builds.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-builds.test.tsx
@@ -98,7 +98,7 @@ describe('TableBuilds', () => {
     })
   })
 
-  it('opens install dialog prefilled with the build tag', async () => {
+  it('opens install dialog with bare reference and version split out of the build tag', async () => {
     const user = userEvent.setup()
     const router = makeRouter()
     renderRoute(router)
@@ -109,9 +109,12 @@ describe('TableBuilds', () => {
     await user.click(install)
 
     await waitFor(() => {
+      // Reference comes from build.name (already bare) and the version is
+      // pre-split rather than baked into the reference.
       expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
-        'localhost/my-skill:v1.0.0'
+        'my-skill'
       )
+      expect(screen.getByPlaceholderText('e.g. v1.0.0')).toHaveValue('v1.0.0')
     })
   })
 

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -169,7 +169,7 @@ describe('TableRegistrySkills', () => {
     expect(screen.queryByRole('button', { name: 'standalone' })).toBeNull()
   })
 
-  it('opens install dialog with OCI package identifier when no ref is available', async () => {
+  it('opens install dialog with OCI identifier and falls back to skill.version when no tag/ref is present', async () => {
     const user = userEvent.setup()
     const router = makeRouter([ociSkill])
     renderRoute(router)
@@ -184,7 +184,9 @@ describe('TableRegistrySkills', () => {
         'ghcr.io/org/my-skill'
       )
     })
-    expect(screen.getByPlaceholderText(/e\.g\. v1\.0\.0/i)).toHaveValue('')
+    expect(screen.getByPlaceholderText(/e\.g\. v1\.0\.0/i)).toHaveValue(
+      'v1.0.0'
+    )
   })
 
   it('splits a tagged OCI identifier so the version fills the version field', async () => {

--- a/renderer/src/features/skills/components/build-detail-page.tsx
+++ b/renderer/src/features/skills/components/build-detail-page.tsx
@@ -19,7 +19,7 @@ import { DialogDeleteBuild } from './dialog-delete-build'
 import { SkillDetailLayout } from './skill-detail-layout'
 import { SkillMarkdown } from './skill-markdown'
 import { trackEvent } from '@/common/lib/analytics'
-import { getBuildTitle } from '../lib/build-reference'
+import { getBuildInstallDefaults, getBuildTitle } from '../lib/build-reference'
 
 interface BuildDetailPageProps {
   build: LocalBuild
@@ -35,6 +35,7 @@ export function BuildDetailPage({ build }: BuildDetailPageProps) {
   const tag = build.tag
   const digest = build.digest
   const description = build.description
+  const installDefaults = getBuildInstallDefaults(build)
 
   const shortDigest = digest
     ? digest.startsWith('sha256:')
@@ -144,11 +145,11 @@ export function BuildDetailPage({ build }: BuildDetailPageProps) {
       />
 
       <DialogInstallSkill
-        key={`${build.name ?? tag ?? title}-${version ?? ''}`}
+        key={`${installDefaults.reference ?? title}-${installDefaults.version ?? ''}`}
         open={installOpen}
         onOpenChange={setInstallOpen}
-        defaultReference={build.name ?? tag}
-        defaultVersion={version ?? ''}
+        defaultReference={installDefaults.reference}
+        defaultVersion={installDefaults.version ?? ''}
       />
       <DialogDeleteBuild
         open={deleteOpen}

--- a/renderer/src/features/skills/components/card-build.tsx
+++ b/renderer/src/features/skills/components/card-build.tsx
@@ -8,7 +8,7 @@ import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogDeleteBuild } from './dialog-delete-build'
 import { CardSkillBase } from './card-skill-base'
 import { trackEvent } from '@/common/lib/analytics'
-import { getBuildTitle } from '../lib/build-reference'
+import { getBuildInstallDefaults, getBuildTitle } from '../lib/build-reference'
 
 export function CardBuild({ build }: { build: LocalBuild }) {
   const [installOpen, setInstallOpen] = useState(false)
@@ -20,6 +20,7 @@ export function CardBuild({ build }: { build: LocalBuild }) {
   const version = build.version
   const tag = build.tag
   const digest = build.digest
+  const installDefaults = getBuildInstallDefaults(build)
 
   const shortDigest = digest
     ? digest.startsWith('sha256:')
@@ -98,11 +99,11 @@ export function CardBuild({ build }: { build: LocalBuild }) {
       />
 
       <DialogInstallSkill
-        key={`${build.name ?? tag ?? title}-${version ?? ''}`}
+        key={`${installDefaults.reference ?? title}-${installDefaults.version ?? ''}`}
         open={installOpen}
         onOpenChange={setInstallOpen}
-        defaultReference={build.name ?? tag}
-        defaultVersion={version ?? ''}
+        defaultReference={installDefaults.reference}
+        defaultVersion={installDefaults.version ?? ''}
       />
       <DialogDeleteBuild
         open={deleteOpen}

--- a/renderer/src/features/skills/components/dialog-build-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-build-skill.tsx
@@ -106,9 +106,20 @@ export function DialogBuildSkill({
 
       if (reference) {
         const parsed = parseSkillReference(reference)
+        // The build form's Tag field accepts arbitrary strings, so the
+        // user might have typed either a clean version (`v3.4.5`) or a
+        // full OCI reference (`ghcr.io/org/skill:v3.4.5`). Extract just
+        // the version portion before falling back to it; only use the
+        // raw value when it is a plain version-only string (no `/`).
+        const userTagParsed = values.tag
+          ? parseSkillReference(values.tag)
+          : undefined
+        const userVersion =
+          userTagParsed?.version ??
+          (values.tag && !values.tag.includes('/') ? values.tag : undefined)
         setBuiltInstallDefaults({
           reference: parsed.reference,
-          version: parsed.version ?? values.tag ?? undefined,
+          version: parsed.version ?? userVersion ?? undefined,
         })
         toast.success(`Skill built: ${reference}`, {
           duration: 10_000,

--- a/renderer/src/features/skills/components/dialog-build-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-build-skill.tsx
@@ -25,6 +25,7 @@ import { FolderOpenIcon, TriangleAlertIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { useMutationBuildSkill } from '../hooks/use-mutation-build-skill'
 import { DialogInstallSkill } from './dialog-install-skill'
+import { parseSkillReference } from '../lib/skill-reference'
 import { trackEvent } from '@/common/lib/analytics'
 
 const formSchema = z.object({
@@ -54,7 +55,10 @@ export function DialogBuildSkill({
 }: DialogBuildSkillProps) {
   const { mutateAsync: buildSkill, isPending } = useMutationBuildSkill()
   const [installOpen, setInstallOpen] = useState(false)
-  const [builtReference, setBuiltReference] = useState<string | undefined>()
+  const [builtInstallDefaults, setBuiltInstallDefaults] = useState<{
+    reference: string
+    version?: string
+  } | null>(null)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
   const form = useForm<FormSchema>({
@@ -101,7 +105,11 @@ export function DialogBuildSkill({
       onOpenChange(false)
 
       if (reference) {
-        setBuiltReference(reference)
+        const parsed = parseSkillReference(reference)
+        setBuiltInstallDefaults({
+          reference: parsed.reference,
+          version: parsed.version ?? values.tag ?? undefined,
+        })
         toast.success(`Skill built: ${reference}`, {
           duration: 10_000,
           closeButton: true,
@@ -217,10 +225,11 @@ export function DialogBuildSkill({
       </Dialog>
 
       <DialogInstallSkill
-        key={builtReference}
+        key={`${builtInstallDefaults?.reference ?? ''}-${builtInstallDefaults?.version ?? ''}`}
         open={installOpen}
         onOpenChange={setInstallOpen}
-        defaultReference={builtReference}
+        defaultReference={builtInstallDefaults?.reference}
+        defaultVersion={builtInstallDefaults?.version ?? ''}
       />
     </>
   )

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useForm, useWatch } from 'react-hook-form'
+import { useForm, useFormState, useWatch } from 'react-hook-form'
 import z from 'zod/v4'
 import { zodV4Resolver } from '@/common/lib/zod-v4-resolver'
 import { useQuery } from '@tanstack/react-query'
@@ -102,6 +102,11 @@ export function DialogInstallSkill({
   })
 
   const scope = useWatch({ control: form.control, name: 'scope' })
+  // Subscribe to dirtyFields so the blur splitter below can reliably
+  // tell prefilled defaults apart from values the user actually typed.
+  // Reading `form.formState.dirtyFields.version` from inside a callback
+  // is not enough because RHF tracks subscriptions at render-time.
+  const { dirtyFields } = useFormState({ control: form.control })
 
   function handleClose() {
     trackEvent('Skills: install dialog cancelled')
@@ -193,7 +198,12 @@ export function DialogInstallSkill({
                           shouldValidate: true,
                           shouldDirty: true,
                         })
-                        if (!form.getValues('version')) {
+                        // Only preserve the version if the user has
+                        // actively edited it; a value that came from
+                        // `defaultVersion` is still considered pristine
+                        // and should be replaced when the pasted ref
+                        // disagrees with the prefill.
+                        if (!dirtyFields.version) {
                           form.setValue('version', parsed.version, {
                             shouldDirty: true,
                           })

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -40,6 +40,7 @@ import {
 import { TooltipInfoIcon } from '@/common/components/ui/tooltip-info-icon'
 import { ChevronDown, FolderOpenIcon, TriangleAlertIcon } from 'lucide-react'
 import { useMutationInstallSkill } from '../hooks/use-mutation-install-skill'
+import { parseSkillReference } from '../lib/skill-reference'
 import { trackEvent } from '@/common/lib/analytics'
 
 const formSchema = z
@@ -182,6 +183,22 @@ export function DialogInstallSkill({
                       {...field}
                       placeholder="e.g. your-org/your-skill"
                       autoFocus
+                      onBlur={(e) => {
+                        field.onBlur()
+                        const value = e.target.value.trim()
+                        if (!value) return
+                        const parsed = parseSkillReference(value)
+                        if (!parsed.version) return
+                        form.setValue('name', parsed.reference, {
+                          shouldValidate: true,
+                          shouldDirty: true,
+                        })
+                        if (!form.getValues('version')) {
+                          form.setValue('version', parsed.version, {
+                            shouldDirty: true,
+                          })
+                        }
+                      }}
                     />
                   </FormControl>
                   <FormMessage />

--- a/renderer/src/features/skills/components/table-builds.tsx
+++ b/renderer/src/features/skills/components/table-builds.tsx
@@ -24,6 +24,7 @@ import {
 import { HammerIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { DialogInstallSkill } from './dialog-install-skill'
 import { DialogDeleteBuild } from './dialog-delete-build'
+import { getBuildInstallDefaults } from '../lib/build-reference'
 import { trackEvent } from '@/common/lib/analytics'
 
 function getShortDigest(digest: string | undefined): string | undefined {
@@ -53,6 +54,7 @@ function BuildRow({ build }: { build: LocalBuild }) {
   const shortDigest = getShortDigest(build.digest)
   const subtitle = tag && tag !== title ? tag : undefined
   const canNavigate = !!tag
+  const installDefaults = getBuildInstallDefaults(build)
 
   function goToDetail() {
     if (!tag) return
@@ -182,10 +184,11 @@ function BuildRow({ build }: { build: LocalBuild }) {
       </TableRow>
 
       <DialogInstallSkill
-        key={tag ?? title}
+        key={`${installDefaults.reference ?? title}-${installDefaults.version ?? ''}`}
         open={installOpen}
         onOpenChange={setInstallOpen}
-        defaultReference={tag ?? build.name}
+        defaultReference={installDefaults.reference}
+        defaultVersion={installDefaults.version ?? ''}
       />
       <DialogDeleteBuild
         open={deleteOpen}

--- a/renderer/src/features/skills/lib/__tests__/get-build-install-defaults.test.ts
+++ b/renderer/src/features/skills/lib/__tests__/get-build-install-defaults.test.ts
@@ -119,4 +119,16 @@ describe('getBuildInstallDefaults', () => {
       version: undefined,
     })
   })
+
+  it('does not treat a bare OCI reference tag as a version (no slash heuristic)', () => {
+    const build: LocalBuild = {
+      name: 'my-skill',
+      tag: 'ghcr.io/org/my-skill',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'my-skill',
+      version: undefined,
+    })
+  })
 })

--- a/renderer/src/features/skills/lib/__tests__/get-build-install-defaults.test.ts
+++ b/renderer/src/features/skills/lib/__tests__/get-build-install-defaults.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from '@common/api/generated/types.gen'
+import { getBuildInstallDefaults } from '../build-reference'
+
+describe('getBuildInstallDefaults', () => {
+  it('uses build.name and build.version when both are present', () => {
+    const build: LocalBuild = {
+      name: 'my-skill',
+      tag: 'localhost/my-skill:v1.0.0',
+      version: 'v1.0.0',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'my-skill',
+      version: 'v1.0.0',
+    })
+  })
+
+  it('falls back to splitting build.tag for both reference and version when build.name is absent', () => {
+    const build: LocalBuild = {
+      tag: 'localhost/my-skill:v1.0.0',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'localhost/my-skill',
+      version: 'v1.0.0',
+    })
+  })
+
+  it('falls back to splitting build.tag for the version when build.version is absent', () => {
+    const build: LocalBuild = {
+      name: 'my-skill',
+      tag: 'localhost/my-skill:v2.3.4',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'my-skill',
+      version: 'v2.3.4',
+    })
+  })
+
+  it('extracts a sha256 digest from build.tag as the version', () => {
+    const build: LocalBuild = {
+      name: 'my-skill',
+      tag: 'localhost/my-skill@sha256:deadbeef',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'my-skill',
+      version: 'sha256:deadbeef',
+    })
+  })
+
+  it('returns the bare tag as reference and undefined version when no tag/version info is present', () => {
+    const build: LocalBuild = {
+      tag: 'localhost/my-skill',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'localhost/my-skill',
+      version: undefined,
+    })
+  })
+
+  it('prefers the explicit build.version over the tag suffix', () => {
+    const build: LocalBuild = {
+      name: 'my-skill',
+      tag: 'localhost/my-skill:latest',
+      version: 'v9.9.9',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'my-skill',
+      version: 'v9.9.9',
+    })
+  })
+
+  it('returns undefined for both fields when the build has nothing usable', () => {
+    const build: LocalBuild = {}
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: undefined,
+      version: undefined,
+    })
+  })
+
+  it('treats a bare version-only tag as the version when build.name covers the reference', () => {
+    const build: LocalBuild = {
+      name: 'toolhive-studio-pr-review',
+      tag: 'v0.0.1',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'toolhive-studio-pr-review',
+      version: 'v0.0.1',
+    })
+  })
+
+  it('treats a non-semver bare tag like "latest" as the version when build.name covers the reference', () => {
+    const build: LocalBuild = {
+      name: 'my-skill',
+      tag: 'latest',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'my-skill',
+      version: 'latest',
+    })
+  })
+
+  it('does not treat a tag equal to the name as a version', () => {
+    const build: LocalBuild = {
+      name: 'my-skill',
+      tag: 'my-skill',
+    }
+
+    expect(getBuildInstallDefaults(build)).toEqual({
+      reference: 'my-skill',
+      version: undefined,
+    })
+  })
+})

--- a/renderer/src/features/skills/lib/__tests__/get-skill-install-defaults.test.ts
+++ b/renderer/src/features/skills/lib/__tests__/get-skill-install-defaults.test.ts
@@ -37,11 +37,24 @@ describe('getSkillInstallDefaults', () => {
     })
   })
 
-  it('returns a bare OCI identifier with no version when no ref is available', () => {
+  it('falls back to skill.version when the bare OCI identifier has no ref', () => {
     const skill: RegistrySkill = {
       name: 'my-skill',
       namespace: 'io.github.user',
       version: 'v1.0.0',
+      packages: [{ registryType: 'oci', identifier: 'ghcr.io/org/my-skill' }],
+    }
+
+    expect(getSkillInstallDefaults(skill)).toEqual({
+      reference: 'ghcr.io/org/my-skill',
+      version: 'v1.0.0',
+    })
+  })
+
+  it('returns no version when bare OCI identifier has no ref and skill has no version', () => {
+    const skill: RegistrySkill = {
+      name: 'my-skill',
+      namespace: 'io.github.user',
       packages: [{ registryType: 'oci', identifier: 'ghcr.io/org/my-skill' }],
     }
 
@@ -90,11 +103,24 @@ describe('getSkillInstallDefaults', () => {
     })
   })
 
-  it('falls back to namespace/name with no version for non-OCI registry skills', () => {
+  it('falls back to namespace/name and skill.version for non-OCI registry skills', () => {
     const skill: RegistrySkill = {
       name: 'git-skill',
       namespace: 'io.github.other',
       version: 'v2.0.0',
+      packages: [{ registryType: 'git', identifier: 'https://github.com/x/y' }],
+    }
+
+    expect(getSkillInstallDefaults(skill)).toEqual({
+      reference: 'io.github.other/git-skill',
+      version: 'v2.0.0',
+    })
+  })
+
+  it('returns no version for non-OCI registry skills without a version', () => {
+    const skill: RegistrySkill = {
+      name: 'git-skill',
+      namespace: 'io.github.other',
       packages: [{ registryType: 'git', identifier: 'https://github.com/x/y' }],
     }
 

--- a/renderer/src/features/skills/lib/build-reference.ts
+++ b/renderer/src/features/skills/lib/build-reference.ts
@@ -37,12 +37,16 @@ export function getBuildInstallDefaults(
   const parsedTag = tag ? parseSkillReference(tag) : undefined
 
   if (build.name) {
-    // When build.name covers the reference, a leftover tag that isn't
-    // the same as the name and carries no parseable suffix is best
-    // interpreted as the version itself (e.g. `name="my-skill"`,
-    // `tag="v0.0.1"` -> version "v0.0.1").
+    // When build.name covers the reference, a leftover tag that is a
+    // plain version-only string (no `/`, so we know it's not an OCI
+    // ref) is best interpreted as the version itself (e.g.
+    // `name="my-skill"`, `tag="v0.0.1"` -> version "v0.0.1"). A bare
+    // OCI reference like `ghcr.io/org/my-skill` has no version info
+    // and must NOT bleed into the Version field.
     const tagAsVersion =
-      tag && tag !== build.name && !parsedTag?.version ? tag : undefined
+      tag && tag !== build.name && !tag.includes('/') && !parsedTag?.version
+        ? tag
+        : undefined
 
     return {
       reference: build.name,

--- a/renderer/src/features/skills/lib/build-reference.ts
+++ b/renderer/src/features/skills/lib/build-reference.ts
@@ -1,5 +1,57 @@
 import type { GithubComStacklokToolhivePkgSkillsLocalBuild as LocalBuild } from '@common/api/generated/types.gen'
+import { parseSkillReference } from './skill-reference'
 
 export function getBuildTitle(build: LocalBuild): string {
   return build.name?.trim() || build.tag?.trim() || 'Unnamed build'
+}
+
+interface BuildInstallDefaults {
+  /**
+   * Bare reference to prefill in the install dialog's name field. The
+   * tag suffix (e.g. `:v1.0.0`) is stripped so it doesn't get baked into
+   * the name. Falls back to `build.tag` (already-bare) and finally to
+   * `build.name` when the tag is unavailable.
+   */
+  reference: string | undefined
+  /**
+   * Version to prefill in the install dialog's version field. Resolution
+   * order: explicit `build.version` (from artifact metadata) -> the tag
+   * portion parsed out of `build.tag` (e.g. `v1.0.0` from
+   * `localhost/my-skill:v1.0.0`) -> the whole `build.tag` when it is a
+   * bare version-only string and `build.name` already covers the
+   * reference (e.g. `name="my-skill"`, `tag="v0.0.1"`).
+   */
+  version: string | undefined
+}
+
+/**
+ * Derives the values to prefill in the install dialog when installing a
+ * locally built skill. Mirrors `getSkillInstallDefaults` for registry
+ * skills: the OCI tag is split out so the version lives in its own
+ * field instead of being baked into the reference.
+ */
+export function getBuildInstallDefaults(
+  build: LocalBuild
+): BuildInstallDefaults {
+  const tag = build.tag
+  const parsedTag = tag ? parseSkillReference(tag) : undefined
+
+  if (build.name) {
+    // When build.name covers the reference, a leftover tag that isn't
+    // the same as the name and carries no parseable suffix is best
+    // interpreted as the version itself (e.g. `name="my-skill"`,
+    // `tag="v0.0.1"` -> version "v0.0.1").
+    const tagAsVersion =
+      tag && tag !== build.name && !parsedTag?.version ? tag : undefined
+
+    return {
+      reference: build.name,
+      version: build.version ?? parsedTag?.version ?? tagAsVersion,
+    }
+  }
+
+  return {
+    reference: parsedTag?.reference ?? tag,
+    version: build.version ?? parsedTag?.version,
+  }
 }

--- a/renderer/src/features/skills/lib/skill-reference.ts
+++ b/renderer/src/features/skills/lib/skill-reference.ts
@@ -19,35 +19,40 @@ function getNamespaceNameReference(skill: RegistrySkill): string | undefined {
   return undefined
 }
 
-interface OciIdentifierParts {
-  identifier: string
+interface ParsedSkillReference {
+  reference: string
   version?: string
 }
 
 /**
- * Splits an OCI identifier into the bare identifier and an optional
- * version (tag or digest). Returns the original input when no version
- * suffix is present.
+ * Splits a skill reference into the bare reference and an optional
+ * version (OCI tag or digest). Returns the original input as `reference`
+ * with no `version` when no version suffix is present.
+ *
+ * Examples:
+ * - "ghcr.io/org/skill:v1.0.0" -> { reference: "ghcr.io/org/skill", version: "v1.0.0" }
+ * - "ghcr.io/org/skill@sha256:deadbeef" -> { reference: "ghcr.io/org/skill", version: "sha256:deadbeef" }
+ * - "ghcr.io/org/skill" -> { reference: "ghcr.io/org/skill" }
  */
-function splitOciIdentifier(identifier: string): OciIdentifierParts {
-  const digestIndex = identifier.indexOf('@')
+export function parseSkillReference(reference: string): ParsedSkillReference {
+  const digestIndex = reference.indexOf('@')
   if (digestIndex !== -1) {
     return {
-      identifier: identifier.slice(0, digestIndex),
-      version: identifier.slice(digestIndex + 1),
+      reference: reference.slice(0, digestIndex),
+      version: reference.slice(digestIndex + 1),
     }
   }
 
-  const lastSlashIndex = identifier.lastIndexOf('/')
-  const lastColonIndex = identifier.lastIndexOf(':')
+  const lastSlashIndex = reference.lastIndexOf('/')
+  const lastColonIndex = reference.lastIndexOf(':')
   if (lastColonIndex > lastSlashIndex) {
     return {
-      identifier: identifier.slice(0, lastColonIndex),
-      version: identifier.slice(lastColonIndex + 1),
+      reference: reference.slice(0, lastColonIndex),
+      version: reference.slice(lastColonIndex + 1),
     }
   }
 
-  return { identifier }
+  return { reference }
 }
 
 /**
@@ -69,8 +74,9 @@ interface SkillInstallDefaults {
   reference: string
   /**
    * The version to prefill in the install dialog's version field,
-   * derived from the OCI tag/digest or the package `ref` field.
-   * Undefined when no version information is available.
+   * derived (in order) from the OCI tag/digest, the package `ref`
+   * field, or the top-level `skill.version`. Undefined when no version
+   * information is available anywhere on the skill.
    */
   version?: string
 }
@@ -79,7 +85,9 @@ interface SkillInstallDefaults {
  * Derives the values to prefill in the install dialog. The OCI identifier
  * is split so the version (tag or digest) lives in its own field rather
  * than being baked into the reference. Falls back to `namespace/name`,
- * then `name`, when no OCI package is available.
+ * then `name`, when no OCI package is available. The version field falls
+ * back to `skill.version` (the same value shown as a badge on the detail
+ * page) when the OCI package carries no tag/digest/ref of its own.
  */
 export function getSkillInstallDefaults(
   skill: RegistrySkill
@@ -88,16 +96,17 @@ export function getSkillInstallDefaults(
   const ociIdentifier = ociPackage?.identifier
 
   if (ociIdentifier) {
-    const { identifier, version } = splitOciIdentifier(ociIdentifier)
+    const { reference, version } = parseSkillReference(ociIdentifier)
 
     return {
-      reference: identifier,
-      version: version ?? ociPackage?.ref ?? undefined,
+      reference,
+      version: version ?? ociPackage?.ref ?? skill.version ?? undefined,
     }
   }
 
   return {
     reference:
       getNamespaceNameReference(skill) ?? skill.name ?? 'Unknown skill',
+    version: skill.version ?? undefined,
   }
 }


### PR DESCRIPTION
Following up on #2122 — the install dialog still landed with an empty **Version** field (or with the version baked into the **Name or reference** field) for several entry points outside the registry table. This PR makes the prefill behavior uniform across every place that opens the install dialog.

## Root cause

`getSkillInstallDefaults` only consulted the OCI identifier's tag/digest and `package.ref`, ignoring the top-level `skill.version` that the detail page already shows as a badge. On the local-build side, each call site (`card-build`, `build-detail-page`, `table-builds`, the chat "Skill built" card) rolled its own `defaultReference` / `defaultVersion` derivation, producing inconsistent results — including the case where `build.tag` was a bare version-only string like `"v0.0.1"` and `parseSkillReference` couldn't recognise it as a version (no `:` after `/`, no `@`).

## Changes

- **[`lib/skill-reference.ts`](renderer/src/features/skills/lib/skill-reference.ts)** — promote the private `splitOciIdentifier` to an exported `parseSkillReference(reference)` and add `skill.version` as the final fallback in `getSkillInstallDefaults` (used by both the OCI and non-OCI branches).
- **[`components/dialog-install-skill.tsx`](renderer/src/features/skills/components/dialog-install-skill.tsx)** — when the user pastes/types `name:tag` or `name@sha256:…` into the Name field, split the suffix into the Version field on blur. An existing user-typed version is never overwritten.
- **[`components/dialog-build-skill.tsx`](renderer/src/features/skills/components/dialog-build-skill.tsx)** — after a successful build, parse the canonical reference returned by the API and forward `{ reference, version }` separately to the install dialog. Falls back to the user-supplied build tag when the canonical reference has no version suffix.
- **[`lib/build-reference.ts`](renderer/src/features/skills/lib/build-reference.ts)** — new `getBuildInstallDefaults(build)` helper that mirrors the registry version. Resolution order: `build.version` → tag suffix parsed out of `build.tag` → the whole `build.tag` when it is a bare version-only string and `build.name` already covers the reference (handles the `name="my-skill"`, `tag="v0.0.1"` case).
- **All local-build entry points** — [`card-build.tsx`](renderer/src/features/skills/components/card-build.tsx), [`build-detail-page.tsx`](renderer/src/features/skills/components/build-detail-page.tsx), [`table-builds.tsx`](renderer/src/features/skills/components/table-builds.tsx), and [`tool-results/skill-build-result-card.tsx`](renderer/src/features/chat/components/tool-results/skill-build-result-card.tsx) now go through the helper and pass `defaultReference` / `defaultVersion` separately.

## Verification

1. **Skills → Registry → detail page → Install** on a skill with no tagged OCI identifier (just a top-level `version`). Name shows the OCI repo, Version is prefilled with `skill.version`.
2. **Skills → Registry → table → Install** on the same skill — same prefill as the detail page.
3. **Skills → Builds → detail → Install** on a build with `name="toolhive-studio-pr-review"` and `tag="v0.0.1"`. Name shows `toolhive-studio-pr-review`, Version shows `v0.0.1`.
4. **Skills → Builds → table → Install** on a build with `tag="localhost/my-skill:v1.0.0"`. Name shows `my-skill` (bare), Version shows `v1.0.0` — no more conjoined string.
5. **Build dialog → "Install now"** toast after a successful build. The install modal opens with the version split out of the canonical `name:tag` reference.
6. **Playground → Skills Builder agent → "Skill built" card → Install** mirrors the same prefill.
7. Pasting `ghcr.io/org/skill:v1.2.3` into the install dialog's Name field and tabbing out moves `v1.2.3` into the Version field; an existing user-typed version stays put.
8. `pnpm run type-check`, `pnpm run lint`, and `pnpm run test:nonInteractive` all pass (322 skills tests + 129 chat tool-results tests).