### PR TITLE
feat(playground): tailor empty-state claim to selected agent

### DIFF
--- a/renderer/src/features/chat/components/__tests__/chat-interface.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/chat-interface.test.tsx
@@ -5,6 +5,8 @@ import React, { createRef } from 'react'
 import { ChatInterface } from '../chat-interface'
 import type { ChatUIMessage } from '../../types'
 import { useChatComposer } from '../chat-composer-context'
+import type { AgentConfig } from '@common/types/agents'
+import { BUILTIN_AGENT_IDS } from '@common/types/agents'
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -132,6 +134,49 @@ vi.mock('../../lib/utils', () => ({
     !!settings.apiKey || !!settings.endpointURL,
 }))
 
+const now = Date.now()
+const TOOLHIVE_ASSISTANT_AGENT: AgentConfig = {
+  id: BUILTIN_AGENT_IDS.toolhiveAssistant,
+  kind: 'builtin',
+  name: 'ToolHive Assistant',
+  description:
+    'General-purpose assistant with access to all enabled MCP tools.',
+  instructions: '',
+  builtinToolsKey: null,
+  createdAt: now,
+  updatedAt: now,
+}
+const SKILLS_AGENT: AgentConfig = {
+  id: BUILTIN_AGENT_IDS.skills,
+  kind: 'builtin',
+  name: 'Skill Engineer',
+  description: 'Designs and builds new skills.',
+  instructions: '',
+  builtinToolsKey: 'skills',
+  createdAt: now,
+  updatedAt: now,
+}
+const CUSTOM_AGENT: AgentConfig = {
+  id: 'custom.my-bot',
+  kind: 'custom',
+  name: 'MyBot',
+  description: 'A custom agent.',
+  instructions: '',
+  builtinToolsKey: null,
+  createdAt: now,
+  updatedAt: now,
+}
+
+const mockAgents = {
+  list: [TOOLHIVE_ASSISTANT_AGENT, SKILLS_AGENT, CUSTOM_AGENT] as AgentConfig[],
+  threadAgentId: null as string | null,
+}
+
+vi.mock('../../../agents/hooks/use-agents', () => ({
+  useAgents: () => ({ data: mockAgents.list, isLoading: false }),
+  useThreadAgentId: () => ({ data: mockAgents.threadAgentId }),
+}))
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -155,6 +200,7 @@ function resetMock() {
   mockStreamingReturn.lastUserMessageId = null
   mockStreamingReturn.rewindAndResend.mockReset()
   mockShowScrollToBottom = false
+  mockAgents.threadAgentId = null
 }
 
 // ---------------------------------------------------------------------------
@@ -246,6 +292,44 @@ describe('ChatInterface', () => {
       expect(
         screen.queryByRole('button', { name: /configure your providers/i })
       ).not.toBeInTheDocument()
+    })
+
+    describe('per-agent empty-state copy', () => {
+      it('shows ToolHive Assistant copy when no thread agent is set (default)', () => {
+        renderInterface({ threadId: 'thread-1' })
+        expect(
+          screen.getByText('Test & evaluate your MCP Servers')
+        ).toBeInTheDocument()
+        expect(
+          screen.getByText(
+            /configure an ai service provider to use to test the responses from your mcp servers/i
+          )
+        ).toBeInTheDocument()
+      })
+
+      it('shows Skill Engineer copy when the Skills agent is selected', () => {
+        mockAgents.threadAgentId = BUILTIN_AGENT_IDS.skills
+        renderInterface({ threadId: 'thread-1' })
+        expect(
+          screen.getByText('Build & audit your Skills')
+        ).toBeInTheDocument()
+        expect(
+          screen.getByText(
+            /configure an ai service provider to design, build, and audit skills/i
+          )
+        ).toBeInTheDocument()
+      })
+
+      it('shows "Chat with {name}" when a custom agent is selected', () => {
+        mockAgents.threadAgentId = CUSTOM_AGENT.id
+        renderInterface({ threadId: 'thread-1' })
+        expect(screen.getByText('Chat with MyBot')).toBeInTheDocument()
+        expect(
+          screen.getByText(
+            /configure an ai service provider to chat with your agent/i
+          )
+        ).toBeInTheDocument()
+      })
     })
   })
 

