### PR TITLE
fix(skills): drop namespace prefix from install prefill for git-only skills

### DIFF
--- a/renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx
@@ -215,7 +215,7 @@ describe('CardRegistrySkill', () => {
       })
     })
 
-    it('prefills the install dialog with namespace/name for non-OCI skills', async () => {
+    it('prefills the install dialog with the bare skill name for non-OCI skills', async () => {
       const user = userEvent.setup()
       renderRoute(router)
 
@@ -223,7 +223,7 @@ describe('CardRegistrySkill', () => {
 
       await waitFor(() => {
         expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
-          'io.github.user/my-skill'
+          'my-skill'
         )
       })
     })

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -241,7 +241,7 @@ describe('TableRegistrySkills', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText(/name or reference/i)).toHaveValue(
-        'io.github.other/git-skill'
+        'git-skill'
       )
     })
   })

--- a/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx
@@ -50,7 +50,7 @@ const gitSkill: RegistrySkill = {
   namespace: 'io.github.other',
   description: 'A git-based skill',
   version: 'v2.0.0',
-  packages: [{ registryType: 'git', identifier: 'https://github.com/x/y' }],
+  packages: [{ registryType: 'git', url: 'https://github.com/x/y' }],
 }
 
 const skillNoNamespace: RegistrySkill = {

--- a/renderer/src/features/skills/lib/__tests__/get-skill-install-defaults.test.ts
+++ b/renderer/src/features/skills/lib/__tests__/get-skill-install-defaults.test.ts
@@ -103,7 +103,7 @@ describe('getSkillInstallDefaults', () => {
     })
   })
 
