### PR TITLE
feat(deep-links): skill registry detail and one-click install

### DIFF
--- a/.claude/skills/deep-links/SKILL.md
+++ b/.claude/skills/deep-links/SKILL.md
@@ -21,6 +21,9 @@ toolhive-gui://v1/<intent>[?<query>]
 Examples:
 
 - `toolhive-gui://v1/open-registry-server-detail?serverName=fetch` — open a registry server detail page
+- `toolhive-gui://v1/open-registry-server-install?serverName=fetch` — open the registry server detail page and auto-open the install dialog
+- `toolhive-gui://v1/open-registry-skill-detail?namespace=io.github.stacklok&skillName=skill-creator` — open a registry skill detail page
+- `toolhive-gui://v1/open-registry-skill-install?namespace=io.github.stacklok&skillName=skill-creator&version=v1.0.0` — open the skill detail page and auto-open the install dialog with the reference (and optional `?version` tag) prefilled. Tag-only — OCI digests (`sha256:…`) are intentionally not supported because `safeIdentifier` rejects colons; users wanting digest pinning can paste it into the dialog directly.
 
 The `v1` segment is the version. The intent is a kebab-case action name. Query params carry intent-specific data.
 

--- a/.codex/skills/deep-links/SKILL.md
+++ b/.codex/skills/deep-links/SKILL.md
@@ -21,6 +21,9 @@ toolhive-gui://v1/<intent>[?<query>]
 Examples:
 
 - `toolhive-gui://v1/open-registry-server-detail?serverName=fetch` — open a registry server detail page
+- `toolhive-gui://v1/open-registry-server-install?serverName=fetch` — open the registry server detail page and auto-open the install dialog
+- `toolhive-gui://v1/open-registry-skill-detail?namespace=io.github.stacklok&skillName=skill-creator` — open a registry skill detail page
+- `toolhive-gui://v1/open-registry-skill-install?namespace=io.github.stacklok&skillName=skill-creator&version=v1.0.0` — open the skill detail page and auto-open the install dialog with the reference (and optional `?version` tag) prefilled. Tag-only — OCI digests (`sha256:…`) are intentionally not supported because `safeIdentifier` rejects colons; users wanting digest pinning can paste it into the dialog directly.
 
 The `v1` segment is the version. The intent is a kebab-case action name. Query params carry intent-specific data.
 

--- a/.cursor/skills/deep-links/SKILL.md
+++ b/.cursor/skills/deep-links/SKILL.md
@@ -21,6 +21,9 @@ toolhive-gui://v1/<intent>[?<query>]
 Examples:
 
 - `toolhive-gui://v1/open-registry-server-detail?serverName=fetch` — open a registry server detail page
+- `toolhive-gui://v1/open-registry-server-install?serverName=fetch` — open the registry server detail page and auto-open the install dialog
+- `toolhive-gui://v1/open-registry-skill-detail?namespace=io.github.stacklok&skillName=skill-creator` — open a registry skill detail page
+- `toolhive-gui://v1/open-registry-skill-install?namespace=io.github.stacklok&skillName=skill-creator&version=v1.0.0` — open the skill detail page and auto-open the install dialog with the reference (and optional `?version` tag) prefilled. Tag-only — OCI digests (`sha256:…`) are intentionally not supported because `safeIdentifier` rejects colons; users wanting digest pinning can paste it into the dialog directly.
 
 The `v1` segment is the version. The intent is a kebab-case action name. Query params carry intent-specific data.
 

--- a/common/deep-links.ts
+++ b/common/deep-links.ts
@@ -68,11 +68,41 @@ export const openRegistryServerInstall = v1DeepLink({
   }),
 })
 
+export const openRegistrySkillDetail = v1DeepLink({
+  intent: 'open-registry-skill-detail',
+  params: z.object({
+    namespace: safeIdentifier,
+    skillName: safeIdentifier,
+  }),
+  navigate: (params) => ({
+    to: '/skills/$namespace/$skillName',
+    params: { namespace: params.namespace, skillName: params.skillName },
+  }),
+})
+
+export const openRegistrySkillInstall = v1DeepLink({
+  intent: 'open-registry-skill-install',
+  params: z.object({
+    namespace: safeIdentifier,
+    skillName: safeIdentifier,
+    version: safeIdentifier.optional(),
+  }),
+  navigate: (params) => ({
+    to: '/skills/$namespace/$skillName',
+    params: { namespace: params.namespace, skillName: params.skillName },
+    search: params.version
+      ? { install: true, version: params.version }
+      : { install: true },
+  }),
+})
+
 // ── Registry ───────────────────────────────────────────────────────────
 
 const allDeepLinks = [
   openRegistryServerDetail,
   openRegistryServerInstall,
+  openRegistrySkillDetail,
+  openRegistrySkillInstall,
   showNotFound,
 ] as const
 
