### PR TITLE
fix(flatpak): grant access to Docker Desktop on Linux socket

### DIFF
--- a/utils/forge-makers/MakerFlatpakBuilder.ts
+++ b/utils/forge-makers/MakerFlatpakBuilder.ts
@@ -168,6 +168,10 @@ export default class MakerFlatpakBuilder extends MakerBase<
         '--filesystem=/run/docker.sock',
         '--filesystem=/run/podman/podman.sock',
         '--filesystem=xdg-run/podman/podman.sock',
+        // Docker Desktop on Linux registers a `desktop-linux` Docker context whose
+        // socket lives in the user's home dir. `thv` v0.26.1+ probes this path; the
+        // sandbox needs to expose it so detection can find it.
+        '--filesystem=~/.docker/desktop/docker.sock',
         // CLI alignment: wrapper script + marker file
         '--filesystem=~/.toolhive:create',
         // CLI alignment: PATH entries in shell RC files

--- a/utils/forge-makers/__tests__/MakerFlatpakBuilder.test.ts
+++ b/utils/forge-makers/__tests__/MakerFlatpakBuilder.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import MakerFlatpakBuilder from '../MakerFlatpakBuilder'
+
+// Access the private generateManifest method for black-box testing via a
+// structural cast. This avoids `any` while keeping the test hermetic
+// (no file-system I/O, no thv binary required).
+interface ManifestGenerator {
+  generateManifest(
+    appDir: string,
+    flatpakDir: string,
+    iconPath: string,
+    clientFilesystemEntries: string[]
+  ): { 'finish-args': string[] }
+}
+
+describe('MakerFlatpakBuilder.generateManifest finish-args', () => {
+  const maker = new MakerFlatpakBuilder()
+  const { 'finish-args': finishArgs } = (
+    maker as unknown as ManifestGenerator
+  ).generateManifest('app', 'flatpak', 'icon.png', [])
+
+  it('includes the standard Docker socket', () => {
+    expect(finishArgs).toContain('--filesystem=/run/docker.sock')
+  })
+
+  it('includes the Podman sockets', () => {
+    expect(finishArgs).toContain('--filesystem=/run/podman/podman.sock')
+    expect(finishArgs).toContain('--filesystem=xdg-run/podman/podman.sock')
+  })
+
+  it('includes the Docker Desktop on Linux socket', () => {
+    expect(finishArgs).toContain('--filesystem=~/.docker/desktop/docker.sock')
+  })
+})


### PR DESCRIPTION
## Summary

On Linux machines where the only Docker installation is Docker Desktop, ToolHive's Flatpak build exits at startup with *"no container runtime available"*.

**Root cause:** Docker Desktop on Linux registers a `desktop-linux` context whose socket lives at `~/.docker/desktop/docker.sock`. The bundled `thv` (v0.26.1+) probes this path, but the Flatpak sandbox was not exposing it — `os.Stat` returned `ENOENT` inside the sandbox and container-runtime detection bailed.

**Fix:** Add the narrowest possible Flatpak `finish-args` grant (`--filesystem=~/.docker/desktop/docker.sock`) so the socket file is visible to `thv`. A broader `~/.docker` or `~/.docker:ro` grant is intentionally avoided to keep the manifest Flathub-friendly. Also adds a unit test for `generateManifest()` that pins presence of all four socket grants.

**Upstream context:**
- stacklok/toolhive#5122 — `thv` auto-detection of Docker Desktop on Linux socket
- stacklok/toolhive#5120 — related `desktop-linux` context discovery

**Workaround for users on the current release:**
```bash
flatpak override --user --filesystem=~/.docker:ro com.stacklok.ToolHive
```

> **Note:** `flatpak-builder` is not available on the macOS development host used for this PR. Local Flatpak smoke testing was not performed; validation relied on unit tests and type-check only.

## Changes

- `utils/forge-makers/MakerFlatpakBuilder.ts` — add `--filesystem=~/.docker/desktop/docker.sock` with explanatory comment under the existing Docker/Podman socket block
- `utils/forge-makers/__tests__/MakerFlatpakBuilder.test.ts` — new unit test asserting all four socket grants are present in `generateManifest()` output

Made with [Cursor](https://cursor.com)