### PR TITLE
fix(deps): pin @electron/node-gyp to npm registry version

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
   "pnpm": {
     "overrides": {
       "@electron/rebuild": "^4.0.4",
+      "@electron/node-gyp": "10.2.0-electron.2",
       "@hono/node-server": ">=1.19.14",
       "@xmldom/xmldom": ">=0.9.10",
       "fast-uri": ">=3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@electron/rebuild': ^4.0.4
+  '@electron/node-gyp': 10.2.0-electron.2
   '@hono/node-server': '>=1.19.14'
   '@xmldom/xmldom': '>=0.9.10'
   fast-uri: '>=3.1.2'


### PR DESCRIPTION
Belt-and-suspenders complement to the @electron/rebuild@^4 override (#2224). Renovate's pnpm install (pnpm 10.31 with blockExoticSubdeps enforced) re-resolves the entire lockfile via --lockfile-only and trips on the git-tarball @electron/node-gyp before the @electron/rebuild parent override kicks in. Pinning the package directly to its identical registry version (10.2.0-electron.2) guarantees the exotic check passes regardless of resolution order. Refs #2224.