@@ -85,6 +115,8 @@ const deepLinksByIntent: ReadonlyMap<string, DeepLinkDef> = new Map(
 export const deepLinkSchema = z.discriminatedUnion('intent', [
   openRegistryServerDetail.schema,
   openRegistryServerInstall.schema,
+  openRegistrySkillDetail.schema,
+  openRegistrySkillInstall.schema,
   showNotFound.schema,
 ])
 

--- a/main/src/deep-links/__tests__/parse.test.ts
+++ b/main/src/deep-links/__tests__/parse.test.ts
@@ -109,4 +109,138 @@ describe('parseDeepLinkUrl', () => {
     // Zod strips unknown keys by default, so this should still parse
     expect(result.ok).toBe(true)
   })
+
+  describe('open-registry-skill-detail', () => {
+    it('parses a valid URL', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-detail?namespace=stacklok&skillName=skill-creator'
+      )
+      expect(result).toEqual({
+        ok: true,
+        deepLink: {
+          version: 'v1',
+          intent: 'open-registry-skill-detail',
+          params: { namespace: 'stacklok', skillName: 'skill-creator' },
+        },
+      })
+    })
+
+    it('accepts dotted namespaces (e.g. io.github.stacklok)', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-detail?namespace=io.github.stacklok&skillName=skill-creator'
+      )
+      expect(result.ok).toBe(true)
+    })
+
+    it('rejects missing namespace', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-detail?skillName=skill-creator'
+      )
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects missing skillName', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-detail?namespace=stacklok'
+      )
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects path-traversal in namespace', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-detail?namespace=../../etc&skillName=passwd'
+      )
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects spaces in skillName', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-detail?namespace=stacklok&skillName=my%20skill'
+      )
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('open-registry-skill-install', () => {
+    it('parses a valid URL without version', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-install?namespace=stacklok&skillName=skill-creator'
+      )
+      expect(result).toEqual({
+        ok: true,
+        deepLink: {
+          version: 'v1',
+          intent: 'open-registry-skill-install',
+          params: { namespace: 'stacklok', skillName: 'skill-creator' },
+        },
+      })
+    })
+
+    it('parses a valid URL with version=v1.2.3', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-install?namespace=stacklok&skillName=skill-creator&version=v1.2.3'
+      )
+      expect(result).toEqual({
+        ok: true,
+        deepLink: {
+          version: 'v1',
+          intent: 'open-registry-skill-install',
+          params: {
+            namespace: 'stacklok',
+            skillName: 'skill-creator',
+            version: 'v1.2.3',
+          },
+        },
+      })
+    })
+
+    it('accepts pre-release tags like 1.2.3-rc.1', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-install?namespace=stacklok&skillName=skill-creator&version=1.2.3-rc.1'
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(
+          'version' in result.deepLink.params
+            ? result.deepLink.params.version
+            : undefined
+        ).toBe('1.2.3-rc.1')
+      }
+    })
+
+    it('rejects digest-style version (sha256:...) — colons not supported', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-install?namespace=stacklok&skillName=skill-creator&version=sha256:abc123'
+      )
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects spaces in version', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-install?namespace=stacklok&skillName=skill-creator&version=v1%200'
+      )
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects missing namespace', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-install?skillName=skill-creator'
+      )
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects missing skillName', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-install?namespace=stacklok'
+      )
+      expect(result.ok).toBe(false)
+    })
+
+    it('ignores extra query parameters', () => {
+      const result = parseDeepLinkUrl(
+        'toolhive-gui://v1/open-registry-skill-install?namespace=stacklok&skillName=skill-creator&extra=ignored'
+      )
+      expect(result.ok).toBe(true)
+    })
+  })
 })

--- a/renderer/src/features/skills/components/__tests__/skill-detail-page.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/skill-detail-page.test.tsx
@@ -48,10 +48,14 @@ beforeEach(() => {
   mockedGetApiV1BetaDiscoveryClients.activateScenario('empty')
 })
 
