### PR TITLE
chore: group AI SDK packages into a single Renovate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,10 +30,7 @@
       "description": "Group streamdown core + plugin renderers — sub-plugins must move with the core to avoid API mismatch",
       "groupName": "streamdown",
       "groupSlug": "streamdown",
-      "matchPackageNames": [
-        "streamdown",
-        "/^@streamdown\\//"
-      ]
+      "matchPackageNames": ["streamdown", "/^@streamdown\\//"]
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,15 @@
         "/^@modelcontextprotocol\\//",
         "/^@openrouter\\//"
       ]
+    },
+    {
+      "description": "Group streamdown core + plugin renderers — sub-plugins must move with the core to avoid API mismatch",
+      "groupName": "streamdown",
+      "groupSlug": "streamdown",
+      "matchPackageNames": [
+        "streamdown",
+        "/^@streamdown\\//"
+      ]
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,18 @@
       "matchPackageNames": ["stacklok/toolhive"],
       "prPriority": 10,
       "schedule": []
+    },
+    {
+      "description": "Group all AI SDK packages into a single PR — they are tightly coupled and should move together",
+      "groupName": "ai stack",
+      "groupSlug": "ai-stack",
+      "matchPackageNames": [
+        "ai",
+        "ai-sdk-ollama",
+        "/^@ai-sdk\\//",
+        "/^@modelcontextprotocol\\//",
+        "/^@openrouter\\//"
+      ]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Add two Renovate `packageRule` groups so tightly-coupled package families land in a single PR each instead of one PR per package.

### Group 1: `ai stack` (13 packages)
The Vercel AI SDK, MCP SDK, OpenRouter providers and `ai` / `ai-sdk-ollama` runtimes are tightly coupled — bumping one at a time risks landing incompatible combinations on `main`.

- `ai`, `ai-sdk-ollama`
- `@ai-sdk/*` — anthropic, google (Gemini), mcp, openai, openai-compatible, provider, react, xai
- `@modelcontextprotocol/*` — sdk, ext-apps
- `@openrouter/*` — ai-sdk-provider

Regex patterns also auto-cover future providers (e.g. `@ai-sdk/mistral`, `@ai-sdk/groq`, `@ai-sdk/cohere`) the day they're added.

### Group 2: `streamdown` (4 packages)
`streamdown` is Vercel's streaming-markdown renderer, paired with sub-plugin packages (`@streamdown/cjk`, `@streamdown/code`, `@streamdown/mermaid`) that consume the core's renderer API. The plugins need to move with the core to avoid API mismatch.

## Test plan

- [ ] Merge
- [ ] On next Renovate run, verify a single `renovate/ai-stack` PR opens when any of the 13 AI deps has an upstream update
- [ ] On next Renovate run, verify a single `renovate/streamdown` PR opens when streamdown core or any `@streamdown/*` plugin updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)