### PR TITLE
feat(playground): enable agents for everyone

### DIFF
--- a/main/src/feature-flags/__tests__/flags.test.ts
+++ b/main/src/feature-flags/__tests__/flags.test.ts
@@ -68,29 +68,6 @@ describe('Feature Flags', () => {
       }
     )
 
-    it('should return value from SQLite when available', () => {
-      vi.mocked(readFeatureFlag).mockReturnValueOnce(true)
-
-      const result = getFeatureFlag(featureFlagKeys.AGENTS)
-      expect(result).toBe(true)
-    })
-
-    it('should return false (default) when SQLite returns undefined', () => {
-      vi.mocked(readFeatureFlag).mockReturnValueOnce(undefined)
-
-      const result = getFeatureFlag(featureFlagKeys.AGENTS)
-      expect(result).toBe(false)
-    })
-
-    it('should return false (default) when SQLite read throws', () => {
-      vi.mocked(readFeatureFlag).mockImplementationOnce(() => {
-        throw new Error('DB error')
-      })
-
-      const result = getFeatureFlag(featureFlagKeys.AGENTS)
-      expect(result).toBe(false)
-    })
-
     it('should always return false for disabled flags regardless of SQLite', () => {
       vi.mocked(readFeatureFlag).mockReturnValueOnce(true)
 
@@ -135,15 +112,6 @@ describe('Feature Flags', () => {
   })
 
   describe('enableFeatureFlag', () => {
-    it('should write true to SQLite for enabled flags', () => {
-      enableFeatureFlag(featureFlagKeys.AGENTS)
-
-      expect(writeFeatureFlag).toHaveBeenCalledWith(
-        `feature_flag_${featureFlagKeys.AGENTS}`,
-        true
-      )
-    })
-
     it('should not write to SQLite for disabled flags', () => {
       // META_OPTIMIZER is disabled (isDisabled: true)
       enableFeatureFlag(featureFlagKeys.META_OPTIMIZER)

--- a/main/src/feature-flags/flags.ts
+++ b/main/src/feature-flags/flags.ts
@@ -15,11 +15,6 @@ const featureFlagOptions: Record<FeatureFlagKey, FeatureFlagOptions> = {
     defaultValue: false,
     isExperimental: true,
   },
-  [featureFlagKeys.AGENTS]: {
-    isDisabled: false,
-    defaultValue: false,
-    isExperimental: false,
-  },
 }
 
 // Kept for one-time reconciliation migration; remove after migration grace period

--- a/renderer/src/features/chat/components/__tests__/chat-input-prompt.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/chat-input-prompt.test.tsx
@@ -31,10 +31,6 @@ vi.mock('@/common/lib/analytics', () => ({
   trackEvent: vi.fn(),
 }))
 
-vi.mock('@/common/hooks/use-feature-flag', () => ({
-  useFeatureFlag: () => false,
-}))
-
 vi.mock('electron-log/renderer', () => ({
   default: {
     error: vi.fn(),

--- a/renderer/src/features/chat/components/__tests__/chat-input-prompt.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/chat-input-prompt.test.tsx
@@ -138,6 +138,13 @@ describe('ChatInputPrompt', () => {
     }
   })
 
+  describe('toolbar selectors', () => {
+    it('renders the AgentSelector unconditionally when provider and model are configured', () => {
+      renderPrompt({ status: 'ready' })
+      expect(screen.getByTestId('agent-selector')).toBeInTheDocument()
+    })
+  })
+
   describe('submit decision', () => {
     it('calls onRewindAndResend when editingMessageId matches lastUserMessageId and streaming', async () => {
       const {

--- a/renderer/src/features/chat/components/__tests__/playground-sidebar.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/playground-sidebar.test.tsx
@@ -10,11 +10,6 @@ vi.mock('@/common/hooks/use-confirm', () => ({
   useConfirm: () => mockConfirm,
 }))
 
-const mockUseFeatureFlag = vi.fn()
-vi.mock('@/common/hooks/use-feature-flag', () => ({
-  useFeatureFlag: (key: string) => mockUseFeatureFlag(key),
-}))
-
 vi.mock('@tanstack/react-router', () => ({
   Link: ({
     children,
@@ -64,8 +59,6 @@ function renderSidebar(props: Partial<typeof defaultProps> = {}) {
 describe('PlaygroundSidebar', () => {
   beforeEach(() => {
     mockConfirm.mockResolvedValue(true)
-    mockUseFeatureFlag.mockReset()
-    mockUseFeatureFlag.mockReturnValue(false)
     // Reset all callback mocks
     Object.assign(defaultProps, {
       onSelectThread: vi.fn(),
@@ -76,21 +69,8 @@ describe('PlaygroundSidebar', () => {
     })
   })
 
-  describe('agents feature flag', () => {
-    it('hides the Agents link when the agents feature flag is off', () => {
-      mockUseFeatureFlag.mockImplementation((key: string) =>
-        key === 'agents' ? false : false
-      )
-      renderSidebar()
-      expect(
-        screen.queryByRole('link', { name: /agents/i })
-      ).not.toBeInTheDocument()
-    })
-
-    it('shows the Agents link when the agents feature flag is on', () => {
-      mockUseFeatureFlag.mockImplementation((key: string) =>
-        key === 'agents' ? true : false
-      )
+  describe('agents link', () => {
+    it('renders the Agents link pointing to /playground/agents', () => {
       renderSidebar()
       const link = screen.getByRole('link', { name: /agents/i })
       expect(link).toBeInTheDocument()

--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -35,8 +35,6 @@ import { toastVariants } from '@/common/lib/toast'
 import { useThreadDraft } from '../hooks/use-thread-draft'
 import { useComposerHandle } from '../hooks/use-composer-handle'
 import { QueuedMessageChip } from './queued-message-chip'
-import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
-import { featureFlagKeys } from '@utils/feature-flags'
 
 const errorToastConfig = {
   max_files: {
@@ -146,7 +144,6 @@ function InputWithAttachments({
 }) {
   const attachments = usePromptInputAttachments()
   const prevTextRef = useRef(text)
-  const isAgentsEnabled = useFeatureFlag(featureFlagKeys.AGENTS)
 
   // Clear attachments when text is cleared and message is ready
   useEffect(() => {
@@ -252,7 +249,7 @@ function InputWithAttachments({
           </PromptInputActionMenu>
           {hasProviderAndModel && (
             <>
-              {isAgentsEnabled && <AgentSelector threadId={threadId} />}
+              <AgentSelector threadId={threadId} />
               <ModelSelector
                 settings={settings}
                 onSettingsChange={updateSettings}

--- a/renderer/src/features/chat/components/playground-sidebar.tsx
+++ b/renderer/src/features/chat/components/playground-sidebar.tsx
@@ -26,8 +26,6 @@ import {
 } from '@/common/components/ui/dropdown-menu'
 import { cn } from '@/common/lib/utils'
 import { useConfirm } from '@/common/hooks/use-confirm'
-import { useFeatureFlag } from '@/common/hooks/use-feature-flag'
-import { featureFlagKeys } from '@utils/feature-flags'
 import type { PlaygroundThread } from '../hooks/use-playground-threads'
 
 interface PlaygroundSidebarProps {
@@ -284,10 +282,8 @@ export function PlaygroundSidebar({
   const starredThreads = threads.filter((t) => t.starred)
   const recentThreads = threads.filter((t) => !t.starred)
   const hasStarred = starredThreads.length > 0
-  const isAgentsEnabled = useFeatureFlag(featureFlagKeys.AGENTS)
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const isAgentsActive =
-    isAgentsEnabled && pathname.startsWith('/playground/agents')
+  const isAgentsActive = pathname.startsWith('/playground/agents')
 
   const renderItem = (thread: PlaygroundThread) => (
     <ThreadItem
@@ -308,24 +304,22 @@ export function PlaygroundSidebar({
         shrink-0 flex-col border-r"
     >
       <div className="flex flex-col gap-0.5 px-2 pt-2 pb-1">
-        {isAgentsEnabled && (
-          <Button
-            asChild
-            variant="ghost"
-            size="sm"
-            className={cn(
-              'w-full justify-start gap-2 px-2',
-              isAgentsActive
-                ? 'bg-accent text-accent-foreground'
-                : 'text-muted-foreground'
-            )}
-          >
-            <Link to="/playground/agents" aria-label="Agents">
-              <Bot className="h-4 w-4 shrink-0" />
-              Agents
-            </Link>
-          </Button>
-        )}
+        <Button
+          asChild
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'w-full justify-start gap-2 px-2',
+            isAgentsActive
+              ? 'bg-accent text-accent-foreground'
+              : 'text-muted-foreground'
+          )}
+        >
+          <Link to="/playground/agents" aria-label="Agents">
+            <Bot className="h-4 w-4 shrink-0" />
+            Agents
+          </Link>
+        </Button>
         <Button
           variant="ghost"
           size="sm"

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -1,4 +1,3 @@
 export const featureFlagKeys = {
   META_OPTIMIZER: 'meta_optimizer',
-  AGENTS: 'agents',
 } as const


### PR DESCRIPTION
## Summary

- Remove the `agents` feature flag that gated the Agents sidebar link and the `AgentSelector` in the chat input. The flag defaulted to `false` and was never exposed in the Settings UI (`isExperimental: false`), so users had to call `FeatureFlag.agents.enable()` from the dev console to try the feature.
- Drop the `AGENTS` entry from `utils/feature-flags.ts` and `main/src/feature-flags/flags.ts`, plus the `useFeatureFlag` checks/imports in `chat-input-prompt.tsx` and `playground-sidebar.tsx`.
- The feature-flag infrastructure (IPC, SQLite table, `getFeatureFlag`/`enable`/`disable`, `featureFlagStore`) stays in place — it still backs `META_OPTIMIZER`.

Net diff: `+20 / −91` across 7 files.

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run type-check` clean
- [x] `pnpm run test:nonInteractive` — 210 files / 2382 tests pass, including the updated `playground-sidebar.test.tsx`, `chat-input-prompt.test.tsx`, and `main/src/feature-flags/__tests__/flags.test.ts`
- [x] Manual: `pnpm run start`, open the playground and confirm the Agents sidebar link is visible to a fresh user without enabling any flag, and the `AgentSelector` chip appears in the chat input toolbar
- [x] Manual: `window.FeatureFlag.agents` is `undefined` in the renderer dev console (the helper enumerates `featureFlagKeys` automatically, so it disappears with the key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)