### PR TITLE
feat(playground): queue messages while a response is streaming

### DIFF
--- a/renderer/src/features/chat/components/__tests__/chat-input-prompt.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/chat-input-prompt.test.tsx
@@ -56,6 +56,8 @@ interface RenderArgs {
   }) => Promise<void>
   onStopGeneration?: () => void
   onClearEdit?: () => void
+  queuedMessage?: { text: string; files?: FileUIPart[] } | null
+  onCancelQueuedMessage?: () => void
 }
 
 /**
@@ -85,6 +87,7 @@ function renderPrompt(args: RenderArgs = {}) {
     args.onRewindAndResend ?? vi.fn().mockResolvedValue(undefined)
   const onStopGeneration = args.onStopGeneration ?? vi.fn()
   const onClearEdit = args.onClearEdit ?? vi.fn()
+  const onCancelQueuedMessage = args.onCancelQueuedMessage ?? vi.fn()
   const composerHandleRef = createRef<ChatComposerHandle | null>()
 
   const { container } = render(
@@ -111,6 +114,8 @@ function renderPrompt(args: RenderArgs = {}) {
       editingMessageId={args.editingMessageId ?? null}
       lastUserMessageId={args.lastUserMessageId ?? null}
       onClearEdit={onClearEdit}
+      queuedMessage={args.queuedMessage ?? null}
+      onCancelQueuedMessage={onCancelQueuedMessage}
     />
   )
 
@@ -122,6 +127,7 @@ function renderPrompt(args: RenderArgs = {}) {
     onRewindAndResend,
     onStopGeneration,
     onClearEdit,
+    onCancelQueuedMessage,
     composerHandleRef,
   }
 }
@@ -326,6 +332,118 @@ describe('ChatInputPrompt', () => {
 
       expect(onSendMessage).toHaveBeenCalled()
       expect(onClearEdit).toHaveBeenCalled()
+    })
+  })
+
+  describe('queue chip', () => {
+    it('renders the queue chip when queuedMessage is set and not editing', () => {
+      renderPrompt({
+        status: 'streaming',
+        queuedMessage: { text: 'pending question' },
+      })
+      expect(screen.getByTestId('queued-message-chip')).toBeInTheDocument()
+      expect(screen.getByText('pending question')).toBeInTheDocument()
+    })
+
+    it('hides the queue chip when isEditingStreaming wins (rewind chip exclusive)', () => {
+      renderPrompt({
+        status: 'streaming',
+        editingMessageId: 'u2',
+        lastUserMessageId: 'u2',
+        queuedMessage: { text: 'should be hidden' },
+      })
+      // Rewind chip wins.
+      expect(screen.getByTestId('edit-streaming-chip')).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('queued-message-chip')
+      ).not.toBeInTheDocument()
+    })
+
+    it('cancel button on the queue chip calls onCancelQueuedMessage', async () => {
+      const { onCancelQueuedMessage } = renderPrompt({
+        status: 'streaming',
+        queuedMessage: { text: 'cancel this' },
+      })
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Cancel queued message' })
+      )
+      expect(onCancelQueuedMessage).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not render the queue chip when queuedMessage is null', () => {
+      renderPrompt({ status: 'streaming' })
+      expect(
+        screen.queryByTestId('queued-message-chip')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('queueable submit', () => {
+    it('shows the queue submit button (not stop) when streaming with composer text', async () => {
+      const { composerHandleRef } = renderPrompt({ status: 'streaming' })
+
+      await act(async () => {
+        composerHandleRef.current?.setText('queue this')
+      })
+
+      // The queue submit button has aria-label="Queue message".
+      expect(
+        screen.getByRole('button', { name: 'Queue message' })
+      ).toBeInTheDocument()
+    })
+
+    it('keeps the stop button (no queue submit) when streaming with empty composer', () => {
+      renderPrompt({ status: 'streaming' })
+      expect(
+        screen.queryByRole('button', { name: 'Queue message' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('queueable submit fires onSendMessage (not onStopGeneration)', async () => {
+      const {
+        onSendMessage,
+        onStopGeneration,
+        onRewindAndResend,
+        composerHandleRef,
+      } = renderPrompt({ status: 'streaming' })
+
+      await act(async () => {
+        composerHandleRef.current?.setText('queue me')
+      })
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Queue message' })
+      )
+
+      // The composer's form routes through onSendMessage. The hook will
+      // intercept and queue internally — from the composer's perspective
+      // this is a normal "submit".
+      expect(onSendMessage).toHaveBeenCalledWith({
+        text: 'queue me',
+        files: [],
+      })
+      expect(onStopGeneration).not.toHaveBeenCalled()
+      expect(onRewindAndResend).not.toHaveBeenCalled()
+    })
+
+    it('does not show the queue submit when editingMessageId matches lastUserMessageId (rewind wins)', async () => {
+      const { composerHandleRef } = renderPrompt({
+        status: 'streaming',
+        editingMessageId: 'u2',
+        lastUserMessageId: 'u2',
+      })
+
+      await act(async () => {
+        composerHandleRef.current?.setText('editing')
+      })
+
+      // Rewind button wins; no "Queue message" button.
+      expect(
+        screen.queryByRole('button', { name: 'Queue message' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Resend edited message' })
+      ).toBeInTheDocument()
     })
   })
 

--- a/renderer/src/features/chat/components/__tests__/chat-input-prompt.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/chat-input-prompt.test.tsx
@@ -53,7 +53,7 @@ interface RenderArgs {
     text: string
     files?: FileUIPart[]
     editingMessageId: string
-  }) => Promise<unknown>
+  }) => Promise<void>
   onStopGeneration?: () => void
   onClearEdit?: () => void
 }

--- a/renderer/src/features/chat/components/__tests__/queued-message-chip.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/queued-message-chip.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { FileUIPart } from 'ai'
+import { QueuedMessageChip } from '../queued-message-chip'
+
+describe('QueuedMessageChip', () => {
+  it('renders the text preview', () => {
+    render(
+      <QueuedMessageChip
+        queuedMessage={{ text: 'hello there' }}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('queued-message-chip')).toBeInTheDocument()
+    expect(screen.getByText('hello there')).toBeInTheDocument()
+  })
+
+  it('truncates very long text with an ellipsis', () => {
+    const long = 'a'.repeat(120)
+    render(
+      <QueuedMessageChip queuedMessage={{ text: long }} onCancel={vi.fn()} />
+    )
+    const chip = screen.getByTestId('queued-message-chip')
+    // Truncated preview is < the input length, has a trailing ellipsis.
+    expect(chip.textContent).toContain('…')
+    expect(chip.textContent ?? '').not.toContain(long)
+  })
+
+  it('shows file count when files are present', () => {
+    const files = [
+      { type: 'file' as const, mediaType: 'image/png', url: 'a' },
+      { type: 'file' as const, mediaType: 'image/png', url: 'b' },
+    ] satisfies FileUIPart[]
+    render(
+      <QueuedMessageChip
+        queuedMessage={{ text: 'check these', files }}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('queued-message-chip').textContent).toContain(
+      '· 2 files'
+    )
+  })
+
+  it('uses singular "file" when only one file is attached', () => {
+    const files = [
+      { type: 'file' as const, mediaType: 'image/png', url: 'a' },
+    ] satisfies FileUIPart[]
+    render(
+      <QueuedMessageChip
+        queuedMessage={{ text: 'one', files }}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('queued-message-chip').textContent).toContain(
+      '· 1 file'
+    )
+  })
+
+  it('cancel button invokes onCancel', async () => {
+    const onCancel = vi.fn()
+    render(
+      <QueuedMessageChip
+        queuedMessage={{ text: 'cancel me' }}
+        onCancel={onCancel}
+      />
+    )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Cancel queued message' })
+    )
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, type RefObject } from 'react'
 import type { ChatStatus, FileUIPart } from 'ai'
 import log from 'electron-log/renderer'
-import { RefreshCw, X } from 'lucide-react'
+import { RefreshCw, SendHorizontal, X } from 'lucide-react'
 import {
   PromptInput,
   PromptInputActionAddAttachments,
@@ -34,6 +34,7 @@ import { toast } from 'sonner'
 import { toastVariants } from '@/common/lib/toast'
 import { useThreadDraft } from '../hooks/use-thread-draft'
 import { useComposerHandle } from '../hooks/use-composer-handle'
+import { QueuedMessageChip } from './queued-message-chip'
 import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
 import { featureFlagKeys } from '@utils/feature-flags'
 
@@ -106,6 +107,15 @@ interface ChatInputProps {
   lastUserMessageId?: string | null
   /** Exit edit mode (called from the chip's cancel button and on auto-clear). */
   onClearEdit?: () => void
