### PR TITLE
fix(playground): re-hydrate chat thread after stream-recovery refetch

### DIFF
--- a/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -761,5 +761,75 @@ describe('useChatStreaming', () => {
         expect(mockUseChat.setMessages).toHaveBeenCalledWith(snapshotMessages)
       })
     })
+
+    it('re-hydrates with the finalized snapshot when the stream finishes between peek and resume', async () => {
+      // Pre-recovery state: snapshot has a stale trailing assistant that
+      // the hook will drop on the assumption a replay is coming.
+      const finalAssistant: ChatUIMessage = {
+        id: 'a1-final',
+        role: 'assistant',
+        parts: [{ type: 'text' as const, text: 'Complete answer' }],
+      }
+      const finalizedMessages: ChatUIMessage[] = [
+        snapshotMessages[0]!,
+        finalAssistant,
+      ]
+
+      // The query refetches on invalidation; serve the stale snapshot
+      // first, then the finalized one.
+      mockChatAPI.getThread
+        .mockResolvedValueOnce({
+          id: 'toolhive-chat',
+          messages: snapshotMessages,
+          lastEditTimestamp: 0,
+          createdAt: 0,
+        })
+        .mockResolvedValue({
+          id: 'toolhive-chat',
+          messages: finalizedMessages,
+          lastEditTimestamp: 1,
+          createdAt: 0,
+        })
+      mockChatAPI.getThreadMessagesForTransport
+        .mockResolvedValueOnce(snapshotMessages)
+        .mockResolvedValue(finalizedMessages)
+
+      // First peek: a stream looks live, so the trailing assistant is
+      // dropped. Second peek (post-resume): the stream finished while we
+      // were resuming, so the hook must invalidate + re-hydrate.
+      mockChatAPI.getActiveStreamId
+        .mockResolvedValueOnce('stream-A')
+        .mockResolvedValueOnce(null)
+
+      mockUseChat.resumeStream.mockResolvedValue(undefined)
+
+      const { Wrapper } = createTestUtils()
+      renderHook(() => useChatStreaming(), { wrapper: Wrapper })
+
+      // First pass: trimmed list (stale assistant dropped because the
+      // initial peek said a stream was live).
+      await waitFor(() => {
+        expect(mockUseChat.setMessages).toHaveBeenCalledWith([
+          snapshotMessages[0],
+        ])
+      })
+
+      // Recovery pass: ref must be cleared so the effect re-runs on the
+      // refetched data and seeds the full finalized list. Without the
+      // fix, this assertion would time out and the UI would be stuck
+      // missing the final assistant turn until reload.
+      await waitFor(() => {
+        expect(mockUseChat.setMessages).toHaveBeenCalledWith(finalizedMessages)
+      })
+
+      // Sanity: the initial peek + the post-resume re-peek both fired
+      // (the second hydration pass adds one more peek on the refetched
+      // data, so >= 2 covers both the pre-recovery and post-recovery
+      // peeks reliably).
+      expect(
+        mockChatAPI.getActiveStreamId.mock.calls.length
+      ).toBeGreaterThanOrEqual(2)
+      expect(mockUseChat.resumeStream).toHaveBeenCalled()
+    })
   })
 })

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -142,6 +142,12 @@ export function useChatStreaming(externalThreadId?: string | null) {
           stillActive = null
         }
         if (!stillActive) {
+          // Allow re-hydration when the refetch lands — we trimmed the
+          // trailing assistant assuming a live replay, but the stream is
+          // gone. Without clearing the ref, the guard at the top of this
+          // effect would skip the next run and the UI would stay missing
+          // the final assistant turn until reload.
+          hydratedThreadRef.current = null
           try {
             void queryClient.invalidateQueries({
               queryKey: chatThreadQueryOptions(threadIdAtResume).queryKey,


### PR DESCRIPTION
Returning to a playground chat thread shortly after the last stream finished sometimes left the UI **missing the final assistant turn** until a full reload. The bug was a latent recovery-path race in the renderer-side hydration effect — the recovery code already detected the situation and asked for a refetch, but a sibling ref-guard then silently dropped the recovery on the floor. This PR is a one-line semantic fix plus a regression test.

## Root cause

[`useChatStreaming`'s hydration effect](renderer/src/features/chat/hooks/use-chat-streaming.ts) (lines 94-155 before this PR) gates re-runs through a `hydratedThreadRef`:

```ts
if (hydratedThreadRef.current === currentThreadId) return    // (A) guard
hydratedThreadRef.current = currentThreadId
...
let activeStreamId = await window.electronAPI.chat.getActiveStreamId(threadIdAtResume)
const messagesToSet = activeStreamId
  ? dropTrailingAssistant(threadData.messages)               // (B) drop the trailing assistant
  : threadData.messages
setMessages(messagesToSet)

await resumeStream()
...
if (activeStreamId) {
  const stillActive = await window.electronAPI.chat.getActiveStreamId(threadIdAtResume)
  if (!stillActive) {
    queryClient.invalidateQueries({ queryKey: chatThreadQueryOptions(threadIdAtResume).queryKey })  // (C) recovery
  }
}
```

The race when re-entering a thread whose stream *just* finished:

1. (B) `getActiveStreamId` returns the stale registry id → trailing assistant is dropped under the assumption a live replay will rebuild it.
2. `resumeStream()` attaches but no chunks arrive — the stream is already done.
3. (C) Post-resume re-peek sees the registry empty → `invalidateQueries` fires.
4. The query refetches the finalized snapshot from SQLite. `threadData` updates → the effect re-runs.
5. **Guard (A) returns early** because `hydratedThreadRef.current === currentThreadId`. `setMessages` is never called with the fresh data.
6. UI is stuck with `threadData.messages.slice(0, -1)` — the trailing assistant is gone until reload.

The ref-guard is intentional protection against later live-streaming refetches clobbering in-flight state — but it also blocks the recovery refetch that the same effect just kicked off.

## Changes

- **[`renderer/src/features/chat/hooks/use-chat-streaming.ts`](renderer/src/features/chat/hooks/use-chat-streaming.ts)** — inside the `if (!stillActive)` branch, reset `hydratedThreadRef.current = null` **before** invalidating the query. The next effect run is then allowed to re-hydrate from the freshly-refetched snapshot. Inline comment explains the recovery path so the next reader doesn't accidentally re-introduce the guard.
- **[`renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts`](renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts)** — new regression test: mocks `getActiveStreamId` to return `'stream-A'` on the first peek and `null` on the post-resume peek, and flips `getThread` / `getThreadMessagesForTransport` from a stale `[user, assistant]` snapshot to the finalized `[user, assistant_final]`. Asserts that `setMessages` ends up called with the finalized list. Without the fix this assertion times out.

## How to validate

1. **Repro the bug pre-fix**: revert the one-line change, then in the playground send a message in thread A, navigate to thread B while A is still streaming, wait ~1s for A to finish, navigate back to A. The trailing assistant message is missing from the UI until reload. With the fix, the message is present.
2. `pnpm run test:nonInteractive run renderer/src/features/chat/hooks` — 271/271 pass locally.
3. `pnpm run type-check` — clean.
4. SQLite sanity check: even pre-fix, `select messages from chat_threads where id = '<A>'` already contains the final assistant turn — confirming this was purely a renderer-side display bug, no data was ever lost.

## Out of scope

- The throttled persistence in [`main/src/chat/active-streams.ts`](main/src/chat/active-streams.ts) (`PERSIST_THROTTLE_MS = 250ms`) can still leave a brief snapshot lag if the user navigates A→B→A within ~250ms of a stream completing. This is a smaller window than the bug fixed here and resolves itself on any subsequent refetch; not addressed in this PR.
- `signalStreamingComplete` (lines 222-241) is bound to the currently selected `useChat` instance, so it doesn't fire for backgrounded threads. The `staleTime: 0` on `chatThreadQueryOptions` masks this for re-entry, and the recovery path fixed here handles the active-stream-id false-positive case. A more comprehensive fix would route stream-completion signals through the main process — out of scope for this PR.