### PR TITLE
feat(error): add technical crash report to generic error screen

### DIFF
--- a/renderer/src/common/components/error/__tests__/technical-details.test.tsx
+++ b/renderer/src/common/components/error/__tests__/technical-details.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TechnicalDetails } from '../technical-details'
+
+vi.mock('../../layout/top-nav/minimal', () => ({
+  TopNavMinimal: () => <div />,
+}))
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
+
+describe('TechnicalDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    window.electronAPI.platform = 'darwin'
+    window.electronAPI.getAppVersion = vi.fn().mockResolvedValue({
+      currentVersion: '0.34.0',
+      latestVersion: '0.34.0',
+      isNewVersionAvailable: false,
+    })
+    window.electronAPI.getToolhiveVersion = vi.fn().mockReturnValue('0.8.0')
+    window.electronAPI.isOfficialReleaseBuild = vi.fn().mockResolvedValue(false)
+    window.electronAPI.getToolhiveStatus = vi
+      .fn()
+      .mockResolvedValue({ isRunning: false, processError: null })
+    window.electronAPI.checkContainerEngine = vi
+      .fn()
+      .mockResolvedValue({ available: true })
+  })
+
+  it('renders collapsed by default with show details toggle', () => {
+    const error = new Error('Something broke')
+
+    renderWithProviders(<TechnicalDetails error={error} />)
+
+    expect(screen.getByRole('button', { name: /show details/i })).toBeVisible()
+    expect(screen.queryByText(/Something broke/)).not.toBeInTheDocument()
+  })
+
+  it('shows error name and message when expanded', async () => {
+    const user = userEvent.setup()
+    const error = new TypeError('Cannot read property x')
+
+    renderWithProviders(<TechnicalDetails error={error} />)
+
+    await user.click(screen.getByRole('button', { name: /show details/i }))
+
+    expect(screen.getByText('TypeError: Cannot read property x')).toBeVisible()
+  })
+
+  it('shows metadata and stack trace when expanded', async () => {
+    const user = userEvent.setup()
+    const error = new Error('Stack test')
+    error.stack = 'Error: Stack test\n    at Component (file.tsx:42:5)'
+
+    renderWithProviders(<TechnicalDetails error={error} />)
+
+    await user.click(screen.getByRole('button', { name: /show details/i }))
+
+    expect(screen.getByText(/at Component \(file\.tsx:42:5\)/)).toBeVisible()
+    expect(screen.getByRole('button', { name: /hide details/i })).toBeVisible()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Desktop: 0\.34\.0/)).toBeVisible()
+    })
+    expect(screen.getByText(/CLI: 0\.8\.0/)).toBeVisible()
+    expect(screen.getByText(/Platform: darwin/)).toBeVisible()
+    expect(screen.getByText(/ToolHive: no/)).toBeVisible()
+    expect(screen.getByText(/Engine: available/)).toBeVisible()
+  })
+
+  it('copies full crash report to clipboard', async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    })
+
+    const error = new Error('Crash error')
+    error.stack = 'Error: Crash error\n    at Component (file.tsx:42:5)'
+
+    renderWithProviders(<TechnicalDetails error={error} />)
+
+    await user.click(screen.getByRole('button', { name: /show details/i }))
+    await user.click(screen.getByRole('button', { name: /copy error report/i }))
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    const reportText = writeText.mock.calls[0]?.[0] as string
+    expect(reportText).toContain('ToolHive Crash Report')
+    expect(reportText).toContain('Error: Crash error')
+    expect(reportText).toContain('Desktop Version:')
+    expect(reportText).toContain('CLI Version:')
+    expect(reportText).toContain('Platform:')
+    expect(reportText).toContain('ToolHive Running:')
+    expect(reportText).toContain('Container Engine:')
+    expect(reportText).toContain('Stack Trace:')
+    expect(reportText).toContain('at Component (file.tsx:42:5)')
+  })
+
+  it('shows copied feedback after clicking copy', async () => {
+    const user = userEvent.setup()
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    })
+
+    const error = new Error('Test error')
+
+    renderWithProviders(<TechnicalDetails error={error} />)
+
+    await user.click(screen.getByRole('button', { name: /show details/i }))
+    await user.click(screen.getByRole('button', { name: /copy error report/i }))
+
+    expect(screen.getByRole('button', { name: /copied/i })).toBeVisible()
+  })
+
+  it('handles missing stack trace gracefully', async () => {
+    const user = userEvent.setup()
+    const error = new Error('No stack')
+    error.stack = undefined
+
+    const { container } = renderWithProviders(
+      <TechnicalDetails error={error} />
+    )
+
+    await user.click(screen.getByRole('button', { name: /show details/i }))
+
+    expect(screen.getByText(/No stack/)).toBeVisible()
+    expect(container.querySelector('code')).not.toBeInTheDocument()
+  })
+})

