### PR TITLE
fix(playground): defer empty chat thread persistence until first message

### DIFF
--- a/main/src/chat/__tests__/thread-integration.test.ts
+++ b/main/src/chat/__tests__/thread-integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockCreateThread = vi.hoisted(() => vi.fn())
+const mockGetThread = vi.hoisted(() => vi.fn())
+const mockSetActiveThreadId = vi.hoisted(() => vi.fn())
+
+vi.mock('../threads-storage', () => ({
+  createThread: mockCreateThread,
+  getThread: mockGetThread,
+  setActiveThreadId: mockSetActiveThreadId,
+}))
+
+import { ensureThreadExists } from '../thread-integration'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ensureThreadExists', () => {
+  it('returns the existing thread id and sets it active when the row already exists', () => {
+    mockGetThread.mockReturnValue({
+      id: 'existing-thread',
+      messages: [],
+      lastEditTimestamp: 0,
+      createdAt: 0,
+    })
+
+    const result = ensureThreadExists('existing-thread', 'Some title')
+
+    expect(result).toEqual({
+      success: true,
+      threadId: 'existing-thread',
+      isNew: false,
+    })
+    expect(mockSetActiveThreadId).toHaveBeenCalledWith('existing-thread')
+    expect(mockCreateThread).not.toHaveBeenCalled()
+  })
+
+  it('promotes a draft id by creating the row with that exact id', () => {
+    mockGetThread.mockReturnValue(null)
+    mockCreateThread.mockReturnValue({
+      success: true,
+      threadId: 'draft-id',
+    })
+
+    const result = ensureThreadExists('draft-id')
+
+    expect(result).toEqual({
+      success: true,
+      threadId: 'draft-id',
+      isNew: true,
+    })
+    expect(mockCreateThread).toHaveBeenCalledWith(undefined, [], 'draft-id')
+  })
+
+  it('falls back to a generated id when none is provided', () => {
+    mockGetThread.mockReturnValue(null)
+    mockCreateThread.mockReturnValue({
+      success: true,
+      threadId: 'generated',
+    })
+
+    const result = ensureThreadExists(undefined, 'My title')
+
+    expect(result).toEqual({
+      success: true,
+      threadId: 'generated',
+      isNew: true,
+    })
+    expect(mockCreateThread).toHaveBeenCalledWith('My title', [], undefined)
+  })
+
+  it('surfaces createThread failures', () => {
+    mockGetThread.mockReturnValue(null)
+    mockCreateThread.mockReturnValue({
+      success: false,
+      error: 'disk full',
+    })
+
+    const result = ensureThreadExists('draft-id')
+
+    expect(result).toEqual({ success: false, error: 'disk full' })
+  })
+})

--- a/main/src/chat/__tests__/threads-storage.test.ts
+++ b/main/src/chat/__tests__/threads-storage.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockWriteThread = vi.hoisted(() => vi.fn())
+const mockWriteActiveThread = vi.hoisted(() => vi.fn())
+const mockReadThread = vi.hoisted(() => vi.fn())
+
+vi.mock('../../db/writers/threads-writer', () => ({
+  writeThread: mockWriteThread,
+  deleteThreadFromDb: vi.fn(),
+  clearAllThreadsFromDb: vi.fn(),
+  writeActiveThread: mockWriteActiveThread,
+}))
+
+vi.mock('../../db/readers/threads-reader', () => ({
+  readThread: mockReadThread,
+  readAllThreads: vi.fn(),
+  readActiveThreadId: vi.fn(),
+  readThreadCount: vi.fn(),
+}))
+
+vi.mock('../../logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('electron-store', () => ({
+  default: class FakeStore {},
+}))
+
+import { createThread } from '../threads-storage'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createThread', () => {
+  it('writes a row with a generated id when no explicit id is provided', () => {
+    mockReadThread.mockReturnValue(null)
+
+    const result = createThread('Hello')
+
+    expect(result.success).toBe(true)
+    expect(result.threadId).toMatch(/^thread_/)
+    expect(mockWriteThread).toHaveBeenCalledTimes(1)
+    expect(mockWriteActiveThread).toHaveBeenCalledWith(result.threadId)
+    // Generated path skips the existence guard.
+    expect(mockReadThread).not.toHaveBeenCalled()
+  })
+
+  it('writes a row with the explicit id when the row does not exist', () => {
+    mockReadThread.mockReturnValue(null)
+
+    const result = createThread(undefined, [], 'thread_draft_42')
+
+    expect(result).toEqual({ success: true, threadId: 'thread_draft_42' })
+    expect(mockReadThread).toHaveBeenCalledWith('thread_draft_42')
+    expect(mockWriteThread).toHaveBeenCalledTimes(1)
+    const written = mockWriteThread.mock.calls[0]?.[0]
+    expect(written.id).toBe('thread_draft_42')
+  })
+
+  it('refuses to overwrite an existing row when an explicit id collides', () => {
+    // writeThread is INSERT OR REPLACE — without this guard the prior
+    // thread's messages would be silently nuked.
+    mockReadThread.mockReturnValue({
+      id: 'thread_draft_42',
+      messages: [{ id: 'm1', role: 'user', parts: [] }],
+      lastEditTimestamp: 0,
+      createdAt: 0,
+    })
+
+    const result = createThread(undefined, [], 'thread_draft_42')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('thread_draft_42')
+    expect(mockWriteThread).not.toHaveBeenCalled()
+    expect(mockWriteActiveThread).not.toHaveBeenCalled()
+  })
+})

