### PR TITLE
chore(sentry): tone down session replay sampling

### DIFF
--- a/renderer/src/lib/sentry.ts
+++ b/renderer/src/lib/sentry.ts
@@ -18,12 +18,12 @@ export function initSentry() {
     // Learn more at
     // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
     tracesSampleRate: 1.0,
-    // Capture Replay for 10% of all sessions,
-    // plus for 100% of sessions with an error
+    // Disable random session replays and capture 10% of sessions with an
+    // error to keep replay volume low.
     // Learn more at
     // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#general-integration-configuration
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 0.1,
     // It will send errors, exceptions and captured messages to Sentry only if the user has enabled telemetry
     beforeSend: async (event) =>
       (await window.electronAPI.sentry.isEnabled()) ? event : null,


### PR DESCRIPTION
## Summary
- Drop `replaysSessionSampleRate` from `0.1` to `0` — stop randomly recording user sessions.
- Drop `replaysOnErrorSampleRate` from `1.0` to `0.1` — capture 10% of error sessions instead of 100%.

This significantly reduces replay volume sent to Sentry while keeping a small sample of error replays for debugging.

## Test plan
- [ ] CI lint/type-check/tests pass
- [ ] After release, verify replay event volume in Sentry drops as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)