### PR TITLE
fix(main): prevent orphaned thv serve when parent exits before SIGKILL timer

### DIFF
--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -112,6 +112,8 @@ const mockGetQuittingState = vi.mocked(getQuittingState)
 class MockProcess extends EventEmitter {
   pid = 12345
   killed = false
+  exitCode: number | null = null
+  signalCode: NodeJS.Signals | null = null
   stderr = new EventEmitter()
   kill() {
     // Don't automatically set killed - let tests control this
@@ -820,10 +822,15 @@ describe('toolhive-manager', () => {
 
       stopToolhive()
       expect(killSpy).toHaveBeenCalledWith('SIGTERM')
+      // Mirror real Node: a successful kill() sets .killed=true even though
+      // the child has not exited yet. exitCode/signalCode stay null until the
+      // process actually terminates. This is the production state the
+      // parent-exit force kill must escalate from.
+      mockProcess.killed = true
       killSpy.mockClear()
 
-      // Simulate process.on('exit') firing synchronously before the
-      // scheduled 2s SIGKILL timer can run.
+      // Parent-exit handler fires synchronously before the scheduled 2s
+      // SIGKILL timer can run; force=true must bypass the in-flight stop.
       stopToolhive({ force: true })
 
       expect(killSpy).toHaveBeenCalledWith('SIGKILL')

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -801,6 +801,35 @@ describe('toolhive-manager', () => {
     })
   })
 
+  // Regression: orphaned thv after Cmd+Q.
+  // Graceful stop sent SIGTERM and scheduled SIGKILL via setTimeout, then
+  // nulled the module-level reference. When Electron's parent exited before
+  // the 2s timer fired, the synchronous `process.on('exit')` handler called
+  // stopToolhive({ force: true }) but it short-circuited on `!toolhiveProcess`
+  // - leaving the child alive and blocking the next launch's port.
+  describe('Bug: orphaned thv after parent exits before SIGKILL timer fires', () => {
+    beforeEach(async () => {
+      const startPromise = startToolhive()
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
+      vi.clearAllMocks()
+    })
+
+    it('stopToolhive({ force: true }) sends SIGKILL after a graceful stopToolhive() initiated shutdown', () => {
+      const killSpy = vi.spyOn(mockProcess, 'kill')
+
+      stopToolhive()
+      expect(killSpy).toHaveBeenCalledWith('SIGTERM')
+      killSpy.mockClear()
+
+      // Simulate process.on('exit') firing synchronously before the
+      // scheduled 2s SIGKILL timer can run.
+      stopToolhive({ force: true })
+
+      expect(killSpy).toHaveBeenCalledWith('SIGKILL')
+    })
+  })
+
   describe('restartToolhive', () => {
     it('stops existing process and starts a new one', async () => {
       // Start initial process

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -37,6 +37,7 @@ let toolhiveProcess: ReturnType<typeof spawn> | undefined
 let toolhiveMcpPort: number | undefined
 let toolhiveSocketPath: string | undefined
 let isRestarting = false
+let isStopping = false
 let killTimer: NodeJS.Timeout | undefined
 let processError: ToolhiveProcessError | undefined
 
@@ -54,7 +55,7 @@ export function isToolhiveRunning(): boolean {
   // so renderer guards (e.g. setupSecretProvider) and tray UI behave the
   // same as in the bundled-binary case.
   if (isUsingCustomSocket()) return true
-  const isRunning = !!toolhiveProcess && !toolhiveProcess.killed
+  const isRunning = !!toolhiveProcess && !toolhiveProcess.killed && !isStopping
   return isRunning
 }
 
@@ -228,6 +229,7 @@ export async function startToolhive(): Promise<void> {
       },
     })
     toolhiveProcess = child
+    isStopping = false
 
     log.info(`[startToolhive] Process spawned with PID: ${child.pid}`)
 
@@ -280,6 +282,7 @@ export async function startToolhive(): Promise<void> {
         toolhiveProcess = undefined
         toolhiveSocketPath = undefined
         toolhiveMcpPort = undefined
+        isStopping = false
       }
       if (!isRestarting && !getQuittingState()) {
         updateTrayStatus(false)
@@ -361,32 +364,36 @@ function scheduleForceKill(
 export function stopToolhive(options?: { force?: boolean }): void {
   const force = options?.force ?? false
 
-  // Clear any pending kill timer
-  if (killTimer) {
-    clearTimeout(killTimer)
-    killTimer = undefined
-  }
-
-  // Early return if no process to stop
-  if (!toolhiveProcess || toolhiveProcess.killed) {
+  // Early return if no process to stop, or a graceful stop is already in
+  // flight and the caller isn't asking us to escalate to SIGKILL. The
+  // reference must stay alive until the child's 'exit' event fires so the
+  // synchronous parent-exit handler can still SIGKILL an orphaned child.
+  if (!toolhiveProcess || toolhiveProcess.killed || (isStopping && !force)) {
     log.info(
-      `[stopToolhive] No process to stop (process=${!!toolhiveProcess}, killed=${toolhiveProcess?.killed})`
+      `[stopToolhive] No process to stop (process=${!!toolhiveProcess}, killed=${toolhiveProcess?.killed}, isStopping=${isStopping})`
     )
     // Drop stale managed socket path (e.g. after crash) without touching external
     // THV_SOCKET — that path is not owned by this process and must stay visible.
-    if (!isUsingCustomSocket()) {
+    if (
+      (!toolhiveProcess || toolhiveProcess.killed) &&
+      !isUsingCustomSocket()
+    ) {
       toolhiveSocketPath = undefined
       toolhiveMcpPort = undefined
     }
     return
   }
 
-  const pidToKill = toolhiveProcess.pid
-  log.info(`Stopping ToolHive process (PID: ${pidToKill})...`)
+  // Clear any pending kill timer - we're (re)issuing a kill below.
+  if (killTimer) {
+    clearTimeout(killTimer)
+    killTimer = undefined
+  }
 
-  // Capture process reference before clearing global
+  const pidToKill = toolhiveProcess.pid
   const processToKill = toolhiveProcess
-  toolhiveProcess = undefined
+  isStopping = true
+  log.info(`Stopping ToolHive process (PID: ${pidToKill})...`)
 
   // Attempt to kill the process
   const signal: NodeJS.Signals = force ? 'SIGKILL' : 'SIGTERM'

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -55,7 +55,13 @@ export function isToolhiveRunning(): boolean {
   // so renderer guards (e.g. setupSecretProvider) and tray UI behave the
   // same as in the bundled-binary case.
   if (isUsingCustomSocket()) return true
-  const isRunning = !!toolhiveProcess && !toolhiveProcess.killed && !isStopping
+  // .killed only signals "kill() was called", not "process has exited" - use
+  // exitCode/signalCode for true liveness.
+  const isRunning =
+    !!toolhiveProcess &&
+    toolhiveProcess.exitCode === null &&
+    toolhiveProcess.signalCode === null &&
+    !isStopping
   return isRunning
 }
 
@@ -283,6 +289,12 @@ export async function startToolhive(): Promise<void> {
         toolhiveSocketPath = undefined
         toolhiveMcpPort = undefined
         isStopping = false
+        // Drop the pending SIGKILL timer - the child is already gone and a
+        // live setTimeout would keep the event loop alive during shutdown.
+        if (killTimer) {
+          clearTimeout(killTimer)
+          killTimer = undefined
+        }
       }
       if (!isRestarting && !getQuittingState()) {
         updateTrayStatus(false)
@@ -368,16 +380,19 @@ export function stopToolhive(options?: { force?: boolean }): void {
   // flight and the caller isn't asking us to escalate to SIGKILL. The
   // reference must stay alive until the child's 'exit' event fires so the
   // synchronous parent-exit handler can still SIGKILL an orphaned child.
-  if (!toolhiveProcess || toolhiveProcess.killed || (isStopping && !force)) {
+  // .killed is not a liveness check (it's true after any successful kill()
+  // call, including the SIGTERM we want to escalate from) - use
+  // exitCode/signalCode to detect a process that has actually exited.
+  const hasExited =
+    !!toolhiveProcess &&
+    (toolhiveProcess.exitCode !== null || toolhiveProcess.signalCode !== null)
+  if (!toolhiveProcess || hasExited || (isStopping && !force)) {
     log.info(
-      `[stopToolhive] No process to stop (process=${!!toolhiveProcess}, killed=${toolhiveProcess?.killed}, isStopping=${isStopping})`
+      `[stopToolhive] No process to stop (process=${!!toolhiveProcess}, hasExited=${hasExited}, isStopping=${isStopping})`
     )
     // Drop stale managed socket path (e.g. after crash) without touching external
     // THV_SOCKET — that path is not owned by this process and must stay visible.
-    if (
-      (!toolhiveProcess || toolhiveProcess.killed) &&
-      !isUsingCustomSocket()
-    ) {
+    if ((!toolhiveProcess || hasExited) && !isUsingCustomSocket()) {
       toolhiveSocketPath = undefined
       toolhiveMcpPort = undefined
     }


### PR DESCRIPTION
## Summary

- `stopToolhive()` nulled the module-level `toolhiveProcess` reference immediately after sending SIGTERM and scheduling SIGKILL via `setTimeout`. When Electron's parent process exited before that 2s timer fired, the synchronous `process.on('exit')` handler at `main/src/app-events/process-exit.ts:7` called `stopToolhive({ force: true })` but it short-circuited on `!toolhiveProcess` — leaving the spawned `thv serve` alive. The next launch then collided on the port, `thv` exited with code 1, and the renderer was pointed at a dead port (all API calls fail with `TypeError: Failed to fetch`).
- Hold `toolhiveProcess` alive until the child's `'exit'` event fires. Use a new `isStopping` flag so `isToolhiveRunning()` still reports `false` once a stop is in flight, preserving the existing contract.
- Guard the child's `'exit'` handler so a late-firing exit on a stale process can't clobber globals already pointing at a fresh restart.

## Test plan

- [x] `pnpm run test:nonInteractive` — full suite passes (2245/2245), including the new regression test under `Bug: orphaned thv after parent exits before SIGKILL timer fires`
- [x] `pnpm run lint`
- [x] `pnpm run type-check`
- [ ] Manual: Cmd+Q the packaged app while `thv serve` is running, then `pgrep -fl 'thv serve'` to confirm no orphan; relaunch and confirm the renderer reaches the backend (no "Failed to fetch")

🤖 Generated with [Claude Code](https://claude.com/claude-code)