-  it('falls back to namespace/name and skill.version for non-OCI registry skills', () => {
+  it('falls back to the bare skill name and skill.version for non-OCI registry skills', () => {
     const skill: RegistrySkill = {
       name: 'git-skill',
       namespace: 'io.github.other',
@@ -112,7 +112,7 @@ describe('getSkillInstallDefaults', () => {
     }
 
     expect(getSkillInstallDefaults(skill)).toEqual({
-      reference: 'io.github.other/git-skill',
+      reference: 'git-skill',
       version: 'v2.0.0',
     })
   })
@@ -125,8 +125,32 @@ describe('getSkillInstallDefaults', () => {
     }
 
     expect(getSkillInstallDefaults(skill)).toEqual({
-      reference: 'io.github.other/git-skill',
+      reference: 'git-skill',
       version: undefined,
+    })
+  })
+
+  it('uses the bare name (not namespace/name) for git-package-only skills so the install backend can resolve them via the index', () => {
+    // Regression for #2208: the install backend rejects `namespace/name`
+    // values because it interprets the `/` as an OCI reference and tries
+    // to dial the namespace as a registry host.
+    const skill: RegistrySkill = {
+      name: 'skill-creator',
+      namespace: 'io.github.stacklok',
+      version: '0.1.0',
+      packages: [
+        {
+          registryType: 'git',
+          url: 'https://github.com/stacklok/toolhive-catalog',
+          ref: 'main',
+          subfolder: 'registries/toolhive/skills/skill-creator/skill',
+        },
+      ],
+    }
+
+    expect(getSkillInstallDefaults(skill)).toEqual({
+      reference: 'skill-creator',
+      version: '0.1.0',
     })
   })
 })

--- a/renderer/src/features/skills/lib/__tests__/get-skill-install-defaults.test.ts
+++ b/renderer/src/features/skills/lib/__tests__/get-skill-install-defaults.test.ts
@@ -108,7 +108,7 @@ describe('getSkillInstallDefaults', () => {
       name: 'git-skill',
       namespace: 'io.github.other',
       version: 'v2.0.0',
-      packages: [{ registryType: 'git', identifier: 'https://github.com/x/y' }],
+      packages: [{ registryType: 'git', url: 'https://github.com/x/y' }],
     }
 
     expect(getSkillInstallDefaults(skill)).toEqual({
@@ -121,7 +121,7 @@ describe('getSkillInstallDefaults', () => {
     const skill: RegistrySkill = {
       name: 'git-skill',
       namespace: 'io.github.other',
-      packages: [{ registryType: 'git', identifier: 'https://github.com/x/y' }],
+      packages: [{ registryType: 'git', url: 'https://github.com/x/y' }],
     }
 
     expect(getSkillInstallDefaults(skill)).toEqual({

--- a/renderer/src/features/skills/lib/skill-reference.ts
+++ b/renderer/src/features/skills/lib/skill-reference.ts
@@ -85,12 +85,13 @@ interface SkillInstallDefaults {
  * Derives the values to prefill in the install dialog. The OCI identifier
  * is split so the version (tag or digest) lives in its own field rather
  * than being baked into the reference. Falls back to the bare `skill.name`
- * when no OCI package is available — the install backend resolves bare
- * names against the registry index, while a `namespace/name` value would
- * be misinterpreted as an OCI reference and fail with a DNS error. The
- * version field falls back to `skill.version` (the same value shown as a
- * badge on the detail page) when the OCI package carries no
- * tag/digest/ref of its own.
+ * when no OCI package identifier is available — i.e. when the skill has
+ * no `registryType: 'oci'` package, or the OCI package carries no
+ * `identifier`. The install backend resolves bare names against the
+ * registry index, while a `namespace/name` value would be misinterpreted
+ * as an OCI reference and fail with a DNS error. The version field falls
+ * back to `skill.version` (the same value shown as a badge on the detail
+ * page) when the OCI package carries no tag/digest/ref of its own.
  */
 export function getSkillInstallDefaults(
   skill: RegistrySkill

--- a/renderer/src/features/skills/lib/skill-reference.ts
+++ b/renderer/src/features/skills/lib/skill-reference.ts
@@ -84,10 +84,13 @@ interface SkillInstallDefaults {
 /**
  * Derives the values to prefill in the install dialog. The OCI identifier
  * is split so the version (tag or digest) lives in its own field rather
- * than being baked into the reference. Falls back to `namespace/name`,
- * then `name`, when no OCI package is available. The version field falls
- * back to `skill.version` (the same value shown as a badge on the detail
- * page) when the OCI package carries no tag/digest/ref of its own.
+ * than being baked into the reference. Falls back to the bare `skill.name`
+ * when no OCI package is available — the install backend resolves bare
+ * names against the registry index, while a `namespace/name` value would
+ * be misinterpreted as an OCI reference and fail with a DNS error. The
+ * version field falls back to `skill.version` (the same value shown as a
+ * badge on the detail page) when the OCI package carries no
+ * tag/digest/ref of its own.
  */
 export function getSkillInstallDefaults(
   skill: RegistrySkill
@@ -105,8 +108,7 @@ export function getSkillInstallDefaults(
   }
 
   return {
-    reference:
-      getNamespaceNameReference(skill) ?? skill.name ?? 'Unknown skill',
+    reference: skill.name ?? 'Unknown skill',
     version: skill.version ?? undefined,
   }
 }


### PR DESCRIPTION
Installing a registry skill whose only package entry is `registryType: "git"` (e.g. `skill-creator` from the toolhive-catalog) failed with a DNS error: the install dialog prefilled `Name or reference` with `<namespace>/<name>`, and the install backend interpreted the `/` as an OCI reference and tried to dial `io.github.stacklok` as a registry host. Manually deleting the namespace prefix and submitting just `skill-creator` worked because the backend then resolves the bare name against the registry index. This PR removes the namespace prefix from the prefill, so git-only skills install with no manual editing.

Closes #2208.

## Root cause

`getSkillInstallDefaults` in [`renderer/src/features/skills/lib/skill-reference.ts`](renderer/src/features/skills/lib/skill-reference.ts) preferred the first OCI package's `identifier`, then fell back to `getNamespaceNameReference(skill)` (`namespace/name`). For git-package-only skills the OCI branch was skipped and the fallback fired, producing a string the install backend can't resolve. Skills with an OCI package were unaffected because the OCI identifier branch was hit first.

## Changes

- **[`lib/skill-reference.ts`](renderer/src/features/skills/lib/skill-reference.ts)** — `getSkillInstallDefaults` now falls back to the bare `skill.name` (then `'Unknown skill'`) when no OCI package is present. JSDoc updated to spell out why the namespace prefix is intentionally dropped here. `getSkillOciRef` (used to fetch SKILL.md from the content API, which DOES accept `namespace/name`) is unchanged.
- **[`lib/__tests__/get-skill-install-defaults.test.ts`](renderer/src/features/skills/lib/__tests__/get-skill-install-defaults.test.ts)** — flips the two non-OCI cases to expect the bare name, and adds a focused regression mirroring the bug report: a `skill-creator` skill with namespace `io.github.stacklok` and a single git package, asserting `reference: 'skill-creator'`.
- **[`components/__tests__/card-registry-skill.test.tsx`](renderer/src/features/skills/components/__tests__/card-registry-skill.test.tsx)** — renamed test; expected prefill is now `my-skill` instead of `io.github.user/my-skill`.
- **[`components/__tests__/table-registry-skills.test.tsx`](renderer/src/features/skills/components/__tests__/table-registry-skills.test.tsx)** — git-skill table prefill expectation updated to `git-skill`.

## How to validate

1. **Skills → Registry**, find `skill-creator` from the toolhive-catalog (its only package is `registryType: "git"`). Click **Install** → `Name or reference` is prefilled with `skill-creator` (no namespace prefix). Submit → install succeeds via the registry index.
2. Repeat from the registry table view — same bare prefill, same successful install.
3. **Skills with an OCI package** (e.g. anything that ships `ghcr.io/...`): prefill is unchanged — the OCI identifier branch still fires, the tag/digest is still split out into the Version field.
4. **Skill detail page → SKILL.md preview** still renders. The content-API path (`getSkillOciRef`) was deliberately not touched.
5. `pnpm run type-check` and `pnpm run test:nonInteractive renderer/src/features/skills` (212 / 212) green locally.

## Out of scope

The open question raised in the issue — bare-name resolution colliding when two skills in different namespaces share a name — is a backend / catalog concern (see stacklok/toolhive#4015) and is not addressed here.