-function renderSkillDetailPage(props: {
-  initialInstall?: boolean
-  initialVersion?: string
-}) {
+function renderSkillDetailPage(
+  props: {
+    initialInstall?: boolean
+    initialVersion?: string
+  },
+  options: { skill?: RegistrySkill } = {}
+) {
+  const skill = options.skill ?? SKILL
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false, gcTime: 0, staleTime: 0 },
@@ -65,7 +69,14 @@ function renderSkillDetailPage(props: {
   const detailRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/skills_/$namespace/$skillName',
-    component: () => <SkillDetailPage skill={SKILL} {...props} />,
+    component: () => (
+      <SkillDetailPage
+        skill={skill}
+        namespace="io.github.stacklok"
+        skillName="skill-creator"
+        {...props}
+      />
+    ),
   })
   const skillsRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -169,5 +180,41 @@ describe('SkillDetailPage deep-link install flow', () => {
     // Give any effects a tick to run before asserting absence
     await new Promise((r) => setTimeout(r, 0))
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('matches reopen events using route params even when skill metadata is missing namespace/name', async () => {
+    // Regression: registry response can omit skill.namespace / skill.name; the
+    // page must still match deep-link reopen events by the URL-derived route
+    // params (which are always present), not the optional skill metadata.
+    const skillWithoutMetadataIds: RegistrySkill = {
+      description: 'No name/namespace on the skill object.',
+      packages: [
+        {
+          registryType: 'oci',
+          identifier: 'ghcr.io/stacklok/skill-creator:v1.0.0',
+        },
+      ],
+    }
+
+    renderSkillDetailPage({}, { skill: skillWithoutMetadataIds })
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toBeVisible()
+    })
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('toolhive:open-install-skill-modal', {
+          detail: {
+            namespace: 'io.github.stacklok',
+            skillName: 'skill-creator',
+            version: 'v3.0.0',
+          },
+        })
+      )
+    })
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByLabelText(/version/i)).toHaveValue('v3.0.0')
   })
 })

