### PR TITLE
test: refine Istanbul/Vitest coverage exclude globs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,6 +49,12 @@ export default defineConfig({
         'main/src/csp.ts',
         'main/src/logger.ts',
         'main/src/headers.ts',
+        // Generated files
+        '**/*.gen.ts',
+        '**/*.gen.tsx',
+        'renderer/src/route-tree.gen.ts',
+        // shadcn/ui components (generated, not project-specific)
+        'renderer/src/common/components/ui/**',
       ],
     },
   },


### PR DESCRIPTION
## Summary

Refines test coverage exclusions to exclude generated files and shadcn/ui components, as requested in #596.

## Changes

Added the following exclusions to `vitest.config.ts` coverage configuration:

### 1. Generated files
```typescript
'**/*.gen.ts',
'**/*.gen.tsx',
'renderer/src/route-tree.gen.ts',
```

**Rationale**: These files are auto-generated (e.g., by TanStack Router plugin) and should not be modified or tested directly.

### 2. shadcn/ui components
```typescript
'renderer/src/common/components/ui/**',
```

**Rationale**: As mentioned in the issue, shadcn/ui components are generated/copied from the shadcn/ui library and should almost never be individually tested in this project. Testing them would:
- Inflate coverage metrics without adding value
- Test third-party code rather than project-specific logic
- Create maintenance burden for code we don't own

## Impact

### Before
- Coverage included auto-generated files
- Coverage included third-party UI components
- Metrics were inflated with non-project code

### After
- Coverage focuses on project-specific code
- More accurate representation of actual test coverage
- Overall coverage percentage should rise (as stated in issue)

## Testing

### Verification steps

1. Run tests with coverage:
   ```bash
   pnpm run test:coverage
   ```

2. Verify that coverage report excludes:
   - `renderer/src/route-tree.gen.ts`
   - All files in `renderer/src/common/components/ui/`
   - Any other `*.gen.ts` or `*.gen.tsx` files

3. Confirm CI still passes

### Expected results

- CI passes
- Coverage percentage increases (excludes untested generated code)
- Coverage report is cleaner and more focused

## Related

- Fixes #596

Fixes #596