### PR TITLE
fix(playground): persist agent selection on draft threads

### DIFF
--- a/renderer/src/features/agents/hooks/__tests__/use-agents.test.tsx
+++ b/renderer/src/features/agents/hooks/__tests__/use-agents.test.tsx
@@ -29,6 +29,10 @@ const mockAgentsApi = {
   getThreadAgentId: vi.fn(),
 }
 
+const mockChatApi = {
+  ensureThreadExists: vi.fn(),
+}
+
 const sampleAgent: AgentConfig = {
   id: 'custom.my-agent',
   kind: 'custom',
@@ -50,11 +54,17 @@ beforeEach(() => {
   mockAgentsApi.delete.mockResolvedValue({ success: true })
   mockAgentsApi.duplicate.mockResolvedValue(sampleAgent)
   mockAgentsApi.getThreadAgentId.mockResolvedValue(null)
+  mockChatApi.ensureThreadExists.mockResolvedValue({
+    success: true,
+    threadId: 'thread-1',
+    isNew: false,
+  })
 
   window.electronAPI = {
     ...(window.electronAPI ?? {}),
     chat: {
       ...(window.electronAPI?.chat ?? {}),
+      ensureThreadExists: mockChatApi.ensureThreadExists,
       agents: mockAgentsApi,
     },
   } as unknown as typeof window.electronAPI
@@ -238,5 +248,107 @@ describe('useSetThreadAgent', () => {
         null
       )
     })
+  })
+
+  it('promotes a draft thread via ensureThreadExists before writing the agent assignment', async () => {
+    mockChatApi.ensureThreadExists.mockResolvedValueOnce({
+      success: true,
+      threadId: 'thread-draft',
+      isNew: true,
+    })
+    const { result } = renderSetThreadAgent()
+
+    result.current.mutate({
+      threadId: 'thread-draft',
+      agentId: 'builtin.skills',
+    })
+
+    await waitFor(() => {
+      expect(mockChatApi.ensureThreadExists).toHaveBeenCalledWith(
+        'thread-draft'
+      )
+      expect(mockAgentsApi.setThreadAgent).toHaveBeenCalledWith(
+        'thread-draft',
+        'builtin.skills'
+      )
+    })
+
+    // ensureThreadExists must run BEFORE setThreadAgent — otherwise the
+    // UPDATE on the threads row matches 0 rows and the selection is lost.
+    const ensureOrder = mockChatApi.ensureThreadExists.mock.invocationCallOrder
+    const setOrder = mockAgentsApi.setThreadAgent.mock.invocationCallOrder
+    expect(ensureOrder[0]!).toBeLessThan(setOrder[0]!)
+  })
+
+  it('signals threadStarted when ensureThreadExists promoted a draft', async () => {
+    mockChatApi.ensureThreadExists.mockResolvedValueOnce({
+      success: true,
+      threadId: 'thread-draft',
+      isNew: true,
+    })
+    const { result, queryClient } = renderSetThreadAgent()
+
+    result.current.mutate({
+      threadId: 'thread-draft',
+      agentId: 'builtin.skills',
+    })
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData(['chat', 'threadStarted']) as
+        | { threadId: string }
+        | undefined
+      expect(data?.threadId).toBe('thread-draft')
+    })
+  })
+
+  it('does not signal threadStarted when the thread already existed', async () => {
+    mockChatApi.ensureThreadExists.mockResolvedValueOnce({
+      success: true,
+      threadId: 'thread-existing',
+      isNew: false,
+    })
+    const { result, queryClient } = renderSetThreadAgent()
+
+    result.current.mutate({
+      threadId: 'thread-existing',
+      agentId: 'builtin.skills',
+    })
+
+    await waitFor(() => {
+      expect(mockAgentsApi.setThreadAgent).toHaveBeenCalled()
+    })
+    expect(queryClient.getQueryData(['chat', 'threadStarted'])).toBeUndefined()
+  })
+
+  it('skips ensureThreadExists when clearing the agent (agentId: null)', async () => {
+    const { result } = renderSetThreadAgent()
+
+    result.current.mutate({ threadId: 'thread-9', agentId: null })
+
+    await waitFor(() => {
+      expect(mockAgentsApi.setThreadAgent).toHaveBeenCalledWith(
+        'thread-9',
+        null
+      )
+    })
+    expect(mockChatApi.ensureThreadExists).not.toHaveBeenCalled()
+  })
+
+  it('does not call setThreadAgent when ensureThreadExists fails', async () => {
+    mockChatApi.ensureThreadExists.mockResolvedValueOnce({
+      success: false,
+      error: 'boom',
+    })
+    const { result } = renderSetThreadAgent()
+
+    result.current.mutate({
+      threadId: 'thread-draft',
+      agentId: 'builtin.skills',
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(mockAgentsApi.setThreadAgent).not.toHaveBeenCalled()
   })
 })

