### PR TITLE
fix(playground): avoid renderer freeze on large MCP tool results

### DIFF
--- a/renderer/src/features/chat/components/chat-message/__tests__/tool-output-content.test.tsx
+++ b/renderer/src/features/chat/components/chat-message/__tests__/tool-output-content.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { ToolOutputContent } from '../tool-output-content'
 
@@ -9,7 +9,6 @@ vi.mock('streamdown', () => ({
   ),
 }))
 vi.mock('@streamdown/code', () => ({ code: {} }))
-vi.mock('@streamdown/mermaid', () => ({ mermaid: {} }))
 vi.mock('@streamdown/cjk', () => ({ cjk: {} }))
 
 describe('ToolOutputContent', () => {
@@ -86,14 +85,134 @@ describe('ToolOutputContent', () => {
       expect(screen.getByText(/Type: audio/)).toBeInTheDocument()
       expect(screen.getByText(/"data": "ZZZZ"/)).toBeInTheDocument()
     })
+
+    it('renders JSON-shaped text as a pretty-printed pre, not Streamdown', () => {
+      render(
+        <ToolOutputContent
+          status="ready"
+          output={{
+            content: [
+              {
+                type: 'text',
+                text: '[{"id":1,"title":"PR"}]',
+              },
+            ],
+          }}
+        />
+      )
+      // No Streamdown for JSON content — the markdown engine is bypassed.
+      expect(screen.queryByTestId('streamdown')).not.toBeInTheDocument()
+      // Pretty-printed output is in the DOM.
+      expect(screen.getByText(/"id": 1/)).toBeInTheDocument()
+      expect(screen.getByText(/"title": "PR"/)).toBeInTheDocument()
+      expect(screen.getByText(/^JSON ·/)).toBeInTheDocument()
+    })
+
+    it('treats text-shaped values that only look like JSON as plain text', () => {
+      render(
+        <ToolOutputContent
+          status="ready"
+          output={{
+            content: [
+              {
+                type: 'text',
+                text: '{not really json}',
+              },
+            ],
+          }}
+        />
+      )
+      // Failed parse → renders through Streamdown as before.
+      expect(screen.getByTestId('streamdown')).toHaveTextContent(
+        '{not really json}'
+      )
+    })
+
+    it('renders very large non-JSON text as a raw <pre> with an opt-in markdown toggle', () => {
+      const huge = 'a'.repeat(60_000)
+      render(
+        <ToolOutputContent
+          status="ready"
+          output={{ content: [{ type: 'text', text: huge }] }}
+        />
+      )
+
+      // Streamdown is bypassed by default to avoid the freeze.
+      expect(screen.queryByTestId('streamdown')).not.toBeInTheDocument()
+      expect(screen.getByText(/Plain text · 60,000 chars/)).toBeInTheDocument()
+
+      // Opting in flips to the Streamdown branch.
+      fireEvent.click(
+        screen.getByRole('button', { name: /render as markdown/i })
+      )
+      expect(screen.getByTestId('streamdown')).toBeInTheDocument()
+    })
+
+    it('truncates extremely large payloads in the rendered <pre> and surfaces a notice', () => {
+      const enormous = 'b'.repeat(600_000)
+      const { container } = render(
+        <ToolOutputContent
+          status="ready"
+          output={{ content: [{ type: 'text', text: enormous }] }}
+        />
+      )
+      expect(
+        screen.getByText(/Plain text · 600,000 chars \(truncated\)/)
+      ).toBeInTheDocument()
+
+      // Avoid getByText's full text-node walk: the <pre> contains 600k b's
+      // which makes the matcher do real work. Inspect the <pre> directly.
+      const pre = container.querySelector('pre')
+      expect(pre).not.toBeNull()
+      expect(pre?.textContent).toMatch(/truncated, 100,000 more characters/)
+      expect(pre?.textContent?.length).toBeLessThan(600_000)
+    })
+
+    it('always exposes a Copy button for raw blocks', () => {
+      const writeText = vi.fn()
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      })
+
+      const huge = 'c'.repeat(60_000)
+      render(
+        <ToolOutputContent
+          status="ready"
+          output={{ content: [{ type: 'text', text: huge }] }}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+      expect(writeText).toHaveBeenCalledWith(huge)
+    })
+
+    it('Copy on a JSON block copies the original (un-prettified) text', () => {
+      const writeText = vi.fn()
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      })
+
+      const original = '[{"id":1}]'
+      render(
+        <ToolOutputContent
+          status="ready"
+          output={{ content: [{ type: 'text', text: original }] }}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+      expect(writeText).toHaveBeenCalledWith(original)
+    })
   })
 
   describe('non-MCP outputs', () => {
     it('renders a plain JSON pre-block when `output.content` is missing', () => {
-      render(
+      const { container } = render(
         <ToolOutputContent status="ready" output={{ result: 42, ok: true }} />
       )
-      const pre = screen.getByText(/"result": 42/)
+      const pre = within(container).getByText(/"result": 42/)
       expect(pre.tagName).toBe('PRE')
       expect(pre).toHaveTextContent('"ok": true')
     })

--- a/renderer/src/features/chat/components/chat-message/__tests__/tool-output-content.test.tsx
+++ b/renderer/src/features/chat/components/chat-message/__tests__/tool-output-content.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { ToolOutputContent } from '../tool-output-content'
 
@@ -10,6 +16,15 @@ vi.mock('streamdown', () => ({
 }))
 vi.mock('@streamdown/code', () => ({ code: {} }))
 vi.mock('@streamdown/cjk', () => ({ cjk: {} }))
+
+const mockToastSuccess = vi.fn()
+const mockToastError = vi.fn()
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}))
 
 describe('ToolOutputContent', () => {
   describe('MCP server response shape (output.content array)', () => {
@@ -168,8 +183,8 @@ describe('ToolOutputContent', () => {
       expect(pre?.textContent?.length).toBeLessThan(600_000)
     })
 
-    it('always exposes a Copy button for raw blocks', () => {
-      const writeText = vi.fn()
+    it('always exposes a Copy button for raw blocks', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
       Object.defineProperty(navigator, 'clipboard', {
         value: { writeText },
         configurable: true,
@@ -184,11 +199,11 @@ describe('ToolOutputContent', () => {
       )
 
       fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
-      expect(writeText).toHaveBeenCalledWith(huge)
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith(huge))
     })
 
-    it('Copy on a JSON block copies the original (un-prettified) text', () => {
-      const writeText = vi.fn()
+    it('Copy on a JSON block copies the original (un-prettified) text', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
       Object.defineProperty(navigator, 'clipboard', {
         value: { writeText },
         configurable: true,
@@ -203,7 +218,66 @@ describe('ToolOutputContent', () => {
       )
 
       fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
-      expect(writeText).toHaveBeenCalledWith(original)
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith(original))
+    })
+
+    it('skips JSON parsing while the tool result is streaming', () => {
+      // Streaming partial JSON would fail-parse on every chunk update —
+      // route it through the markdown path until the stream completes.
+      render(
+        <ToolOutputContent
+          status="streaming"
+          output={{
+            content: [{ type: 'text', text: '[{"id":1,"title":"PR"}]' }],
+          }}
+        />
+      )
+
+      // No JSON header — the text goes through Streamdown instead.
+      expect(screen.queryByText(/^JSON ·/)).not.toBeInTheDocument()
+      expect(screen.getByTestId('streamdown')).toHaveTextContent(
+        '[{"id":1,"title":"PR"}]'
+      )
+    })
+
+    it('skips JSON parsing for oversized payloads and renders as raw text', () => {
+      // A 60kB JSON-shaped string: the parse + stringify is itself a freeze
+      // risk, so the JSON branch bails and the raw <pre> renders the source.
+      const big = `[${'"x",'.repeat(15_000)}"x"]`
+      expect(big.length).toBeGreaterThan(50_000)
+      render(
+        <ToolOutputContent
+          status="ready"
+          output={{ content: [{ type: 'text', text: big }] }}
+        />
+      )
+
+      expect(screen.queryByText(/^JSON ·/)).not.toBeInTheDocument()
+      expect(screen.queryByTestId('streamdown')).not.toBeInTheDocument()
+      expect(screen.getByText(/Plain text ·/)).toBeInTheDocument()
+    })
+
+    it('toasts on clipboard failure instead of throwing an unhandled rejection', async () => {
+      mockToastError.mockClear()
+      const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      })
+
+      render(
+        <ToolOutputContent
+          status="ready"
+          output={{ content: [{ type: 'text', text: '[{"id":1}]' }] }}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+      await waitFor(() =>
+        expect(mockToastError).toHaveBeenCalledWith(
+          'Failed to copy to clipboard'
+        )
+      )
     })
   })
 

--- a/renderer/src/features/chat/components/chat-message/tool-output-content.tsx
+++ b/renderer/src/features/chat/components/chat-message/tool-output-content.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo, useState } from 'react'
 import { Streamdown } from 'streamdown'
 import { code } from '@streamdown/code'
 import { cjk } from '@streamdown/cjk'
+import { toast } from 'sonner'
 import type { ChatStatus } from 'ai'
 
 // Module-scope for stable prop identity. Mermaid omitted: heavy runtime,
@@ -20,8 +21,13 @@ interface ToolOutputContentProps {
   status: ChatStatus
 }
 
-// Pretty-print if `text` parses as JSON object/array, else null.
-function tryFormatAsJson(text: string): string | null {
+// Pretty-print if `text` parses as JSON object/array, else null. Bails on
+// streaming (partial JSON would fail-parse on every chunk → O(n²) over the
+// stream) and on oversized payloads (the parse + stringify cost is itself a
+// freeze risk and the raw <pre> branch already handles these correctly).
+function tryFormatAsJson(text: string, isStreaming: boolean): string | null {
+  if (isStreaming) return null
+  if (text.length > RAW_RENDER_THRESHOLD) return null
   const trimmed = text.trimStart()
   const first = trimmed[0]
   if (first !== '{' && first !== '[') return null
@@ -39,7 +45,10 @@ function TextItem({
   text: string
   isStreaming: boolean
 }) {
-  const formattedJson = useMemo(() => tryFormatAsJson(text), [text])
+  const formattedJson = useMemo(
+    () => tryFormatAsJson(text, isStreaming),
+    [text, isStreaming]
+  )
   const [forceMarkdown, setForceMarkdown] = useState(false)
 
   if (formattedJson !== null) {
@@ -95,6 +104,15 @@ function RawBlock({
     ? `${text.slice(0, RAW_RENDER_TRUNCATE_AT)}\n\n… (truncated, ${(text.length - RAW_RENDER_TRUNCATE_AT).toLocaleString()} more characters — use Copy to get the full payload)`
     : text
 
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(copyText)
+      toast.success('Copied to clipboard')
+    } catch {
+      toast.error('Failed to copy to clipboard')
+    }
+  }
+
   return (
     <div className="bg-background rounded border p-2">
       <div
@@ -109,9 +127,7 @@ function RawBlock({
           {action}
           <button
             type="button"
-            onClick={() => {
-              void navigator.clipboard.writeText(copyText)
-            }}
+            onClick={handleCopy}
             className="text-muted-foreground hover:text-foreground text-xs
               underline underline-offset-2"
           >

--- a/renderer/src/features/chat/components/chat-message/tool-output-content.tsx
+++ b/renderer/src/features/chat/components/chat-message/tool-output-content.tsx
@@ -1,17 +1,132 @@
-import { memo } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { Streamdown } from 'streamdown'
 import { code } from '@streamdown/code'
-import { mermaid } from '@streamdown/mermaid'
 import { cjk } from '@streamdown/cjk'
 import type { ChatStatus } from 'ai'
+
+// Module-scope for stable prop identity. Mermaid omitted: heavy runtime,
+// no realistic tool output uses it.
+const TOOL_OUTPUT_PLUGINS = { code, cjk } as const
+
+// Above this, skip Streamdown and render as <pre> to avoid freezing the
+// renderer (large MCP payloads lock the main thread in markdown parsing).
+const RAW_RENDER_THRESHOLD = 50_000
+
+// Hard cap on what we put in the DOM; full payload is still copyable.
+const RAW_RENDER_TRUNCATE_AT = 500_000
 
 interface ToolOutputContentProps {
   output: unknown
   status: ChatStatus
 }
 
+// Pretty-print if `text` parses as JSON object/array, else null.
+function tryFormatAsJson(text: string): string | null {
+  const trimmed = text.trimStart()
+  const first = trimmed[0]
+  if (first !== '{' && first !== '[') return null
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2)
+  } catch {
+    return null
+  }
+}
+
+function TextItem({
+  text,
+  isStreaming,
+}: {
+  text: string
+  isStreaming: boolean
+}) {
+  const formattedJson = useMemo(() => tryFormatAsJson(text), [text])
+  const [forceMarkdown, setForceMarkdown] = useState(false)
+
+  if (formattedJson !== null) {
+    return <RawBlock text={formattedJson} label="JSON" copyText={text} />
+  }
+
+  if (text.length > RAW_RENDER_THRESHOLD && !forceMarkdown) {
+    return (
+      <RawBlock
+        text={text}
+        label="Plain text"
+        copyText={text}
+        action={
+          <button
+            type="button"
+            onClick={() => setForceMarkdown(true)}
+            className="text-muted-foreground hover:text-foreground text-xs
+              underline underline-offset-2"
+          >
+            Render as markdown
+          </button>
+        }
+      />
+    )
+  }
+
+  return (
+    <div className="bg-background rounded border p-2 text-sm">
+      <Streamdown
+        plugins={TOOL_OUTPUT_PLUGINS}
+        isAnimating={isStreaming}
+        className="prose prose-sm max-w-none"
+      >
+        {text}
+      </Streamdown>
+    </div>
+  )
+}
+
+function RawBlock({
+  text,
+  label,
+  copyText,
+  action,
+}: {
+  text: string
+  label: string
+  copyText: string
+  action?: React.ReactNode
+}) {
+  const isTruncated = text.length > RAW_RENDER_TRUNCATE_AT
+  const displayed = isTruncated
+    ? `${text.slice(0, RAW_RENDER_TRUNCATE_AT)}\n\n… (truncated, ${(text.length - RAW_RENDER_TRUNCATE_AT).toLocaleString()} more characters — use Copy to get the full payload)`
+    : text
+
+  return (
+    <div className="bg-background rounded border p-2">
+      <div
+        className="text-muted-foreground mb-1 flex flex-wrap items-center
+          justify-between gap-2 text-xs"
+      >
+        <span>
+          {label} · {text.length.toLocaleString()} chars
+          {isTruncated ? ' (truncated)' : ''}
+        </span>
+        <div className="flex items-center gap-3">
+          {action}
+          <button
+            type="button"
+            onClick={() => {
+              void navigator.clipboard.writeText(copyText)
+            }}
+            className="text-muted-foreground hover:text-foreground text-xs
+              underline underline-offset-2"
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+      <pre className="max-h-96 overflow-auto text-xs whitespace-pre-wrap">
+        {displayed}
+      </pre>
+    </div>
+  )
+}
+
 function ToolOutputContentImpl({ output, status }: ToolOutputContentProps) {
-  // Parse first, render second — JSX in try/catch can't catch render errors.
   let mcpContent: Record<string, unknown>[] | null = null
   try {
     const out = output as Record<string, unknown>
@@ -33,18 +148,11 @@ function ToolOutputContentImpl({ output, status }: ToolOutputContentProps) {
         {mcpContent.map((item, idx) => {
           if (item.type === 'text') {
             return (
-              <div
+              <TextItem
                 key={`text-${idx}`}
-                className="bg-background rounded border p-2 text-sm"
-              >
-                <Streamdown
-                  plugins={{ code, mermaid, cjk }}
-                  isAnimating={status === 'streaming'}
-                  className="prose prose-sm max-w-none"
-                >
-                  {String(item.text || '')}
-                </Streamdown>
-              </div>
+                text={String(item.text || '')}
+                isStreaming={status === 'streaming'}
+              />
             )
           }
           if (item.type === 'image') {


### PR DESCRIPTION
Clicking a tool result from a large MCP payload (e.g. GitHub MCP's `search_pull_requests`) locked the renderer for tens of seconds and tripped Electron's `WebContents#unresponsive`. The cause was `ToolOutputContent` pushing every text item — often hundreds of KB of JSON-stringified PR bodies — through Streamdown + the syntax-highlighter + the mermaid plugin synchronously on the main thread. This PR keeps the markdown experience for normal payloads and short-circuits to a plain `<pre>` for the pathological ones, with an opt-in to fall back to markdown.


<img width="971" height="425" alt="Screenshot 2026-05-12 at 12 47 56" src="https://github.com/user-attachments/assets/507e6ba8-c97a-4e9e-b01a-060bc9db1fa2" />

## What changes

- **Raw render above 50k chars** in [`tool-output-content.tsx`](renderer/src/features/chat/components/chat-message/tool-output-content.tsx). `TextItem` now checks `text.length > RAW_RENDER_THRESHOLD` and renders the payload through a small `RawBlock` component (a `<pre>` with a header showing `<label> · <chars> chars`) instead of mounting Streamdown. A `Render as markdown` button flips a local `forceMarkdown` flag for users who explicitly want the formatted view on a large payload.
- **JSON detection.** Anything that trims to `{` / `[` and survives `JSON.parse` is pretty-printed and rendered through `RawBlock` with a `JSON` label. Failed parses fall through to the normal markdown path, so strings that just happen to start with a brace are unaffected.
- **DOM truncation at 500k chars.** `RawBlock` slices excessively large text and appends a `(truncated, N more characters — use Copy to get the full payload)` notice. The Copy button always writes the **original, untruncated** payload to the clipboard (and on the JSON branch it copies the source text, not the pretty-printed form).
- **Hoisted plugins, dropped mermaid.** `TOOL_OUTPUT_PLUGINS = { code, cjk }` is module-scoped so prop identity is stable across re-renders; the mermaid plugin is removed on this surface — it lazy-loads a heavy runtime and scans every fenced block, which dominates cost for the payloads we render here and is never useful for tool output.
- **`memo` wrapper** around `ToolOutputContent` since props are stable per message.
- **New tests** in [`tool-output-content.test.tsx`](renderer/src/features/chat/components/chat-message/__tests__/tool-output-content.test.tsx): JSON-shaped text bypasses Streamdown, JSON-looking-but-invalid falls through to markdown, >50k text renders as a raw block with the markdown opt-in, >500k text is truncated with a notice, and Copy on both raw and JSON blocks writes the original payload.

## How to validate

1. Open a Playground thread and trigger the GitHub MCP `search_pull_requests` tool (or any tool whose response runs into hundreds of KB). Click the result card → it expands instantly, the renderer stays responsive, and you see a `Plain text · NNN,NNN chars` header above a scrollable `<pre>`. `Render as markdown` re-mounts Streamdown if you want the formatted view.
2. Trigger a tool that returns JSON (most GitHub MCP read tools) → header reads `JSON · NNN,NNN chars`, the body is pretty-printed, and `Copy` writes the original (un-prettified) payload to the clipboard.
3. Trigger a tool that returns a small markdown blob (e.g. a short `fetch` result) → it still renders through Streamdown exactly as before, no header / Copy chrome.
4. Force a >500k payload (e.g. a wide `list_pull_requests` page) → the rendered `<pre>` is capped, the header reads `(truncated)`, and the Copy button still yields the full text.
5. `pnpm run type-check`, `pnpm run lint`, and `pnpm run test:nonInteractive run renderer/src/features/chat/components/chat-message/__tests__/tool-output-content.test.tsx` all pass locally (133/133 in the affected suite).

## Out of scope

- No change to how MCP tool results are fetched, persisted, or streamed — the fix is purely on the render path inside `ToolOutputContent`.
- Mermaid rendering elsewhere in the chat (assistant text, reasoning blocks) is untouched; the plugin is only dropped on the tool-output surface.
- Virtualization of the rendered `<pre>` is intentionally not done — for our cap of 500k chars a single `<pre>` with `overflow: auto` is well within what the browser handles smoothly, and avoids invalidating any text-search / select-all interactions inside the block.