### PR TITLE
test(e2e): use LONG_TIMEOUT on registry install/uninstall flow

### DIFF
--- a/e2e-tests/registry.spec.ts
+++ b/e2e-tests/registry.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures/electron'
+import { test, expect, LONG_TIMEOUT } from './fixtures/electron'
 
 test('install and uninstall server from registry', async ({ window }) => {
   await window.getByRole('button', { name: /add an mcp server/i }).click()
@@ -14,8 +14,15 @@ test('install and uninstall server from registry', async ({ window }) => {
     .click()
   await window.getByRole('button', { name: /install server/i }).click()
 
-  await window.getByRole('link', { name: /^view$/i }).click()
-  await window.getByText('Running').waitFor()
+  // Installing from the registry pulls the mcp/everything image and boots
+  // the workload container (plus the egress squid proxy, since the server's
+  // manifest declares no outbound network). On CI cold-cache runners that
+  // chain regularly exceeds Playwright's default 30s action timeout, causing
+  // a flaky timeout on the "View" link that appears once install completes.
+  await window
+    .getByRole('link', { name: /^view$/i })
+    .click({ timeout: LONG_TIMEOUT })
+  await window.getByText('Running').waitFor({ timeout: LONG_TIMEOUT })
 
   await window.getByRole('button', { name: /more options/i }).click()
   await window.getByRole('menuitem', { name: /remove/i }).click()


### PR DESCRIPTION
## Summary

The `install and uninstall server from registry` E2E test consistently times out on CI at `getByRole('link', { name: /^view$/i }).click()` (default 30s action timeout).

Between clicking the dialog's _Install server_ and the _View_ link rendering, the backend has to:

1. pull \`docker.io/mcp/everything:latest\` (cold cache on most runners),
2. start the egress squid proxy (the server manifest declares no outbound network, so a proxy container is required),
3. start the workload container,
4. wait for it to become healthy.

On the default CI shared runners that chain regularly exceeds 30s, producing:

```
TimeoutError: locator.click: Timeout 30000ms exceeded.
  - waiting for getByRole('link', { name: /^view$/i })
```

Reproduced in [stacklok-enterprise-platform PR #1176](https://github.com/stacklok/stacklok-enterprise-platform/pull/1176) (sync to v0.35.2) and [PR #1178](https://github.com/stacklok/stacklok-enterprise-platform/pull/1178) (regen client) — both fail identically on this test only.

## Fix

The fixture already exports \`LONG_TIMEOUT\` (180s) for *\"operations that may take a while, like LLM inference on CI\"*. The registry-install path is in the same class of slow container-orchestration operations, so reuse it for the two waits that depend on the spawned containers being up:

- the click on the \"View\" link (rendered once install completes),
- the \`Running\` text appearing on the workload detail page.

## Test plan
- [ ] CI passes \`install and uninstall server from registry\` reliably without flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)