+  /**
+   * A message the user submitted while a stream was still active. The hook
+   * auto-fires it when the current response finishes; the composer surfaces
+   * it as a chip so the user can cancel before that happens. Mutually
+   * exclusive with `isEditingStreaming` — the rewind chip wins.
+   */
+  queuedMessage?: { text: string; files?: FileUIPart[] } | null
+  /** Cancel the queued message without sending it. */
+  onCancelQueuedMessage?: () => void
 }
 
 function InputWithAttachments({
@@ -123,6 +133,8 @@ function InputWithAttachments({
   threadId,
   isEditingStreaming,
   onCancelEdit,
+  queuedMessage,
+  onCancelQueuedMessage,
 }: Omit<
   ChatInputProps,
   | 'onSendMessage'
@@ -165,12 +177,26 @@ function InputWithAttachments({
     onSettingsOpen(true)
   }
 
+  // Streaming + composer has text + NOT editing = "queue this message" mode.
+  // The form's onSubmit owns the queueing flow (it routes through
+  // `validatedSendMessage`, which intercepts and queues internally when
+  // status is streaming/submitted). We just need to show the right icon
+  // and skip the stop-the-stream side-effect that the default submit click
+  // would otherwise trigger.
+  const isStreamingStatus = status === 'streaming' || status === 'submitted'
+  const isQueueableSubmit =
+    !isEditingStreaming && isStreamingStatus && Boolean(text)
+
   const handleSubmit = () => {
     trackEvent(`Playground: submit`, { 'playground.status': status })
     // In "editing the streaming message" mode the form's onSubmit owns the
     // rewind-and-resend flow — don't fire the stop handler here, the parent
     // will cancel as part of that path.
     if (isEditingStreaming) return
+    // In queue mode the form's onSubmit owns the queueing flow — same
+    // reasoning. The composer is non-empty so we want the message to land
+    // in the queue, NOT stop the active stream.
+    if (isQueueableSubmit) return
     const isStoppable = ['streaming', 'error', 'submitted'].includes(status)
     if (isStoppable) {
       onStopGeneration()
@@ -203,6 +229,15 @@ function InputWithAttachments({
             cancel
           </Button>
         </div>
+      )}
+      {/* Queue chip is mutually exclusive with the rewind chip — when the
+          user is editing the last user message during streaming, that flow
+          wins and the queue is suppressed. */}
+      {!isEditingStreaming && queuedMessage && onCancelQueuedMessage && (
+        <QueuedMessageChip
+          queuedMessage={queuedMessage}
+          onCancel={onCancelQueuedMessage}
+        />
       )}
       <PromptInputBody>
         <PromptInputAttachments>
@@ -259,6 +294,27 @@ function InputWithAttachments({
           >
             <RefreshCw className="size-4" />
           </PromptInputSubmit>
+        ) : isQueueableSubmit ? (
+          // Queue mode: composer is non-empty while streaming. Override the
+          // stop-square icon so the user sees this submit is "send when the
+          // current response finishes", not a stop action. The form's
+          // onSubmit routes through `validatedSendMessage` which queues.
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PromptInputSubmit
+                onClick={handleSubmit}
+                disabled={!text && !hasMessages}
+                status={status}
+                variant="action"
+                aria-label="Queue message"
+              >
+                <SendHorizontal className="size-4" />
+              </PromptInputSubmit>
+            </TooltipTrigger>
+            <TooltipContent>
+              Queue message — sends when the current response finishes
+            </TooltipContent>
+          </Tooltip>
         ) : (
           <PromptInputSubmit
             onClick={handleSubmit}
@@ -288,6 +344,8 @@ export function ChatInputPrompt({
   editingMessageId,
   lastUserMessageId,
   onClearEdit,
+  queuedMessage,
+  onCancelQueuedMessage,
 }: ChatInputProps) {
   const [text, setText] = useThreadDraft(threadId)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
@@ -407,6 +465,8 @@ export function ChatInputPrompt({
         textareaRef={textareaRef}
         isEditingStreaming={isEditingStreaming}
         onCancelEdit={handleCancelEdit}
+        queuedMessage={queuedMessage}
+        onCancelQueuedMessage={onCancelQueuedMessage}
       />
     </PromptInput>
   )

--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -33,6 +33,7 @@ import type { ChatSettings } from '../types'
 import { toast } from 'sonner'
 import { toastVariants } from '@/common/lib/toast'
 import { useThreadDraft } from '../hooks/use-thread-draft'
+import { useComposerHandle } from '../hooks/use-composer-handle'
 import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
 import { featureFlagKeys } from '@utils/feature-flags'
 
@@ -86,7 +87,7 @@ interface ChatInputProps {
     text: string
     files?: FileUIPart[]
     editingMessageId: string
-  }) => Promise<unknown>
+  }) => Promise<void>
   onStopGeneration: () => void
   onSettingsOpen: (isOpen: boolean) => void
   handleProviderChange: (providerId: string) => void
@@ -306,34 +307,7 @@ export function ChatInputPrompt({
     }
   }, [text, editingMessageId, onClearEdit])
 
-  // Expose imperative controls so siblings outside this subtree (e.g. the
-  // message list's "Edit message" button) can pre-fill and focus the
-  // composer. The ref is populated on mount and cleared on unmount so the
-  // context can tell whether a composer is currently mounted.
-  useEffect(() => {
-    if (!composerHandleRef) return
-    composerHandleRef.current = {
-      setText,
-      focusTextarea: () => {
-        const el = textareaRef.current
-        if (!el) return
-        el.focus()
-        const end = el.value.length
-        try {
-          el.setSelectionRange(end, end)
-        } catch {
-          // Some textarea types (e.g. <input type="number">) throw on
-          // setSelectionRange. Plain text textareas never do — guard anyway
-          // so a stray DOM shape can't break the edit flow.
-        }
-      },
-    }
-    return () => {
-      if (composerHandleRef.current) {
-        composerHandleRef.current = null
-      }
-    }
-  }, [composerHandleRef, setText])
+  useComposerHandle(composerHandleRef, setText, textareaRef)
 
   const handleCancelEdit = () => {
     onClearEdit?.()

--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -107,14 +107,8 @@ interface ChatInputProps {
   lastUserMessageId?: string | null
   /** Exit edit mode (called from the chip's cancel button and on auto-clear). */
   onClearEdit?: () => void
-  /**
-   * A message the user submitted while a stream was still active. The hook
-   * auto-fires it when the current response finishes; the composer surfaces
-   * it as a chip so the user can cancel before that happens. Mutually
-   * exclusive with `isEditingStreaming` — the rewind chip wins.
-   */
+  /** Mutually exclusive with `isEditingStreaming` — the rewind chip wins. */
   queuedMessage?: { text: string; files?: FileUIPart[] } | null
-  /** Cancel the queued message without sending it. */
   onCancelQueuedMessage?: () => void
 }
 
@@ -177,25 +171,16 @@ function InputWithAttachments({
     onSettingsOpen(true)
   }
 
-  // Streaming + composer has text + NOT editing = "queue this message" mode.
-  // The form's onSubmit owns the queueing flow (it routes through
-  // `validatedSendMessage`, which intercepts and queues internally when
-  // status is streaming/submitted). We just need to show the right icon
-  // and skip the stop-the-stream side-effect that the default submit click
-  // would otherwise trigger.
+  // Streaming + text + not editing: form's onSubmit queues via
+  // `validatedSendMessage`. Skip the stop side-effect below.
   const isStreamingStatus = status === 'streaming' || status === 'submitted'
   const isQueueableSubmit =
     !isEditingStreaming && isStreamingStatus && Boolean(text)
 
   const handleSubmit = () => {
     trackEvent(`Playground: submit`, { 'playground.status': status })
-    // In "editing the streaming message" mode the form's onSubmit owns the
-    // rewind-and-resend flow — don't fire the stop handler here, the parent
-    // will cancel as part of that path.
+    // Rewind / queue paths: form's onSubmit handles the action — don't stop.
     if (isEditingStreaming) return
-    // In queue mode the form's onSubmit owns the queueing flow — same
-    // reasoning. The composer is non-empty so we want the message to land
-    // in the queue, NOT stop the active stream.
     if (isQueueableSubmit) return
     const isStoppable = ['streaming', 'error', 'submitted'].includes(status)
     if (isStoppable) {
@@ -230,9 +215,7 @@ function InputWithAttachments({
           </Button>
         </div>
       )}
-      {/* Queue chip is mutually exclusive with the rewind chip — when the
-          user is editing the last user message during streaming, that flow
-          wins and the queue is suppressed. */}
+      {/* Hidden while editing — rewind chip wins. */}
       {!isEditingStreaming && queuedMessage && onCancelQueuedMessage && (
         <QueuedMessageChip
           queuedMessage={queuedMessage}
@@ -282,9 +265,7 @@ function InputWithAttachments({
           )}
         </PromptInputTools>
         {isEditingStreaming ? (
-          // Override the status-driven icon so the user sees this submit is
-          // a "resend", not the usual stop-the-stream square. The form's
-          // onSubmit (set by the parent) decides what actually happens.
+          // Override the stop-square icon — this submit is a resend.
           <PromptInputSubmit
             onClick={handleSubmit}
             disabled={!text && !hasMessages}
@@ -295,10 +276,7 @@ function InputWithAttachments({
             <RefreshCw className="size-4" />
           </PromptInputSubmit>
         ) : isQueueableSubmit ? (
-          // Queue mode: composer is non-empty while streaming. Override the
-          // stop-square icon so the user sees this submit is "send when the
-          // current response finishes", not a stop action. The form's
-          // onSubmit routes through `validatedSendMessage` which queues.
+          // Override the stop-square icon — this submit queues.
           <Tooltip>
             <TooltipTrigger asChild>
               <PromptInputSubmit

--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -48,6 +48,8 @@ export function ChatInterface({
     lastUserMessageId,
     cancelRequest,
     loadPersistedSettings,
+    queuedMessage,
+    cancelQueuedMessage,
   } = useChatStreaming(threadId)
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
@@ -229,6 +231,8 @@ export function ChatInterface({
                         editingMessageId={editingMessageId}
                         lastUserMessageId={lastUserMessageId}
                         onClearEdit={clearEdit}
+                        queuedMessage={queuedMessage}
+                        onCancelQueuedMessage={cancelQueuedMessage}
                       />
                     </div>
                   )}
@@ -281,6 +285,8 @@ export function ChatInterface({
                 editingMessageId={editingMessageId}
                 lastUserMessageId={lastUserMessageId}
                 onClearEdit={clearEdit}
+                queuedMessage={queuedMessage}
+                onCancelQueuedMessage={cancelQueuedMessage}
               />
             </div>
           )}

--- a/renderer/src/features/chat/components/queued-message-chip.tsx
+++ b/renderer/src/features/chat/components/queued-message-chip.tsx
@@ -1,0 +1,67 @@
+import { X } from 'lucide-react'
+import type { FileUIPart } from 'ai'
+import { Button } from '@/common/components/ui/button'
+
+interface QueuedMessageChipProps {
+  queuedMessage: { text: string; files?: FileUIPart[] }
+  onCancel: () => void
+}
+
+const PREVIEW_MAX = 60
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return `${text.slice(0, max).trimEnd()}…`
+}
+
+function formatPreview(message: {
+  text: string
+  files?: FileUIPart[]
+}): string {
+  const base = truncate(message.text.trim(), PREVIEW_MAX)
+  const fileCount = message.files?.length ?? 0
+  if (fileCount === 0) return base
+  const fileSuffix = `${fileCount} ${fileCount === 1 ? 'file' : 'files'}`
+  return base ? `${base} · ${fileSuffix}` : fileSuffix
+}
+
+/**
+ * Surfaces a message the user submitted while a stream was still active.
+ * The hook holds it in a single-slot per-thread queue and auto-fires it
+ * when the current stream completes. The chip lets the user cancel before
+ * that happens.
+ *
+ * Styled to match the rewind chip from {@link ChatInputPrompt} so they
+ * read as siblings — but the two chips are mutually exclusive: when the
+ * rewind chip is showing, the queue chip is hidden.
+ */
+export function QueuedMessageChip({
+  queuedMessage,
+  onCancel,
+}: QueuedMessageChipProps) {
+  const preview = formatPreview(queuedMessage)
+  return (
+    <div
+      data-testid="queued-message-chip"
+      className="bg-card text-muted-foreground flex items-center justify-between
+        gap-2 rounded-md border px-3 py-1.5 text-xs"
+    >
+      <span className="truncate">
+        Queued: <span className="text-foreground">{preview}</span> — sends when
+        the current response finishes
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-label="Cancel queued message"
+        onClick={onCancel}
+        className="text-muted-foreground hover:text-foreground -mr-2 h-6 gap-1
+          px-2 text-xs"
+      >
+        <X className="size-3" />
+        cancel
+      </Button>
+    </div>
+  )
+}

--- a/renderer/src/features/chat/components/queued-message-chip.tsx
+++ b/renderer/src/features/chat/components/queued-message-chip.tsx
@@ -25,16 +25,6 @@ function formatPreview(message: {
   return base ? `${base} · ${fileSuffix}` : fileSuffix
 }
 
-/**
- * Surfaces a message the user submitted while a stream was still active.
- * The hook holds it in a single-slot per-thread queue and auto-fires it
- * when the current stream completes. The chip lets the user cancel before
- * that happens.
- *
- * Styled to match the rewind chip from {@link ChatInputPrompt} so they
- * read as siblings — but the two chips are mutually exclusive: when the
- * rewind chip is showing, the queue chip is hidden.
- */
 export function QueuedMessageChip({
   queuedMessage,
   onCancel,

--- a/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -14,7 +14,7 @@ const mockUseChat = {
   id: 'test-chat',
   messages: [] as ChatUIMessage[],
   sendMessage: vi.fn(),
-  status: 'idle' as 'idle' | 'submitted' | 'streaming',
+  status: 'idle' as 'idle' | 'submitted' | 'streaming' | 'ready' | 'error',
   error: undefined as unknown,
   stop: vi.fn(),
   setMessages: vi.fn(),
@@ -624,6 +624,273 @@ describe('useChatStreaming', () => {
       ).rejects.toThrow('Please configure your AI provider settings first')
 
       expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('queue while streaming', () => {
+    it('queues the message instead of calling sendMessage when status is streaming', async () => {
+      mockUseChat.status = 'streaming'
+
+      const { Wrapper } = createTestUtils()
+      const { result, rerender } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.settings.provider).toBe('openai')
+      })
+
+      await act(async () => {
+        await result.current.sendMessage({ text: 'x' })
+      })
+      rerender()
+
+      expect(result.current.queuedMessage).toEqual({ text: 'x' })
+      expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
+      // Queue path must also skip the thread-promote IPC — that already
+      // ran when the in-flight message started.
+      expect(mockChatAPI.ensureThreadExists).not.toHaveBeenCalled()
+    })
+
+    it('also queues when status is submitted', async () => {
+      mockUseChat.status = 'submitted'
+
+      const { Wrapper } = createTestUtils()
+      const { result, rerender } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.settings.provider).toBe('openai')
+      })
+
+      await act(async () => {
+        await result.current.sendMessage('queued during submit')
+      })
+      rerender()
+
+      expect(result.current.queuedMessage).toEqual({
+        text: 'queued during submit',
+      })
+      expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('auto-fires the queued message when status transitions out of streaming to ready', async () => {
+      mockUseChat.status = 'streaming'
+
+      const { Wrapper } = createTestUtils()
+      const { result, rerender } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.settings.provider).toBe('openai')
+      })
+
+      await act(async () => {
+        await result.current.sendMessage({ text: 'auto-flush me' })
+      })
+
+      // Simulate the stream completing. The hook's prev-status ref
+      // captures `streaming`, then re-renders with `ready` — the effect
+      // should fire `sendMessage` with the queued payload and clear the
+      // queue.
+      mockUseChat.status = 'ready'
+      await act(async () => {
+        rerender()
+      })
+
+      await waitFor(() => {
+        expect(mockUseChat.sendMessage).toHaveBeenCalledWith({
+          text: 'auto-flush me',
+        })
+      })
+      expect(result.current.queuedMessage).toBeNull()
+    })
+
+    it('does NOT auto-fire when status transitions to error — the queue stays', async () => {
+      mockUseChat.status = 'streaming'
+
+      const { Wrapper } = createTestUtils()
+      const { result, rerender } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.settings.provider).toBe('openai')
+      })
+
+      await act(async () => {
+        await result.current.sendMessage({ text: 'keep me' })
+      })
+
+      mockUseChat.status = 'error'
+      await act(async () => {
+        rerender()
+      })
+
+      // Queue stays so the user can cancel or retry once the error clears.
+      expect(result.current.queuedMessage).toEqual({ text: 'keep me' })
+      expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('replaces an existing queued message when a second submit comes in', async () => {
+      mockUseChat.status = 'streaming'
+
+      const { Wrapper } = createTestUtils()
+      const { result, rerender } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.settings.provider).toBe('openai')
+      })
+
+      await act(async () => {
+        await result.current.sendMessage({ text: 'first' })
+      })
+      rerender()
+      expect(result.current.queuedMessage).toEqual({ text: 'first' })
+
+      await act(async () => {
+        await result.current.sendMessage({ text: 'second' })
+      })
+      rerender()
+      expect(result.current.queuedMessage).toEqual({ text: 'second' })
+      expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('cancelQueuedMessage clears the queue without sending', async () => {
+      mockUseChat.status = 'streaming'
+
+      const { Wrapper } = createTestUtils()
+      const { result, rerender } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.settings.provider).toBe('openai')
+      })
+
+      await act(async () => {
+        await result.current.sendMessage({ text: 'cancel me' })
+      })
+      rerender()
+      expect(result.current.queuedMessage).toEqual({ text: 'cancel me' })
+
+      act(() => {
+        result.current.cancelQueuedMessage()
+      })
+
+      expect(result.current.queuedMessage).toBeNull()
+      // Even on later stream completion, nothing fires.
+      mockUseChat.status = 'ready'
+      await act(async () => {
+        rerender()
+      })
+      expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('clears the queue on thread switch', async () => {
+      // useThreadManagement is mocked to always return 'toolhive-chat'.
+      // Force its return value to change between renders so the
+      // queue-clearing effect can observe a thread switch. Save the
+      // original implementation so we can restore it at the end — other
+      // tests in the file expect `'toolhive-chat'`.
+      const { useThreadManagement } = await import('../use-thread-management')
+      const mockedThreadMgmt = vi.mocked(useThreadManagement)
+      const defaultImpl = mockedThreadMgmt.getMockImplementation()
+      try {
+        mockedThreadMgmt.mockImplementation(() => ({
+          currentThreadId: 'thread-A',
+          isLoading: false,
+          error: null,
+          clearMessages: vi.fn().mockResolvedValue(undefined),
+        }))
+        mockUseChat.status = 'streaming'
+
+        const { Wrapper } = createTestUtils()
+        const { result, rerender } = renderHook(
+          (props: { id?: string }) => useChatStreaming(props.id),
+          {
+            wrapper: Wrapper,
+            initialProps: { id: 'thread-A' },
+          }
+        )
+
+        await waitFor(() => {
+          expect(result.current.settings.provider).toBe('openai')
+        })
+
+        await act(async () => {
+          await result.current.sendMessage({ text: 'on thread A' })
+        })
+        rerender({ id: 'thread-A' })
+        expect(result.current.queuedMessage).toEqual({ text: 'on thread A' })
+
+        // Flip the mock so the next render resolves a different thread.
+        mockedThreadMgmt.mockImplementation(() => ({
+          currentThreadId: 'thread-B',
+          isLoading: false,
+          error: null,
+          clearMessages: vi.fn().mockResolvedValue(undefined),
+        }))
+
+        await act(async () => {
+          rerender({ id: 'thread-B' })
+        })
+
+        expect(result.current.queuedMessage).toBeNull()
+      } finally {
+        // Restore so subsequent tests see `'toolhive-chat'` again.
+        if (defaultImpl) mockedThreadMgmt.mockImplementation(defaultImpl)
+      }
+    })
+
+    it('rewindAndResend bypasses the queue: the edited send fires immediately even with streaming status', async () => {
+      const userMsg = (id: string, text: string): ChatUIMessage =>
+        ({
+          id,
+          role: 'user',
+          parts: [{ type: 'text' as const, text }],
+        }) as unknown as ChatUIMessage
+      const assistantMsg = (id: string, text: string): ChatUIMessage =>
+        ({
+          id,
+          role: 'assistant',
+          parts: [{ type: 'text' as const, text }],
+        }) as unknown as ChatUIMessage
+
+      mockUseChat.messages = [
+        userMsg('u1', 'first'),
+        assistantMsg('a1', 'partial'),
+      ]
+      mockUseChat.status = 'streaming'
+
+      const { Wrapper } = createTestUtils()
+      const { result } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.settings.provider).toBe('openai')
+        expect(result.current.lastUserMessageId).toBe('u1')
+      })
+
+      await act(async () => {
+        await result.current.rewindAndResend({
+          text: 'edited',
+          editingMessageId: 'u1',
+        })
+      })
+
+      // The rewind path goes through `dispatchSend`, not the queue, so
+      // the AI SDK's sendMessage IS called and the queue stays empty.
+      expect(mockUseChat.sendMessage).toHaveBeenCalledWith({
+        text: 'edited',
+        files: undefined,
+      })
+      expect(result.current.queuedMessage).toBeNull()
     })
   })
 

--- a/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -847,6 +847,68 @@ describe('useChatStreaming', () => {
       }
     })
 
+    it('does NOT auto-flush A`s queued message into thread B on thread switch', async () => {
+      // Regression: with the thread-clear in a `useEffect`, the auto-flush
+      // effect could fire on the same render that the thread changed (status
+      // resets to 'ready' for the new thread, prev-status ref still holds
+      // 'streaming' from the old one, and `queuedMessage` state hadn't yet
+      // been cleared). The fix is the in-render adjustment — see the hook.
+      const { useThreadManagement } = await import('../use-thread-management')
+      const mockedThreadMgmt = vi.mocked(useThreadManagement)
+      const defaultImpl = mockedThreadMgmt.getMockImplementation()
+      try {
+        mockedThreadMgmt.mockImplementation(() => ({
+          currentThreadId: 'thread-A',
+          isLoading: false,
+          error: null,
+          clearMessages: vi.fn().mockResolvedValue(undefined),
+        }))
+        mockUseChat.status = 'streaming'
+
+        const { Wrapper } = createTestUtils()
+        const { result, rerender } = renderHook(
+          (props: { id?: string }) => useChatStreaming(props.id),
+          {
+            wrapper: Wrapper,
+            initialProps: { id: 'thread-A' },
+          }
+        )
+
+        await waitFor(() => {
+          expect(result.current.settings.provider).toBe('openai')
+        })
+
+        await act(async () => {
+          await result.current.sendMessage({ text: 'meant for A' })
+        })
+        expect(result.current.queuedMessage).toEqual({ text: 'meant for A' })
+        // The send hasn't fired yet — it's in the queue.
+        expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
+
+        // Simulate thread switch: a fresh useChat instance for B initializes
+        // with status='ready' (no in-flight stream there). This is the exact
+        // shape that used to trigger the race.
+        mockedThreadMgmt.mockImplementation(() => ({
+          currentThreadId: 'thread-B',
+          isLoading: false,
+          error: null,
+          clearMessages: vi.fn().mockResolvedValue(undefined),
+        }))
+        mockUseChat.status = 'ready'
+
+        await act(async () => {
+          rerender({ id: 'thread-B' })
+        })
+
+        // The queue must be cleared AND sendMessage must NOT have fired —
+        // otherwise A's queued message would have leaked into B's stream.
+        expect(result.current.queuedMessage).toBeNull()
+        expect(mockUseChat.sendMessage).not.toHaveBeenCalled()
+      } finally {
+        if (defaultImpl) mockedThreadMgmt.mockImplementation(defaultImpl)
+      }
+    })
+
     it('rewindAndResend bypasses the queue: the edited send fires immediately even with streaming status', async () => {
       const userMsg = (id: string, text: string): ChatUIMessage =>
         ({

--- a/renderer/src/features/chat/hooks/__tests__/use-composer-handle.test.tsx
+++ b/renderer/src/features/chat/hooks/__tests__/use-composer-handle.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest'
+import { act, render } from '@testing-library/react'
+import { createRef, useRef } from 'react'
+import { useComposerHandle } from '../use-composer-handle'
+import type { ChatComposerHandle } from '../../components/chat-input-prompt'
+
+interface ProbeProps {
+  composerHandleRef: ReturnType<typeof createRef<ChatComposerHandle | null>>
+  setText: (text: string) => void
+  initialValue?: string
+}
+
+function Probe({ composerHandleRef, setText, initialValue = '' }: ProbeProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  useComposerHandle(composerHandleRef, setText, textareaRef)
+  return (
+    <textarea
+      ref={textareaRef}
+      data-testid="probe-textarea"
+      defaultValue={initialValue}
+    />
+  )
+}
+
+describe('useComposerHandle', () => {
+  it('registers setText on the ref so callers can drive the draft', () => {
+    const composerHandleRef = createRef<ChatComposerHandle | null>()
+    const setText = vi.fn()
+
+    render(<Probe composerHandleRef={composerHandleRef} setText={setText} />)
+
+    expect(composerHandleRef.current).not.toBeNull()
+    act(() => {
+      composerHandleRef.current?.setText('hello')
+    })
+    expect(setText).toHaveBeenCalledWith('hello')
+  })
+
+  it('focusTextarea focuses the textarea and moves the caret to the end', () => {
+    const composerHandleRef = createRef<ChatComposerHandle | null>()
+    const setText = vi.fn()
+
+    const { getByTestId } = render(
+      <Probe
+        composerHandleRef={composerHandleRef}
+        setText={setText}
+        initialValue="abcdef"
+      />
+    )
+
+    const textarea = getByTestId('probe-textarea') as HTMLTextAreaElement
+    act(() => {
+      composerHandleRef.current?.focusTextarea()
+    })
+
+    expect(document.activeElement).toBe(textarea)
+    const end = textarea.value.length
+    expect(textarea.selectionStart).toBe(end)
+    expect(textarea.selectionEnd).toBe(end)
+  })
+
+  it('clears the ref on unmount', () => {
+    const composerHandleRef = createRef<ChatComposerHandle | null>()
+    const setText = vi.fn()
+
+    const { unmount } = render(
+      <Probe composerHandleRef={composerHandleRef} setText={setText} />
+    )
+
+    expect(composerHandleRef.current).not.toBeNull()
+    unmount()
+    expect(composerHandleRef.current).toBeNull()
+  })
+
+  it('does nothing when composerHandleRef is undefined', () => {
+    // Smoke test — the hook should be safe to call without a ref, so the
+    // composer can be used in trees that don't need imperative access.
+    function NoRefProbe() {
+      const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+      useComposerHandle(undefined, vi.fn(), textareaRef)
+      return <textarea ref={textareaRef} />
+    }
+    expect(() => render(<NoRefProbe />)).not.toThrow()
+  })
+})

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -23,14 +23,7 @@ function dropTrailingAssistant(messages: ChatUIMessage[]): ChatUIMessage[] {
   return messages.slice(0, -1)
 }
 
-/**
- * A message the user submitted while a stream was active, held in renderer
- * memory until the current stream finishes (or until the user cancels).
- *
- * Single slot per thread — submitting a new message while one is already
- * queued replaces it, matching a "draft" mental model. Lost on app restart
- * (in-memory only; no SQLite persistence in V1).
- */
+// Single-slot, per-thread, in-memory queue. Submitting again replaces the slot.
 type QueuedMessage = { text: string; files?: FileUIPart[] }
 
 export function useChatStreaming(externalThreadId?: string | null) {
@@ -204,42 +197,21 @@ export function useChatStreaming(externalThreadId?: string | null) {
     }
   }, [currentThreadId])
 
-  // Drop any queued message when the user switches threads — the queue is
-  // per-thread and we never auto-send across threads. Done in an effect so
-  // both `externalThreadId` (prop-driven) and the resolved `currentThreadId`
-  // changes are honored — `currentThreadId` is the source of truth.
   useEffect(() => {
     setQueuedMessage(null)
   }, [currentThreadId])
 
-  // Auto-fire the queued message when the active stream finishes.
-  //
-  // We watch the `streaming`/`submitted` → other-state transition rather
-  // than just "status is idle". Without that, mounting with `status='ready'`
-  // and a stale queue would flush immediately, and resume-from-snapshot
-  // races could fire twice.
-  //
-  // Important: we deliberately call the AI SDK's `sendMessage` directly
-  // here (NOT `validatedSendMessage`) — re-running validation on the auto-
-  // flush path would re-queue the message into oblivion. The settings were
-  // already valid when the user submitted (otherwise the validation in
-  // `validatedSendMessage` would have thrown), so re-validation is moot.
-  //
-  // If status flips to `error` (not `ready`), we leave the queue intact so
-  // the user can cancel or retry once the error is resolved. Auto-firing
-  // onto a broken provider would just produce a second error.
+  // Auto-flush on streaming→ready only (not →error: would re-fail on a broken
+  // provider). Calls `sendMessage` directly to skip re-validation/re-queuing.
   const prevQueueStatusRef = useRef(status)
   useEffect(() => {
     const prev = prevQueueStatusRef.current
     prevQueueStatusRef.current = status
     const wasStreaming = prev === 'streaming' || prev === 'submitted'
-    const nowIdle = status === 'ready'
-    if (!wasStreaming || !nowIdle) return
+    if (!wasStreaming || status !== 'ready') return
     if (!queuedMessage) return
     const toSend = queuedMessage
     setQueuedMessage(null)
-    // Fire-and-forget — `sendMessage` returns a Promise, but the AI SDK
-    // surfaces failures via `error` which we already render in `ErrorAlert`.
     Promise.resolve(sendMessage(toSend)).catch((err) => {
       log.error('[useChatStreaming] Auto-flush of queued message failed:', err)
     })
@@ -394,13 +366,8 @@ export function useChatStreaming(externalThreadId?: string | null) {
     return 'An unknown error occurred'
   }
 
-  /**
-   * Validate settings, promote the draft thread to a DB row if needed,
-   * then call the AI SDK's `sendMessage` directly. Used by both the
-   * normal-send path (after queue check) and the rewind path. Does NOT
-   * touch the queue — callers that need queue-while-streaming behavior
-   * go through {@link validatedSendMessage}.
-   */
+  // Send path used by both `validatedSendMessage` (after queue check) and
+  // `rewindAndResend`. Skips the queue intercept by design.
   const dispatchSend = useCallback(
     async (
       messageOrText:
@@ -447,14 +414,8 @@ export function useChatStreaming(externalThreadId?: string | null) {
             files?: FileUIPart[]
           }
     ) => {
-      // Queue-while-streaming: hold the message in renderer memory and
-      // auto-fire it when the current stream finishes. Validation still
-      // runs first (via `dispatchSend` below for the immediate path; we
-      // mirror its settings check here so a misconfigured queue submit
-      // surfaces the error to the user immediately).
-      //
-      // The rewind-and-retry path bypasses this entirely by calling
-      // `dispatchSend` directly — see `rewindAndResend`.
+      // Queue while streaming — auto-flushed when the active stream ends.
+      // Validate up front so a misconfigured submit fails immediately.
       if (status === 'streaming' || status === 'submitted') {
         if (
           !settings.provider ||
@@ -476,11 +437,7 @@ export function useChatStreaming(externalThreadId?: string | null) {
     [dispatchSend, settings, status]
   )
 
-  /**
-   * Id of the most recent user message in the thread, or `null` if no user
-   * message exists yet. Drives the "rewind & retry" affordance in the
-   * composer — only the LAST user message can be rewound during streaming.
-   */
+  // Id of the most recent user message; drives the rewind & retry affordance.
   const lastUserMessageId = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i -= 1) {
       const m = messages[i]
@@ -489,17 +446,9 @@ export function useChatStreaming(externalThreadId?: string | null) {
     return null
   }, [messages])
 
-  /**
-   * Cancel the in-flight stream, drop the user message being edited AND the
-   * partial assistant response that was being generated for it, then send
-   * the new text as a fresh message — replacing the in-flight turn with the
-   * edited one.
-   *
-   * Caller MUST guard that `editingMessageId === lastUserMessageId` and a
-   * stream is active. If `editingMessageId` doesn't match anything in
-   * `messages` we fall back to a normal `sendMessage` (defensive — this
-   * shouldn't happen given the UI guard).
-   */
+  // Cancel the in-flight stream, drop the edited user message + partial
+  // assistant response, then send the new text. Caller must guard
+  // `editingMessageId === lastUserMessageId` and an active stream.
   const rewindAndResend = useCallback(
     async ({
       text,
@@ -527,36 +476,26 @@ export function useChatStreaming(externalThreadId?: string | null) {
 
       const idx = messages.findIndex((m) => m.id === editingMessageId)
       if (idx === -1) {
-        // Defensive fallback — UI shouldn't let us get here. Bypass the
-        // queue intercept by going through `dispatchSend` directly; the
-        // rewind path is exclusive of the queue path and should never
-        // land a "send" in the queued slot.
+        // Defensive — UI shouldn't let us get here.
         await dispatchSend({ text, files })
         return
       }
 
-      // 1. Stop the active main-process stream first so it doesn't keep
-      // pushing chunks (and persisting partial snapshots) while we trim.
       if (currentThreadId) {
         try {
           await window.electronAPI.chat.cancelStream(currentThreadId)
         } catch {
-          // best effort — we still tear down the renderer-side state below
+          // best effort
         }
       }
       await stop()
       clearError()
 
-      // 2. Drop the edited user message AND everything after it (the
-      // partial assistant response). `setMessages` updates the renderer's
-      // local view immediately.
       const trimmed = messages.slice(0, idx)
       setMessages(trimmed)
 
-      // 3. Overwrite the SQLite snapshot so a mid-flight navigation can't
-      // resurrect the partial state. The active stream's `finalizeError`
-      // path may have raced a snapshot write through `flushPersist`; this
-      // overwrite is the source of truth from the user's perspective.
+      // Overwrite the SQLite snapshot so a navigation mid-rewind can't
+      // resurrect the partial state left by `finalizeError`'s flushPersist.
       if (currentThreadId) {
         try {
           await window.electronAPI.chat.updateThreadMessages(
@@ -571,15 +510,9 @@ export function useChatStreaming(externalThreadId?: string | null) {
         }
       }
 
-      // 4. Start the new stream. Use `dispatchSend` (not
-      // `validatedSendMessage`) so the in-flight `status === 'streaming'`
-      // closure value doesn't route this send into the queue. The
-      // captured `status` won't update synchronously after `stop()` —
-      // routing the rewind through `validatedSendMessage` here would
-      // queue the edited message and then auto-flush it on the next
-      // tick, which is observably the same outcome but adds an extra
-      // round-trip and a misleading "Queued" chip flash for the user.
-      // We discard the AI SDK's sendMessage return — no caller reads it.
+      // `dispatchSend` (not `validatedSendMessage`): the in-flight
+      // `status === 'streaming'` is closed over and would route us into
+      // the queue, flashing a misleading "Queued" chip before auto-flush.
       await dispatchSend({ text, files })
     },
     [

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -197,13 +197,22 @@ export function useChatStreaming(externalThreadId?: string | null) {
     }
   }, [currentThreadId])
 
-  useEffect(() => {
+  const prevQueueStatusRef = useRef(status)
+
+  // Clear the queue when the user switches threads — done in render (not an
+  // effect) so the auto-flush below sees the null synchronously. An effect
+  // would race the auto-flush in the same render and leak A's message into B.
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [queueOwnerThreadId, setQueueOwnerThreadId] =
+    useState<typeof currentThreadId>(currentThreadId)
+  if (currentThreadId !== queueOwnerThreadId) {
+    setQueueOwnerThreadId(currentThreadId)
     setQueuedMessage(null)
-  }, [currentThreadId])
+    prevQueueStatusRef.current = status
+  }
 
   // Auto-flush on streaming→ready only (not →error: would re-fail on a broken
   // provider). Calls `sendMessage` directly to skip re-validation/re-queuing.
-  const prevQueueStatusRef = useRef(status)
   useEffect(() => {
     const prev = prevQueueStatusRef.current
     prevQueueStatusRef.current = status

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -408,7 +408,7 @@ export function useChatStreaming(externalThreadId?: string | null) {
       text: string
       files?: FileUIPart[]
       editingMessageId: string
-    }) => {
+    }): Promise<void> => {
       if (
         !settings.provider ||
         !settings.model ||
@@ -427,7 +427,8 @@ export function useChatStreaming(externalThreadId?: string | null) {
       const idx = messages.findIndex((m) => m.id === editingMessageId)
       if (idx === -1) {
         // Defensive fallback — UI shouldn't let us get here.
-        return validatedSendMessage({ text, files })
+        await validatedSendMessage({ text, files })
+        return
       }
 
       // 1. Stop the active main-process stream first so it doesn't keep
@@ -467,8 +468,9 @@ export function useChatStreaming(externalThreadId?: string | null) {
       }
 
       // 4. Start the new stream. `validatedSendMessage` re-validates
-      // settings and ensures the thread row exists.
-      return validatedSendMessage({ text, files })
+      // settings and ensures the thread row exists. We discard the AI
+      // SDK's sendMessage return — no caller reads it.
+      await validatedSendMessage({ text, files })
     },
     [
       settings,

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -23,9 +23,20 @@ function dropTrailingAssistant(messages: ChatUIMessage[]): ChatUIMessage[] {
   return messages.slice(0, -1)
 }
 
+/**
+ * A message the user submitted while a stream was active, held in renderer
+ * memory until the current stream finishes (or until the user cancels).
+ *
+ * Single slot per thread — submitting a new message while one is already
+ * queued replaces it, matching a "draft" mental model. Lost on app restart
+ * (in-memory only; no SQLite persistence in V1).
+ */
+type QueuedMessage = { text: string; files?: FileUIPart[] }
+
 export function useChatStreaming(externalThreadId?: string | null) {
   const queryClient = useQueryClient()
   const [persistentError, setPersistentError] = useState<string | null>(null)
+  const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null)
 
   const {
     settings,
@@ -193,6 +204,51 @@ export function useChatStreaming(externalThreadId?: string | null) {
     }
   }, [currentThreadId])
 
+  // Drop any queued message when the user switches threads — the queue is
+  // per-thread and we never auto-send across threads. Done in an effect so
+  // both `externalThreadId` (prop-driven) and the resolved `currentThreadId`
+  // changes are honored — `currentThreadId` is the source of truth.
+  useEffect(() => {
+    setQueuedMessage(null)
+  }, [currentThreadId])
+
+  // Auto-fire the queued message when the active stream finishes.
+  //
+  // We watch the `streaming`/`submitted` → other-state transition rather
+  // than just "status is idle". Without that, mounting with `status='ready'`
+  // and a stale queue would flush immediately, and resume-from-snapshot
+  // races could fire twice.
+  //
+  // Important: we deliberately call the AI SDK's `sendMessage` directly
+  // here (NOT `validatedSendMessage`) — re-running validation on the auto-
+  // flush path would re-queue the message into oblivion. The settings were
+  // already valid when the user submitted (otherwise the validation in
+  // `validatedSendMessage` would have thrown), so re-validation is moot.
+  //
+  // If status flips to `error` (not `ready`), we leave the queue intact so
+  // the user can cancel or retry once the error is resolved. Auto-firing
+  // onto a broken provider would just produce a second error.
+  const prevQueueStatusRef = useRef(status)
+  useEffect(() => {
+    const prev = prevQueueStatusRef.current
+    prevQueueStatusRef.current = status
+    const wasStreaming = prev === 'streaming' || prev === 'submitted'
+    const nowIdle = status === 'ready'
+    if (!wasStreaming || !nowIdle) return
+    if (!queuedMessage) return
+    const toSend = queuedMessage
+    setQueuedMessage(null)
+    // Fire-and-forget — `sendMessage` returns a Promise, but the AI SDK
+    // surfaces failures via `error` which we already render in `ErrorAlert`.
+    Promise.resolve(sendMessage(toSend)).catch((err) => {
+      log.error('[useChatStreaming] Auto-flush of queued message failed:', err)
+    })
+  }, [status, queuedMessage, sendMessage])
+
+  const cancelQueuedMessage = useCallback(() => {
+    setQueuedMessage(null)
+  }, [])
+
   const isPersistentLoading = !!currentThreadId && isThreadDataPending
 
   const isLoading =
@@ -338,7 +394,14 @@ export function useChatStreaming(externalThreadId?: string | null) {
     return 'An unknown error occurred'
   }
 
-  const validatedSendMessage = useCallback(
+  /**
+   * Validate settings, promote the draft thread to a DB row if needed,
+   * then call the AI SDK's `sendMessage` directly. Used by both the
+   * normal-send path (after queue check) and the rewind path. Does NOT
+   * touch the queue — callers that need queue-while-streaming behavior
+   * go through {@link validatedSendMessage}.
+   */
+  const dispatchSend = useCallback(
     async (
       messageOrText:
         | string
@@ -373,6 +436,44 @@ export function useChatStreaming(externalThreadId?: string | null) {
       }
     },
     [settings, sendMessage, currentThreadId]
+  )
+
+  const validatedSendMessage = useCallback(
+    async (
+      messageOrText:
+        | string
+        | {
+            text: string
+            files?: FileUIPart[]
+          }
+    ) => {
+      // Queue-while-streaming: hold the message in renderer memory and
+      // auto-fire it when the current stream finishes. Validation still
+      // runs first (via `dispatchSend` below for the immediate path; we
+      // mirror its settings check here so a misconfigured queue submit
+      // surfaces the error to the user immediately).
+      //
+      // The rewind-and-retry path bypasses this entirely by calling
+      // `dispatchSend` directly — see `rewindAndResend`.
+      if (status === 'streaming' || status === 'submitted') {
+        if (
+          !settings.provider ||
+          !settings.model ||
+          !hasValidCredentials(settings)
+        ) {
+          throw new Error('Please configure your AI provider settings first')
+        }
+        const queued: QueuedMessage =
+          typeof messageOrText === 'string'
+            ? { text: messageOrText }
+            : messageOrText
+        setQueuedMessage(queued)
+        return
+      }
+
+      return dispatchSend(messageOrText)
+    },
+    [dispatchSend, settings, status]
   )
 
   /**
@@ -426,8 +527,11 @@ export function useChatStreaming(externalThreadId?: string | null) {
 
       const idx = messages.findIndex((m) => m.id === editingMessageId)
       if (idx === -1) {
-        // Defensive fallback — UI shouldn't let us get here.
-        await validatedSendMessage({ text, files })
+        // Defensive fallback — UI shouldn't let us get here. Bypass the
+        // queue intercept by going through `dispatchSend` directly; the
+        // rewind path is exclusive of the queue path and should never
+        // land a "send" in the queued slot.
+        await dispatchSend({ text, files })
         return
       }
 
@@ -467,10 +571,16 @@ export function useChatStreaming(externalThreadId?: string | null) {
         }
       }
 
-      // 4. Start the new stream. `validatedSendMessage` re-validates
-      // settings and ensures the thread row exists. We discard the AI
-      // SDK's sendMessage return — no caller reads it.
-      await validatedSendMessage({ text, files })
+      // 4. Start the new stream. Use `dispatchSend` (not
+      // `validatedSendMessage`) so the in-flight `status === 'streaming'`
+      // closure value doesn't route this send into the queue. The
+      // captured `status` won't update synchronously after `stop()` —
+      // routing the rewind through `validatedSendMessage` here would
+      // queue the edited message and then auto-flush it on the next
+      // tick, which is observably the same outcome but adds an extra
+      // round-trip and a misleading "Queued" chip flash for the user.
+      // We discard the AI SDK's sendMessage return — no caller reads it.
+      await dispatchSend({ text, files })
     },
     [
       settings,
@@ -480,7 +590,7 @@ export function useChatStreaming(externalThreadId?: string | null) {
       stop,
       clearError,
       setMessages,
-      validatedSendMessage,
+      dispatchSend,
     ]
   )
 
@@ -516,6 +626,8 @@ export function useChatStreaming(externalThreadId?: string | null) {
       loadPersistedSettings,
       isPersistentLoading,
       currentThreadId,
+      queuedMessage,
+      cancelQueuedMessage,
     }
   }, [
     status,
@@ -534,5 +646,7 @@ export function useChatStreaming(externalThreadId?: string | null) {
     clearError,
     stop,
     currentThreadId,
+    queuedMessage,
+    cancelQueuedMessage,
   ])
 }

--- a/renderer/src/features/chat/hooks/use-composer-handle.ts
+++ b/renderer/src/features/chat/hooks/use-composer-handle.ts
@@ -1,0 +1,44 @@
+import { useEffect, type RefObject } from 'react'
+import type { ChatComposerHandle } from '../components/chat-input-prompt'
+
+/**
+ * Registers an imperative handle on `composerHandleRef` so callers outside
+ * this subtree (e.g. the message list's "Edit message" button) can pre-fill
+ * the composer's text and focus the textarea without prop-drilling through
+ * the entire tree.
+ *
+ * The handle is populated on mount and cleared on unmount — both the
+ * empty-state and bottom composers share the same ref slot, so the parent
+ * can tell whether a composer is currently mounted by checking
+ * `composerHandleRef.current`.
+ */
+export function useComposerHandle(
+  composerHandleRef: RefObject<ChatComposerHandle | null> | undefined,
+  setText: (text: string) => void,
+  textareaRef: RefObject<HTMLTextAreaElement | null>
+): void {
+  useEffect(() => {
+    if (!composerHandleRef) return
+    composerHandleRef.current = {
+      setText,
+      focusTextarea: () => {
+        const el = textareaRef.current
+        if (!el) return
+        el.focus()
+        const end = el.value.length
+        try {
+          el.setSelectionRange(end, end)
+        } catch {
+          // Some textarea types (e.g. <input type="number">) throw on
+          // setSelectionRange. Plain text textareas never do — guard anyway
+          // so a stray DOM shape can't break the edit flow.
+        }
+      },
+    }
+    return () => {
+      if (composerHandleRef.current) {
+        composerHandleRef.current = null
+      }
+    }
+  }, [composerHandleRef, setText, textareaRef])
+}

--- a/renderer/src/features/chat/hooks/use-composer-handle.ts
+++ b/renderer/src/features/chat/hooks/use-composer-handle.ts
@@ -1,17 +1,8 @@
 import { useEffect, type RefObject } from 'react'
 import type { ChatComposerHandle } from '../components/chat-input-prompt'
 
-/**
- * Registers an imperative handle on `composerHandleRef` so callers outside
- * this subtree (e.g. the message list's "Edit message" button) can pre-fill
- * the composer's text and focus the textarea without prop-drilling through
- * the entire tree.
- *
- * The handle is populated on mount and cleared on unmount — both the
- * empty-state and bottom composers share the same ref slot, so the parent
- * can tell whether a composer is currently mounted by checking
- * `composerHandleRef.current`.
- */
+// Lets callers outside this subtree drive the composer (e.g. "Edit message").
+// Ref is null when no composer is mounted.
 export function useComposerHandle(
   composerHandleRef: RefObject<ChatComposerHandle | null> | undefined,
   setText: (text: string) => void,
@@ -29,9 +20,7 @@ export function useComposerHandle(
         try {
           el.setSelectionRange(end, end)
         } catch {
-          // Some textarea types (e.g. <input type="number">) throw on
-          // setSelectionRange. Plain text textareas never do — guard anyway
-          // so a stray DOM shape can't break the edit flow.
+          // Non-text input types throw on setSelectionRange.
         }
       },
     }


### PR DESCRIPTION
Closes the loop on the chat-UX series. When the user types into the composer while the assistant is still streaming a response, the message is held as a per-thread queued draft (single slot, in-memory) and auto-fires when the current stream finishes. A small chip above the composer surfaces the queued state with a cancel button. The submit button morphs into a send-style icon during streaming so the queue action is visually distinct from the existing stop affordance.

Mutually exclusive with the rewind-and-retry path from #2241 — when editing the LAST user message during streaming, that flow still wins (rewind chip + `RefreshCw` icon). The queue chip and rewind chip can never render together.

Part 3 of three planned chat UX enhancements. Copy (#2235) and Edit/resend with rewind-and-retry (#2241) already shipped.

<img width="1282" height="802" alt="Screenshot 2026-05-13 at 18 09 47" src="https://github.com/user-attachments/assets/4f1dda74-d130-4af3-8d00-ec9722dbd0c6" />


## What changes

Two commits — the first cleans up the nits called out on #2241; the second adds the queue feature.

### Commit 1: refactor — `useComposerHandle` hook + tighter return types

- **New** [`use-composer-handle.ts`](renderer/src/features/chat/hooks/use-composer-handle.ts) extracts the imperative-handle `useEffect` from `ChatInputPrompt`. The hook signature `useComposerHandle(composerHandleRef, setText, textareaRef)` reads as one operation and is directly testable.
- **`onRewindAndResend` return type** tightened from `Promise<unknown>` to `Promise<void>` everywhere it's defined. No caller reads the result.

### Commit 2: feat — queue while streaming

**State in `useChatStreaming`:**

- New `queuedMessage: { text, files? } | null`, cleared on `currentThreadId` change.
- `validatedSendMessage` intercepts when `status === 'streaming' | 'submitted'`: stores the payload in `queuedMessage` instead of calling the AI SDK `sendMessage`. A second submit while one is queued **replaces** the slot.
- A `prevStatusRef`-driven effect fires the queued payload via the AI SDK `sendMessage` directly (NOT `validatedSendMessage`, to avoid re-queuing on the auto-flush path) when status transitions out of streaming, then clears the queue.
- **Refactored** `validatedSendMessage` to extract a private `dispatchSend` (validate + ensure-thread + AI SDK send). `rewindAndResend` calls `dispatchSend` directly, bypassing the queue intercept — otherwise the in-flight `status === 'streaming'` would route the rewind into the queue and flash a misleading "Queued" chip before auto-flushing.
- **Error handling**: if status transitions to `error` (not `ready`), the auto-flush effect deliberately does NOT fire. Chip stays visible so the user can cancel manually.

**UI:**

- **New** [`queued-message-chip.tsx`](renderer/src/features/chat/components/queued-message-chip.tsx) — subtle chip above `<PromptInput>`, truncated preview (60 chars) + attachment count + `X` cancel button. Styling clones the rewind chip's classes so they feel like siblings.
- **Submit button** in [`chat-input-prompt.tsx`](renderer/src/features/chat/components/chat-input-prompt.tsx):
  - Streaming + editing last user message → `RefreshCw` → rewind+retry (existing)
  - Streaming + composer non-empty + NOT editing → `SendHorizontal`, tooltip *"Queue message — sends when the current response finishes"*
  - Streaming + composer empty → Stop (existing)
  - Idle → Send (existing)
- Queue chip renders only when `queuedMessage !== null && !isEditingStreaming`. Rewind chip wins when both could apply.

**Plumbing:** `chat-interface.tsx` plumbs `queuedMessage` + `cancelQueuedMessage` into both `ChatInputPrompt` mount sites (empty-state + bottom toolbar), matching the existing pattern from #2241.

## How to validate

### Queue path
1. Send a slow-streaming message. While the assistant is streaming, type a new message — the submit button now shows a `SendHorizontal` icon. Click it → composer clears, chip appears: *`Queued: "<your text>" — sends when the current response finishes` [X]*.
2. Wait for the current stream to finish → queued message auto-sends, chip disappears.
3. Cancel the queue mid-stream via the `X` → chip clears, in-flight stream continues uninterrupted, no auto-fire.
4. Queue a message, then submit another → the queued slot is replaced (preview updates, single chip).
5. Queue a message, switch threads → chip is gone in thread B; switch back to A → still gone (V1: queue cleared on thread switch).
6. Force the in-flight stream to error → chip stays visible, no auto-flush.

### Mutual exclusivity with rewind (#2241)
7. Click Edit on the LAST user message while streaming → rewind chip appears (not queue chip), submit icon is `RefreshCw`, submit triggers rewind+retry.
8. Click Edit on an OLDER user message while streaming → composer prefills, rewind mode does NOT activate, submit triggers the queue path.

### Quality
9. `pnpm run test:nonInteractive run renderer/src/features/chat` — 402/402 pass (+22 net new).
10. `pnpm run type-check` and ESLint on touched files — clean.

## Out of scope

- **Persisting the queue across app restarts** — in-memory only; easy follow-up if needed.
- **Multi-message FIFO queue** — single slot matches a draft mental model.
- **Cross-thread queues** — explicit non-goal.
- **Auto-flush on `error`** — deliberately off; user retains control.