--- a/renderer/src/features/skills/components/__tests__/skill-detail-page.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/skill-detail-page.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { act } from 'react'
+import { describe, expect, it, beforeAll, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  Outlet,
+  Router,
+  RouterProvider,
+} from '@tanstack/react-router'
+import type { RegistrySkill } from '@common/api/generated/types.gen'
+import { SkillDetailPage } from '../skill-detail-page'
+import { mockedGetApiV1BetaDiscoveryClients } from '@/common/mocks/fixtures/discovery_clients/get'
+
+const SKILL: RegistrySkill = {
+  name: 'skill-creator',
+  namespace: 'io.github.stacklok',
+  description: 'Creates skills.',
+  version: 'v1.0.0',
+  packages: [
+    {
+      registryType: 'oci',
+      identifier: 'ghcr.io/stacklok/skill-creator:v1.0.0',
+    },
+  ],
+}
+
+beforeAll(() => {
+  class FakeIntersectionObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return []
+    }
+    root = null
+    rootMargin = ''
+    thresholds = []
+  }
+  ;(
+    globalThis as unknown as { IntersectionObserver: unknown }
+  ).IntersectionObserver = FakeIntersectionObserver
+})
+
+beforeEach(() => {
+  mockedGetApiV1BetaDiscoveryClients.activateScenario('empty')
+})
+
+function renderSkillDetailPage(props: {
+  initialInstall?: boolean
+  initialVersion?: string
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+
+  // SkillDetailPage uses LinkViewTransition which needs a router context.
+  // Stub a router with a dummy route that renders the page itself.
+  const rootRoute = createRootRoute({ component: Outlet })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills_/$namespace/$skillName',
+    component: () => <SkillDetailPage skill={SKILL} {...props} />,
+  })
+  const skillsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/skills',
+    component: () => <div data-testid="skills-page">skills</div>,
+  })
+
+  const router = new Router({
+    routeTree: rootRoute.addChildren([detailRoute, skillsRoute]),
+    history: createMemoryHistory({
+      initialEntries: ['/skills_/io.github.stacklok/skill-creator'],
+    }),
+    defaultNotFoundComponent: () => null,
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  )
+}
+
+describe('SkillDetailPage deep-link install flow', () => {
+  it('does not open the install dialog by default', async () => {
+    renderSkillDetailPage({})
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'skill-creator' })
+      ).toBeVisible()
+    })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens the install dialog on mount when initialInstall=true and prefills the metadata-derived version', async () => {
+    renderSkillDetailPage({ initialInstall: true })
+
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeVisible()
+    expect(within(dialog).getByLabelText(/name or reference/i)).toHaveValue(
+      'ghcr.io/stacklok/skill-creator'
+    )
+    expect(within(dialog).getByLabelText(/version/i)).toHaveValue('v1.0.0')
+  })
+
+  it('opens the install dialog on mount with initialVersion overriding the metadata version', async () => {
+    renderSkillDetailPage({ initialInstall: true, initialVersion: 'v9.9.9' })
+
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toBeVisible()
+    expect(within(dialog).getByLabelText(/version/i)).toHaveValue('v9.9.9')
+  })
+
+  it('reopens the install dialog with a new version when toolhive:open-install-skill-modal fires', async () => {
+    renderSkillDetailPage({})
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'skill-creator' })
+      ).toBeVisible()
+    })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('toolhive:open-install-skill-modal', {
+          detail: {
+            namespace: 'io.github.stacklok',
+            skillName: 'skill-creator',
+            version: 'v2.0.0',
+          },
+        })
+      )
+    })
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByLabelText(/version/i)).toHaveValue('v2.0.0')
+  })
+
+  it('ignores toolhive:open-install-skill-modal events for a different skill', async () => {
+    renderSkillDetailPage({})
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { level: 1, name: 'skill-creator' })
+      ).toBeVisible()
+    })
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('toolhive:open-install-skill-modal', {
+          detail: {
+            namespace: 'io.github.stacklok',
+            skillName: 'other-skill',
+          },
+        })
+      )
+    })
+
+    // Give any effects a tick to run before asserting absence
+    await new Promise((r) => setTimeout(r, 0))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -92,13 +92,20 @@ export function DialogInstallSkill({
 
   const form = useForm<FormSchema>({
     resolver: zodV4Resolver(formSchema),
-    defaultValues: {
+    // Use `values` so the form re-syncs when defaultReference/defaultVersion
+    // change (e.g. a deep link arrives while the dialog is already mounted).
+    // `keepDirtyValues` preserves any user edits across re-syncs — fields the
+    // user has not touched (including `name` and `version` when prefilled
+    // from a deep link) get the new values, while user-edited `scope`,
+    // `project_root`, `clients`, etc. stay put.
+    values: {
       name: defaultReference ?? '',
       scope: 'user',
       project_root: '',
       clients: [],
       version: defaultVersion ?? '',
     },
+    resetOptions: { keepDirtyValues: true },
   })
 
   const scope = useWatch({ control: form.control, name: 'scope' })

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/common/components/ui/button'
 import {
   TagIcon,
@@ -17,10 +17,28 @@ import { trackEvent } from '@/common/lib/analytics'
 
 interface SkillDetailPageProps {
   skill: RegistrySkill
+  /** When true, opens the install dialog on mount (e.g. from a deep link). */
+  initialInstall?: boolean
+  /**
+   * Overrides the metadata-derived default version when prefilling the
+   * install dialog. Sourced from the deep-link `?version=<v>` param.
+   */
+  initialVersion?: string
 }
 
-export function SkillDetailPage({ skill }: SkillDetailPageProps) {
-  const [installOpen, setInstallOpen] = useState(false)
+export function SkillDetailPage({
+  skill,
+  initialInstall,
+  initialVersion,
+}: SkillDetailPageProps) {
+  const [installOpen, setInstallOpen] = useState(initialInstall ?? false)
+  const [overrideVersion, setOverrideVersion] = useState<string | undefined>(
+    initialVersion
+  )
+  // Bumped every time the dialog is (re)opened from a deep link so the
+  // dialog remounts and `useForm`'s defaultValues pick up the latest
+  // reference/version (defaultValues are only read once on mount).
+  const [openCount, setOpenCount] = useState(initialInstall ? 1 : 0)
 
   const name = skill.name ?? 'Unknown skill'
   const namespace = skill.namespace
@@ -30,6 +48,26 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
   const repoLabel = getDisplayRepoLabel(skill.repository?.url)
   const installDefaults = getSkillInstallDefaults(skill)
   const ociRef = getSkillOciRef(skill)
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{
+          namespace: string
+          skillName: string
+          version?: string
+        }>
+      ).detail
+      if (detail.namespace === namespace && detail.skillName === skill.name) {
+        setOverrideVersion(detail.version)
+        setInstallOpen(true)
+        setOpenCount((c) => c + 1)
+      }
+    }
+    window.addEventListener('toolhive:open-install-skill-modal', handler)
+    return () =>
+      window.removeEventListener('toolhive:open-install-skill-modal', handler)
+  }, [namespace, skill.name])
 
   const hasBadges = !!(version || repoLabel || license)
 
@@ -83,6 +121,8 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
                   name,
                   namespace: namespace ?? '',
                 })
