### PR TITLE
feat(playground): copy button on chat messages

### DIFF
--- a/renderer/src/common/hooks/__tests__/use-copy-to-clipboard.test.ts
+++ b/renderer/src/common/hooks/__tests__/use-copy-to-clipboard.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCopyToClipboard } from '../use-copy-to-clipboard'
+
+const mockToastSuccess = vi.fn()
+const mockToastError = vi.fn()
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}))
+
+const writeText = vi.fn()
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText },
+  writable: true,
+  configurable: true,
+})
+
+describe('useCopyToClipboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    writeText.mockResolvedValue(undefined)
+  })
+
+  it('writes text to the clipboard and shows the default success toast', async () => {
+    const { result } = renderHook(() => useCopyToClipboard())
+
+    await act(async () => {
+      await result.current.copy('hi')
+    })
+
+    expect(writeText).toHaveBeenCalledWith('hi')
+    expect(mockToastSuccess).toHaveBeenCalledWith('Copied to clipboard')
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+
+  it('shows the default error toast when clipboard write fails', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'))
+    const { result } = renderHook(() => useCopyToClipboard())
+
+    await act(async () => {
+      await result.current.copy('hi')
+    })
+
+    expect(mockToastError).toHaveBeenCalledWith('Failed to copy to clipboard')
+    expect(mockToastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('uses a custom success message when provided', async () => {
+    const { result } = renderHook(() => useCopyToClipboard())
+
+    await act(async () => {
+      await result.current.copy('payload', {
+        successMessage: 'Copied skill name to clipboard',
+      })
+    })
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      'Copied skill name to clipboard'
+    )
+  })
+
+  it('uses a custom error message when provided', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'))
+    const { result } = renderHook(() => useCopyToClipboard())
+
+    await act(async () => {
+      await result.current.copy('payload', {
+        errorMessage: 'Failed to copy skill name',
+      })
+    })
+
+    expect(mockToastError).toHaveBeenCalledWith('Failed to copy skill name')
+  })
+})

--- a/renderer/src/common/hooks/use-copy-to-clipboard.ts
+++ b/renderer/src/common/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+
+interface CopyOptions {
+  successMessage?: string
+  errorMessage?: string
+}
+
+const DEFAULT_SUCCESS_MESSAGE = 'Copied to clipboard'
+const DEFAULT_ERROR_MESSAGE = 'Failed to copy to clipboard'
+
+/**
+ * Hook that wraps `navigator.clipboard.writeText` and surfaces success/failure
+ * via `sonner` toasts. Returns a stable `copy` function so consumers can pass
+ * it into event handlers without re-binding on every render.
+ */
+export function useCopyToClipboard() {
+  const copy = useCallback(
+    async (text: string, opts?: CopyOptions): Promise<void> => {
+      const successMessage = opts?.successMessage ?? DEFAULT_SUCCESS_MESSAGE
+      const errorMessage = opts?.errorMessage ?? DEFAULT_ERROR_MESSAGE
+      try {
+        await navigator.clipboard.writeText(text)
+        toast.success(successMessage)
+      } catch {
+        toast.error(errorMessage)
+      }
+    },
+    []
+  )
+
+  return { copy }
+}