--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -18,6 +18,9 @@ import {
 import { Separator } from '@/common/components/ui/separator'
 import { ThreadTitleBar } from './thread-title-bar'
 import { hasCredentials } from '../lib/utils'
+import { getEmptyStateCopy } from '../lib/empty-state-copy'
+import { useAgents, useThreadAgentId } from '../../agents/hooks/use-agents'
+import { DEFAULT_AGENT_ID } from '@common/types/agents'
 
 interface ChatInterfaceProps {
   threadId?: string | null
@@ -130,6 +133,12 @@ export function ChatInterface({
     [editingMessageId, beginEdit, clearEdit]
   )
 
+  const { data: agents = [] } = useAgents()
+  const { data: threadAgentId } = useThreadAgentId(threadId ?? undefined)
+  const selectedAgentId = threadAgentId || DEFAULT_AGENT_ID
+  const selectedAgent = agents.find((a) => a.id === selectedAgentId)
+  const emptyStateCopy = getEmptyStateCopy(selectedAgent)
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {threadId && (
@@ -187,7 +196,7 @@ export function ChatInterface({
                           className="mx-auto mb-2 scale-x-[-1] font-light"
                         />
                       )}
-                      Test & evaluate your MCP Servers
+                      {emptyStateCopy.heading}
                     </div>
                     {!hasProviderAndModel && (
                       <>
@@ -195,8 +204,7 @@ export function ChatInterface({
                           className="text-muted-foreground mt-4 font-sans
                             text-base"
                         >
-                          Configure an AI service provider to use to test the
-                          responses from your MCP servers
+                          {emptyStateCopy.subtext}
                         </p>
                         <Button
                           variant="action"

--- a/renderer/src/features/chat/lib/empty-state-copy.ts
+++ b/renderer/src/features/chat/lib/empty-state-copy.ts
@@ -1,0 +1,34 @@
+import { BUILTIN_AGENT_IDS } from '@common/types/agents'
+import type { AgentConfig } from '@common/types/agents'
+
+export interface EmptyStateCopy {
+  heading: string
+  subtext: string
+}
+
+const TOOLHIVE_ASSISTANT_COPY: EmptyStateCopy = {
+  heading: 'Test & evaluate your MCP Servers',
+  subtext:
+    'Configure an AI service provider to use to test the responses from your MCP servers',
+}
+
+const SKILLS_COPY: EmptyStateCopy = {
+  heading: 'Build & audit your Skills',
+  subtext:
+    'Configure an AI service provider to design, build, and audit Skills',
+}
+
+export function getEmptyStateCopy(
+  agent: AgentConfig | undefined
+): EmptyStateCopy {
+  if (agent?.id === BUILTIN_AGENT_IDS.skills) {
+    return SKILLS_COPY
+  }
+  if (agent?.kind === 'custom') {
+    return {
+      heading: `Chat with ${agent.name}`,
+      subtext: 'Configure an AI service provider to chat with your agent',
+    }
+  }
+  return TOOLHIVE_ASSISTANT_COPY
+}


### PR DESCRIPTION
## Summary

- The playground empty-state heading was hardcoded to **"Test & evaluate your MCP Servers"**, which only describes the ToolHive Assistant use case. With Skill Engineer and custom agents now selectable per thread, that single tagline misrepresents the experience.
- The heading and provider-config subtext now resolve from the selected agent via a small pure helper (`renderer/src/features/chat/lib/empty-state-copy.ts`):
  - **ToolHive Assistant** (default / fallback) → keeps the existing copy.
  - **Skill Engineer** → "Build & audit your Skills".
  - **Custom agents** → "Chat with {agent.name}".
- `chat-interface.tsx` resolves the thread's agent with the same `useThreadAgentId` + `useAgents` pattern already used by `AgentSelector`.

## Test plan

- [x] `pnpm run test run renderer/src/features/chat/components/__tests__/chat-interface.test.tsx` — 37/37 pass (3 new cases under `empty state (no messages) › per-agent empty-state copy`).
- [x] `pnpm run type-check` — clean.
- [x] `eslint` on the three changed files — clean.
- [x] Manual smoke (Docker running): `pnpm run start`
  - [x] Land on `/playground` with no threads → empty state shows **"Test & evaluate your MCP Servers"**.
  - [x] Switch to **Skill Engineer** via the agent selector → heading reads **"Build & audit your Skills"**.
  - [x] Create a custom agent (e.g. "Reviewer"), switch to it → heading reads **"Chat with Reviewer"**.
  - [ ] With no provider configured, confirm the subtext under each heading reads naturally and **"Configure your providers"** still opens the settings dialog.
  - [ ] Send a message → empty state disappears, normal chat layout renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)