### PR TITLE
feat(registry): surface legacy registry format with targeted UI

### DIFF
--- a/renderer/src/common/components/error/__tests__/registry-error.test.tsx
+++ b/renderer/src/common/components/error/__tests__/registry-error.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { RegistryError } from '../registry-error'
 import {
   REGISTRY_AUTH_REQUIRED_UI_MESSAGE,
+  REGISTRY_LEGACY_FORMAT_UI_MESSAGE,
   REGISTRY_UNAVAILABLE_UI_MESSAGE,
 } from '../../settings/registry/registry-errors-message'
 import { createTestRouter } from '@/common/test/create-test-router'
@@ -85,6 +86,45 @@ describe('RegistryError', () => {
         screen.queryByText(/something went wrong while loading the registry/i)
       ).not.toBeInTheDocument()
       expect(screen.queryByText('Discord')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('registry_legacy_format error', () => {
+    const legacyError = {
+      code: 'registry_legacy_format',
+      message:
+        'registry at https://example.com/registry.json: registry file appears to be in the legacy ToolHive format; run `thv registry convert --in <path> --in-place` to migrate to the upstream MCP format',
+    }
+
+    it('shows unsupported format title and user-friendly message', async () => {
+      renderRegistryError(legacyError)
+
+      await waitFor(() => {
+        expect(screen.getByText('Unsupported registry format')).toBeVisible()
+      })
+      expect(screen.getByText(REGISTRY_LEGACY_FORMAT_UI_MESSAGE)).toBeVisible()
+    })
+
+    it('renders Resolve issues button', async () => {
+      renderRegistryError(legacyError)
+
+      await waitFor(() => {
+        expect(screen.getByText('Unsupported registry format')).toBeVisible()
+      })
+      expect(screen.getByText('Resolve issues')).toBeVisible()
+    })
+
+    it('does not leak the raw CLI migration hint into the visible UI', async () => {
+      renderRegistryError(legacyError)
+
+      await waitFor(() => {
+        expect(screen.getByText('Unsupported registry format')).toBeVisible()
+      })
+      // The raw API message contains a CLI command — desktop users should not
+      // see it. The UI copy must come from REGISTRY_LEGACY_FORMAT_UI_MESSAGE.
+      expect(screen.queryByText(/thv registry convert/)).not.toBeInTheDocument()
+      expect(screen.queryByText('Authentication error')).not.toBeInTheDocument()
+      expect(screen.queryByText('Registry unavailable')).not.toBeInTheDocument()
     })
   })
 

--- a/renderer/src/common/components/error/registry-error.tsx
+++ b/renderer/src/common/components/error/registry-error.tsx
@@ -4,8 +4,10 @@ import { EmptyState } from '../empty-state'
 import { Link } from '@tanstack/react-router'
 import {
   isRegistryAuthRequiredError,
+  isRegistryLegacyFormatError,
   isRegistryUnavailableError,
   REGISTRY_AUTH_REQUIRED_UI_MESSAGE,
+  REGISTRY_LEGACY_FORMAT_UI_MESSAGE,
   REGISTRY_UNAVAILABLE_UI_MESSAGE,
 } from '../settings/registry/registry-errors-message'
 import { IllustrationLock } from '../illustrations/illustration-lock'
@@ -14,6 +16,7 @@ import { IllustrationError } from '../illustrations/illustration-error'
 export function RegistryError({ error }: { error: unknown }) {
   const isAuthRequired = isRegistryAuthRequiredError(error)
   const isUnavailable = isRegistryUnavailableError(error)
+  const isLegacyFormat = isRegistryLegacyFormatError(error)
 
   const registrySettingsButton = (
     <Button asChild variant="secondary" className="mt-6 rounded-full" size="lg">
@@ -45,6 +48,14 @@ export function RegistryError({ error }: { error: unknown }) {
           illustration={IllustrationError}
           title="Registry unavailable"
           body={REGISTRY_UNAVAILABLE_UI_MESSAGE}
+        >
+          {registrySettingsButton}
+        </EmptyState>
+      ) : isLegacyFormat ? (
+        <EmptyState
+          illustration={IllustrationError}
+          title="Unsupported registry format"
+          body={REGISTRY_LEGACY_FORMAT_UI_MESSAGE}
         >
           {registrySettingsButton}
         </EmptyState>

--- a/renderer/src/common/components/settings/registry/registry-errors-message.ts
+++ b/renderer/src/common/components/settings/registry/registry-errors-message.ts
@@ -101,7 +101,7 @@ export function getRegistryUnavailableUrl(error: unknown): string | undefined {
 
 /** Shown in the registry error page when the source serves legacy ToolHive JSON. */
 export const REGISTRY_LEGACY_FORMAT_UI_MESSAGE =
-  'The configured registry is using an outdated format that is no longer supported. Please update the registry source to use the upstream MCP format, or reset to the default registry.'
+  'The configured registry is using an outdated format that is no longer supported. Update the registry source or reset to the default registry to continue.'
 
 /**
  * Message under the registry source field when GET /api/v1beta/registry failed.

--- a/renderer/src/common/components/settings/registry/registry-errors-message.ts
+++ b/renderer/src/common/components/settings/registry/registry-errors-message.ts
@@ -19,6 +19,7 @@ export const REGISTRY_AUTH_TOAST_ID = 'registry-auth-required'
 
 const REGISTRY_AUTH_REQUIRED_CODE = 'registry_auth_required'
 const REGISTRY_UNAVAILABLE_CODE = 'registry_unavailable'
+const REGISTRY_LEGACY_FORMAT_CODE = 'registry_legacy_format'
 
 /** Shown when GET /api/v1beta/registry fails with `code: registry_auth_required` (Registry Server API + OAuth). */
 export const REGISTRY_AUTH_REQUIRED_UI_MESSAGE =
@@ -32,6 +33,10 @@ export const REGISTRY_AUTH_REQUIRED_TOAST_MESSAGE =
 export const REGISTRY_UNAVAILABLE_TOAST_MESSAGE =
   'The configured registry is unreachable. The app will not work correctly until the registry URL is fixed or reset to default.'
 
+/** Persistent toast shown when the app detects the registry serves data in the legacy ToolHive format. */
+export const REGISTRY_LEGACY_FORMAT_TOAST_MESSAGE =
+  'The configured registry is using an outdated format that is no longer supported. The app will not work correctly until the registry is updated or reset to default.'
+
 /** Returns the appropriate toast message for a registry config error. */
 export function getRegistryErrorToastMessage(
   error: unknown
@@ -40,6 +45,8 @@ export function getRegistryErrorToastMessage(
     return REGISTRY_AUTH_REQUIRED_TOAST_MESSAGE
   if (isRegistryUnavailableError(error))
     return REGISTRY_UNAVAILABLE_TOAST_MESSAGE
+  if (isRegistryLegacyFormatError(error))
+    return REGISTRY_LEGACY_FORMAT_TOAST_MESSAGE
   return undefined
 }
 
@@ -58,6 +65,10 @@ export function isRegistryAuthRequiredError(error: unknown): boolean {
 
 export function isRegistryUnavailableError(error: unknown): boolean {
   return getErrorField(error, 'code') === REGISTRY_UNAVAILABLE_CODE
+}
+
+export function isRegistryLegacyFormatError(error: unknown): boolean {
+  return getErrorField(error, 'code') === REGISTRY_LEGACY_FORMAT_CODE
 }
 
 /**
@@ -87,6 +98,10 @@ export function getRegistryUnavailableUrl(error: unknown): string | undefined {
   const match = raw.match(/upstream registry at (\S+) is unavailable/)
   return match?.[1]
 }
+
+/** Shown in the registry error page when the source serves legacy ToolHive JSON. */
+export const REGISTRY_LEGACY_FORMAT_UI_MESSAGE =
+  'The configured registry is using an outdated format that is no longer supported. Please update the registry source to use the upstream MCP format, or reset to the default registry.'
 
 /**
  * Message under the registry source field when GET /api/v1beta/registry failed.

--- a/renderer/src/routes/root/guards/__tests__/handle-registry-auth-redirect.test.ts
+++ b/renderer/src/routes/root/guards/__tests__/handle-registry-auth-redirect.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@common/types/toolhive-status'
 import {
   REGISTRY_AUTH_REQUIRED_TOAST_MESSAGE,
+  REGISTRY_LEGACY_FORMAT_TOAST_MESSAGE,
   REGISTRY_UNAVAILABLE_TOAST_MESSAGE,
 } from '@/common/components/settings/registry/registry-errors-message'
 
@@ -142,6 +143,22 @@ describe('handleRegistryAuthRedirect', () => {
 
       expect(queryClient.getQueryData(REGISTRY_PENDING_TOAST_KEY)).toBe(
         REGISTRY_UNAVAILABLE_TOAST_MESSAGE
+      )
+    })
+
+    it('redirects when GET /registry returns registry_legacy_format', async () => {
+      mockGetRegistry.mockRejectedValue({
+        code: 'registry_legacy_format',
+        message:
+          'registry at https://example.com/registry.json: registry file appears to be in the legacy ToolHive format',
+      })
+
+      await expect(
+        handleRegistryAuthRedirect(queryClient, '/')
+      ).rejects.toMatchObject(REDIRECT_MATCH)
+
+      expect(queryClient.getQueryData(REGISTRY_PENDING_TOAST_KEY)).toBe(
+        REGISTRY_LEGACY_FORMAT_TOAST_MESSAGE
       )
     })
 


### PR DESCRIPTION
## Summary
<img width="1257" height="801" alt="Screenshot 2026-05-12 at 14 12 52" src="https://github.com/user-attachments/assets/cde2d57c-3f65-4c63-b1d9-6a6babed0ffa" />

When the configured custom registry serves data in the legacy ToolHive format, today the user sees the generic "Oops, something went wrong" error boundary even though the backend (stacklok/toolhive#5260) returns a structured `HTTP 502 Bad Gateway` with `code: "registry_legacy_format"`. This PR wires the renderer to that contract so the user is redirected to Settings > Registry with a clear toast, just like the existing `registry_auth_required` / `registry_unavailable` flows.

Closes #2228
Depends on stacklok/toolhive#5260

## Why this matters

Real-world report (#user-chat, May 12, 2026): after upgrading Studio to 0.34, the app failed to start because the previously-saved custom registry URL was returning legacy JSON. Recovery required CLI debugging and `thv config unset-registry`. The actionable hint is already in the API response — the renderer just needed to read it.

## Changes

- `registry-errors-message.ts` — new `REGISTRY_LEGACY_FORMAT_CODE` constant, `isRegistryLegacyFormatError` detector, `REGISTRY_LEGACY_FORMAT_UI_MESSAGE` + `REGISTRY_LEGACY_FORMAT_TOAST_MESSAGE` (no raw `thv registry convert` hint — desktop users should not see CLI commands), and an extension of `getRegistryErrorToastMessage` so the root `beforeLoad` guard already redirects to Settings on this code.
- `registry-error.tsx` — third empty-state branch ("Unsupported registry format") for users who navigate directly to `/registry` while the source is misconfigured.
- `__tests__/registry-error.test.tsx` — three new cases covering the legacy-format branch, including an explicit assertion that the raw CLI hint never reaches the visible UI.
- `__tests__/handle-registry-auth-redirect.test.ts` — verifies the guard redirects to `/settings?tab=registry` with the legacy-format toast when the API returns the new code.

## Test plan

- [x] `pnpm run test:nonInteractive` on the touched files — 23 tests pass
- [x] `pnpm run type-check` clean
- [x] `pnpm run lint` clean
- [ ] Manual E2E against a backend serving legacy JSON: registry GET returns 502 + `code: registry_legacy_format` → Studio redirects to Settings > Registry with the toast, no error boundary

### Reproducing locally

A backend in the failing state is needed. Until stacklok/toolhive#5260 merges:

\`\`\`bash
# Build backend from PR branch
cd <toolhive-checkout> && git checkout issues/5259
go build -o /tmp/thv-fix ./cmd/thv

# Isolate config and point to a legacy JSON file
mkdir -p /tmp/thv-fix-test/toolhive
cat > /tmp/legacy-registry.json <<'JSON'
{"version":"1.0.0","servers":{"demo":{"image":"demo:latest","tier":"Community","transport":"stdio"}}}
JSON
cat > /tmp/thv-fix-test/toolhive/config.yaml <<'YAML'
secrets: { provider_type: "", setup_completed: false }
clients: { registered_clients: [] }
local_registry_path: /tmp/legacy-registry.json
YAML

# Run backend
XDG_CONFIG_HOME=/tmp/thv-fix-test TOOLHIVE_SKIP_DESKTOP_CHECK=1 /tmp/thv-fix serve --port 8181

# Run Studio dev from this worktree, attached to the backend
THV_PORT=8181 pnpm run start
\`\`\`

To restore once verified:
\`\`\`bash
curl -s -X PUT http://localhost:8181/api/v1beta/registry/default -H 'Content-Type: application/json' -d '{}'
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)