--- a/renderer/src/common/components/error/base-error-screen.tsx
+++ b/renderer/src/common/components/error/base-error-screen.tsx
@@ -42,7 +42,7 @@ export function BaseErrorScreen({
           justify-center px-8"
       >
         <Card
-          className="mt-10 flex max-h-[min(600px,_100%)] w-full max-w-md
+          className="mt-10 flex max-h-[min(600px,_100%)] w-full max-w-lg
             flex-col"
         >
           <CardHeader className="text-center">

--- a/renderer/src/common/components/error/generic-error.tsx
+++ b/renderer/src/common/components/error/generic-error.tsx
@@ -1,8 +1,13 @@
 import { AlertCircle } from 'lucide-react'
 import { LinkErrorDiscord } from '../workloads/link-error-discord'
 import { BaseErrorScreen } from './base-error-screen'
+import { TechnicalDetails } from './technical-details'
 
-export function GenericError() {
+interface GenericErrorProps {
+  error?: Error
+}
+
+export function GenericError({ error }: GenericErrorProps) {
   return (
     <BaseErrorScreen
       title="Oops, something went wrong"
@@ -15,6 +20,11 @@ export function GenericError() {
       <p>
         If issues persist, contact the ToolHive team via <LinkErrorDiscord />
       </p>
+      {error && (
+        <div className="-mt-2 pb-4">
+          <TechnicalDetails error={error} />
+        </div>
+      )}
     </BaseErrorScreen>
   )
 }

--- a/renderer/src/common/components/error/index.tsx
+++ b/renderer/src/common/components/error/index.tsx
@@ -29,5 +29,5 @@ export function Error({ error }: ErrorProps = {}) {
     return <ConnectionRefusedError />
   }
 
-  return <GenericError />
+  return <GenericError error={error} />
 }

--- a/renderer/src/common/components/error/technical-details.tsx
+++ b/renderer/src/common/components/error/technical-details.tsx
@@ -1,0 +1,165 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useAppVersion } from '@/common/hooks/use-app-version'
+import { Button } from '../ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../ui/collapsible'
+import { ChevronRight, Copy, Check } from 'lucide-react'
+import {
+  buildCrashReport,
+  METADATA_FIELDS,
+  type EnvironmentInfo,
+} from './utils'
+
+const COPY_FEEDBACK_MS = 2000
+
+interface CopyButtonProps {
+  getText: () => string
+}
+
+function CopyButton({ getText }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(getText())
+      setCopied(true)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+    } catch {
+      // clipboard not available
+    }
+  }, [getText])
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleCopy}
+      className="text-muted-foreground hover:text-foreground size-7 shrink-0"
+      aria-label={copied ? 'Copied' : 'Copy error report'}
+      title={copied ? 'Copied!' : 'Copy error report'}
+    >
+      {copied ? (
+        <Check className="size-3.5 text-green-600" />
+      ) : (
+        <Copy className="size-3.5" />
+      )}
+    </Button>
+  )
+}
+
+function useEnvironmentInfo(enabled: boolean): EnvironmentInfo {
+  const { data: appVersion } = useAppVersion()
+
+  const { data: diagnostics } = useQuery({
+    queryKey: ['error-diagnostics'],
+    queryFn: async () => {
+      const [thvStatus, engine] = await Promise.allSettled([
+        window.electronAPI.getToolhiveStatus(),
+        window.electronAPI.checkContainerEngine(),
+      ])
+      return {
+        toolhiveRunning:
+          thvStatus.status === 'fulfilled'
+            ? thvStatus.value.isRunning
+              ? 'yes'
+              : 'no'
+            : 'N/A',
+        containerEngine:
+          engine.status === 'fulfilled'
+            ? engine.value.available
+              ? 'available'
+              : 'unavailable'
+            : 'N/A',
+      }
+    },
+    retry: false,
+    enabled,
+  })
+
+  return {
+    desktopVersion: appVersion?.currentVersion ?? 'N/A',
+    cliVersion: appVersion?.toolhiveVersion ?? 'N/A',
+    platform: window.electronAPI?.platform ?? navigator.platform,
+    userAgent: navigator.userAgent,
+    toolhiveRunning: diagnostics?.toolhiveRunning ?? 'N/A',
+    containerEngine: diagnostics?.containerEngine ?? 'N/A',
+  }
+}
+
+interface TechnicalDetailsProps {
+  error: Error
+}
+
+export function TechnicalDetails({ error }: TechnicalDetailsProps) {
+  const [open, setOpen] = useState(false)
+  const env = useEnvironmentInfo(open)
+
+  const getCrashReport = useCallback(
+    () => buildCrashReport(error, env),
+    [error, env]
+  )
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground -ml-2 gap-1
+            text-xs"
+        >
+          <ChevronRight
+            className={`size-3 transition-transform ${open ? 'rotate-90' : ''}`}
+          />
+          {open ? 'Hide' : 'Show'} details
+        </Button>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <div className="bg-muted mt-2 space-y-3 rounded-md p-3">
+          <div className="flex items-center gap-2">
+            <p
+              className="text-muted-foreground min-w-0 flex-1 text-sm break-all"
+            >
+              {error.toString()}
+            </p>
+            <CopyButton getText={getCrashReport} />
+          </div>
+
+          <div className="flex flex-wrap gap-1.5">
+            {METADATA_FIELDS.map(({ label, key }) => (
+              <span
+                key={key}
+                className="bg-background text-muted-foreground rounded-full
+                  border px-2 py-0.5 text-[11px]"
+              >
+                {label}: {env[key]}
+              </span>
+            ))}
+          </div>
+
+          {error.stack && (
+            <pre
+              className="bg-background overflow-x-auto rounded-md border p-2
+                font-mono text-[11px] leading-relaxed"
+            >
+              <code>{error.stack}</code>
+            </pre>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/renderer/src/common/components/error/utils.ts
+++ b/renderer/src/common/components/error/utils.ts
@@ -1,3 +1,43 @@
+export interface EnvironmentInfo {
+  desktopVersion: string
+  cliVersion: string
+  platform: string
+  userAgent: string
+  toolhiveRunning: string
+  containerEngine: string
+}
+
+export const METADATA_FIELDS: {
+  label: string
+  key: keyof EnvironmentInfo
+}[] = [
+  { label: 'Desktop', key: 'desktopVersion' },
+  { label: 'CLI', key: 'cliVersion' },
+  { label: 'Platform', key: 'platform' },
+  { label: 'ToolHive', key: 'toolhiveRunning' },
+  { label: 'Engine', key: 'containerEngine' },
+]
+
+export function buildCrashReport(error: Error, env: EnvironmentInfo): string {
+  const timestamp = new Date().toISOString()
+  return [
+    'ToolHive Crash Report',
+    '=====================',
+    `Timestamp: ${timestamp}`,
+    `Desktop Version: ${env.desktopVersion}`,
+    `CLI Version: ${env.cliVersion}`,
+    `Platform: ${env.platform}`,
+    `ToolHive Running: ${env.toolhiveRunning}`,
+    `Container Engine: ${env.containerEngine}`,
+    `User Agent: ${env.userAgent}`,
+    '',
+    error.toString(),
+    '',
+    'Stack Trace:',
+    error.stack ?? '(no stack trace available)',
+  ].join('\n')
+}
+
 // Helper function to ensure minimum display time
 export async function withMinimumDelay<T>(
   action: () => Promise<T>,


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/8975c755-fa3f-40d8-9c74-291cba24a4c4


- Enhance the GenericError screen with a collapsible "Show details" section that surfaces the error message, stack trace, and environment metadata (desktop/CLI versions, platform, ToolHive running status, container engine status)
- Add a one-click copy button that copies a formatted crash report to clipboard for easy pasting into GitHub issues or Slack
- Widen the error card from `max-w-md` to `max-w-lg` to accommodate technical details

## Changes
| File | Change |
|------|--------|
| `error/technical-details.tsx` | New component: collapsible details with error message, metadata badges, stack trace, and copy-to-clipboard |
| `error/generic-error.tsx` | Accept `error` prop and render `<TechnicalDetails>` |
| `error/index.tsx` | Pass `error` through to `<GenericError>` |
| `error/base-error-screen.tsx` | Widen card from `max-w-md` to `max-w-lg` |
| `error/__tests__/technical-details.test.tsx` | 5 unit tests covering collapsed/expanded states, clipboard copy, metadata, and graceful fallback |

## How it works
- **Default view**: "Oops, something went wrong" + "Show details" toggle — non-technical users are not overwhelmed
- **Expanded view**: error message with copy icon, environment metadata as badges (Desktop, CLI, Platform, ToolHive status, Engine status), full stack trace
- **Copy button**: copies a full crash report (timestamp, versions, platform, ToolHive/engine status, user agent, error message, stack trace) — users can paste it directly into a bug report

Closes #2210

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] 23 unit tests pass (5 new + 18 existing unchanged)
- [x] Manually verified in Electron dev build: error message displays, details expand/collapse, copy produces formatted report

🤖 Generated with [Claude Code](https://claude.com/claude-code)