### PR TITLE
fix(flatpak): add filesystem mapping for copilot-cli client

### DIFF
--- a/utils/flatpak-client-paths.ts
+++ b/utils/flatpak-client-paths.ts
@@ -19,6 +19,7 @@ export const CLIENT_FLATPAK_PATHS: Record<string, string[]> = {
   cline: ['~/.config/Code'],
   codex: ['~/.codex', '~/.agents'],
   continue: ['~/.continue'],
+  'copilot-cli': ['~/.copilot'],
   cursor: ['~/.cursor'],
   factory: ['~/.factory'],
   'gemini-cli': ['~/.gemini'],


### PR DESCRIPTION
## Summary

- ToolHive v0.28.0 added GitHub Copilot CLI as a supported MCP client ([stacklok/toolhive#5287](https://github.com/stacklok/toolhive/pull/5287))
- `MakerFlatpakBuilder` runs `thv client register --help` at make time and fails if any reported client is missing from `CLIENT_FLATPAK_PATHS` in `utils/flatpak-client-paths.ts`
- This is why the Renovate bump PR #2268 is red on all Linux Flatpak build jobs while `main` is green (still on v0.27.2, which doesn't yet expose `copilot-cli`)
- Maps `copilot-cli` → `~/.copilot`, matching the `RelPath: []string{".copilot"}` declared in toolhive `pkg/client/config.go`

After this lands, PR #2268 can be rebased/retried and the Flatpak makers should pass.

## Test plan

- [ ] Linux Flatpak build matrix jobs pass on this branch (no `copilot-cli` to trigger the guard yet — exercised once toolhive bump lands)
- [ ] Static checks (lint, type-check, prettier, knip) pass
- [ ] Once merged, rebase #2268 and confirm all `Build App on ubuntu-latest` / `ubuntu-24.04-arm` jobs go green