### PR TITLE
fix(security): bump hono override to >=4.12.16 (CVE-2026-44456, CVE-2026-44455)

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
       "@xmldom/xmldom": ">=0.9.10",
       "fast-xml-parser": "5.5.8",
       "dompurify": ">=3.4.0",
-      "hono": ">=4.12.14",
+      "hono": ">=4.12.16",
       "ip-address": ">=10.1.1",
       "lodash": ">=4.18.0",
       "lodash-es": ">=4.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@xmldom/xmldom': '>=0.9.10'
   fast-xml-parser: 5.5.8
   dompurify: '>=3.4.0'
-  hono: '>=4.12.14'
+  hono: '>=4.12.16'
   ip-address: '>=10.1.1'
   lodash: '>=4.18.0'
   lodash-es: '>=4.18.0'
@@ -1257,7 +1257,7 @@ packages:
     resolution: {integrity: sha512-n3GfHwwCvHCkGmOwKfxUPOlbfzuO64Sbc5XC4NGPIXxkuOnJrdgExdRKmHfF924r914WRJPT397GdqLvdYTeyQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.14'
+      hono: '>=4.12.16'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5602,8 +5602,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -9941,9 +9941,9 @@ snapshots:
 
   '@hey-api/types@0.1.4': {}
 
-  '@hono/node-server@2.0.0(hono@4.12.14)':
+  '@hono/node-server@2.0.0(hono@4.12.18)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.18
 
   '@humanfs/core@0.19.1': {}
 
@@ -10354,7 +10354,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.2)':
     dependencies:
-      '@hono/node-server': 2.0.0(hono@4.12.14)
+      '@hono/node-server': 2.0.0(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -10364,7 +10364,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.14
+      hono: 4.12.18
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -14738,7 +14738,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.14: {}
+  hono@4.12.18: {}
 
   hosted-git-info@2.8.9: {}
 


### PR DESCRIPTION
## Summary

Bumps `hono` via `pnpm.overrides` from `>=4.12.14` to `>=4.12.16` (resolved to `4.12.18`) to remediate two production vulnerabilities reported through `@modelcontextprotocol/sdk`.

## Changes

| CVE | Package | Severity | Production | Action | Verified |
| --- | ------- | -------- | ---------- | ------ | -------- |
| CVE-2026-44456 (GHSA-9vqf-7f2p-gf9v) | hono 4.12.14 -> 4.12.18 | Medium | Yes | Override bump | Pass |
| CVE-2026-44455 (GHSA-69xw-7hcm-h432) | hono 4.12.14 -> 4.12.18 | Medium | Yes | Override bump | Pass |

## Files Modified

- `package.json`: bumped `pnpm.overrides.hono` to `>=4.12.16`
- `pnpm-lock.yaml`: regenerated; `hono` now resolves to `4.12.18`

## Verification

- `pnpm audit --prod --audit-level=moderate`: Pass
- `grype . --config .grype.yaml`: Pass