--- a/renderer/src/features/chat/components/chat-message/__tests__/message-actions.test.tsx
+++ b/renderer/src/features/chat/components/chat-message/__tests__/message-actions.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MessageActions } from '../message-actions'
+
+const mockToastSuccess = vi.fn()
+const mockToastError = vi.fn()
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}))
+
+const writeText = vi.fn()
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText },
+  writable: true,
+  configurable: true,
+})
+
+describe('MessageActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    writeText.mockResolvedValue(undefined)
+  })
+
+  it('renders a Copy message button when copyText is non-empty', () => {
+    render(<MessageActions copyText="hello world" />)
+    expect(
+      screen.getByRole('button', { name: 'Copy message' })
+    ).toBeInTheDocument()
+  })
+
+  it('copies the provided text to the clipboard and toasts on click', async () => {
+    render(<MessageActions copyText="hello world" />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy message' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('hello world'))
+    expect(mockToastSuccess).toHaveBeenCalledWith('Copied to clipboard')
+  })
+
+  it('surfaces an error toast when the clipboard write fails', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'))
+    render(<MessageActions copyText="hello world" />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy message' }))
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith('Failed to copy to clipboard')
+    )
+  })
+
+  it('does not render an Edit button in this PR even when onEdit is supplied', () => {
+    render(<MessageActions copyText="hello" onEdit={() => {}} />)
+    // PR 1 is Copy-only; Edit is intentionally deferred.
+    expect(
+      screen.queryByRole('button', { name: /edit/i })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/renderer/src/features/chat/components/chat-message/__tests__/message-actions.test.tsx
+++ b/renderer/src/features/chat/components/chat-message/__tests__/message-actions.test.tsx
@@ -59,4 +59,15 @@ describe('MessageActions', () => {
       screen.queryByRole('button', { name: /edit/i })
     ).not.toBeInTheDocument()
   })
+
+  it('is non-interactive while hidden — pointer-events disabled by default, re-enabled on hover/focus', () => {
+    // The wrapper relies on `pointer-events-none` to prevent accidental
+    // clicks on the invisible button before it's revealed. The reveal
+    // selectors must re-enable interaction.
+    const { container } = render(<MessageActions copyText="hello" />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toMatch(/\bpointer-events-none\b/)
+    expect(wrapper.className).toMatch(/group-hover:pointer-events-auto/)
+    expect(wrapper.className).toMatch(/focus-within:pointer-events-auto/)
+  })
 })

--- a/renderer/src/features/chat/components/chat-message/assistant-message.tsx
+++ b/renderer/src/features/chat/components/chat-message/assistant-message.tsx
@@ -14,6 +14,8 @@ import { ReasoningComponent } from './reasoning-component'
 import { StepStartComponent } from './step-start-component'
 import { ToolCallComponent } from './tool-call-component'
 import { JoinedAssistantText } from './joined-assistant-text'
+import { MessageActions } from './message-actions'
+import { getMessageCopyText } from '../../lib/message-copy-text'
 
 interface AssistantMessageProps {
   message: ChatUIMessage
@@ -29,9 +31,10 @@ export function AssistantMessage({
   const providerIcon =
     message.metadata?.model &&
     getProviderIconByModel(message.metadata.model, message.metadata.providerId)
+  const copyText = getMessageCopyText(message)
 
   return (
-    <div className="flex items-start gap-4">
+    <div className="group flex items-start gap-4">
       <div
         className="bg-card flex h-8 w-8 shrink-0 items-center justify-center
           rounded-lg"
@@ -202,18 +205,21 @@ export function AssistantMessage({
         </div>
 
         <div className="mt-2 flex items-center justify-between">
-          <div className="text-muted-foreground text-xs">
-            {formatDistanceToNow(
-              message.metadata?.createdAt
-                ? new Date(message.metadata.createdAt)
-                : new Date(),
-              { addSuffix: true }
-            )}
-            {message.metadata?.model && (
-              <span className="text-muted-foreground/70 ml-2">
-                • {message.metadata.model}
-              </span>
-            )}
+          <div className="flex items-center gap-2">
+            <div className="text-muted-foreground text-xs">
+              {formatDistanceToNow(
+                message.metadata?.createdAt
+                  ? new Date(message.metadata.createdAt)
+                  : new Date(),
+                { addSuffix: true }
+              )}
+              {message.metadata?.model && (
+                <span className="text-muted-foreground/70 ml-2">
+                  • {message.metadata.model}
+                </span>
+              )}
+            </div>
+            {copyText && <MessageActions copyText={copyText} />}
           </div>
 
           {message.role === 'assistant' && (

--- a/renderer/src/features/chat/components/chat-message/message-actions.tsx
+++ b/renderer/src/features/chat/components/chat-message/message-actions.tsx
@@ -22,8 +22,10 @@ export function MessageActions({ copyText, className }: MessageActionsProps) {
   return (
     <div
       className={cn(
-        'flex items-center gap-1 opacity-0 transition-opacity',
-        'group-hover:opacity-100 focus-within:opacity-100',
+        `pointer-events-none flex items-center gap-1 opacity-0
+        transition-opacity`,
+        'group-hover:pointer-events-auto group-hover:opacity-100',
+        'focus-within:pointer-events-auto focus-within:opacity-100',
         className
       )}
     >

--- a/renderer/src/features/chat/components/chat-message/message-actions.tsx
+++ b/renderer/src/features/chat/components/chat-message/message-actions.tsx
@@ -1,0 +1,44 @@
+import { Copy } from 'lucide-react'
+import { Button } from '@/common/components/ui/button'
+import { cn } from '@/common/lib/utils'
+import { useCopyToClipboard } from '@/common/hooks/use-copy-to-clipboard'
+
+interface MessageActionsProps {
+  copyText: string
+  // Reserved for a future PR (edit/resend). Intentionally NOT rendered yet —
+  // PR 1 is strictly the Copy affordance.
+  onEdit?: () => void
+  className?: string
+}
+
+/**
+ * Hover-revealed action slot for a chat message row. Sits at the bottom of
+ * the row and currently exposes a Copy button only. The parent row must use
+ * a `group` className so the opacity transition reveals on hover.
+ */
+export function MessageActions({ copyText, className }: MessageActionsProps) {
+  const { copy } = useCopyToClipboard()
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-1 opacity-0 transition-opacity',
+        'group-hover:opacity-100 focus-within:opacity-100',
+        className
+      )}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Copy message"
+        onClick={() => {
+          void copy(copyText)
+        }}
+        className="text-muted-foreground hover:text-foreground size-7"
+      >
+        <Copy className="size-3.5" />
+      </Button>
+    </div>
+  )
+}

--- a/renderer/src/features/chat/components/chat-message/tool-output-content.tsx
+++ b/renderer/src/features/chat/components/chat-message/tool-output-content.tsx
@@ -2,8 +2,8 @@ import { memo, useMemo, useState } from 'react'
 import { Streamdown } from 'streamdown'
 import { code } from '@streamdown/code'
 import { cjk } from '@streamdown/cjk'
-import { toast } from 'sonner'
 import type { ChatStatus } from 'ai'
+import { useCopyToClipboard } from '@/common/hooks/use-copy-to-clipboard'
 
 // Module-scope for stable prop identity. Mermaid omitted: heavy runtime,
 // no realistic tool output uses it.
@@ -104,13 +104,9 @@ function RawBlock({
     ? `${text.slice(0, RAW_RENDER_TRUNCATE_AT)}\n\n… (truncated, ${(text.length - RAW_RENDER_TRUNCATE_AT).toLocaleString()} more characters — use Copy to get the full payload)`
     : text
 
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(copyText)
-      toast.success('Copied to clipboard')
-    } catch {
-      toast.error('Failed to copy to clipboard')
-    }
+  const { copy } = useCopyToClipboard()
+  const handleCopy = () => {
+    void copy(copyText)
   }
 
   return (

--- a/renderer/src/features/chat/components/chat-message/user-message.tsx
+++ b/renderer/src/features/chat/components/chat-message/user-message.tsx
@@ -6,6 +6,8 @@ import { mermaid } from '@streamdown/mermaid'
 import { cjk } from '@streamdown/cjk'
 import type { ChatStatus } from 'ai'
 import { AttachmentPreview } from './attachment-preview'
+import { MessageActions } from './message-actions'
+import { getMessageCopyText } from '../../lib/message-copy-text'
 import type { ChatUIMessage } from '../../types'
 
 interface UserMessageProps {
@@ -31,8 +33,10 @@ function UserAttachments({ parts }: { parts: ChatUIMessage['parts'] }) {
 }
 
 export function UserMessage({ message, status }: UserMessageProps) {
+  const copyText = getMessageCopyText(message)
+
   return (
-    <div className="flex justify-end">
+    <div className="group flex justify-end">
       <div className="flex max-w-[80%] items-start gap-3">
         <div className="space-y-2">
           <div
@@ -54,13 +58,16 @@ export function UserMessage({ message, status }: UserMessageProps) {
             <UserAttachments parts={message.parts} />
           </div>
 
-          <div className="text-muted-foreground text-right text-xs">
-            {formatDistanceToNow(
-              message.metadata?.createdAt
-                ? new Date(message.metadata.createdAt)
-                : new Date(),
-              { addSuffix: true }
-            )}
+          <div className="flex items-center justify-end gap-2">
+            {copyText && <MessageActions copyText={copyText} />}
+            <div className="text-muted-foreground text-right text-xs">
+              {formatDistanceToNow(
+                message.metadata?.createdAt
+                  ? new Date(message.metadata.createdAt)
+                  : new Date(),
+                { addSuffix: true }
+              )}
+            </div>
           </div>
         </div>
 

--- a/renderer/src/features/chat/lib/message-copy-text.ts
+++ b/renderer/src/features/chat/lib/message-copy-text.ts
@@ -1,0 +1,15 @@
+import type { ChatUIMessage } from '../types'
+
+/**
+ * Extract the plain-text payload of a chat message for the Copy action.
+ * Joins all `text` parts with blank lines; ignores tool calls, reasoning,
+ * attachments, etc. (tool outputs already have their own copy affordance).
+ * Returns a trimmed string — callers should treat `''` as "nothing to copy".
+ */
+export function getMessageCopyText(message: ChatUIMessage): string {
+  return message.parts
+    .filter((p): p is Extract<typeof p, { type: 'text' }> => p.type === 'text')
+    .map((p) => p.text)
+    .join('\n\n')
+    .trim()
+}


### PR DESCRIPTION
Adds a small Copy affordance to every chat message in the playground. Hover-revealed icon button at the bottom of each row, copying the message's text content (excluding tool outputs and reasoning blocks, which already have their own copy paths). Part 1 of three planned UX enhancements — Edit/resend and Queue-while-streaming follow in separate PRs.

<img width="1287" height="800" alt="Screenshot 2026-05-12 at 16 17 11" src="https://github.com/user-attachments/assets/1bcdcf13-5e2d-4c78-9986-d01ff17c5bc4" />



## What changes

- **New shared hook** [`renderer/src/common/hooks/use-copy-to-clipboard.ts`](renderer/src/common/hooks/use-copy-to-clipboard.ts) — `useCopyToClipboard()` returns `{ copy(text, { successMessage?, errorMessage? }) }`. Wraps `navigator.clipboard.writeText` in `try/catch` and toasts success/failure via sonner. Replaces the two inline implementations that have been growing in the chat feature.
- **New message-actions slot** [`renderer/src/features/chat/components/chat-message/message-actions.tsx`](renderer/src/features/chat/components/chat-message/message-actions.tsx) — small flex row, hover-revealed (`opacity-0` → `group-hover:opacity-100`, plus `focus-within` so keyboard users can discover it). For this PR only the Copy button is rendered; the `onEdit` prop is reserved for the follow-up PR and intentionally not wired up yet.
- **Copy-text extraction** [`renderer/src/features/chat/lib/message-copy-text.ts`](renderer/src/features/chat/lib/message-copy-text.ts) — `getMessageCopyText(message)` walks `message.parts`, keeps only `text` parts, joins with `\n\n`. Excludes tool outputs and reasoning (internal traces aren't what the user is reaching for when they hit Copy on the visible answer).
- **Row wire-up** in [`user-message.tsx`](renderer/src/features/chat/components/chat-message/user-message.tsx) and [`assistant-message.tsx`](renderer/src/features/chat/components/chat-message/assistant-message.tsx) — added `group` to the row, rendered `<MessageActions copyText={…} />` only when `copyText` is non-empty. Placement: bottom-right on user rows (same side as the right-aligned bubble), bottom-left on assistant rows alongside the timestamp/model footer.
- **Refactor** [`tool-output-content.tsx`](renderer/src/features/chat/components/chat-message/tool-output-content.tsx) — drops its inline `handleCopy` (try/catch + sonner) in favor of the new hook. Behavior preserved.

## How to validate

1. Open a playground thread with at least one user message and one assistant response.
2. Hover over a user message → Copy button fades in at the bottom-right. Click → toast `Copied to clipboard`, paste somewhere external shows the message text.
3. Hover over an assistant message that contains text + a tool call → Copy button fades in at the bottom-left. Copying yields only the assistant's text response, not the tool input/output (those have their own per-block Copy inside `tool-output-content`).
4. Tab through the chat with the keyboard → focusing the Copy button keeps it visible (via `focus-within`) so it's discoverable without a mouse.
5. Triggering a tool that produces a large output → confirm the per-tool-output Copy button still works after the refactor (it now routes through the same shared hook).
6. `pnpm run test:nonInteractive run renderer/src/common/hooks renderer/src/features/chat` — 465/465 locally, including 8 new tests (4 for the hook, 4 for `<MessageActions>`).
7. `pnpm run type-check` and `npx eslint` on the touched files — clean.

## Out of scope

- The Edit button in `<MessageActions>` is intentionally not rendered — that's PR 2 (`feat: edit/resend user message`). The `onEdit` prop already exists in the component's type so PR 2 only has to wire the button body and call site.
- Queue-while-streaming is PR 3.
- [`skill-build-result-card.tsx`](renderer/src/features/chat/components/tool-results/skill-build-result-card.tsx) was left untouched. Its inline copy fires a `trackEvent('Skills: copy reference', …)` on the success branch only; faithfully preserving that through the new hook would require broadening the hook's API (returning a success boolean), which felt like scope creep for this PR. Easy follow-up if we decide we want it.