### PR TITLE
feat(playground): per-thread model, MCP, and skills selection

### DIFF
--- a/main/src/chat/__tests__/mcp-tools.test.ts
+++ b/main/src/chat/__tests__/mcp-tools.test.ts
@@ -64,6 +64,15 @@ vi.mock('../settings-storage', () => ({
   getEnabledMcpTools: mockGetEnabledMcpTools,
 }))
 
+vi.mock('../thread-settings-storage', () => ({
+  getThreadEnabledMcpTools: vi.fn().mockReturnValue({}),
+  getThreadEnabledSkills: vi.fn().mockReturnValue([]),
+  getThreadSelectedModel: vi.fn().mockReturnValue(null),
+  setThreadEnabledMcpTools: vi.fn().mockReturnValue({ success: true }),
+  setThreadEnabledSkill: vi.fn().mockReturnValue({ success: true }),
+  setThreadSelectedModel: vi.fn().mockReturnValue({ success: true }),
+}))
+
 vi.mock('../../utils/mcp-tools', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('../../utils/mcp-tools')>()

--- a/main/src/chat/__tests__/streaming.test.ts
+++ b/main/src/chat/__tests__/streaming.test.ts
@@ -230,7 +230,9 @@ describe('handleChatStreamRealtime — agent resolution', () => {
       fakeSender
     )
 
-    expect(mockCreateBuiltinAgentTools).toHaveBeenCalledWith('skills')
+    expect(mockCreateBuiltinAgentTools).toHaveBeenCalledWith('skills', {
+      threadId: 'thread-1',
+    })
     expect(mockToolLoopAgentCtor).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: expect.objectContaining({ build_skill: expect.anything() }),
@@ -255,7 +257,9 @@ describe('handleChatStreamRealtime — agent resolution', () => {
       fakeSender
     )
 
-    expect(mockCreateBuiltinAgentTools).toHaveBeenCalledWith('skills')
+    expect(mockCreateBuiltinAgentTools).toHaveBeenCalledWith('skills', {
+      threadId: 'thread-1',
+    })
     expect(mockToolLoopAgentCtor).toHaveBeenCalledWith(
       expect.objectContaining({
         instructions:

--- a/main/src/chat/__tests__/thread-settings-storage.test.ts
+++ b/main/src/chat/__tests__/thread-settings-storage.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockReadThread = vi.hoisted(() => vi.fn())
+const mockReadThreadSelectedModel = vi.hoisted(() => vi.fn())
+const mockReadThreadEnabledMcpTools = vi.hoisted(() => vi.fn())
+const mockReadThreadEnabledSkills = vi.hoisted(() => vi.fn())
+
+const mockWriteThread = vi.hoisted(() => vi.fn())
+const mockWriteThreadSelectedModel = vi.hoisted(() => vi.fn())
+const mockWriteThreadEnabledMcpTools = vi.hoisted(() => vi.fn())
+const mockWriteThreadEnabledSkills = vi.hoisted(() => vi.fn())
+
+vi.mock('../../db/readers/threads-reader', () => ({
+  readThread: mockReadThread,
+  readThreadSelectedModel: mockReadThreadSelectedModel,
+  readThreadEnabledMcpTools: mockReadThreadEnabledMcpTools,
+  readThreadEnabledSkills: mockReadThreadEnabledSkills,
+}))
+
+vi.mock('../../db/writers/threads-writer', () => ({
+  writeThread: mockWriteThread,
+  writeThreadSelectedModel: mockWriteThreadSelectedModel,
+  writeThreadEnabledMcpTools: mockWriteThreadEnabledMcpTools,
+  writeThreadEnabledSkills: mockWriteThreadEnabledSkills,
+}))
+
+vi.mock('../../logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import {
+  getThreadSelectedModel,
+  setThreadSelectedModel,
+  getThreadEnabledMcpTools,
+  setThreadEnabledMcpTools,
+  getThreadEnabledSkills,
+  setThreadEnabledSkill,
+} from '../thread-settings-storage'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockReadThread.mockReturnValue({
+    id: 'thread-1',
+    messages: [],
+    lastEditTimestamp: 0,
+    createdAt: 0,
+  })
+})
+
+describe('getThreadSelectedModel', () => {
+  it('returns the per-thread row when it has both fields', () => {
+    mockReadThreadSelectedModel.mockReturnValue({
+      provider: 'openai',
+      model: 'gpt-4o',
+    })
+    expect(getThreadSelectedModel('thread-1')).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o',
+    })
+  })
+
+  it('returns null when the per-thread row has no model set', () => {
+    mockReadThreadSelectedModel.mockReturnValue(null)
+    expect(getThreadSelectedModel('thread-1')).toBeNull()
+  })
+
+  it('returns null and logs when the reader throws', () => {
+    mockReadThreadSelectedModel.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    expect(getThreadSelectedModel('thread-1')).toBeNull()
+  })
+})
+
+describe('setThreadSelectedModel', () => {
+  it('writes the model to the per-thread row and reports success', () => {
+    const result = setThreadSelectedModel('thread-1', 'openai', 'gpt-4o')
+    expect(result).toEqual({ success: true })
+    expect(mockWriteThreadSelectedModel).toHaveBeenCalledWith(
+      'thread-1',
+      'openai',
+      'gpt-4o'
+    )
+  })
+
+  it('materialises a draft thread row before writing the model', () => {
+    mockReadThread.mockReturnValueOnce(null)
+    setThreadSelectedModel('thread-draft', 'openai', 'gpt-4o')
+    // writeThread is called first to materialise the row, then the model
+    // is written.
+    expect(mockWriteThread).toHaveBeenCalledTimes(1)
+    expect(mockWriteThread.mock.calls[0]?.[0]?.id).toBe('thread-draft')
+    expect(mockWriteThreadSelectedModel).toHaveBeenCalledWith(
+      'thread-draft',
+      'openai',
+      'gpt-4o'
+    )
+  })
+
+  it('stores NULL when provider or model is an empty string', () => {
+    setThreadSelectedModel('thread-1', '', '')
+    expect(mockWriteThreadSelectedModel).toHaveBeenCalledWith(
+      'thread-1',
+      null,
+      null
+    )
+  })
+
+  it('returns a failure result when row materialisation throws', () => {
+    mockReadThread.mockReturnValueOnce(null)
+    mockWriteThread.mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+    const result = setThreadSelectedModel('thread-draft', 'openai', 'gpt-4o')
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('disk full')
+    expect(mockWriteThreadSelectedModel).not.toHaveBeenCalled()
+  })
+
+  it('returns a failure result when the model writer throws', () => {
+    mockWriteThreadSelectedModel.mockImplementationOnce(() => {
+      throw new Error('locked')
+    })
+    const result = setThreadSelectedModel('thread-1', 'openai', 'gpt-4o')
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('locked')
+  })
+})
+
+describe('getThreadEnabledMcpTools', () => {
+  it('returns the per-thread record', () => {
+    mockReadThreadEnabledMcpTools.mockReturnValue({ alpha: ['t1', 't2'] })
+    expect(getThreadEnabledMcpTools('thread-1')).toEqual({
+      alpha: ['t1', 't2'],
+    })
+  })
+
+  it('returns an empty object when the reader throws', () => {
+    mockReadThreadEnabledMcpTools.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    expect(getThreadEnabledMcpTools('thread-1')).toEqual({})
+  })
+})
+
+describe('setThreadEnabledMcpTools', () => {
+  it('merges the new server entry into the existing per-thread map', () => {
+    mockReadThreadEnabledMcpTools.mockReturnValue({
+      alpha: ['t1'],
+      beta: ['z1'],
+    })
+    const result = setThreadEnabledMcpTools('thread-1', 'beta', ['z2', 'z3'])
+    expect(result).toEqual({ success: true })
+    expect(mockWriteThreadEnabledMcpTools).toHaveBeenCalledWith('thread-1', {
+      alpha: ['t1'],
+      beta: ['z2', 'z3'],
+    })
+  })
+
+  it('seeds a new server entry when the per-thread map is empty', () => {
+    mockReadThreadEnabledMcpTools.mockReturnValue({})
+    setThreadEnabledMcpTools('thread-1', 'alpha', ['t1'])
+    expect(mockWriteThreadEnabledMcpTools).toHaveBeenCalledWith('thread-1', {
+      alpha: ['t1'],
+    })
+  })
+
+  it('materialises a draft thread row before merging the tools map', () => {
+    mockReadThread.mockReturnValueOnce(null)
+    mockReadThreadEnabledMcpTools.mockReturnValue({})
+    setThreadEnabledMcpTools('thread-draft', 'alpha', ['t1'])
+    expect(mockWriteThread).toHaveBeenCalledTimes(1)
+    expect(mockWriteThread.mock.calls[0]?.[0]?.id).toBe('thread-draft')
+  })
+})
+
+describe('getThreadEnabledSkills', () => {
+  it('returns the per-thread skill list', () => {
+    mockReadThreadEnabledSkills.mockReturnValue(['s1', 's2'])
+    expect(getThreadEnabledSkills('thread-1')).toEqual(['s1', 's2'])
+  })
+
+  it('returns an empty array when the reader throws', () => {
+    mockReadThreadEnabledSkills.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    expect(getThreadEnabledSkills('thread-1')).toEqual([])
+  })
+})
+
+describe('setThreadEnabledSkill', () => {
+  it('adds a skill to the per-thread allow-list when enabling', () => {
+    mockReadThreadEnabledSkills.mockReturnValue(['existing'])
+    const result = setThreadEnabledSkill('thread-1', 'new-skill', true)
+    expect(result).toEqual({ success: true })
+    expect(mockWriteThreadEnabledSkills).toHaveBeenCalledWith('thread-1', [
+      'existing',
+      'new-skill',
+    ])
+  })
+
+  it('removes a skill when disabling', () => {
+    mockReadThreadEnabledSkills.mockReturnValue(['s1', 's2', 's3'])
+    setThreadEnabledSkill('thread-1', 's2', false)
+    expect(mockWriteThreadEnabledSkills).toHaveBeenCalledWith('thread-1', [
+      's1',
+      's3',
+    ])
+  })
+
+  it('deduplicates when enabling an already-enabled skill', () => {
+    mockReadThreadEnabledSkills.mockReturnValue(['s1'])
+    setThreadEnabledSkill('thread-1', 's1', true)
+    expect(mockWriteThreadEnabledSkills).toHaveBeenCalledWith('thread-1', [
+      's1',
+    ])
+  })
+
+  it('writes the list sorted to keep the storage shape stable', () => {
+    mockReadThreadEnabledSkills.mockReturnValue(['zeta', 'alpha'])
+    setThreadEnabledSkill('thread-1', 'mid', true)
+    expect(mockWriteThreadEnabledSkills).toHaveBeenCalledWith('thread-1', [
+      'alpha',
+      'mid',
+      'zeta',
+    ])
+  })
+
+  it('refuses empty skill names with a failure result', () => {
+    const result = setThreadEnabledSkill('thread-1', '   ', true)
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/empty/i)
+    expect(mockWriteThreadEnabledSkills).not.toHaveBeenCalled()
+  })
+
+  it('materialises a draft thread row before toggling', () => {
+    mockReadThread.mockReturnValueOnce(null)
+    mockReadThreadEnabledSkills.mockReturnValue([])
+    setThreadEnabledSkill('thread-draft', 'skill-a', true)
+    expect(mockWriteThread).toHaveBeenCalledTimes(1)
+    expect(mockWriteThread.mock.calls[0]?.[0]?.id).toBe('thread-draft')
+  })
+
+  it('returns a failure result when row materialisation throws', () => {
+    mockReadThread.mockReturnValueOnce(null)
+    mockWriteThread.mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+    const result = setThreadEnabledSkill('thread-draft', 's1', true)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('disk full')
+    expect(mockWriteThreadEnabledSkills).not.toHaveBeenCalled()
+  })
+})

--- a/main/src/chat/agents/builtin-agent-tools/__tests__/index.test.ts
+++ b/main/src/chat/agents/builtin-agent-tools/__tests__/index.test.ts
@@ -17,6 +17,10 @@ vi.mock('../skills', () => ({
   createSkillsAgentTools: vi.fn(() => Promise.resolve(mockSkillsHandle)),
 }))
 
+vi.mock('../../../thread-settings-storage', () => ({
+  getThreadEnabledSkills: vi.fn().mockReturnValue([]),
+}))
+
 import { createBuiltinAgentTools } from '../index'
 import { createSkillsAgentTools } from '../skills'
 

--- a/main/src/chat/agents/builtin-agent-tools/index.ts
+++ b/main/src/chat/agents/builtin-agent-tools/index.ts
@@ -1,6 +1,7 @@
 import type { ToolSet } from 'ai'
 import type { BuiltinToolsKey } from '@common/types/agents'
 import { createSkillsAgentTools, type SkillsAgentToolsHandle } from './skills'
+import { getThreadEnabledSkills } from '../../thread-settings-storage'
 
 interface BuiltinToolsHandle {
   tools: ToolSet
@@ -19,13 +20,20 @@ const EMPTY_HANDLE: BuiltinToolsHandle = {
 }
 
 export async function createBuiltinAgentTools(
-  key: BuiltinToolsKey | null | undefined
+  key: BuiltinToolsKey | null | undefined,
+  options: { threadId?: string } = {}
 ): Promise<BuiltinToolsHandle> {
   if (!key) return EMPTY_HANDLE
 
   switch (key) {
     case 'skills': {
-      const handle: SkillsAgentToolsHandle = await createSkillsAgentTools()
+      const handle: SkillsAgentToolsHandle = await createSkillsAgentTools(
+        options.threadId
+          ? {
+              getEnabledSkills: () => getThreadEnabledSkills(options.threadId!),
+            }
+          : undefined
+      )
       return handle
     }
     default:

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -17,6 +17,7 @@ import { createMainProcessApiClient } from '../unix-socket-fetch'
 import log from '../logger'
 import type { AvailableServer } from './types'
 import { getEnabledMcpTools } from './settings-storage'
+import { getThreadEnabledMcpTools } from './thread-settings-storage'
 import {
   type McpToolDefinition,
   buildRawTransport,
@@ -278,7 +279,8 @@ export async function getToolhiveMcpInfo(
 
 // Get MCP server tools information
 export async function getMcpServerTools(
-  serverName: string
+  serverName: string,
+  threadId?: string
 ): Promise<AvailableServer | null> {
   if (!serverName) {
     log.error('getMcpServerTools: serverName is not passed')
@@ -287,8 +289,11 @@ export async function getMcpServerTools(
   const workloads = await fetchWorkloads()
   const workload = workloads.find((w) => w.name === serverName)
 
-  // Get enabled tools for this server
-  const enabledTools = await getEnabledMcpTools()
+  // Get enabled tools for this server (per-thread when threadId is given,
+  // otherwise fall back to the global defaults used by settings UIs).
+  const enabledTools = threadId
+    ? getThreadEnabledMcpTools(threadId)
+    : await getEnabledMcpTools()
   const enabledToolNames = enabledTools[serverName] || []
 
   if (!workload && serverName === TOOLHIVE_MCP_SERVER_NAME) {
@@ -337,7 +342,7 @@ export async function getMcpServerTools(
 }
 
 // Create MCP tools for AI SDK
-export async function createMcpTools(): Promise<{
+export async function createMcpTools(threadId?: string): Promise<{
   tools: ToolSet
   clients: Awaited<ReturnType<typeof createMCPClient>>[]
   enabledTools: Record<string, string[]>
@@ -393,7 +398,9 @@ export async function createMcpTools(): Promise<{
   try {
     const [workloads, resolvedEnabledTools] = await Promise.all([
       fetchWorkloads(),
-      getEnabledMcpTools(),
+      threadId
+        ? Promise.resolve(getThreadEnabledMcpTools(threadId))
+        : getEnabledMcpTools(),
     ])
     enabledTools = resolvedEnabledTools
     // Flag is set here, AFTER the two required calls resolved, so any

--- a/main/src/chat/streaming.ts
+++ b/main/src/chat/streaming.ts
@@ -86,16 +86,18 @@ export async function handleChatStreamRealtime(
           ? (getAgent(request.agentId) ?? resolveAgentForThread(request.chatId))
           : resolveAgentForThread(request.chatId)
 
-        // Get MCP tools if enabled
+        // Get MCP tools if enabled (per-thread when chatId is given)
         const {
           tools: mcpTools,
           clients: mcpClients,
           enabledTools,
-        } = await createMcpTools()
+        } = await createMcpTools(request.chatId)
 
-        // Agent-specific built-in tools (e.g. Skills Builder, Skill Tester)
+        // Agent-specific built-in tools (e.g. Skills Builder, Skill Tester).
+        // Pass the threadId so per-thread skill enablement is honoured.
         const builtinToolsHandle = await createBuiltinAgentTools(
-          agentConfig.builtinToolsKey ?? null
+          agentConfig.builtinToolsKey ?? null,
+          { threadId: request.chatId }
         )
         const builtinTools = builtinToolsHandle.tools
 

--- a/main/src/chat/thread-settings-storage.ts
+++ b/main/src/chat/thread-settings-storage.ts
@@ -1,27 +1,41 @@
 import log from '../logger'
 import {
+  readThread,
   readThreadSelectedModel,
   readThreadEnabledMcpTools,
   readThreadEnabledSkills,
 } from '../db/readers/threads-reader'
 import {
+  writeThread,
   writeThreadSelectedModel,
   writeThreadEnabledMcpTools,
   writeThreadEnabledSkills,
 } from '../db/writers/threads-writer'
-import { ensureThreadExists } from './thread-integration'
 
 type Result = { success: boolean; error?: string }
 
+// Materialise a draft thread row before per-thread settings are written. Done
+// directly via DB primitives (rather than `thread-integration`) so this module
+// avoids a hard import on `threads-storage`, whose top-level `new ElectronStore`
+// blows up in tests that don't mock electron.
 function ensureRow(threadId: string): Result {
-  const res = ensureThreadExists(threadId)
-  if (!res.success) {
+  try {
+    const existing = readThread(threadId)
+    if (existing) return { success: true }
+    const now = Date.now()
+    writeThread({
+      id: threadId,
+      messages: [],
+      lastEditTimestamp: now,
+      createdAt: now,
+    })
+    return { success: true }
+  } catch (error) {
     return {
       success: false,
-      error: res.error ?? 'Failed to materialise thread',
+      error: error instanceof Error ? error.message : 'Failed to ensure thread',
     }
   }
-  return { success: true }
 }
 
 export function getThreadSelectedModel(

--- a/main/src/chat/thread-settings-storage.ts
+++ b/main/src/chat/thread-settings-storage.ts
@@ -1,0 +1,123 @@
+import log from '../logger'
+import {
+  readThreadSelectedModel,
+  readThreadEnabledMcpTools,
+  readThreadEnabledSkills,
+} from '../db/readers/threads-reader'
+import {
+  writeThreadSelectedModel,
+  writeThreadEnabledMcpTools,
+  writeThreadEnabledSkills,
+} from '../db/writers/threads-writer'
+import { ensureThreadExists } from './thread-integration'
+
+type Result = { success: boolean; error?: string }
+
+function ensureRow(threadId: string): Result {
+  const res = ensureThreadExists(threadId)
+  if (!res.success) {
+    return {
+      success: false,
+      error: res.error ?? 'Failed to materialise thread',
+    }
+  }
+  return { success: true }
+}
+
+export function getThreadSelectedModel(
+  threadId: string
+): { provider: string; model: string } | null {
+  try {
+    return readThreadSelectedModel(threadId)
+  } catch (err) {
+    log.error('[THREAD-SETTINGS] Failed to read selected model:', err)
+    return null
+  }
+}
+
+export function setThreadSelectedModel(
+  threadId: string,
+  provider: string,
+  model: string
+): Result {
+  try {
+    const promoted = ensureRow(threadId)
+    if (!promoted.success) return promoted
+    writeThreadSelectedModel(threadId, provider || null, model || null)
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+export function getThreadEnabledMcpTools(
+  threadId: string
+): Record<string, string[]> {
+  try {
+    return readThreadEnabledMcpTools(threadId)
+  } catch (err) {
+    log.error('[THREAD-SETTINGS] Failed to read enabled MCP tools:', err)
+    return {}
+  }
+}
+
+export function setThreadEnabledMcpTools(
+  threadId: string,
+  serverName: string,
+  toolNames: string[]
+): Result {
+  try {
+    const promoted = ensureRow(threadId)
+    if (!promoted.success) return promoted
+    const current = readThreadEnabledMcpTools(threadId)
+    const next = { ...current, [serverName]: toolNames }
+    writeThreadEnabledMcpTools(threadId, next)
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+export function getThreadEnabledSkills(threadId: string): string[] {
+  try {
+    return readThreadEnabledSkills(threadId)
+  } catch (err) {
+    log.error('[THREAD-SETTINGS] Failed to read enabled skills:', err)
+    return []
+  }
+}
+
+export function setThreadEnabledSkill(
+  threadId: string,
+  name: string,
+  enabled: boolean
+): Result {
+  try {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      return { success: false, error: 'Skill name cannot be empty.' }
+    }
+    const promoted = ensureRow(threadId)
+    if (!promoted.success) return promoted
+    const current = readThreadEnabledSkills(threadId)
+    const set = new Set(current)
+    if (enabled) {
+      set.add(trimmed)
+    } else {
+      set.delete(trimmed)
+    }
+    writeThreadEnabledSkills(threadId, Array.from(set).sort())
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}

--- a/main/src/chat/threads-storage.ts
+++ b/main/src/chat/threads-storage.ts
@@ -30,6 +30,14 @@ export interface ChatSettingsThread {
    * main process falls back to the default built-in agent.
    */
   agentId?: string | null
+  /** Per-thread selected provider id (e.g. "openai"). NULL falls back to global. */
+  selectedProvider?: string | null
+  /** Per-thread selected model id. NULL falls back to global. */
+  selectedModel?: string | null
+  /** Per-thread enabled MCP tools, keyed by server name. NULL falls back to global. */
+  enabledMcpTools?: Record<string, string[]> | null
+  /** Per-thread enabled skill names. NULL falls back to global. */
+  enabledSkills?: string[] | null
 }
 
 interface ChatSettingsThreads {

--- a/main/src/db/__tests__/schema-and-migrator.test.ts
+++ b/main/src/db/__tests__/schema-and-migrator.test.ts
@@ -4,6 +4,7 @@ import { up as applyInitialSchema } from '../migrations/001-initial-schema'
 import { up as applyMigration002 } from '../migrations/002-thread-title-flag'
 import { up as applyMigration003 } from '../migrations/003-thread-starred'
 import { up as applyMigration006 } from '../migrations/006-enabled-skills'
+import { up as applyMigration007 } from '../migrations/007-per-thread-settings'
 
 vi.mock('electron', () => ({
   app: { getPath: vi.fn(() => ':memory:') },
@@ -277,6 +278,132 @@ describe('006-enabled-skills migration', () => {
     }[]
     expect(rows).toHaveLength(1)
     expect(rows[0]!.name).toBe('foo')
+  })
+})
+
+describe('007-per-thread-settings migration', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    applyInitialSchema(db)
+    applyMigration006(db)
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  it('adds the per-thread settings columns to threads', () => {
+    applyMigration007(db)
+    const cols = db.prepare("PRAGMA table_info('threads')").all() as {
+      name: string
+    }[]
+    const names = cols.map((c) => c.name)
+    expect(names).toContain('selected_provider')
+    expect(names).toContain('selected_model')
+    expect(names).toContain('enabled_mcp_tools')
+    expect(names).toContain('enabled_skills')
+  })
+
+  it('snapshots current globals into every existing thread row', () => {
+    db.prepare(
+      "INSERT INTO threads (id, title, created_at, last_edit_timestamp) VALUES ('t1', 'A', 1000, 1000)"
+    ).run()
+    db.prepare(
+      "INSERT INTO threads (id, title, created_at, last_edit_timestamp) VALUES ('t2', 'B', 2000, 2000)"
+    ).run()
+    db.prepare(
+      "INSERT INTO selected_model (id, provider, model) VALUES (1, 'openai', 'gpt-4o')"
+    ).run()
+    db.prepare(
+      "INSERT INTO enabled_mcp_tools (server_name, tool_names) VALUES ('alpha', ?)"
+    ).run(JSON.stringify(['t1', 't2']))
+    db.prepare("INSERT INTO enabled_skills (name) VALUES ('skill-a')").run()
+    db.prepare("INSERT INTO enabled_skills (name) VALUES ('skill-b')").run()
+
+    applyMigration007(db)
+
+    const rows = db
+      .prepare(
+        `SELECT id, selected_provider, selected_model,
+                enabled_mcp_tools, enabled_skills
+         FROM threads ORDER BY id`
+      )
+      .all() as {
+      id: string
+      selected_provider: string | null
+      selected_model: string | null
+      enabled_mcp_tools: string | null
+      enabled_skills: string | null
+    }[]
+    expect(rows).toHaveLength(2)
+    for (const row of rows) {
+      expect(row.selected_provider).toBe('openai')
+      expect(row.selected_model).toBe('gpt-4o')
+      expect(JSON.parse(row.enabled_mcp_tools!)).toEqual({
+        alpha: ['t1', 't2'],
+      })
+      expect(JSON.parse(row.enabled_skills!)).toEqual(['skill-a', 'skill-b'])
+    }
+  })
+
+  it('writes NULL provider/model when no global selected_model row exists', () => {
+    db.prepare(
+      "INSERT INTO threads (id, title, created_at, last_edit_timestamp) VALUES ('t1', 'A', 1000, 1000)"
+    ).run()
+
+    applyMigration007(db)
+
+    const row = db
+      .prepare(
+        `SELECT selected_provider, selected_model,
+                enabled_mcp_tools, enabled_skills
+         FROM threads WHERE id = 't1'`
+      )
+      .get() as {
+      selected_provider: string | null
+      selected_model: string | null
+      enabled_mcp_tools: string | null
+      enabled_skills: string | null
+    }
+    expect(row.selected_provider).toBeNull()
+    expect(row.selected_model).toBeNull()
+    // Tools and skills always snapshot as a JSON value, never NULL.
+    expect(JSON.parse(row.enabled_mcp_tools!)).toEqual({})
+    expect(JSON.parse(row.enabled_skills!)).toEqual([])
+  })
+
+  it('writes NULL provider/model when global row has empty strings', () => {
+    db.prepare(
+      "INSERT INTO threads (id, title, created_at, last_edit_timestamp) VALUES ('t1', 'A', 1000, 1000)"
+    ).run()
+    db.prepare(
+      "INSERT INTO selected_model (id, provider, model) VALUES (1, '', '')"
+    ).run()
+
+    applyMigration007(db)
+
+    const row = db
+      .prepare(
+        `SELECT selected_provider, selected_model
+         FROM threads WHERE id = 't1'`
+      )
+      .get() as {
+      selected_provider: string | null
+      selected_model: string | null
+    }
+    expect(row.selected_provider).toBeNull()
+    expect(row.selected_model).toBeNull()
+  })
+
+  it('snapshots empty defaults when no threads exist', () => {
+    applyMigration007(db)
+    const count = db.prepare('SELECT COUNT(*) AS c FROM threads').get() as {
+      c: number
+    }
+    expect(count.c).toBe(0)
   })
 })
 

--- a/main/src/db/__tests__/test-helpers.ts
+++ b/main/src/db/__tests__/test-helpers.ts
@@ -5,6 +5,7 @@ import { up as applyMigration003 } from '../migrations/003-thread-starred'
 import { up as applyMigration004 } from '../migrations/004-mcp-app-ui-metadata'
 import { up as applyMigration005 } from '../migrations/005-agents'
 import { up as applyMigration006 } from '../migrations/006-enabled-skills'
+import { up as applyMigration007 } from '../migrations/007-per-thread-settings'
 
 /**
  * Creates a fresh in-memory SQLite database with the full schema applied,
@@ -19,5 +20,6 @@ export function createTestDb(): Database.Database {
   applyMigration004(db)
   applyMigration005(db)
   applyMigration006(db)
+  applyMigration007(db)
   return db
 }

--- a/main/src/db/migrations/007-per-thread-settings.ts
+++ b/main/src/db/migrations/007-per-thread-settings.ts
@@ -1,0 +1,48 @@
+import type Database from 'better-sqlite3'
+
+export function up(db: Database.Database): void {
+  db.exec(`
+    -- Per-thread selection of model, MCP tools, and skills.
+    -- Nullable; NULL means "no override, fall back to global".
+    -- After the snapshot below, every existing thread has non-NULL values,
+    -- so the fallback path only matters for edge cases (manually cleared).
+    ALTER TABLE threads ADD COLUMN selected_provider TEXT;
+    ALTER TABLE threads ADD COLUMN selected_model TEXT;
+    ALTER TABLE threads ADD COLUMN enabled_mcp_tools TEXT;
+    ALTER TABLE threads ADD COLUMN enabled_skills TEXT;
+  `)
+
+  const selectedModel = db
+    .prepare('SELECT provider, model FROM selected_model WHERE id = 1')
+    .get() as { provider: string; model: string } | undefined
+
+  const mcpRows = db
+    .prepare('SELECT server_name, tool_names FROM enabled_mcp_tools')
+    .all() as { server_name: string; tool_names: string }[]
+  const mcpSnapshot: Record<string, string[]> = {}
+  for (const row of mcpRows) {
+    try {
+      mcpSnapshot[row.server_name] = JSON.parse(row.tool_names)
+    } catch {
+      mcpSnapshot[row.server_name] = []
+    }
+  }
+
+  const skillRows = db
+    .prepare('SELECT name FROM enabled_skills ORDER BY name')
+    .all() as { name: string }[]
+  const skillSnapshot = skillRows.map((r) => r.name)
+
+  db.prepare(
+    `UPDATE threads SET
+       selected_provider = ?,
+       selected_model = ?,
+       enabled_mcp_tools = ?,
+       enabled_skills = ?`
+  ).run(
+    selectedModel?.provider || null,
+    selectedModel?.model || null,
+    JSON.stringify(mcpSnapshot),
+    JSON.stringify(skillSnapshot)
+  )
+}

--- a/main/src/db/migrator.ts
+++ b/main/src/db/migrator.ts
@@ -15,6 +15,7 @@ import * as m003 from './migrations/003-thread-starred'
 import * as m004 from './migrations/004-mcp-app-ui-metadata'
 import * as m005 from './migrations/005-agents'
 import * as m006 from './migrations/006-enabled-skills'
+import * as m007 from './migrations/007-per-thread-settings'
 
 const migrations: Migration[] = [
   { id: 1, name: '001-initial-schema', up: m001.up },
@@ -23,6 +24,7 @@ const migrations: Migration[] = [
   { id: 4, name: '004-mcp-app-ui-metadata', up: m004.up },
   { id: 5, name: '005-agents', up: m005.up },
   { id: 6, name: '006-enabled-skills', up: m006.up },
+  { id: 7, name: '007-per-thread-settings', up: m007.up },
 ]
 
 export function runMigrations(): void {

--- a/main/src/db/readers/threads-reader.ts
+++ b/main/src/db/readers/threads-reader.ts
@@ -10,6 +10,10 @@ interface DbThread {
   title_edited_by_user: number
   starred: number
   agent_id: string | null
+  selected_provider: string | null
+  selected_model: string | null
+  enabled_mcp_tools: string | null
+  enabled_skills: string | null
 }
 
 interface DbMessage {
@@ -19,6 +23,26 @@ interface DbMessage {
   parts: string
   metadata: string | null
   position: number
+}
+
+function parseMcpTools(raw: string | null): Record<string, string[]> | null {
+  if (raw == null) return null
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function parseSkills(raw: string | null): string[] | null {
+  if (raw == null) return null
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
 }
 
 function hydrateThread(row: DbThread): ChatSettingsThread {
@@ -35,6 +59,10 @@ function hydrateThread(row: DbThread): ChatSettingsThread {
     titleEditedByUser: row.title_edited_by_user === 1,
     starred: row.starred === 1,
     agentId: row.agent_id ?? null,
+    selectedProvider: row.selected_provider ?? null,
+    selectedModel: row.selected_model ?? null,
+    enabledMcpTools: parseMcpTools(row.enabled_mcp_tools),
+    enabledSkills: parseSkills(row.enabled_skills),
     createdAt: row.created_at,
     lastEditTimestamp: row.last_edit_timestamp,
     messages: messages.map((m) => ({
@@ -90,4 +118,61 @@ export function readThreadCount(): number {
     }
     return row.count
   })
+}
+
+export function readThreadSelectedModel(
+  threadId: string
+): { provider: string; model: string } | null {
+  return withDbSpan(
+    'DB read thread selected model',
+    'db.read',
+    { 'db.thread_id': threadId },
+    () => {
+      const db = getDb()
+      const row = db
+        .prepare(
+          'SELECT selected_provider, selected_model FROM threads WHERE id = ?'
+        )
+        .get(threadId) as
+        | { selected_provider: string | null; selected_model: string | null }
+        | undefined
+      if (!row) return null
+      if (!row.selected_provider || !row.selected_model) return null
+      return { provider: row.selected_provider, model: row.selected_model }
+    }
+  )
+}
+
+export function readThreadEnabledMcpTools(
+  threadId: string
+): Record<string, string[]> {
+  return withDbSpan(
+    'DB read thread enabled MCP tools',
+    'db.read',
+    { 'db.thread_id': threadId },
+    () => {
+      const db = getDb()
+      const row = db
+        .prepare('SELECT enabled_mcp_tools FROM threads WHERE id = ?')
+        .get(threadId) as { enabled_mcp_tools: string | null } | undefined
+      const parsed = parseMcpTools(row?.enabled_mcp_tools ?? null)
+      return parsed ?? {}
+    }
+  )
+}
+
+export function readThreadEnabledSkills(threadId: string): string[] {
+  return withDbSpan(
+    'DB read thread enabled skills',
+    'db.read',
+    { 'db.thread_id': threadId },
+    () => {
+      const db = getDb()
+      const row = db
+        .prepare('SELECT enabled_skills FROM threads WHERE id = ?')
+        .get(threadId) as { enabled_skills: string | null } | undefined
+      const parsed = parseSkills(row?.enabled_skills ?? null)
+      return parsed ?? []
+    }
+  )
 }

--- a/main/src/db/writers/threads-writer.ts
+++ b/main/src/db/writers/threads-writer.ts
@@ -2,6 +2,14 @@ import { getDb, isDbWritable } from '../database'
 import { withDbSpan } from '../telemetry'
 import type { ChatSettingsThread } from '../../chat/threads-storage'
 
+interface ExistingThreadColumns {
+  agent_id: string | null
+  selected_provider: string | null
+  selected_model: string | null
+  enabled_mcp_tools: string | null
+  enabled_skills: string | null
+}
+
 export function writeThread(thread: ChatSettingsThread): void {
   if (!isDbWritable()) return
   withDbSpan(
@@ -14,21 +22,54 @@ export function writeThread(thread: ChatSettingsThread): void {
     () => {
       const db = getDb()
       db.transaction(() => {
-        // Preserve the existing agent_id when the caller didn't provide one
-        // (e.g. message-only updates). If the thread is brand new, previous
-        // will be null.
+        // Preserve existing per-thread columns when the caller didn't provide
+        // them (e.g. message-only updates). If the thread is brand new,
+        // previous will be undefined.
         const previous = db
-          .prepare('SELECT agent_id FROM threads WHERE id = ?')
-          .get(thread.id) as { agent_id: string | null } | undefined
+          .prepare(
+            `SELECT agent_id, selected_provider, selected_model,
+                    enabled_mcp_tools, enabled_skills
+             FROM threads WHERE id = ?`
+          )
+          .get(thread.id) as ExistingThreadColumns | undefined
 
         const nextAgentId =
           thread.agentId !== undefined
             ? thread.agentId
             : (previous?.agent_id ?? null)
 
+        const nextSelectedProvider =
+          thread.selectedProvider !== undefined
+            ? thread.selectedProvider
+            : (previous?.selected_provider ?? null)
+
+        const nextSelectedModel =
+          thread.selectedModel !== undefined
+            ? thread.selectedModel
+            : (previous?.selected_model ?? null)
+
+        const nextEnabledMcpTools =
+          thread.enabledMcpTools !== undefined
+            ? thread.enabledMcpTools === null
+              ? null
+              : JSON.stringify(thread.enabledMcpTools)
+            : (previous?.enabled_mcp_tools ?? null)
+
+        const nextEnabledSkills =
+          thread.enabledSkills !== undefined
+            ? thread.enabledSkills === null
+              ? null
+              : JSON.stringify(thread.enabledSkills)
+            : (previous?.enabled_skills ?? null)
+
         db.prepare(
-          `INSERT OR REPLACE INTO threads (id, title, created_at, last_edit_timestamp, title_edited_by_user, starred, agent_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`
+          `INSERT OR REPLACE INTO threads (
+             id, title, created_at, last_edit_timestamp,
+             title_edited_by_user, starred, agent_id,
+             selected_provider, selected_model,
+             enabled_mcp_tools, enabled_skills
+           )
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         ).run(
           thread.id,
           thread.title ?? null,
@@ -36,7 +77,11 @@ export function writeThread(thread: ChatSettingsThread): void {
           thread.lastEditTimestamp,
           thread.titleEditedByUser ? 1 : 0,
           thread.starred ? 1 : 0,
-          nextAgentId
+          nextAgentId,
+          nextSelectedProvider,
+          nextSelectedModel,
+          nextEnabledMcpTools,
+          nextEnabledSkills
         )
 
         db.prepare('DELETE FROM thread_messages WHERE thread_id = ?').run(
@@ -102,4 +147,69 @@ export function writeActiveThread(threadId: string | undefined): void {
       db.prepare('DELETE FROM active_thread WHERE id = 1').run()
     }
   })
+}
+
+export function writeThreadSelectedModel(
+  threadId: string,
+  provider: string | null,
+  model: string | null
+): void {
+  if (!isDbWritable()) return
+  withDbSpan(
+    'DB write thread selected model',
+    'db.write',
+    { 'db.thread_id': threadId },
+    () => {
+      const db = getDb()
+      db.prepare(
+        `UPDATE threads
+         SET selected_provider = ?, selected_model = ?, last_edit_timestamp = ?
+         WHERE id = ?`
+      ).run(provider, model, Date.now(), threadId)
+    }
+  )
+}
+
+export function writeThreadEnabledMcpTools(
+  threadId: string,
+  tools: Record<string, string[]> | null
+): void {
+  if (!isDbWritable()) return
+  withDbSpan(
+    'DB write thread enabled MCP tools',
+    'db.write',
+    { 'db.thread_id': threadId },
+    () => {
+      const db = getDb()
+      db.prepare(
+        `UPDATE threads
+         SET enabled_mcp_tools = ?, last_edit_timestamp = ?
+         WHERE id = ?`
+      ).run(tools === null ? null : JSON.stringify(tools), Date.now(), threadId)
+    }
+  )
+}
+
+export function writeThreadEnabledSkills(
+  threadId: string,
+  skills: string[] | null
+): void {
+  if (!isDbWritable()) return
+  withDbSpan(
+    'DB write thread enabled skills',
+    'db.write',
+    { 'db.thread_id': threadId },
+    () => {
+      const db = getDb()
+      db.prepare(
+        `UPDATE threads
+         SET enabled_skills = ?, last_edit_timestamp = ?
+         WHERE id = ?`
+      ).run(
+        skills === null ? null : JSON.stringify(skills),
+        Date.now(),
+        threadId
+      )
+    }
+  )
 }

--- a/main/src/db/writers/threads-writer.ts
+++ b/main/src/db/writers/threads-writer.ts
@@ -1,5 +1,10 @@
 import { getDb, isDbWritable } from '../database'
 import { withDbSpan } from '../telemetry'
+import {
+  readSelectedModel,
+  readEnabledMcpTools,
+  readEnabledSkills,
+} from '../readers/chat-settings-reader'
 import type { ChatSettingsThread } from '../../chat/threads-storage'
 
 interface ExistingThreadColumns {
@@ -33,6 +38,19 @@ export function writeThread(thread: ChatSettingsThread): void {
           )
           .get(thread.id) as ExistingThreadColumns | undefined
 
+        // For brand-new rows where the caller didn't supply per-thread
+        // settings, snapshot the current globals so the thread inherits the
+        // last-used selection and stays isolated when globals later change.
+        // For existing rows we just preserve what's already there.
+        const isNewRow = !previous
+        const globalSnapshot = isNewRow
+          ? {
+              selectedModel: readSelectedModel(),
+              enabledMcpTools: readEnabledMcpTools(),
+              enabledSkills: readEnabledSkills(),
+            }
+          : null
+
         const nextAgentId =
           thread.agentId !== undefined
             ? thread.agentId
@@ -41,26 +59,34 @@ export function writeThread(thread: ChatSettingsThread): void {
         const nextSelectedProvider =
           thread.selectedProvider !== undefined
             ? thread.selectedProvider
-            : (previous?.selected_provider ?? null)
+            : previous
+              ? (previous.selected_provider ?? null)
+              : globalSnapshot!.selectedModel.provider || null
 
         const nextSelectedModel =
           thread.selectedModel !== undefined
             ? thread.selectedModel
-            : (previous?.selected_model ?? null)
+            : previous
+              ? (previous.selected_model ?? null)
+              : globalSnapshot!.selectedModel.model || null
 
         const nextEnabledMcpTools =
           thread.enabledMcpTools !== undefined
             ? thread.enabledMcpTools === null
               ? null
               : JSON.stringify(thread.enabledMcpTools)
-            : (previous?.enabled_mcp_tools ?? null)
+            : previous
+              ? (previous.enabled_mcp_tools ?? null)
+              : JSON.stringify(globalSnapshot!.enabledMcpTools)
 
         const nextEnabledSkills =
           thread.enabledSkills !== undefined
             ? thread.enabledSkills === null
               ? null
               : JSON.stringify(thread.enabledSkills)
-            : (previous?.enabled_skills ?? null)
+            : previous
+              ? (previous.enabled_skills ?? null)
+              : JSON.stringify(globalSnapshot!.enabledSkills)
 
         db.prepare(
           `INSERT OR REPLACE INTO threads (

--- a/main/src/ipc-handlers/chat/__tests__/index.test.ts
+++ b/main/src/ipc-handlers/chat/__tests__/index.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   registerStreaming: vi.fn(),
   registerThreads: vi.fn(),
   registerAgents: vi.fn(),
+  registerThreadSettings: vi.fn(),
 }))
 
 vi.mock('../mcp-tools', () => ({ register: mocks.registerMcpTools }))
@@ -21,6 +22,9 @@ vi.mock('../skills', () => ({ register: mocks.registerSkills }))
 vi.mock('../streaming', () => ({ register: mocks.registerStreaming }))
 vi.mock('../threads', () => ({ register: mocks.registerThreads }))
 vi.mock('../agents', () => ({ register: mocks.registerAgents }))
+vi.mock('../thread-settings', () => ({
+  register: mocks.registerThreadSettings,
+}))
 
 import { register } from '../index'
 
@@ -41,5 +45,6 @@ describe('chat register', () => {
     expect(mocks.registerAgents).toHaveBeenCalledOnce()
     expect(mocks.registerSkills).toHaveBeenCalledOnce()
     expect(mocks.registerPricing).toHaveBeenCalledOnce()
+    expect(mocks.registerThreadSettings).toHaveBeenCalledOnce()
   })
 })

--- a/main/src/ipc-handlers/chat/__tests__/thread-settings.test.ts
+++ b/main/src/ipc-handlers/chat/__tests__/thread-settings.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const ctx = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>()
+  return {
+    handlers,
+    getThreadSelectedModel: vi.fn<
+      (threadId: string) => { provider: string; model: string } | null
+    >(() => null),
+    setThreadSelectedModel: vi.fn<
+      (
+        threadId: string,
+        provider: string,
+        model: string
+      ) => { success: boolean; error?: string }
+    >(() => ({ success: true })),
+    getThreadEnabledMcpTools: vi.fn<
+      (threadId: string) => Record<string, string[]>
+    >(() => ({})),
+    setThreadEnabledMcpTools: vi.fn<
+      (
+        threadId: string,
+        serverName: string,
+        toolNames: string[]
+      ) => { success: boolean; error?: string }
+    >(() => ({ success: true })),
+    getThreadEnabledSkills: vi.fn<(threadId: string) => string[]>(() => []),
+    setThreadEnabledSkill: vi.fn<
+      (
+        threadId: string,
+        name: string,
+        enabled: boolean
+      ) => { success: boolean; error?: string }
+    >(() => ({ success: true })),
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      ctx.handlers.set(channel, handler)
+    },
+  },
+}))
+
+vi.mock('../../../chat/thread-settings-storage', () => ({
+  getThreadSelectedModel: ctx.getThreadSelectedModel,
+  setThreadSelectedModel: ctx.setThreadSelectedModel,
+  getThreadEnabledMcpTools: ctx.getThreadEnabledMcpTools,
+  setThreadEnabledMcpTools: ctx.setThreadEnabledMcpTools,
+  getThreadEnabledSkills: ctx.getThreadEnabledSkills,
+  setThreadEnabledSkill: ctx.setThreadEnabledSkill,
+}))
+
+import { register } from '../thread-settings'
+
+describe('chat/thread-settings IPC handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ctx.handlers.clear()
+    register()
+  })
+
+  describe('chat:thread-settings:get-selected-model', () => {
+    it('forwards the threadId and returns the storage result', async () => {
+      ctx.getThreadSelectedModel.mockReturnValue({
+        provider: 'openai',
+        model: 'gpt-4o',
+      })
+
+      const handler = ctx.handlers.get(
+        'chat:thread-settings:get-selected-model'
+      )!
+      const result = await handler(null, 'thread-1')
+
+      expect(ctx.getThreadSelectedModel).toHaveBeenCalledWith('thread-1')
+      expect(result).toEqual({ provider: 'openai', model: 'gpt-4o' })
+    })
+  })
+
+  describe('chat:thread-settings:set-selected-model', () => {
+    it('forwards the model selection to thread storage', async () => {
+      const handler = ctx.handlers.get(
+        'chat:thread-settings:set-selected-model'
+      )!
+      const result = await handler(null, 'thread-1', 'openai', 'gpt-4o')
+
+      expect(ctx.setThreadSelectedModel).toHaveBeenCalledWith(
+        'thread-1',
+        'openai',
+        'gpt-4o'
+      )
+      expect(result).toEqual({ success: true })
+    })
+
+    it('returns the storage failure result verbatim', async () => {
+      ctx.setThreadSelectedModel.mockReturnValue({
+        success: false,
+        error: 'disk full',
+      })
+      const handler = ctx.handlers.get(
+        'chat:thread-settings:set-selected-model'
+      )!
+      const result = await handler(null, 'thread-1', 'openai', 'gpt-4o')
+      expect(result).toEqual({ success: false, error: 'disk full' })
+    })
+  })
+
+  describe('chat:thread-settings:get-enabled-mcp-tools', () => {
+    it('returns the per-thread MCP tools record', async () => {
+      ctx.getThreadEnabledMcpTools.mockReturnValue({ alpha: ['t1', 't2'] })
+
+      const handler = ctx.handlers.get(
+        'chat:thread-settings:get-enabled-mcp-tools'
+      )!
+      const result = await handler(null, 'thread-1')
+
+      expect(ctx.getThreadEnabledMcpTools).toHaveBeenCalledWith('thread-1')
+      expect(result).toEqual({ alpha: ['t1', 't2'] })
+    })
+  })
+
+  describe('chat:thread-settings:set-enabled-mcp-tools', () => {
+    it('forwards the server + tools payload to thread storage', async () => {
+      const handler = ctx.handlers.get(
+        'chat:thread-settings:set-enabled-mcp-tools'
+      )!
+      const result = await handler(null, 'thread-1', 'alpha', ['t1', 't2'])
+
+      expect(ctx.setThreadEnabledMcpTools).toHaveBeenCalledWith(
+        'thread-1',
+        'alpha',
+        ['t1', 't2']
+      )
+      expect(result).toEqual({ success: true })
+    })
+  })
+
+  describe('chat:thread-settings:get-enabled-skills', () => {
+    it('returns the per-thread enabled skill list', async () => {
+      ctx.getThreadEnabledSkills.mockReturnValue(['s1', 's2'])
+
+      const handler = ctx.handlers.get(
+        'chat:thread-settings:get-enabled-skills'
+      )!
+      const result = await handler(null, 'thread-1')
+
+      expect(ctx.getThreadEnabledSkills).toHaveBeenCalledWith('thread-1')
+      expect(result).toEqual(['s1', 's2'])
+    })
+  })
+
+  describe('chat:thread-settings:set-enabled-skill', () => {
+    it('forwards the toggle to thread storage', async () => {
+      const handler = ctx.handlers.get(
+        'chat:thread-settings:set-enabled-skill'
+      )!
+      await handler(null, 'thread-1', 'my-skill', true)
+
+      expect(ctx.setThreadEnabledSkill).toHaveBeenCalledWith(
+        'thread-1',
+        'my-skill',
+        true
+      )
+    })
+
+    it('passes the disabled state through', async () => {
+      const handler = ctx.handlers.get(
+        'chat:thread-settings:set-enabled-skill'
+      )!
+      await handler(null, 'thread-1', 'my-skill', false)
+
+      expect(ctx.setThreadEnabledSkill).toHaveBeenCalledWith(
+        'thread-1',
+        'my-skill',
+        false
+      )
+    })
+  })
+})

--- a/main/src/ipc-handlers/chat/index.ts
+++ b/main/src/ipc-handlers/chat/index.ts
@@ -7,6 +7,7 @@ import { register as registerSettings } from './settings'
 import { register as registerSkills } from './skills'
 import { register as registerStreaming } from './streaming'
 import { register as registerThreads } from './threads'
+import { register as registerThreadSettings } from './thread-settings'
 
 export function register() {
   registerProviders()
@@ -18,4 +19,5 @@ export function register() {
   registerAgents()
   registerSkills()
   registerPricing()
+  registerThreadSettings()
 }

--- a/main/src/ipc-handlers/chat/mcp-tools.ts
+++ b/main/src/ipc-handlers/chat/mcp-tools.ts
@@ -7,8 +7,10 @@ import {
 } from '../../chat/settings-storage'
 
 export function register() {
-  ipcMain.handle('chat:get-mcp-server-tools', (_, serverName: string) =>
-    getMcpServerTools(serverName)
+  ipcMain.handle(
+    'chat:get-mcp-server-tools',
+    (_, serverName: string, threadId?: string) =>
+      getMcpServerTools(serverName, threadId)
   )
   ipcMain.handle('chat:get-enabled-mcp-tools', () => getEnabledMcpTools())
   ipcMain.handle('chat:get-enabled-mcp-servers-from-tools', () =>

--- a/main/src/ipc-handlers/chat/thread-settings.ts
+++ b/main/src/ipc-handlers/chat/thread-settings.ts
@@ -1,0 +1,44 @@
+import { ipcMain } from 'electron'
+import {
+  getThreadSelectedModel,
+  setThreadSelectedModel,
+  getThreadEnabledMcpTools,
+  setThreadEnabledMcpTools,
+  getThreadEnabledSkills,
+  setThreadEnabledSkill,
+} from '../../chat/thread-settings-storage'
+
+export function register() {
+  ipcMain.handle(
+    'chat:thread-settings:get-selected-model',
+    (_, threadId: string) => getThreadSelectedModel(threadId)
+  )
+
+  ipcMain.handle(
+    'chat:thread-settings:set-selected-model',
+    (_, threadId: string, provider: string, model: string) =>
+      setThreadSelectedModel(threadId, provider, model)
+  )
+
+  ipcMain.handle(
+    'chat:thread-settings:get-enabled-mcp-tools',
+    (_, threadId: string) => getThreadEnabledMcpTools(threadId)
+  )
+
+  ipcMain.handle(
+    'chat:thread-settings:set-enabled-mcp-tools',
+    (_, threadId: string, serverName: string, toolNames: string[]) =>
+      setThreadEnabledMcpTools(threadId, serverName, toolNames)
+  )
+
+  ipcMain.handle(
+    'chat:thread-settings:get-enabled-skills',
+    (_, threadId: string) => getThreadEnabledSkills(threadId)
+  )
+
+  ipcMain.handle(
+    'chat:thread-settings:set-enabled-skill',
+    (_, threadId: string, name: string, enabled: boolean) =>
+      setThreadEnabledSkill(threadId, name, enabled)
+  )
+}

--- a/preload/src/api/chat.ts
+++ b/preload/src/api/chat.ts
@@ -70,8 +70,8 @@ export const chatApi = {
     getSelectedModel: () => ipcRenderer.invoke('chat:get-selected-model'),
     saveSelectedModel: (provider: string, model: string) =>
       ipcRenderer.invoke('chat:save-selected-model', provider, model),
-    getMcpServerTools: (serverName: string) =>
-      ipcRenderer.invoke('chat:get-mcp-server-tools', serverName),
+    getMcpServerTools: (serverName: string, threadId?: string) =>
+      ipcRenderer.invoke('chat:get-mcp-server-tools', serverName, threadId),
     getEnabledMcpTools: () => ipcRenderer.invoke('chat:get-enabled-mcp-tools'),
     getEnabledMcpServersFromTools: () =>
       ipcRenderer.invoke('chat:get-enabled-mcp-servers-from-tools'),
@@ -164,6 +164,55 @@ export const chatApi = {
       getThreadAgentId: (threadId: string): Promise<string | null> =>
         ipcRenderer.invoke('chat:agents:get-thread-agent-id', threadId),
     },
+
+    threadSettings: {
+      getSelectedModel: (
+        threadId: string
+      ): Promise<{ provider: string; model: string } | null> =>
+        ipcRenderer.invoke('chat:thread-settings:get-selected-model', threadId),
+      setSelectedModel: (
+        threadId: string,
+        provider: string,
+        model: string
+      ): Promise<{ success: boolean; error?: string }> =>
+        ipcRenderer.invoke(
+          'chat:thread-settings:set-selected-model',
+          threadId,
+          provider,
+          model
+        ),
+      getEnabledMcpTools: (
+        threadId: string
+      ): Promise<Record<string, string[]>> =>
+        ipcRenderer.invoke(
+          'chat:thread-settings:get-enabled-mcp-tools',
+          threadId
+        ),
+      setEnabledMcpTools: (
+        threadId: string,
+        serverName: string,
+        toolNames: string[]
+      ): Promise<{ success: boolean; error?: string }> =>
+        ipcRenderer.invoke(
+          'chat:thread-settings:set-enabled-mcp-tools',
+          threadId,
+          serverName,
+          toolNames
+        ),
+      getEnabledSkills: (threadId: string): Promise<string[]> =>
+        ipcRenderer.invoke('chat:thread-settings:get-enabled-skills', threadId),
+      setEnabledSkill: (
+        threadId: string,
+        name: string,
+        enabled: boolean
+      ): Promise<{ success: boolean; error?: string }> =>
+        ipcRenderer.invoke(
+          'chat:thread-settings:set-enabled-skill',
+          threadId,
+          name,
+          enabled
+        ),
+    },
   },
 }
 
@@ -255,7 +304,10 @@ export interface ChatAPI {
       provider: string,
       model: string
     ) => Promise<{ success: boolean; error?: string }>
-    getMcpServerTools: (serverId: string) => Promise<AvailableServer>
+    getMcpServerTools: (
+      serverId: string,
+      threadId?: string
+    ) => Promise<AvailableServer>
     getEnabledMcpTools: () => Promise<Record<string, string[]>>
     getEnabledMcpServersFromTools: () => Promise<string[]>
     saveEnabledMcpTools: (
@@ -429,6 +481,31 @@ export interface ChatAPI {
         agentId: string | null
       ) => Promise<void>
       getThreadAgentId: (threadId: string) => Promise<string | null>
+    }
+
+    threadSettings: {
+      getSelectedModel: (
+        threadId: string
+      ) => Promise<{ provider: string; model: string } | null>
+      setSelectedModel: (
+        threadId: string,
+        provider: string,
+        model: string
+      ) => Promise<{ success: boolean; error?: string }>
+      getEnabledMcpTools: (
+        threadId: string
+      ) => Promise<Record<string, string[]>>
+      setEnabledMcpTools: (
+        threadId: string,
+        serverName: string,
+        toolNames: string[]
+      ) => Promise<{ success: boolean; error?: string }>
+      getEnabledSkills: (threadId: string) => Promise<string[]>
+      setEnabledSkill: (
+        threadId: string,
+        name: string,
+        enabled: boolean
+      ) => Promise<{ success: boolean; error?: string }>
     }
   }
 }

--- a/renderer/src/features/chat/components/__tests__/skill-selector.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/skill-selector.test.tsx
@@ -52,6 +52,18 @@ const mockChatApi = {
     >(),
 }
 
+const mockThreadSettingsApi = {
+  getEnabledSkills: vi.fn<(threadId: string) => Promise<string[]>>(),
+  setEnabledSkill:
+    vi.fn<
+      (
+        threadId: string,
+        name: string,
+        enabled: boolean
+      ) => Promise<{ success: boolean; error?: string }>
+    >(),
+}
+
 const builtinToolhive: AgentConfig = {
   id: 'builtin.toolhive-assistant',
   kind: 'builtin',
@@ -94,6 +106,7 @@ describe('SkillSelector', () => {
       chat: {
         ...(window.electronAPI?.chat ?? {}),
         agents: mockAgentsApi,
+        threadSettings: mockThreadSettingsApi,
         getEnabledSkills: mockChatApi.getEnabledSkills,
         setEnabledSkill: mockChatApi.setEnabledSkill,
       },
@@ -103,6 +116,8 @@ describe('SkillSelector', () => {
     mockAgentsApi.getThreadAgentId.mockResolvedValue('builtin.skills')
     mockChatApi.getEnabledSkills.mockResolvedValue([])
     mockChatApi.setEnabledSkill.mockResolvedValue({ success: true })
+    mockThreadSettingsApi.getEnabledSkills.mockResolvedValue([])
+    mockThreadSettingsApi.setEnabledSkill.mockResolvedValue({ success: true })
 
     // Default installed-skills response: one user-scope, one with no install
     // sites (so it still appears in the picker but renders no badges).
@@ -147,6 +162,9 @@ describe('SkillSelector', () => {
 
   it('shows the live enabled count on the trigger', async () => {
     mockChatApi.getEnabledSkills.mockResolvedValue(['algorithmic-art'])
+    mockThreadSettingsApi.getEnabledSkills.mockResolvedValue([
+      'algorithmic-art',
+    ])
 
     render(<SkillSelector threadId="thread-1" />, {
       wrapper: createWrapper(),
@@ -190,12 +208,19 @@ describe('SkillSelector', () => {
     })
     await user.click(algorithmicArt)
 
+    // Dual-write: per-thread row is the source of truth, global write keeps
+    // the "last used" default in sync so new threads inherit it.
     await waitFor(() => {
-      expect(mockChatApi.setEnabledSkill).toHaveBeenCalledWith(
+      expect(mockThreadSettingsApi.setEnabledSkill).toHaveBeenCalledWith(
+        'thread-1',
         'algorithmic-art',
         true
       )
     })
+    expect(mockChatApi.setEnabledSkill).toHaveBeenCalledWith(
+      'algorithmic-art',
+      true
+    )
   })
 
   it('clear-all wipes every entry in the raw enabled-skills list, including stale rows', async () => {
@@ -203,6 +228,10 @@ describe('SkillSelector', () => {
     // carries `uninstalled` from a previous install. Clear-all must wipe BOTH
     // — defense in depth alongside the server-side prune.
     mockChatApi.getEnabledSkills.mockResolvedValue([
+      'algorithmic-art',
+      'uninstalled',
+    ])
+    mockThreadSettingsApi.getEnabledSkills.mockResolvedValue([
       'algorithmic-art',
       'uninstalled',
     ])
@@ -226,12 +255,14 @@ describe('SkillSelector', () => {
     await user.click(clearButton)
 
     await waitFor(() => {
-      expect(mockChatApi.setEnabledSkill).toHaveBeenCalledWith(
+      expect(mockThreadSettingsApi.setEnabledSkill).toHaveBeenCalledWith(
+        'thread-1',
         'algorithmic-art',
         false
       )
     })
-    expect(mockChatApi.setEnabledSkill).toHaveBeenCalledWith(
+    expect(mockThreadSettingsApi.setEnabledSkill).toHaveBeenCalledWith(
+      'thread-1',
       'uninstalled',
       false
     )

--- a/renderer/src/features/chat/components/__tests__/skill-selector.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/skill-selector.test.tsx
@@ -223,6 +223,43 @@ describe('SkillSelector', () => {
     )
   })
 
+  it('skips the global "last used" write when the per-thread toggle fails', async () => {
+    // When the per-thread write returns { success: false } (e.g. the row
+    // failed to materialise) the global default must stay untouched —
+    // otherwise the seed for new threads mutates even though the active
+    // thread's selection did not persist.
+    mockThreadSettingsApi.setEnabledSkill.mockResolvedValue({
+      success: false,
+      error: 'failed to materialise',
+    })
+
+    const user = userEvent.setup()
+
+    render(<SkillSelector threadId="thread-1" />, {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-selector-trigger')).not.toBeDisabled()
+    })
+
+    await user.click(screen.getByTestId('skill-selector-trigger'))
+
+    const algorithmicArt = await screen.findByRole('menuitemcheckbox', {
+      name: /algorithmic-art/i,
+    })
+    await user.click(algorithmicArt)
+
+    await waitFor(() => {
+      expect(mockThreadSettingsApi.setEnabledSkill).toHaveBeenCalledWith(
+        'thread-1',
+        'algorithmic-art',
+        true
+      )
+    })
+    expect(mockChatApi.setEnabledSkill).not.toHaveBeenCalled()
+  })
+
   it('clear-all wipes every entry in the raw enabled-skills list, including stale rows', async () => {
     // Backend reports `algorithmic-art` is installed; the allow-list still
     // carries `uninstalled` from a previous install. Clear-all must wipe BOTH

--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -259,7 +259,7 @@ function InputWithAttachments({
                 onOpenSettings={handleOpenSettings}
                 onProviderChange={handleProviderChange}
               />
-              <McpServerSelector />
+              <McpServerSelector threadId={threadId} />
               <SkillSelector threadId={threadId} />
             </>
           )}

--- a/renderer/src/features/chat/components/mcp-server-selector.tsx
+++ b/renderer/src/features/chat/components/mcp-server-selector.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import log from 'electron-log/renderer'
 import { Button } from '@/common/components/ui/button'
@@ -25,7 +25,11 @@ import {
 } from '@/common/components/ui/tooltip'
 import { trackEvent } from '@/common/lib/analytics'
 
-export function McpServerSelector() {
+interface McpServerSelectorProps {
+  threadId?: string | null
+}
+
+export function McpServerSelector({ threadId }: McpServerSelectorProps) {
   const queryClient = useQueryClient()
   const [isOpen, setIsOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
@@ -33,15 +37,45 @@ export function McpServerSelector() {
     null
   )
   const [serverToggling, setServerToggling] = useState<string | null>(null)
-  const { allAvailableMcpServer, enabledMcpServers, backendEnabledTools } =
-    useAvailableServers()
+  const {
+    allAvailableMcpServer,
+    enabledMcpServers,
+    backendEnabledTools,
+    enabledMcpTools,
+  } = useAvailableServers(threadId)
 
-  const { data: enabledMcpTools } = useQuery({
-    queryKey: ['enabled-mcp-tools'],
-    queryFn: async () => await window.electronAPI.chat.getEnabledMcpTools(),
-    refetchInterval: 5000, // Refresh every 5 seconds
-    refetchOnMount: true,
-  })
+  const enabledMcpToolsQueryKey = threadId
+    ? (['chat', 'thread', threadId, 'enabledMcpTools'] as const)
+    : (['chat', 'enabled-mcp-tools'] as const)
+
+  const saveServerTools = async (serverName: string, toolNames: string[]) => {
+    if (threadId) {
+      // Dual-write: per-thread row owns this thread's selection; global
+      // write keeps "last used" so new threads inherit the latest pick.
+      const perThread =
+        await window.electronAPI.chat.threadSettings.setEnabledMcpTools(
+          threadId,
+          serverName,
+          toolNames
+        )
+      try {
+        await window.electronAPI.chat.saveEnabledMcpTools(serverName, toolNames)
+      } catch (err) {
+        log.warn('Failed to update global MCP tools default:', err)
+      }
+      return perThread
+    }
+    return window.electronAPI.chat.saveEnabledMcpTools(serverName, toolNames)
+  }
+
+  const invalidateEnabledTools = () => {
+    queryClient.invalidateQueries({ queryKey: enabledMcpToolsQueryKey })
+    if (threadId) {
+      queryClient.invalidateQueries({
+        queryKey: ['chat', 'enabled-mcp-tools'],
+      })
+    }
+  }
 
   const handleToggleTool = async (serverName: string) => {
     if (backendEnabledTools.includes(serverName)) {
@@ -50,11 +84,8 @@ export function McpServerSelector() {
       })
       // Disable all tools for this server
       try {
-        await window.electronAPI.chat.saveEnabledMcpTools(serverName, [])
-        // Invalidate query to refetch latest state
-        queryClient.invalidateQueries({
-          queryKey: ['chat', 'enabledMcpServers'],
-        })
+        await saveServerTools(serverName, [])
+        invalidateEnabledTools()
       } catch (error) {
         console.error('Failed to disable server tools:', error)
       }
@@ -66,22 +97,15 @@ export function McpServerSelector() {
       // Enable all tools for this server by default
       try {
         // First get the server's available tools
-        const serverTools =
-          await window.electronAPI.chat.getMcpServerTools(serverName)
+        const serverTools = await window.electronAPI.chat.getMcpServerTools(
+          serverName,
+          threadId ?? undefined
+        )
         if (serverTools?.tools && serverTools.tools.length > 0) {
           const allToolNames = serverTools.tools.map((tool) => tool.name)
-          const response = await window.electronAPI.chat.saveEnabledMcpTools(
-            serverName,
-            allToolNames
-          )
+          const response = await saveServerTools(serverName, allToolNames)
           if (response.success) {
-            // Invalidate query to refetch latest state
-            queryClient.invalidateQueries({
-              queryKey: ['chat', 'enabledMcpServers'],
-            })
-            queryClient.invalidateQueries({
-              queryKey: ['enabled-mcp-tools'],
-            })
+            invalidateEnabledTools()
           } else {
             toast.error(`Failed to enable server tools for ${serverName}`)
           }
@@ -100,19 +124,9 @@ export function McpServerSelector() {
         server_count: backendEnabledTools?.length,
       })
       await Promise.allSettled(
-        backendEnabledTools.map((serverName) => {
-          if (backendEnabledTools.includes(serverName)) {
-            return window.electronAPI.chat.saveEnabledMcpTools(serverName, [])
-          }
-          return Promise.resolve()
-        })
+        backendEnabledTools.map((serverName) => saveServerTools(serverName, []))
       )
-      queryClient.invalidateQueries({
-        queryKey: ['chat', 'enabledMcpServers'],
-      })
-      queryClient.invalidateQueries({
-        queryKey: ['enabled-mcp-tools'],
-      })
+      invalidateEnabledTools()
     } catch (error) {
       log.error('Failed to clear enabled servers:', error)
       toast.error('Failed to clear enabled servers')
@@ -130,9 +144,7 @@ export function McpServerSelector() {
   }
 
   const handleToolsChange = () => {
-    queryClient.invalidateQueries({
-      queryKey: ['chat', 'enabledMcpServers'],
-    })
+    invalidateEnabledTools()
   }
 
   const handleOpenSettings = (open: boolean) => {
@@ -254,6 +266,7 @@ export function McpServerSelector() {
         open={!!serverNameSelected && modalOpen}
         onOpenChange={setModalOpen}
         serverName={serverNameSelected ?? ''}
+        threadId={threadId}
         onToolsChange={handleToolsChange}
       />
     </>

--- a/renderer/src/features/chat/components/mcp-server-selector.tsx
+++ b/renderer/src/features/chat/components/mcp-server-selector.tsx
@@ -86,12 +86,19 @@ export function McpServerSelector({ threadId }: McpServerSelectorProps) {
       trackEvent(`Playground: disable server ${serverName}`, {
         tools_count: enabledMcpTools?.[serverName]?.length,
       })
-      // Disable all tools for this server
+      // Disable all tools for this server. Only invalidate the cache when
+      // the write actually persisted — otherwise the UI would show the
+      // server as disabled while the DB still has the old enabled tools.
       try {
-        await saveServerTools(serverName, [])
-        invalidateEnabledTools()
+        const response = await saveServerTools(serverName, [])
+        if (response.success) {
+          invalidateEnabledTools()
+        } else {
+          toast.error(`Failed to disable server tools for ${serverName}`)
+        }
       } catch (error) {
-        console.error('Failed to disable server tools:', error)
+        log.error('Failed to disable server tools:', error)
+        toast.error(`Failed to disable server tools for ${serverName}`)
       }
     } else {
       trackEvent(`Playground: enable server ${serverName}`, {

--- a/renderer/src/features/chat/components/mcp-server-selector.tsx
+++ b/renderer/src/features/chat/components/mcp-server-selector.tsx
@@ -52,12 +52,16 @@ export function McpServerSelector({ threadId }: McpServerSelectorProps) {
     if (threadId) {
       // Dual-write: per-thread row owns this thread's selection; global
       // write keeps "last used" so new threads inherit the latest pick.
+      // Skip the global write when per-thread silently failed — otherwise
+      // we mutate the seed for new threads even though the current one
+      // didn't persist.
       const perThread =
         await window.electronAPI.chat.threadSettings.setEnabledMcpTools(
           threadId,
           serverName,
           toolNames
         )
+      if (!perThread.success) return perThread
       try {
         await window.electronAPI.chat.saveEnabledMcpTools(serverName, toolNames)
       } catch (err) {

--- a/renderer/src/features/chat/components/mcp-tools-modal.tsx
+++ b/renderer/src/features/chat/components/mcp-tools-modal.tsx
@@ -87,7 +87,9 @@ export function McpToolsModal({
 
   // Save tools mutation — dual-writes when a threadId is in scope so the
   // per-thread row owns this thread's selection and the global write keeps
-  // "last used" up to date for new threads.
+  // "last used" up to date for new threads. Skip the global write when
+  // per-thread silently failed — otherwise the seed for new threads would
+  // mutate even though the active thread's save didn't persist.
   const saveToolsMutation = useMutation({
     mutationFn: async (enabledTools: string[]) => {
       if (threadId) {
@@ -97,6 +99,7 @@ export function McpToolsModal({
             serverName,
             enabledTools
           )
+        if (!perThread.success) return perThread
         try {
           await window.electronAPI.chat.saveEnabledMcpTools(
             serverName,

--- a/renderer/src/features/chat/components/mcp-tools-modal.tsx
+++ b/renderer/src/features/chat/components/mcp-tools-modal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import log from 'electron-log/renderer'
 import {
   Dialog,
   DialogContent,
@@ -37,6 +38,7 @@ interface McpToolsModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   serverName: string
+  threadId?: string | null
   onToolsChange?: (serverName: string, enabledTools: string[]) => void
 }
 
@@ -44,6 +46,7 @@ export function McpToolsModal({
   open,
   onOpenChange,
   serverName,
+  threadId,
   onToolsChange,
 }: McpToolsModalProps) {
   const [searchQuery, setSearchQuery] = useState('')
@@ -53,15 +56,19 @@ export function McpToolsModal({
   >(null)
   const queryClient = useQueryClient()
 
-  // Fetch tools for the specific server
+  // Fetch tools for the specific server (per-thread enabled flags when
+  // threadId is provided)
   const {
     data: serverTools,
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['mcp-server-tools', serverName],
+    queryKey: ['mcp-server-tools', serverName, threadId ?? null],
     queryFn: async (): Promise<McpServerToolsResponse | null> => {
-      return window.electronAPI.chat.getMcpServerTools(serverName)
+      return window.electronAPI.chat.getMcpServerTools(
+        serverName,
+        threadId ?? undefined
+      )
     },
     enabled: open && !!serverName,
     refetchOnWindowFocus: false,
@@ -78,9 +85,28 @@ export function McpToolsModal({
     setLastInitializedServer(serverName)
   }
 
-  // Save tools mutation
+  // Save tools mutation — dual-writes when a threadId is in scope so the
+  // per-thread row owns this thread's selection and the global write keeps
+  // "last used" up to date for new threads.
   const saveToolsMutation = useMutation({
     mutationFn: async (enabledTools: string[]) => {
+      if (threadId) {
+        const perThread =
+          await window.electronAPI.chat.threadSettings.setEnabledMcpTools(
+            threadId,
+            serverName,
+            enabledTools
+          )
+        try {
+          await window.electronAPI.chat.saveEnabledMcpTools(
+            serverName,
+            enabledTools
+          )
+        } catch (err) {
+          log.warn('Failed to update global MCP tools default:', err)
+        }
+        return perThread
+      }
       return window.electronAPI.chat.saveEnabledMcpTools(
         serverName,
         enabledTools
@@ -88,14 +114,13 @@ export function McpToolsModal({
     },
     onSuccess: (result) => {
       if (result.success) {
-        // Invalidate the specific server's tools query
-        queryClient.invalidateQueries({
-          queryKey: ['mcp-server-tools', serverName],
-        })
-        // Also invalidate all mcp-server-tools queries to ensure consistency
         queryClient.invalidateQueries({ queryKey: ['mcp-server-tools'] })
-        // Invalidate the global enabled MCP tools query
         queryClient.invalidateQueries({ queryKey: ['enabled-mcp-tools'] })
+        if (threadId) {
+          queryClient.invalidateQueries({
+            queryKey: ['chat', 'thread', threadId, 'enabledMcpTools'],
+          })
+        }
         onToolsChange?.(serverName, localEnabledTools)
         onOpenChange(false)
       }

--- a/renderer/src/features/chat/components/skill-selector.tsx
+++ b/renderer/src/features/chat/components/skill-selector.tsx
@@ -62,7 +62,37 @@ export function SkillSelector({ threadId }: SkillSelectorProps) {
     enabledNames,
     enabledCount,
     isLoading: skillsLoading,
-  } = useAvailableSkills()
+  } = useAvailableSkills(threadId)
+
+  const setSkillEnabled = async (name: string, enabled: boolean) => {
+    if (threadId) {
+      // Dual-write: per-thread row is the source of truth for this thread,
+      // global write keeps "last used" so the next new thread inherits it.
+      const perThread =
+        await window.electronAPI.chat.threadSettings.setEnabledSkill(
+          threadId,
+          name,
+          enabled
+        )
+      // Best-effort global write; failure shouldn't roll back the per-thread one.
+      try {
+        await window.electronAPI.chat.setEnabledSkill(name, enabled)
+      } catch (err) {
+        log.warn('Failed to update global skill default:', err)
+      }
+      return perThread
+    }
+    return window.electronAPI.chat.setEnabledSkill(name, enabled)
+  }
+
+  const invalidateEnabledSkills = () => {
+    if (threadId) {
+      queryClient.invalidateQueries({
+        queryKey: ['chat', 'thread', threadId, 'enabledSkills'],
+      })
+    }
+    queryClient.invalidateQueries({ queryKey: ['enabled-skills'] })
+  }
 
   const handleToggleSkill = async (name: string) => {
     const wasEnabled = enabledSet.has(name)
@@ -73,16 +103,13 @@ export function SkillSelector({ threadId }: SkillSelectorProps) {
     )
     setToggling(name)
     try {
-      const response = await window.electronAPI.chat.setEnabledSkill(
-        name,
-        !wasEnabled
-      )
+      const response = await setSkillEnabled(name, !wasEnabled)
       if (!response.success) {
         toast.error(`Failed to toggle skill "${name}"`, {
           description: response.error,
         })
       }
-      queryClient.invalidateQueries({ queryKey: ['enabled-skills'] })
+      invalidateEnabledSkills()
     } catch (error) {
       log.error('Failed to toggle skill:', error)
       toast.error(`Failed to toggle skill "${name}"`)
@@ -100,11 +127,9 @@ export function SkillSelector({ threadId }: SkillSelectorProps) {
       // button still wipes rows whose underlying skill is no longer
       // installed — defense in depth alongside the server-side prune.
       await Promise.allSettled(
-        enabledNames.map((name) =>
-          window.electronAPI.chat.setEnabledSkill(name, false)
-        )
+        enabledNames.map((name) => setSkillEnabled(name, false))
       )
-      queryClient.invalidateQueries({ queryKey: ['enabled-skills'] })
+      invalidateEnabledSkills()
     } catch (error) {
       log.error('Failed to clear enabled skills:', error)
       toast.error('Failed to clear enabled skills')

--- a/renderer/src/features/chat/components/skill-selector.tsx
+++ b/renderer/src/features/chat/components/skill-selector.tsx
@@ -68,13 +68,16 @@ export function SkillSelector({ threadId }: SkillSelectorProps) {
     if (threadId) {
       // Dual-write: per-thread row is the source of truth for this thread,
       // global write keeps "last used" so the next new thread inherits it.
+      // Skip the global write when per-thread silently failed — otherwise
+      // we'd mutate the seed for new threads even though the current one
+      // didn't persist.
       const perThread =
         await window.electronAPI.chat.threadSettings.setEnabledSkill(
           threadId,
           name,
           enabled
         )
-      // Best-effort global write; failure shouldn't roll back the per-thread one.
+      if (!perThread.success) return perThread
       try {
         await window.electronAPI.chat.setEnabledSkill(name, enabled)
       } catch (err) {

--- a/renderer/src/features/chat/hooks/use-available-servers.ts
+++ b/renderer/src/features/chat/hooks/use-available-servers.ts
@@ -1,10 +1,15 @@
 import { getApiV1BetaWorkloadsOptions } from '@common/api/generated/@tanstack/react-query.gen'
 import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import type { ChatMcpServer } from '../types'
 import { TOOLHIVE_MCP_SERVER_NAME } from '../lib/constants'
 
-export function useAvailableServers() {
+/**
+ * Pass `threadId` to scope the enabled-servers view to that thread; omit it
+ * to read the global default (used by surfaces outside a chat thread).
+ */
+export function useAvailableServers(threadId?: string | null) {
   const queryClient = useQueryClient()
 
   const { data: workloadsData } = useQuery({
@@ -12,11 +17,26 @@ export function useAvailableServers() {
     refetchInterval: 30000,
   })
 
-  const { data: backendEnabledTools = [] } = useQuery({
-    queryKey: ['chat', 'enabledMcpServers'],
-    queryFn: () => window.electronAPI.chat.getEnabledMcpServersFromTools(),
+  const enabledMcpToolsQueryKey = threadId
+    ? (['chat', 'thread', threadId, 'enabledMcpTools'] as const)
+    : (['chat', 'enabled-mcp-tools'] as const)
+
+  const { data: enabledMcpTools = {} } = useQuery({
+    queryKey: enabledMcpToolsQueryKey,
+    queryFn: () =>
+      threadId
+        ? window.electronAPI.chat.threadSettings.getEnabledMcpTools(threadId)
+        : window.electronAPI.chat.getEnabledMcpTools(),
     refetchInterval: 30000,
   })
+
+  const backendEnabledTools = useMemo(
+    () =>
+      Object.entries(enabledMcpTools)
+        .filter(([, tools]) => Array.isArray(tools) && tools.length > 0)
+        .map(([name]) => name),
+    [enabledMcpTools]
+  )
 
   const { data: toolhiveMcpInfo } = useQuery({
     queryKey: ['toolhive-mcp-info'],
@@ -59,13 +79,14 @@ export function useAvailableServers() {
   const handleToolsChange = async () => {
     // Individual tool changes are already saved by the modal,
     // invalidate query to refetch latest state
-    queryClient.invalidateQueries({ queryKey: ['chat', 'enabledMcpServers'] })
+    queryClient.invalidateQueries({ queryKey: enabledMcpToolsQueryKey })
   }
 
   return {
     allAvailableMcpServer,
     backendEnabledTools,
     enabledMcpServers,
+    enabledMcpTools,
     handleToolsChange,
   }
 }

--- a/renderer/src/features/chat/hooks/use-available-skills.ts
+++ b/renderer/src/features/chat/hooks/use-available-skills.ts
@@ -99,16 +99,17 @@ export function groupInstalledSkills(
 
 /**
  * Fetches installed skills (all scopes), dedups them by name, and joins with
- * the local `enabled_skills` allow-list so the selector can render a single
- * row per name with enabled state and a live count.
+ * the per-thread `enabled_skills` allow-list so the selector can render a
+ * single row per name with enabled state and a live count.
  *
- * The two queries are chained: the enabled-skills query passes the live set
- * of installed names to the main process, which prunes stale `enabled_skills`
- * rows in the same round-trip. This way, uninstalling a skill removes its
- * row the next time the picker resyncs — without needing the Skill Engineer
- * agent to fire its own `list_skills` first.
+ * Two parallel queries:
+ * - Installed-skills query also prunes the global `enabled_skills` allow-list
+ *   server-side in the same round-trip so stale rows from uninstalled
+ *   skills disappear (matters because the global table seeds new threads).
+ * - Enabled-skills query is scoped to `threadId` when given; without one we
+ *   fall back to the global allow-list (used by surfaces outside a thread).
  */
-export function useAvailableSkills() {
+export function useAvailableSkills(threadId?: string | null) {
   const { data: skillsPayload, isLoading } = useQuery({
     // Installed skills are static artifacts on disk with no runtime status to
     // track, so a long poll is fine. We refetch on mount to catch anything
@@ -127,14 +128,25 @@ export function useAvailableSkills() {
         .sort()
     : undefined
 
-  const { data: enabledNames = [] } = useQuery({
-    // Including the install-name list in the key means this query
-    // automatically refetches (and re-prunes server-side) whenever the
-    // installed set changes — install, uninstall, scope change, all flow
-    // through here without an explicit invalidation.
-    queryKey: ['enabled-skills', installedSkillNames ?? null],
+  // Fire-and-forget prune of the global allow-list whenever the installed
+  // names change. The global table seeds new threads, so keeping it tidy
+  // matters even when we're reading per-thread enablement.
+  useQuery({
+    queryKey: ['enabled-skills-global-prune', installedSkillNames ?? null],
     queryFn: async () =>
       await window.electronAPI.chat.getEnabledSkills(installedSkillNames),
+    refetchInterval: SKILLS_REFRESH_MS,
+    refetchOnMount: true,
+  })
+
+  const { data: enabledNames = [] } = useQuery({
+    queryKey: threadId
+      ? (['chat', 'thread', threadId, 'enabledSkills'] as const)
+      : (['enabled-skills', installedSkillNames ?? null] as const),
+    queryFn: () =>
+      threadId
+        ? window.electronAPI.chat.threadSettings.getEnabledSkills(threadId)
+        : window.electronAPI.chat.getEnabledSkills(installedSkillNames),
     refetchInterval: SKILLS_REFRESH_MS,
     refetchOnMount: true,
   })

--- a/renderer/src/features/chat/hooks/use-chat-settings.ts
+++ b/renderer/src/features/chat/hooks/use-chat-settings.ts
@@ -265,15 +265,23 @@ export function useChatSettings(threadId?: string | null) {
       model: string
     }) => {
       if (threadId) {
-        await window.electronAPI.chat.threadSettings.setSelectedModel(
-          threadId,
-          provider,
-          model
-        )
+        const perThread =
+          await window.electronAPI.chat.threadSettings.setSelectedModel(
+            threadId,
+            provider,
+            model
+          )
+        // If the per-thread write silently failed, don't touch the global
+        // "last used" default — that would mutate the seed for new threads
+        // even though the user's current selection didn't persist.
+        if (!perThread.success) return perThread
       }
       return window.electronAPI.chat.saveSelectedModel(provider, model)
     },
-    onSuccess: (_, variables) => {
+    onSuccess: (result, variables) => {
+      // Only seed caches when the write actually persisted — otherwise the
+      // UI would show a selection that's about to disappear on refetch.
+      if (!result.success) return
       const next = { provider: variables.provider, model: variables.model }
       queryClient.setQueryData(CHAT_SETTINGS_KEYS.selectedModel, next)
       queryClient.invalidateQueries({

--- a/renderer/src/features/chat/hooks/use-chat-settings.ts
+++ b/renderer/src/features/chat/hooks/use-chat-settings.ts
@@ -45,19 +45,52 @@ function isChatProviderLocalServer(
 // Query keys
 const CHAT_SETTINGS_KEYS = {
   selectedModel: ['chat', 'selectedModel'] as const,
+  threadSelectedModel: (threadId: string) =>
+    ['chat', 'thread', threadId, 'selectedModel'] as const,
+  threadEnabledMcpTools: (threadId: string) =>
+    ['chat', 'thread', threadId, 'enabledMcpTools'] as const,
   settings: (provider: ChatProvider | string) =>
     ['chat', 'settings', provider] as const,
   allSettings: ['chat', 'settings'] as const,
   allProvidersWithSettings: ['chat', 'allProvidersWithSettings'] as const,
 }
 
-function useSelectedModel() {
-  return useQuery({
+type ProviderModel = { provider: string; model: string }
+
+function useEffectiveSelectedModel(threadId?: string | null) {
+  const globalQuery = useQuery({
     queryKey: CHAT_SETTINGS_KEYS.selectedModel,
     queryFn: () => window.electronAPI.chat.getSelectedModel(),
     refetchOnMount: true,
     refetchOnWindowFocus: false,
   })
+
+  const threadQuery = useQuery({
+    queryKey: threadId
+      ? CHAT_SETTINGS_KEYS.threadSelectedModel(threadId)
+      : ['chat', 'thread', '__none__', 'selectedModel'],
+    queryFn: () =>
+      window.electronAPI.chat.threadSettings.getSelectedModel(threadId!),
+    enabled: !!threadId,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+  })
+
+  if (threadId) {
+    const threadModel = threadQuery.data
+    // Per-thread NULL means "fall back to global"; only override when the
+    // thread has both fields set.
+    const effective: ProviderModel | undefined =
+      threadModel && threadModel.provider && threadModel.model
+        ? threadModel
+        : globalQuery.data
+    return {
+      data: effective,
+      isLoading: threadQuery.isLoading || globalQuery.isLoading,
+    }
+  }
+
+  return { data: globalQuery.data, isLoading: globalQuery.isLoading }
 }
 
 function useProviderSettings(provider: string) {
@@ -128,11 +161,15 @@ function useAllProvidersWithSettings() {
   })
 }
 
-// Hook for combined chat settings (selected model + provider settings)
-export function useChatSettings() {
+// Hook for combined chat settings (selected model + provider settings).
+// When `threadId` is provided the selection is per-thread (with global as
+// the default for new threads); writes dual-write so the next new thread
+// inherits the last-used choice. Without `threadId` (e.g. the provider
+// settings dialog) the hook operates purely on globals.
+export function useChatSettings(threadId?: string | null) {
   const queryClient = useQueryClient()
   const { data: selectedModel, isLoading: isSelectedModelLoading } =
-    useSelectedModel()
+    useEffectiveSelectedModel(threadId)
   const { data: providerSettings, isLoading: isProviderSettingsLoading } =
     useProviderSettings(selectedModel?.provider || '')
   const {
@@ -141,28 +178,33 @@ export function useChatSettings() {
     refetch: refetchProviders,
   } = useAllProvidersWithSettings()
 
-  // Query for enabled MCP servers (this is what the UI uses)
-  const { data: enabledMcpServers = [], isLoading: isMcpServersLoading } =
-    useQuery({
-      queryKey: ['chat', 'enabledMcpServers'],
-      queryFn: () => window.electronAPI.chat.getEnabledMcpServersFromTools(),
-      refetchOnWindowFocus: false,
-    })
-
-  // Query for enabled MCP tools (now automatically filters out stopped servers)
+  // Per-thread enabled MCP tools when a threadId is in scope, falling back
+  // to global. Derive enabled servers from the tools blob locally.
   const { data: enabledMcpTools = {}, isLoading: isMcpToolsLoading } = useQuery(
     {
-      queryKey: ['chat', 'enabled-mcp-tools'],
-      queryFn: () => window.electronAPI.chat.getEnabledMcpTools(),
+      queryKey: threadId
+        ? CHAT_SETTINGS_KEYS.threadEnabledMcpTools(threadId)
+        : ['chat', 'enabled-mcp-tools'],
+      queryFn: () =>
+        threadId
+          ? window.electronAPI.chat.threadSettings.getEnabledMcpTools(threadId)
+          : window.electronAPI.chat.getEnabledMcpTools(),
       refetchOnWindowFocus: false,
     }
+  )
+
+  const enabledMcpServers = useMemo(
+    () =>
+      Object.entries(enabledMcpTools)
+        .filter(([, tools]) => Array.isArray(tools) && tools.length > 0)
+        .map(([name]) => name),
+    [enabledMcpTools]
   )
 
   const isLoading =
     isSelectedModelLoading ||
     (selectedModel?.provider && isProviderSettingsLoading) ||
-    isMcpToolsLoading ||
-    isMcpServersLoading
+    isMcpToolsLoading
 
   // Combine the data into a single ChatSettings object
   const settings: ChatSettings = useMemo(() => {
@@ -209,14 +251,43 @@ export function useChatSettings() {
     }
   }, [selectedModel, providerSettings, enabledMcpTools, enabledMcpServers])
 
-  // Mutation to update selected model
+  // Mutation to update selected model. Dual-write when threadId is given:
+  // the per-thread row owns this thread's selection; the global write keeps
+  // "last used" up to date so new threads inherit it. The cache is updated
+  // synchronously via setQueryData so a Send right after the click sees the
+  // new selection — invalidate alone leaves stale data until the refetch.
   const updateSelectedModelMutation = useMutation({
-    mutationFn: ({ provider, model }: { provider: string; model: string }) =>
-      window.electronAPI.chat.saveSelectedModel(provider, model),
-    onSuccess: () => {
+    mutationFn: async ({
+      provider,
+      model,
+    }: {
+      provider: string
+      model: string
+    }) => {
+      if (threadId) {
+        await window.electronAPI.chat.threadSettings.setSelectedModel(
+          threadId,
+          provider,
+          model
+        )
+      }
+      return window.electronAPI.chat.saveSelectedModel(provider, model)
+    },
+    onSuccess: (_, variables) => {
+      const next = { provider: variables.provider, model: variables.model }
+      queryClient.setQueryData(CHAT_SETTINGS_KEYS.selectedModel, next)
       queryClient.invalidateQueries({
         queryKey: CHAT_SETTINGS_KEYS.selectedModel,
       })
+      if (threadId) {
+        queryClient.setQueryData(
+          CHAT_SETTINGS_KEYS.threadSelectedModel(threadId),
+          next
+        )
+        queryClient.invalidateQueries({
+          queryKey: CHAT_SETTINGS_KEYS.threadSelectedModel(threadId),
+        })
+      }
     },
   })
 
@@ -313,7 +384,10 @@ export function useChatSettings() {
     [selectedModel, updateProviderSettingsMutation]
   )
 
-  // Load persisted settings for a provider
+  // Load persisted settings for a provider. Always single-writes to the
+  // global default — this is invoked from the provider-settings dialog
+  // when a new API key is added and must not retroactively mutate any
+  // existing thread's stored selection.
   const loadPersistedSettings = useCallback(
     async (providerId: string) => {
       if (!providerId) return
@@ -326,9 +400,12 @@ export function useChatSettings() {
         if (provider && provider.models.length > 0) {
           const firstModel = provider.models[0]
           if (firstModel) {
-            await updateSelectedModelMutation.mutateAsync({
-              provider: providerId,
-              model: firstModel,
+            await window.electronAPI.chat.saveSelectedModel(
+              providerId,
+              firstModel
+            )
+            queryClient.invalidateQueries({
+              queryKey: CHAT_SETTINGS_KEYS.selectedModel,
             })
           }
         }
@@ -337,7 +414,7 @@ export function useChatSettings() {
         throw error
       }
     },
-    [updateSelectedModelMutation]
+    [queryClient]
   )
 
   // Create a stable isLoading value

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -39,19 +39,19 @@ export function useChatStreaming(externalThreadId?: string | null) {
   const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null)
 
   const {
-    settings,
-    updateSettings,
-    updateEnabledTools,
-    loadPersistedSettings,
-    isLoading: isSettingsLoading,
-  } = useChatSettings()
-
-  const {
     currentThreadId,
     isLoading: isThreadLoading,
     error: threadError,
     clearMessages: clearThreadMessages,
   } = useThreadManagement(externalThreadId)
+
+  const {
+    settings,
+    updateSettings,
+    updateEnabledTools,
+    loadPersistedSettings,
+    isLoading: isSettingsLoading,
+  } = useChatSettings(currentThreadId)
 
   // Primed by the route loader via `ensureQueryData`, so available
   // synchronously on thread switch. Invalidated on streaming completion

--- a/renderer/src/features/chat/transport/electron-ipc-chat-transport.ts
+++ b/renderer/src/features/chat/transport/electron-ipc-chat-transport.ts
@@ -23,7 +23,7 @@ interface AttachOptions {
 export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
   constructor(private config: ElectronIPCChatTransportConfig) {}
 
-  private async getSettingsFromQuery(): Promise<
+  private async getSettingsFromQuery(chatId?: string): Promise<
     | {
         provider: 'ollama' | 'lmstudio'
         model: string
@@ -37,11 +37,24 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
         enabledTools: string[]
       }
   > {
-    // Get selected model from cache
-    const selectedModel = this.config.queryClient.getQueryData<{
+    // Prefer the per-thread selection so a stream picks up the model that
+    // is actually shown in the active thread's picker. Fall back to the
+    // global "last used" default when the thread has no override yet.
+    const perThreadSelectedModel = chatId
+      ? this.config.queryClient.getQueryData<{
+          provider: string
+          model: string
+        } | null>(['chat', 'thread', chatId, 'selectedModel'])
+      : null
+    const globalSelectedModel = this.config.queryClient.getQueryData<{
       provider: string
       model: string
     }>(['chat', 'selectedModel'])
+
+    const selectedModel =
+      perThreadSelectedModel?.provider && perThreadSelectedModel?.model
+        ? perThreadSelectedModel
+        : globalSelectedModel
 
     if (!selectedModel?.provider) {
       return { provider: '', model: '', apiKey: '', enabledTools: [] }
@@ -257,7 +270,7 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
       abortSignal: AbortSignal | undefined
     } & ChatRequestOptions
   ): Promise<ReadableStream<UIMessageChunk>> {
-    const settings = await this.getSettingsFromQuery()
+    const settings = await this.getSettingsFromQuery(options.chatId)
 
     // Validate settings based on provider type
     if (!settings.provider || !settings.model) {


### PR DESCRIPTION
## Summary

- Each playground thread now persists its own model/provider, enabled MCP tools, and enabled skills (agent was already per-thread). Switching threads no longer reshuffles the toolbar.
- Globals stay as the "default for new threads" source. Every per-thread mutation dual-writes the global so the next new thread inherits the last-used selection — UX is unchanged on the first pick.
- A one-time migration (`007-per-thread-settings.ts`) snapshots current globals into every existing thread so no thread regresses on upgrade.

## What changed

- **Schema** — adds nullable `selected_provider`, `selected_model`, `enabled_mcp_tools` (JSON), `enabled_skills` (JSON) columns to `threads`; mirrors the `agent_id` precedent from migration 005. Snapshot happens in the same transaction.
- **Main process** — new `thread-settings-storage.ts` + IPC module; readers/writers extended with focused per-thread helpers; `writeThread` preserves the four new columns when callers don't supply them; streaming path now resolves MCP tools and skills per-thread via `request.chatId`.
- **Preload** — adds a `threadSettings` sub-object mirroring the `agents` shape; `getMcpServerTools` accepts an optional `threadId`.
- **Renderer hooks** — `useChatSettings`, `useAvailableServers`, `useAvailableSkills` accept an optional `threadId`, nest query keys under `['chat','thread',threadId,…]`, and dual-write to the global "last used" default. Mutation does synchronous `setQueryData` before invalidating so a Send immediately after a model click sees the new selection without racing the refetch.
- **Renderer transport** — `ElectronIPCChatTransport` reads the per-thread `selectedModel` cache first, falls back to global. Without this the global "last used" would override the active thread's selection.
- **UI** — `mcp-server-selector`, `mcp-tools-modal`, `skill-selector` thread `threadId` through and dual-write per-thread + global. `chat-input-prompt` passes `threadId` to `McpServerSelector`.
- **Tests** — `skill-selector.test.tsx` mocks updated for the new `threadSettings` IPC surface.

## Behaviour

- **New thread defaults**: inherit last-used selection (via the dual-write into globals).
- **Existing threads on upgrade**: keep working — migration snapshots current globals into every row.
- **Global pickers** (provider settings dialog) stay single-write to globals so they don't retroactively mutate the active thread.

## Test plan

- [x] `pnpm run type-check` clean
- [x] `pnpm run test:nonInteractive` clean for changed files (`use-chat-settings.test.ts`, `skill-selector.test.tsx`, `use-available-skills.test.ts`, `threads-storage.test.ts`)
- [x] **Fresh DB**: pick model X / MCP server A / skill Y → confirm both the global tables and the thread row have matching values
- [x] **Migration**: open a pre-feature DB with existing threads → confirm `SELECT selected_provider, selected_model, enabled_mcp_tools, enabled_skills FROM threads` is non-NULL on every row
- [x] **Per-thread isolation**: change model/MCP/skill in thread A → start new thread (inherits A) → change in thread B → switch back to A and confirm A still shows A's selection
- [x] **Restart persistence**: quit, relaunch, each thread keeps its selection
- [ ] **Draft thread**: open Playground with no thread active, toggle a skill — the row materialises and persists across navigation
- [ ] **Stream correctness**: send a message in thread A and thread B with different selections, confirm responses come from the correct model

🤖 Generated with [Claude Code](https://claude.com/claude-code)