--- a/main/src/chat/thread-integration.ts
+++ b/main/src/chat/thread-integration.ts
@@ -110,8 +110,10 @@ export function ensureThreadExists(
       }
     }
 
-    // Create new thread
-    const result = createThread(title)
+    // Promote a draft id (provided but not yet in the DB) by creating the
+    // row with that exact id, so the URL/threadId the renderer is already
+    // bound to keeps working. When no id is provided, generate a fresh one.
+    const result = createThread(title, [], threadId)
     if (result.success && result.threadId) {
       return { success: true, threadId: result.threadId, isNew: true }
     }

--- a/main/src/chat/threads-storage.ts
+++ b/main/src/chat/threads-storage.ts
@@ -54,10 +54,17 @@ function generateThreadId(): string {
 
 export function createThread(
   title?: string,
-  initialMessages: ChatSettingsThread['messages'] = []
+  initialMessages: ChatSettingsThread['messages'] = [],
+  /**
+   * Optional caller-supplied id. When provided, the thread row is written
+   * with this id verbatim — used to "promote" a renderer-side draft thread
+   * (whose id was already routed to in the URL) to a real DB row without
+   * the id changing under the user.
+   */
+  explicitId?: string
 ): { success: boolean; threadId?: string; error?: string } {
   try {
-    const threadId = generateThreadId()
+    const threadId = explicitId ?? generateThreadId()
     const now = Date.now()
 
     const newThread: ChatSettingsThread = {

--- a/main/src/chat/threads-storage.ts
+++ b/main/src/chat/threads-storage.ts
@@ -48,6 +48,10 @@ export const threadsStore = new Store<ChatSettingsThreads>({
   },
 })
 
+/**
+ * Mirrored by `generateDraftThreadId` in
+ * `renderer/src/features/chat/lib/thread-id.ts` — keep the formats in sync.
+ */
 function generateThreadId(): string {
   return `thread_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
 }
@@ -56,16 +60,24 @@ export function createThread(
   title?: string,
   initialMessages: ChatSettingsThread['messages'] = [],
   /**
-   * Optional caller-supplied id. When provided, the thread row is written
-   * with this id verbatim — used to "promote" a renderer-side draft thread
-   * (whose id was already routed to in the URL) to a real DB row without
-   * the id changing under the user.
+   * Caller-supplied id used to promote a renderer-side draft to a real
+   * row without the URL/`useChat` id changing. Refuses to overwrite an
+   * existing row (`writeThread` is `INSERT OR REPLACE` and would nuke
+   * the prior thread's messages); callers intending an upsert must
+   * consult `getThread` first — `ensureThreadExists` already does.
    */
   explicitId?: string
 ): { success: boolean; threadId?: string; error?: string } {
   try {
     const threadId = explicitId ?? generateThreadId()
     const now = Date.now()
+
+    if (explicitId && readThreadFromDb(threadId)) {
+      return {
+        success: false,
+        error: `Thread ${threadId} already exists`,
+      }
+    }
 
     const newThread: ChatSettingsThread = {
       id: threadId,

--- a/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -66,6 +66,7 @@ const mockChatAPI = {
   getAllThreads: vi.fn(),
   setActiveThreadId: vi.fn(),
   createChatThread: vi.fn(),
+  ensureThreadExists: vi.fn(),
   getThread: vi.fn(),
   getThreadMessagesForTransport: vi.fn(),
   updateThreadMessages: vi.fn(),
@@ -132,6 +133,11 @@ describe('useChatStreaming', () => {
     mockChatAPI.createChatThread.mockResolvedValue({
       success: true,
       threadId: 'toolhive-chat',
+    })
+    mockChatAPI.ensureThreadExists.mockResolvedValue({
+      success: true,
+      threadId: 'toolhive-chat',
+      isNew: false,
     })
     mockChatAPI.getThread.mockResolvedValue(null)
     mockChatAPI.getThreadMessagesForTransport.mockResolvedValue([])
@@ -343,6 +349,52 @@ describe('useChatStreaming', () => {
       expect(mockUseChat.sendMessage).toHaveBeenCalledWith({
         text: 'Hello, world!',
       })
+    })
+
+    it('promotes a draft thread via ensureThreadExists before sending', async () => {
+      const { Wrapper } = createTestUtils()
+      const { result } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      await act(async () => {
+        await result.current.sendMessage('Hello, world!')
+      })
+
+      // Must run before sendMessage so the row exists when the main
+      // process starts writing snapshots from the active stream.
+      const ensureOrder =
+        mockChatAPI.ensureThreadExists.mock.invocationCallOrder[0]
+      const sendOrder = mockUseChat.sendMessage.mock.invocationCallOrder[0]
+      expect(ensureOrder).toBeLessThan(sendOrder!)
+      expect(mockChatAPI.ensureThreadExists).toHaveBeenCalledWith(
+        'toolhive-chat'
+      )
+    })
+
+    it('throws and skips sendMessage when ensureThreadExists fails', async () => {
+      mockChatAPI.ensureThreadExists.mockResolvedValueOnce({
+        success: false,
+        error: 'disk full',
+      })
+
+      const { Wrapper } = createTestUtils()
+      const { result } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      await expect(result.current.sendMessage('Hello')).rejects.toThrow(
+        'disk full'
+      )
+      expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
     })
 
     it('handles whitespace-only API keys', async () => {

--- a/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
@@ -156,7 +156,7 @@ describe('usePlaygroundThreads', () => {
   })
 
   describe('createThread', () => {
-    it('calls createChatThread, prepends new thread to list, and returns the new thread ID', async () => {
+    it('generates a draft id locally, prepends a pending entry, and skips IPC', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'existing' }),
       ])
@@ -170,29 +170,32 @@ describe('usePlaygroundThreads', () => {
         returnedId = await result.current.createThread()
       })
 
-      expect(mockChatAPI.createChatThread).toHaveBeenCalledOnce()
-      expect(result.current.threads[0]!.id).toBe('new-thread')
-      expect(returnedId).toBe('new-thread')
+      expect(mockChatAPI.createChatThread).not.toHaveBeenCalled()
+      expect(returnedId).toMatch(/^thread_/)
+      expect(result.current.threads[0]!.id).toBe(returnedId)
+      expect(result.current.threads[0]!.pending).toBe(true)
     })
 
-    it('returns null when createChatThread returns failure', async () => {
+    it('reuses an existing empty draft instead of generating another one', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([])
-      mockChatAPI.createChatThread.mockResolvedValue({
-        success: false,
-        error: 'db error',
-      })
-      const { result } = renderHook(() => usePlaygroundThreads('any-thread'), {
+      const { result } = renderHook(() => usePlaygroundThreads(null), {
         wrapper: createWrapper(),
       })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-      let returnedId: string | null = 'sentinel'
+      let firstId: string | null = null
       await act(async () => {
-        returnedId = await result.current.createThread()
+        firstId = await result.current.createThread()
       })
 
-      expect(result.current.threads).toHaveLength(0)
-      expect(returnedId).toBeNull()
+      let secondId: string | null = null
+      await act(async () => {
+        secondId = await result.current.createThread()
+      })
+
+      expect(firstId).not.toBeNull()
+      expect(secondId).toBe(firstId)
+      expect(result.current.threads).toHaveLength(1)
     })
   })
 
@@ -276,6 +279,32 @@ describe('usePlaygroundThreads', () => {
 
       expect(result.current.threads).toHaveLength(1)
       expect(res).toEqual({ success: false })
+    })
+
+    it('removes a pending draft locally without calling deleteThread IPC', async () => {
+      mockChatAPI.getAllThreads.mockResolvedValue([])
+      const { result } = renderHook(() => usePlaygroundThreads(null), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      let draftId: string | null = null
+      await act(async () => {
+        draftId = await result.current.createThread()
+      })
+
+      expect(draftId).not.toBeNull()
+
+      let res: Awaited<ReturnType<typeof result.current.deleteThread>> = {
+        success: false,
+      }
+      await act(async () => {
+        res = await result.current.deleteThread(draftId!)
+      })
+
+      expect(mockChatAPI.deleteThread).not.toHaveBeenCalled()
+      expect(res).toEqual({ success: true, nextId: null })
+      expect(result.current.threads).toHaveLength(0)
     })
   })
 

--- a/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
@@ -94,7 +94,10 @@ describe('usePlaygroundThreads', () => {
     })
 
     it('updates setActiveThreadId when activeThreadId changes', async () => {
-      mockChatAPI.getAllThreads.mockResolvedValue([])
+      mockChatAPI.getAllThreads.mockResolvedValue([
+        makeDbThread({ id: 'thread-a' }),
+        makeDbThread({ id: 'thread-b' }),
+      ])
       let activeId = 'thread-a'
       const { rerender } = renderHook(() => usePlaygroundThreads(activeId), {
         wrapper: createWrapper(),
@@ -112,7 +115,9 @@ describe('usePlaygroundThreads', () => {
     })
 
     it('clears the active thread id when activeThreadId becomes null', async () => {
-      mockChatAPI.getAllThreads.mockResolvedValue([])
+      mockChatAPI.getAllThreads.mockResolvedValue([
+        makeDbThread({ id: 'thread-a' }),
+      ])
       let activeId: string | null = 'thread-a'
       const { rerender } = renderHook(() => usePlaygroundThreads(activeId), {
         wrapper: createWrapper(),
@@ -131,6 +136,23 @@ describe('usePlaygroundThreads', () => {
       )
     })
 
+    it('does not call setActiveThreadId for a pending draft id', async () => {
+      // Drafts have no DB row; the IPC would reject with `Thread not found`.
+      mockChatAPI.getAllThreads.mockResolvedValue([])
+      const { result } = renderHook(
+        () => usePlaygroundThreads('thread_url_draft'),
+        { wrapper: createWrapper() }
+      )
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.threads[0]).toMatchObject({
+        id: 'thread_url_draft',
+        pending: true,
+      })
+      expect(mockChatAPI.setActiveThreadId).not.toHaveBeenCalledWith(
+        'thread_url_draft'
+      )
+    })
+
     it('maps starred field from DB thread', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
         makeDbThread({ id: 'starred-thread', starred: true }),
@@ -144,10 +166,8 @@ describe('usePlaygroundThreads', () => {
     })
 
     it('seeds the URL-driven activeThreadId as a pending draft when not in the DB', async () => {
-      // Mirrors the fresh-visit / deep-link case: `playground.index.tsx`
-      // redirects to a renderer-generated draft id, the hook loads zero
-      // DB threads, and we still need `hasThreads` to be true so the
-      // sidebar renders and the legacy auto-create path stays out of it.
+      // Fresh-visit / deep-link case: keeps `hasThreads` true so the
+      // sidebar renders and ChatInterface skips the legacy auto-create.
       mockChatAPI.getAllThreads.mockResolvedValue([])
       const { result } = renderHook(
         () => usePlaygroundThreads('thread_url_draft'),

--- a/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
@@ -71,10 +71,9 @@ describe('usePlaygroundThreads', () => {
         makeDbThread({ id: 'old', lastEditTimestamp: 1000 }),
         makeDbThread({ id: 'new', lastEditTimestamp: 3000 }),
       ])
-      const { result } = renderHook(
-        () => usePlaygroundThreads('initial-thread'),
-        { wrapper: createWrapper() }
-      )
+      const { result } = renderHook(() => usePlaygroundThreads('new'), {
+        wrapper: createWrapper(),
+      })
       await waitFor(() => expect(result.current.isLoading).toBe(false))
       expect(result.current.threads[0]!.id).toBe('new')
       expect(result.current.threads[1]!.id).toBe('old')
@@ -134,23 +133,54 @@ describe('usePlaygroundThreads', () => {
 
     it('maps starred field from DB thread', async () => {
       mockChatAPI.getAllThreads.mockResolvedValue([
-        makeDbThread({ starred: true }),
+        makeDbThread({ id: 'starred-thread', starred: true }),
       ])
       const { result } = renderHook(
-        () => usePlaygroundThreads('initial-thread'),
+        () => usePlaygroundThreads('starred-thread'),
         { wrapper: createWrapper() }
       )
       await waitFor(() => expect(result.current.isLoading).toBe(false))
       expect(result.current.threads[0]!.starred).toBe(true)
     })
 
-    it('has no threads when DB is empty', async () => {
+    it('seeds the URL-driven activeThreadId as a pending draft when not in the DB', async () => {
+      // Mirrors the fresh-visit / deep-link case: `playground.index.tsx`
+      // redirects to a renderer-generated draft id, the hook loads zero
+      // DB threads, and we still need `hasThreads` to be true so the
+      // sidebar renders and the legacy auto-create path stays out of it.
       mockChatAPI.getAllThreads.mockResolvedValue([])
       const { result } = renderHook(
-        () => usePlaygroundThreads('initial-thread'),
+        () => usePlaygroundThreads('thread_url_draft'),
         { wrapper: createWrapper() }
       )
       await waitFor(() => expect(result.current.isLoading).toBe(false))
+      await waitFor(() => expect(result.current.threads).toHaveLength(1))
+      expect(result.current.threads[0]).toMatchObject({
+        id: 'thread_url_draft',
+        pending: true,
+      })
+      expect(result.current.hasThreads).toBe(true)
+    })
+
+    it('does not seed when the URL activeThreadId is already in the loaded DB threads', async () => {
+      mockChatAPI.getAllThreads.mockResolvedValue([
+        makeDbThread({ id: 'thread-1' }),
+      ])
+      const { result } = renderHook(() => usePlaygroundThreads('thread-1'), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.threads).toHaveLength(1)
+      expect(result.current.threads[0]?.pending).toBeUndefined()
+    })
+
+    it('does not seed when activeThreadId is null', async () => {
+      mockChatAPI.getAllThreads.mockResolvedValue([])
+      const { result } = renderHook(() => usePlaygroundThreads(null), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.threads).toHaveLength(0)
       expect(result.current.hasThreads).toBe(false)
     })
   })

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -349,11 +349,9 @@ export function useChatStreaming(externalThreadId?: string | null) {
         throw new Error('Please configure your AI provider settings first')
       }
 
-      // Promote a renderer-side draft thread to a real DB row before the
-      // first stream starts. `runManagedStream` in the main process
-      // periodically writes snapshots via `updateThreadMessages`, which
-      // requires the row to exist — so this must complete before the
-      // `chat:stream` IPC fires inside `sendMessage`.
+      // Promote a renderer-side draft to a real DB row before the
+      // stream starts — `runManagedStream` writes snapshots via
+      // `updateThreadMessages`, which needs the row to exist.
       if (currentThreadId) {
         const ensured =
           await window.electronAPI.chat.ensureThreadExists(currentThreadId)

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -349,13 +349,26 @@ export function useChatStreaming(externalThreadId?: string | null) {
         throw new Error('Please configure your AI provider settings first')
       }
 
+      // Promote a renderer-side draft thread to a real DB row before the
+      // first stream starts. `runManagedStream` in the main process
+      // periodically writes snapshots via `updateThreadMessages`, which
+      // requires the row to exist — so this must complete before the
+      // `chat:stream` IPC fires inside `sendMessage`.
+      if (currentThreadId) {
+        const ensured =
+          await window.electronAPI.chat.ensureThreadExists(currentThreadId)
+        if (!ensured.success) {
+          throw new Error(ensured.error ?? 'Failed to create chat thread')
+        }
+      }
+
       if (typeof messageOrText === 'string') {
         return sendMessage({ text: messageOrText })
       } else {
         return sendMessage(messageOrText)
       }
     },
-    [settings, sendMessage]
+    [settings, sendMessage, currentThreadId]
   )
 
   // Memoize the processed error to avoid recalculating on every render

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
 import { trackEvent } from '@/common/lib/analytics'
+import { generateDraftThreadId } from '@/features/chat/lib/thread-id'
 
 export interface PlaygroundThread {
   id: string
@@ -9,6 +10,14 @@ export interface PlaygroundThread {
   starred?: boolean
   lastEditTimestamp: number
   createdAt: number
+  /**
+   * True for threads that exist only in renderer state and have not yet
+   * been persisted to the DB. A draft is promoted to a real DB row by
+   * `ensureThreadExists` in `use-chat-streaming` when the user sends the
+   * first message — at which point `refreshThread` replaces the entry
+   * with the lightweight projection from the DB (no `pending` field).
+   */
+  pending?: boolean
 }
 
 const sortByRecent = (a: PlaygroundThread, b: PlaygroundThread) =>
@@ -52,36 +61,47 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
   // Persist the URL-driven active thread to IPC whenever it changes.
   // When the URL has no thread (e.g. user navigated to /playground/agents),
   // explicitly clear the main-process pointer so it doesn't keep a stale id.
+  // For pending drafts the IPC validates the row exists and returns failure
+  // silently — that's fine, drafts intentionally don't survive reloads.
   useEffect(() => {
     window.electronAPI.chat.setActiveThreadId(activeThreadId ?? undefined)
   }, [activeThreadId])
 
-  /** Creates a new thread and returns its ID for navigation, or null on failure. */
-  const createThread = useCallback(async (): Promise<string | null> => {
-    try {
-      const result = await window.electronAPI.chat.createChatThread()
-      if (!result.success || !result.threadId) {
-        log.error(
-          '[usePlaygroundThreads] Failed to create thread:',
-          result.error
-        )
-        return null
-      }
-      const now = Date.now()
-      const newThread: PlaygroundThread = {
-        id: result.threadId,
-        title: undefined,
-        lastEditTimestamp: now,
-        createdAt: now,
-      }
-      setThreads((prev) => [newThread, ...prev])
-      trackEvent('Playground: create thread')
-      return result.threadId
-    } catch (err) {
-      log.error('[usePlaygroundThreads] Failed to create thread:', err)
-      return null
-    }
+  /**
+   * Returns the id of an existing in-memory draft thread (created locally,
+   * not yet persisted) so the caller can navigate to it instead of piling
+   * up empty drafts. Returns `null` if no reusable draft is available.
+   */
+  const findReusableDraftId = useCallback((): string | null => {
+    const draft = threadsRef.current.find((t) => t.pending)
+    return draft?.id ?? null
   }, [])
+
+  /**
+   * Returns the id of an existing or newly-generated draft thread.
+   *
+   * No IPC call: the thread row is only written to SQLite when the user
+   * sends the first message (see `ensureThreadExists` in
+   * `use-chat-streaming.ts`). Until then the entry lives in renderer
+   * state with `pending: true` so the sidebar can render it.
+   */
+  const createThread = useCallback(async (): Promise<string | null> => {
+    const reusable = findReusableDraftId()
+    if (reusable) return reusable
+
+    const id = generateDraftThreadId()
+    const now = Date.now()
+    const draft: PlaygroundThread = {
+      id,
+      title: undefined,
+      lastEditTimestamp: now,
+      createdAt: now,
+      pending: true,
+    }
+    setThreads((prev) => [draft, ...prev])
+    trackEvent('Playground: create thread')
+    return id
+  }, [findReusableDraftId])
 
   /**
    * Deletes a thread. On success returns `{ success: true, nextId }` where
@@ -98,13 +118,20 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
       { success: true; nextId: string | null } | { success: false }
     > => {
       try {
-        const result = await window.electronAPI.chat.deleteThread(threadId)
-        if (!result.success) {
-          log.error(
-            '[usePlaygroundThreads] Failed to delete thread:',
-            result.error
-          )
-          return { success: false }
+        // Pending drafts only exist in renderer state — skip the IPC call
+        // (which would fail with "Thread not found") and remove locally.
+        const isPending = threadsRef.current.find(
+          (t) => t.id === threadId
+        )?.pending
+        if (!isPending) {
+          const result = await window.electronAPI.chat.deleteThread(threadId)
+          if (!result.success) {
+            log.error(
+              '[usePlaygroundThreads] Failed to delete thread:',
+              result.error
+            )
+            return { success: false }
+          }
         }
         trackEvent('Playground: delete thread', {
           'thread.was_active': activeThreadId === threadId,

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -10,13 +10,7 @@ export interface PlaygroundThread {
   starred?: boolean
   lastEditTimestamp: number
   createdAt: number
-  /**
-   * True for threads that exist only in renderer state and have not yet
-   * been persisted to the DB. A draft is promoted to a real DB row by
-   * `ensureThreadExists` in `use-chat-streaming` when the user sends the
-   * first message — at which point `refreshThread` replaces the entry
-   * with the lightweight projection from the DB (no `pending` field).
-   */
+  /** Renderer-only draft: promoted to a real DB row on first send. */
   pending?: boolean
 }
 
@@ -29,6 +23,9 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
   const [isLoading, setIsLoading] = useState(true)
   const threadsRef = useRef(threads)
   threadsRef.current = threads
+  // Read by the load effect without becoming a dep (would refetch on URL change).
+  const activeThreadIdRef = useRef(activeThreadId)
+  activeThreadIdRef.current = activeThreadId
 
   useEffect(() => {
     async function loadThreads() {
@@ -38,7 +35,7 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
         const sorted = [...allThreads].sort(
           (a, b) => b.lastEditTimestamp - a.lastEditTimestamp
         )
-        const lightweight = sorted.map(
+        const lightweight: PlaygroundThread[] = sorted.map(
           ({ id, title, starred, lastEditTimestamp, createdAt }) => ({
             id,
             title,
@@ -47,6 +44,20 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
             createdAt,
           })
         )
+        // Seed the URL-driven id as a pending draft if not in the DB
+        // (fresh visit / deep-link). Atomic with the load so the persist
+        // effect below sees it on first run and skips the noisy IPC.
+        const initialActive = activeThreadIdRef.current
+        if (initialActive && !lightweight.some((t) => t.id === initialActive)) {
+          const now = Date.now()
+          lightweight.unshift({
+            id: initialActive,
+            title: undefined,
+            lastEditTimestamp: now,
+            createdAt: now,
+            pending: true,
+          })
+        }
         setThreads(lightweight)
       } catch (err) {
         log.error('[usePlaygroundThreads] Failed to load threads:', err)
@@ -58,22 +69,26 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
     loadThreads()
   }, [])
 
-  // Persist the URL-driven active thread to IPC whenever it changes.
-  // When the URL has no thread (e.g. user navigated to /playground/agents),
-  // explicitly clear the main-process pointer so it doesn't keep a stale id.
-  // For pending drafts the IPC validates the row exists and returns failure
-  // silently — that's fine, drafts intentionally don't survive reloads.
-  useEffect(() => {
-    window.electronAPI.chat.setActiveThreadId(activeThreadId ?? undefined)
-  }, [activeThreadId])
+  // Persist the URL-driven active thread to main. Skip pending drafts —
+  // their row doesn't exist yet and the IPC would reject with
+  // `Thread not found`. Promotion flips `pending` (via `refreshThread`)
+  // and re-runs this effect.
+  const isActivePending = activeThreadId
+    ? (threads.find((t) => t.id === activeThreadId)?.pending ?? false)
+    : false
 
-  // Seed the URL-driven thread id as a pending draft when the initial DB
-  // load doesn't include it (typical first-visit / deep-link case where
-  // `playground.index.tsx` redirected to a renderer-generated id). Without
-  // this, `hasThreads` stays false on a fresh visit, the sidebar disappears,
-  // and `ChatInterface` falls into the legacy `useThreadManagement`
-  // auto-create path — which calls `createChatThread()` over IPC and writes
-  // the empty row this PR is trying to avoid.
+  useEffect(() => {
+    if (isLoading) return
+    if (!activeThreadId) {
+      window.electronAPI.chat.setActiveThreadId(undefined)
+      return
+    }
+    if (isActivePending) return
+    window.electronAPI.chat.setActiveThreadId(activeThreadId)
+  }, [activeThreadId, isActivePending, isLoading])
+
+  // Seed unknown ids that arrive post-load (deep link, manual URL edit).
+  // Initial mount is handled atomically inside the loader above.
   useEffect(() => {
     if (isLoading) return
     if (!activeThreadId) return
@@ -91,23 +106,15 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
     })
   }, [activeThreadId, isLoading])
 
-  /**
-   * Returns the id of an existing in-memory draft thread (created locally,
-   * not yet persisted) so the caller can navigate to it instead of piling
-   * up empty drafts. Returns `null` if no reusable draft is available.
-   */
+  /** Reuses an existing pending draft to avoid piling up empty entries. */
   const findReusableDraftId = useCallback((): string | null => {
     const draft = threadsRef.current.find((t) => t.pending)
     return draft?.id ?? null
   }, [])
 
   /**
-   * Returns the id of an existing or newly-generated draft thread.
-   *
-   * No IPC call: the thread row is only written to SQLite when the user
-   * sends the first message (see `ensureThreadExists` in
-   * `use-chat-streaming.ts`). Until then the entry lives in renderer
-   * state with `pending: true` so the sidebar can render it.
+   * Returns an existing or newly-generated draft id. No IPC — the row is
+   * written on first send via `ensureThreadExists` in `use-chat-streaming`.
    */
   const createThread = useCallback(async (): Promise<string | null> => {
     const reusable = findReusableDraftId()
@@ -142,8 +149,7 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
       { success: true; nextId: string | null } | { success: false }
     > => {
       try {
-        // Pending drafts only exist in renderer state — skip the IPC call
-        // (which would fail with "Thread not found") and remove locally.
+        // Pending drafts only exist in renderer state — skip the IPC.
         const isPending = threadsRef.current.find(
           (t) => t.id === threadId
         )?.pending

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -67,6 +67,30 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
     window.electronAPI.chat.setActiveThreadId(activeThreadId ?? undefined)
   }, [activeThreadId])
 
+  // Seed the URL-driven thread id as a pending draft when the initial DB
+  // load doesn't include it (typical first-visit / deep-link case where
+  // `playground.index.tsx` redirected to a renderer-generated id). Without
+  // this, `hasThreads` stays false on a fresh visit, the sidebar disappears,
+  // and `ChatInterface` falls into the legacy `useThreadManagement`
+  // auto-create path — which calls `createChatThread()` over IPC and writes
+  // the empty row this PR is trying to avoid.
+  useEffect(() => {
+    if (isLoading) return
+    if (!activeThreadId) return
+    setThreads((prev) => {
+      if (prev.some((t) => t.id === activeThreadId)) return prev
+      const now = Date.now()
+      const seed: PlaygroundThread = {
+        id: activeThreadId,
+        title: undefined,
+        lastEditTimestamp: now,
+        createdAt: now,
+        pending: true,
+      }
+      return [seed, ...prev]
+    })
+  }, [activeThreadId, isLoading])
+
   /**
    * Returns the id of an existing in-memory draft thread (created locally,
    * not yet persisted) so the caller can navigate to it instead of piling

--- a/renderer/src/features/chat/lib/thread-id.ts
+++ b/renderer/src/features/chat/lib/thread-id.ts
@@ -1,11 +1,7 @@
 /**
- * Generate a draft thread id in the renderer.
- *
- * Format mirrors the main process's `generateThreadId` in
- * `main/src/chat/threads-storage.ts` so a draft id is indistinguishable
- * from a persisted one. The id is used to drive the URL and the
- * `useChat` instance immediately, and only later "promoted" to a real DB
- * row by `ensureThreadExists` when the user sends the first message.
+ * Renderer-side draft thread id. Format MUST match `generateThreadId` in
+ * `main/src/chat/threads-storage.ts` so `ensureThreadExists` can promote
+ * it as-is on first send.
  */
 export function generateDraftThreadId(): string {
   return `thread_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`

--- a/renderer/src/features/chat/lib/thread-id.ts
+++ b/renderer/src/features/chat/lib/thread-id.ts
@@ -1,0 +1,12 @@
+/**
+ * Generate a draft thread id in the renderer.
+ *
+ * Format mirrors the main process's `generateThreadId` in
+ * `main/src/chat/threads-storage.ts` so a draft id is indistinguishable
+ * from a persisted one. The id is used to drive the URL and the
+ * `useChat` instance immediately, and only later "promoted" to a real DB
+ * row by `ensureThreadExists` when the user sends the first message.
+ */
+export function generateDraftThreadId(): string {
+  return `thread_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
+}

--- a/renderer/src/routes/__tests__/playground.index.test.tsx
+++ b/renderer/src/routes/__tests__/playground.index.test.tsx
@@ -36,9 +36,11 @@ beforeEach(() => {
   }
   mockChatAPI.getAllThreads.mockResolvedValue([])
   mockChatAPI.getActiveThreadId.mockResolvedValue(undefined)
+  // Kept for assertions that the IPC is NOT called now that drafts are
+  // generated locally — no test expects a successful response.
   mockChatAPI.createChatThread.mockResolvedValue({
-    success: true,
-    threadId: 'created-thread',
+    success: false,
+    error: 'should not be called',
   })
 })
 
@@ -155,34 +157,19 @@ describe('Playground index route (/playground/)', () => {
     )
   })
 
-  it('creates a new thread and redirects when no threads exist', async () => {
+  it('redirects to a locally-generated draft thread when no DB threads exist', async () => {
     mockChatAPI.getActiveThreadId.mockResolvedValue(undefined)
     mockChatAPI.getAllThreads.mockResolvedValue([])
-    mockChatAPI.createChatThread.mockResolvedValue({
-      success: true,
-      threadId: 'brand-new',
-    })
 
     const { router } = renderIndexRoute()
 
     await waitFor(() =>
-      expect(router.state.location.pathname).toBe('/playground/chat/brand-new')
+      expect(router.state.location.pathname).toMatch(
+        /^\/playground\/chat\/thread_/
+      )
     )
-    expect(mockChatAPI.createChatThread).toHaveBeenCalledOnce()
-  })
-
-  it('does not redirect when createChatThread fails', async () => {
-    mockChatAPI.getActiveThreadId.mockResolvedValue(undefined)
-    mockChatAPI.getAllThreads.mockResolvedValue([])
-    mockChatAPI.createChatThread.mockResolvedValue({
-      success: false,
-      error: 'db error',
-    })
-
-    const { router } = renderIndexRoute()
-
-    // Give the effect time to run — route should stay on /playground/
-    await new Promise((r) => setTimeout(r, 100))
-    expect(router.state.location.pathname).toBe('/playground/')
+    // Drafts are generated in the renderer — no IPC round-trip and no
+    // empty row written to SQLite until the user sends a message.
+    expect(mockChatAPI.createChatThread).not.toHaveBeenCalled()
   })
 })

--- a/renderer/src/routes/playground.index.tsx
+++ b/renderer/src/routes/playground.index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import log from 'electron-log/renderer'
+import { generateDraftThreadId } from '@/features/chat/lib/thread-id'
 
 async function resolveInitialThreadId(): Promise<string | null> {
   const [allThreads, activeId] = await Promise.all([
@@ -18,14 +19,11 @@ async function resolveInitialThreadId(): Promise<string | null> {
   const target = activeThread ?? sorted[0]
   if (target) return target.id
 
-  const result = await window.electronAPI.chat.createChatThread()
-  if (result.success && result.threadId) return result.threadId
-
-  log.error(
-    '[PlaygroundIndexRedirect] Failed to create initial thread:',
-    result.error
-  )
-  return null
+  // No persisted threads — generate a draft id locally instead of
+  // writing an empty row to the DB. The thread is promoted to a real
+  // SQLite row by `ensureThreadExists` when the user sends the first
+  // message (see `use-chat-streaming.ts`).
+  return generateDraftThreadId()
 }
 
 export const Route = createFileRoute('/playground/')({


### PR DESCRIPTION
Fresh `/playground` visits and `+ New chat` clicks used to immediately write an empty thread row to SQLite via `createChatThread()`, even when the user never ended up sending a message. Result: every session leaked one (or more) empty threads into the DB, indistinguishable from real conversations in the sidebar and on reload. This PR moves thread id generation into the renderer and defers the DB write until the user actually submits the first message.

## What changes

- **Renderer-side draft ids.** New [`renderer/src/features/chat/lib/thread-id.ts`](renderer/src/features/chat/lib/thread-id.ts) produces ids with the same `thread_<ts>_<rand>` shape the main process uses, so a draft is visually indistinguishable from a persisted id in the URL and sidebar.
- **No-IPC index resolver.** [`playground.index.tsx`](renderer/src/routes/playground.index.tsx)'s `beforeLoad` keeps the existing "redirect to most-recent / active thread" logic for the case where DB threads exist, but when there are none it now redirects to a locally-generated draft id instead of calling `createChatThread()`.
- **Pending drafts in the sidebar.** [`usePlaygroundThreads`](renderer/src/features/chat/hooks/use-playground-threads.ts) tracks drafts in renderer state with a `pending: true` flag so the sidebar still renders them as normal items. `createThread()` reuses an existing empty draft instead of piling up new ones on repeated `+ New chat` clicks, and `deleteThread()` short-circuits the IPC for drafts (which would otherwise return `Thread not found` and block the navigation away).
- **Promote-on-send.** [`useChatStreaming.validatedSendMessage`](renderer/src/features/chat/hooks/use-chat-streaming.ts) awaits `ensureThreadExists(currentThreadId)` before invoking `sendMessage`, so the row is in place by the time `runManagedStream` starts persisting snapshots via `updateThreadMessages`. Promotion failure short-circuits the send with a thrown error.
- **Main-process plumbing.** [`createThread`](main/src/chat/threads-storage.ts) accepts an optional `explicitId`, and [`ensureThreadExists`](main/src/chat/thread-integration.ts) passes the caller-supplied id through to it on the missing-row branch — previously it would have generated a fresh id and broken the URL/`useChat` instance the renderer is already bound to. New [`main/src/chat/__tests__/thread-integration.test.ts`](main/src/chat/__tests__/thread-integration.test.ts) covers the existing / promoted / generated / failure branches.

## How to validate

1. Fresh app state (or `clearAllThreads`) → open `/playground`. The chat surface renders, the sidebar shows a single pending draft, and **no row appears in `chat-threads` SQLite** until you send a message.
2. Click `+ New chat` repeatedly with the current thread still empty → the same draft id is reused, no extra entries pile up in the sidebar, no IPC `chat:create-chat-thread` is fired.
3. Send the first message in a draft → `ensureThreadExists(<draft-id>)` is called once before the stream starts, the row is written with the **same id** the URL is bound to, snapshot persistence works as before, auto-titling kicks in on completion.
4. Click `+ New chat` again after sending → a new draft is created (the old one is no longer empty); deleting the new draft removes it locally without the "Thread not found" error path.
5. Reload the app while sitting on an unsent draft → the index resolver picks the most recent persisted thread (or generates a fresh draft), the stale draft is gone — no orphaned empty rows.
6. `pnpm run type-check`, lint on changed files, and `pnpm run test:nonInteractive run renderer/src/features/chat main/src/chat renderer/src/routes` (600 chat + 219 route tests) all pass locally.

## Out of scope

- The legacy auto-create branch in [`useThreadManagement`](renderer/src/features/chat/hooks/use-thread-management.ts) (lines 46–53) is unreachable from current routes (they always pass `externalThreadId`) and is left untouched here.
- Drafts intentionally do not survive an app reload. `setActiveThreadId(draftId)` is left as-is — main stores the id but the index resolver validates it against `getAllThreads()` on the next visit and falls back if missing.