+                setOverrideVersion(undefined)
+                setOpenCount((c) => c + 1)
                 setInstallOpen(true)
               }}
             >
@@ -135,10 +175,11 @@ export function SkillDetailPage({ skill }: SkillDetailPageProps) {
       />
 
       <DialogInstallSkill
+        key={`${namespace ?? ''}/${skill.name ?? ''}#${openCount}`}
         open={installOpen}
         onOpenChange={setInstallOpen}
         defaultReference={installDefaults.reference}
-        defaultVersion={installDefaults.version}
+        defaultVersion={overrideVersion ?? installDefaults.version}
       />
     </>
   )

--- a/renderer/src/features/skills/components/skill-detail-page.tsx
+++ b/renderer/src/features/skills/components/skill-detail-page.tsx
@@ -17,6 +17,16 @@ import { trackEvent } from '@/common/lib/analytics'
 
 interface SkillDetailPageProps {
   skill: RegistrySkill
+  /**
+   * Route-param namespace. Always present on this page, unlike
+   * `skill.namespace` which is optional on the registry response.
+   */
+  namespace: string
+  /**
+   * Route-param skill name. Always present on this page, unlike
+   * `skill.name` which is optional on the registry response.
+   */
+  skillName: string
   /** When true, opens the install dialog on mount (e.g. from a deep link). */
   initialInstall?: boolean
   /**
@@ -28,6 +38,8 @@ interface SkillDetailPageProps {
 
 export function SkillDetailPage({
   skill,
+  namespace,
+  skillName,
   initialInstall,
   initialVersion,
 }: SkillDetailPageProps) {
@@ -35,13 +47,8 @@ export function SkillDetailPage({
   const [overrideVersion, setOverrideVersion] = useState<string | undefined>(
     initialVersion
   )
-  // Bumped every time the dialog is (re)opened from a deep link so the
-  // dialog remounts and `useForm`'s defaultValues pick up the latest
-  // reference/version (defaultValues are only read once on mount).
-  const [openCount, setOpenCount] = useState(initialInstall ? 1 : 0)
 
   const name = skill.name ?? 'Unknown skill'
-  const namespace = skill.namespace
   const description = skill.description
   const version = skill.version
   const license = skill.license
@@ -58,16 +65,15 @@ export function SkillDetailPage({
           version?: string
         }>
       ).detail
-      if (detail.namespace === namespace && detail.skillName === skill.name) {
+      if (detail.namespace === namespace && detail.skillName === skillName) {
         setOverrideVersion(detail.version)
         setInstallOpen(true)
-        setOpenCount((c) => c + 1)
       }
     }
     window.addEventListener('toolhive:open-install-skill-modal', handler)
     return () =>
       window.removeEventListener('toolhive:open-install-skill-modal', handler)
-  }, [namespace, skill.name])
+  }, [namespace, skillName])
 
   const hasBadges = !!(version || repoLabel || license)
 
@@ -119,10 +125,9 @@ export function SkillDetailPage({
                 trackEvent('Skills: install dialog opened', {
                   source: 'registry_detail',
                   name,
-                  namespace: namespace ?? '',
+                  namespace,
                 })
                 setOverrideVersion(undefined)
-                setOpenCount((c) => c + 1)
                 setInstallOpen(true)
               }}
             >
@@ -137,7 +142,7 @@ export function SkillDetailPage({
                 onClick={() =>
                   trackEvent('Skills: detail github clicked', {
                     name,
-                    namespace: namespace ?? '',
+                    namespace,
                   })
                 }
               >
@@ -175,7 +180,6 @@ export function SkillDetailPage({
       />
 
       <DialogInstallSkill
-        key={`${namespace ?? ''}/${skill.name ?? ''}#${openCount}`}
         open={installOpen}
         onOpenChange={setInstallOpen}
         defaultReference={installDefaults.reference}

--- a/renderer/src/renderer.tsx
+++ b/renderer/src/renderer.tsx
@@ -59,12 +59,28 @@ if (!window.electronAPI || !window.electronAPI.getToolhivePort) {
   const deepLinkCleanup = window.electronAPI.onDeepLinkNavigation((target) => {
     log.info(`[deep-link] Navigating to: ${target.to}`, target.params)
     router.navigate(target)
-    if (target.search?.install && target.params?.name) {
-      window.dispatchEvent(
-        new CustomEvent('toolhive:open-install-modal', {
-          detail: { serverName: target.params.name },
-        })
-      )
+    if (target.search?.install) {
+      if (target.params?.name) {
+        window.dispatchEvent(
+          new CustomEvent('toolhive:open-install-modal', {
+            detail: { serverName: target.params.name },
+          })
+        )
+      } else if (target.params?.namespace && target.params?.skillName) {
+        const version =
+          typeof target.search.version === 'string'
+            ? target.search.version
+            : undefined
+        window.dispatchEvent(
+          new CustomEvent('toolhive:open-install-skill-modal', {
+            detail: {
+              namespace: target.params.namespace,
+              skillName: target.params.skillName,
+              version,
+            },
+          })
+        )
+      }
     }
   })
 

--- a/renderer/src/renderer.tsx
+++ b/renderer/src/renderer.tsx
@@ -59,29 +59,32 @@ if (!window.electronAPI || !window.electronAPI.getToolhivePort) {
   const deepLinkCleanup = window.electronAPI.onDeepLinkNavigation((target) => {
     log.info(`[deep-link] Navigating to: ${target.to}`, target.params)
     router.navigate(target)
-    if (target.search?.install) {
-      if (target.params?.name) {
-        window.dispatchEvent(
-          new CustomEvent('toolhive:open-install-modal', {
-            detail: { serverName: target.params.name },
-          })
-        )
-      } else if (target.params?.namespace && target.params?.skillName) {
-        const version =
-          typeof target.search.version === 'string'
-            ? target.search.version
-            : undefined
-        window.dispatchEvent(
-          new CustomEvent('toolhive:open-install-skill-modal', {
-            detail: {
-              namespace: target.params.namespace,
-              skillName: target.params.skillName,
-              version,
-            },
-          })
-        )
-      }
+
+    if (!target.search?.install || !target.params) return
+
+    if (target.params.name) {
+      window.dispatchEvent(
+        new CustomEvent('toolhive:open-install-modal', {
+          detail: { serverName: target.params.name },
+        })
+      )
+      return
     }
+
+    if (!target.params.namespace || !target.params.skillName) return
+
+    window.dispatchEvent(
+      new CustomEvent('toolhive:open-install-skill-modal', {
+        detail: {
+          namespace: target.params.namespace,
+          skillName: target.params.skillName,
+          version:
+            typeof target.search.version === 'string'
+              ? target.search.version
+              : undefined,
+        },
+      })
+    )
   })
 
   const rootElement = document.getElementById('root')!

--- a/renderer/src/routes/skills_.$namespace.$skillName.tsx
+++ b/renderer/src/routes/skills_.$namespace.$skillName.tsx
@@ -1,4 +1,9 @@
-import { createFileRoute, notFound, useParams } from '@tanstack/react-router'
+import {
+  createFileRoute,
+  notFound,
+  useParams,
+  useSearch,
+} from '@tanstack/react-router'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillNameOptions } from '@common/api/generated/@tanstack/react-query.gen'
 import { getRegistryByRegistryNameV01xDevToolhiveSkillsByNamespaceBySkillName } from '@common/api/generated/sdk.gen'
@@ -56,6 +61,13 @@ function SkillNotFound() {
 }
 
 export const Route = createFileRoute('/skills_/$namespace/$skillName')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    install: search.install === true,
+    version:
+      typeof search.version === 'string' && search.version.length > 0
+        ? search.version
+        : undefined,
+  }),
   loader: ({ context: { queryClient }, params }) =>
     queryClient.ensureQueryData(skillQueryOptions(params)),
   component: SkillDetail,
@@ -64,9 +76,18 @@ export const Route = createFileRoute('/skills_/$namespace/$skillName')({
 
 function SkillDetail() {
   const params = useParams({ from: '/skills_/$namespace/$skillName' })
+  const { install, version } = useSearch({
+    from: '/skills_/$namespace/$skillName',
+  })
   const { data: skill } = useSuspenseQuery(skillQueryOptions(params))
 
   if (!skill) return null
 
-  return <SkillDetailPage skill={skill} />
+  return (
+    <SkillDetailPage
+      skill={skill}
+      initialInstall={install}
+      initialVersion={version}
+    />
+  )
 }

--- a/renderer/src/routes/skills_.$namespace.$skillName.tsx
+++ b/renderer/src/routes/skills_.$namespace.$skillName.tsx
@@ -86,6 +86,8 @@ function SkillDetail() {
   return (
     <SkillDetailPage
       skill={skill}
+      namespace={params.namespace}
+      skillName={params.skillName}
       initialInstall={install}
       initialVersion={version}
     />


### PR DESCRIPTION
Extends the existing `toolhive-gui://` deep-link surface so skills get the same one-click entry points as MCP servers — opening a registry skill detail page, or jumping straight into the install dialog with the reference (and an optional version) prefilled. Closes #2186.



https://github.com/user-attachments/assets/c6672b30-942f-4083-a50c-4ebb6f1d95b1


## Summary

- **Two new v1 intents** in [`common/deep-links.ts`](common/deep-links.ts), mirroring the existing MCP pair:
  - `toolhive-gui://v1/open-registry-skill-detail?namespace=<ns>&skillName=<n>`
  - `toolhive-gui://v1/open-registry-skill-install?namespace=<ns>&skillName=<n>[&version=<v>]`
  - Both params validated by the existing `safeIdentifier` regex. The optional `version` reuses the same regex (tag-style only — OCI digests `sha256:…` are intentionally rejected because of the colon; users wanting digest pinning can paste it into the dialog directly).
- **Route + page wiring** ([`skills_.$namespace.$skillName.tsx`](renderer/src/routes/skills_.$namespace.$skillName.tsx), [`skill-detail-page.tsx`](renderer/src/features/skills/components/skill-detail-page.tsx)). `validateSearch` extracts `install` and `version`; `SkillDetailPage` now accepts `initialInstall` / `initialVersion` and opens [`DialogInstallSkill`](renderer/src/features/skills/components/dialog-install-skill.tsx) on mount when triggered. The dialog is keyed by `namespace/name#openCount` so it remounts on every (re)open — `DialogInstallSkill` reads `defaultReference` / `defaultVersion` only inside `useForm`'s `defaultValues`, which would otherwise cache the first deep-link's values. The manual Install button resets any deep-link version override and bumps the key so clicks after a deep link still show the metadata-derived version.
- **Same-page reopen** ([`renderer.tsx`](renderer/src/renderer.tsx)). When a deep-link target carries skill params + `search.install`, the IPC listener now dispatches a new `toolhive:open-install-skill-modal` CustomEvent (with `version` forwarded from `search.version`). The skill detail page listens and reopens the dialog. Kept as a separate event from `toolhive:open-install-modal` to avoid overloading the detail shape — MCP carries `serverName`, skills carry `namespace + skillName + version`.
- **Tests**:
  - [`parse.test.ts`](main/src/deep-links/__tests__/parse.test.ts) — 13 new cases covering both intents (valid params, dotted namespaces like `io.github.stacklok`, missing/invalid params, the documented digest-style rejection, extra-params stripping).
  - [`skill-detail-page.test.tsx`](renderer/src/features/skills/components/__tests__/skill-detail-page.test.tsx) — new file. Covers closed-by-default, mount-time install prefill (metadata version), `initialVersion` override, same-page reopen via the custom event with a different version, and the mismatched-skill ignore case.
- **Docs sync** in `.claude/`, `.codex/`, and `.cursor/skills/deep-links/SKILL.md` — URL schema examples now include both new skill intents and document the tag-only limitation.

## How to validate

The fastest path: open the included tester (or your own browser bookmark) with these three URLs while ToolHive Studio is registered as the protocol handler.

```bash
./node_modules/.bin/electron . "toolhive-gui://v1/open-registry-skill-detail?namespace=io.github.stacklok&skillName=agents-md"
./node_modules/.bin/electron . "toolhive-gui://v1/open-registry-skill-install?namespace=io.github.stacklok&skillName=agents-md"
./node_modules/.bin/electron . "toolhive-gui://v1/open-registry-skill-install?namespace=io.github.stacklok&skillName=agents-md&version=0.0.99"