--- a/renderer/src/features/agents/hooks/use-agents.ts
+++ b/renderer/src/features/agents/hooks/use-agents.ts
@@ -90,20 +90,45 @@ export function useDuplicateAgent() {
 export function useSetThreadAgent() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({
+    mutationFn: async ({
       threadId,
       agentId,
     }: {
       threadId: string
       agentId: string | null
-    }) => window.electronAPI.chat.agents.setThreadAgent(threadId, agentId),
-    onSuccess: (_data, variables) => {
+    }) => {
+      // For a renderer-only draft thread the threads row doesn't exist yet,
+      // so the backend's `UPDATE threads SET agent_id = ...` would silently
+      // match 0 rows. Promote the draft first so the assignment persists.
+      // Skip when clearing (agentId === null): nothing to persist, and we
+      // don't want to materialise an empty row.
+      let isNew = false
+      if (agentId !== null) {
+        const ensured =
+          await window.electronAPI.chat.ensureThreadExists(threadId)
+        if (!ensured.success) {
+          throw new Error(ensured.error ?? 'Failed to create chat thread')
+        }
+        isNew = ensured.isNew ?? false
+      }
+      await window.electronAPI.chat.agents.setThreadAgent(threadId, agentId)
+      return { isNew }
+    },
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({
         queryKey: AGENT_QUERY_KEYS.threadAgent(variables.threadId),
       })
       queryClient.invalidateQueries({
         queryKey: ['chat', 'thread', variables.threadId],
       })
+      if (data.isNew) {
+        // Signal the sidebar (usePlaygroundThreads subscribes) so it flips
+        // `pending: false` for the newly promoted draft.
+        queryClient.setQueryData(['chat', 'threadStarted'], {
+          threadId: variables.threadId,
+          timestamp: Date.now(),
+        })
+      }
     },
   })
 }

--- a/renderer/src/features/chat/components/__tests__/agent-selector.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/agent-selector.test.tsx
@@ -45,6 +45,10 @@ const mockAgentsApi = {
   getThreadAgentId: vi.fn(),
 }
 
+const mockChatApi = {
+  ensureThreadExists: vi.fn(),
+}
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -96,6 +100,7 @@ describe('AgentSelector', () => {
       ...(window.electronAPI ?? {}),
       chat: {
         ...(window.electronAPI?.chat ?? {}),
+        ensureThreadExists: mockChatApi.ensureThreadExists,
         agents: mockAgentsApi,
       },
     } as unknown as typeof window.electronAPI
@@ -107,6 +112,11 @@ describe('AgentSelector', () => {
     ])
     mockAgentsApi.getThreadAgentId.mockResolvedValue(null)
     mockAgentsApi.setThreadAgent.mockResolvedValue({ success: true })
+    mockChatApi.ensureThreadExists.mockResolvedValue({
+      success: true,
+      threadId: 'thread-1',
+      isNew: false,
+    })
   })
 
   it('renders the default agent name when no thread agent is set', async () => {


### PR DESCRIPTION
## Summary

A new chat starts with a renderer-only draft thread whose row isn't written to SQLite until the first message is sent (via `ensureThreadExists`). `setThreadAgent` in the main process runs `UPDATE threads SET agent_id = ? WHERE id = ?`, which silently matched zero rows for those draft ids — so the picked agent was never persisted and the selector reverted to the default on the next refetch.

- Promote the draft via `ensureThreadExists` from `useSetThreadAgent` before writing the assignment.
- When `ensured.isNew`, publish `['chat', 'threadStarted']` so `usePlaygroundThreads` flips `pending: false` and the sidebar stays consistent.
- Skip the ensure call when clearing (`agentId: null`) so we don't materialise an empty row just to record a no-op.

## Test plan

- [x] `pnpm run vitest:electron run renderer/src/features/agents renderer/src/features/chat` — 456/456 pass (5 new regression tests in `use-agents.test.tsx`).
- [x] `pnpm run test:nonInteractive` — 2406/2406 pass.
- [x] `pnpm run type-check` — clean.
- [x] `pnpm run lint` — clean.
- [ ] Manual: open Playground, switch to a new chat, change the agent before sending — selector should hold the new agent across refetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)