### PR TITLE
ci(release): disable pnpm 11 verifyDepsBeforeRun to fix ubuntu-arm hang

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,19 @@
 nodeLinker: hoisted
 engineStrict: true
 
+# Disable pnpm 11's pre-script `verify-deps-before-run` install pass. Without
+# this, the `npm version` step in `on-release.yml` / `pr-build-test.yml`
+# (which mutates `package.json`) makes the next `pnpm run publish` /
+# `pnpm run make` trigger a second install pass that re-resolves overrides
+# and reruns `postinstall: electron-rebuild`. On the `ubuntu-24.04-arm`
+# runner that second pass hangs at end-of-install ~90% of the time in
+# interruptible sleep at ~600MB RSS, blocking the job for 30+ min and
+# producing silent cancels (see v0.35.0-rc.0 through v0.35.3-rc.1).
+# v0.34.x ran on pnpm 10.33.0 which didn't have this setting and shipped
+# arm releases first-try every time — disabling it on pnpm 11.x replicates
+# that behavior without touching the lockfile or override resolution.
+verifyDepsBeforeRun: false
+
 allowBuilds:
   '@sentry/cli': true
   '@swc/core': true


### PR DESCRIPTION
## Summary

Forward-ports the applicable half of [stacklok/stacklok-enterprise-platform#1243](https://github.com/stacklok/stacklok-enterprise-platform/pull/1243) (by @lujunsan) to OSS. The Node 24.15.0 pin from that PR is already in `.github/actions/setup/action.yaml`, but the `verifyDepsBeforeRun: false` half is not — and OSS reproduces every precondition of the regression resolved on the enterprise overlay.

## The bug

| Precondition | OSS |
|---|---|
| `ubuntu-24.04-arm` runner | ✅ `_build-matrix.yml:15`, `pr-build-test.yml:150`, `on-release.yml:83` |
| pnpm 11.1.2 (default `verifyDepsBeforeRun=true`) | ✅ `actions/setup/action.yaml:9` |
| `npm version` mutates `package.json` before `pnpm run X` | ✅ `on-release.yml:111` → `pnpm run publish:170`; `pr-build-test.yml:187` |
| overrides in `pnpm-workspace.yaml` (PR #2239) | ✅ |
| `verifyDepsBeforeRun` unset (defaults to `true` on pnpm 11) | ✅ |

The `npm version` step mutates `package.json`. The next `pnpm run publish` then triggers pnpm 11's `verify-deps-before-run` second install pass — re-resolves overrides, prunes transitive packages, reruns `postinstall: electron-rebuild`. On `ubuntu-24.04-arm` that second pass hangs at end-of-install ~90% of the time in interruptible sleep at ~600MB RSS, blocking the job for 30+ min.

## Evidence in OSS release history

Matches the fingerprint exactly:

| Release | Result |
|---|---|
| v0.35.3-rc.1 | cancelled |
| v0.35.3-rc.0 | failure |
| v0.35.1 | cancelled |
| v0.35.1-rc.0 | cancelled |
| v0.35.0-rc.1 | cancelled |
| v0.35.0-rc.0 | cancelled |
| v0.34.x and earlier | clean (pnpm 10.33.0, no such setting) |

v0.35.x is where this started — pnpm 11.1.2 landed via upstream PR #2239 (2026-05-13), which also moved overrides into `pnpm-workspace.yaml`.

## The fix

Single line in `pnpm-workspace.yaml`:

\`\`\`yaml
verifyDepsBeforeRun: false
\`\`\`

Skips the second install pass while keeping pnpm 11.1.2 (so workspace-level overrides still apply correctly). Idempotent on local dev — first \`pnpm install\` is unaffected; only the pre-script consistency check is dropped.

## Why this differs from the enterprise PR

Enterprise vendors studio as a submodule and mutates \`pnpm-workspace.yaml\` at job-time via \`yq -i\` (so the mutation lives only during the release job). OSS owns the file, so we set it directly — same effect, simpler.

## Test plan

- [ ] CI passes on this PR.
- [ ] Next release / pre-release attempts ship arm artifacts first-try without 30+ min hangs.
- [ ] \`pnpm install --frozen-lockfile\` continues to work locally and in CI (verified — no lockfile change).

## References

- [stacklok/stacklok-enterprise-platform#1243](https://github.com/stacklok/stacklok-enterprise-platform/pull/1243) — Luis's forward-port to enterprise main
- [stacklok/stacklok-enterprise-platform#1228](https://github.com/stacklok/stacklok-enterprise-platform/pull/1228), [#1229](https://github.com/stacklok/stacklok-enterprise-platform/pull/1229) — original fixes on release/0.1
- [nodejs/node#62253](https://github.com/nodejs/node/issues/62253), [npm/cli#9118](https://github.com/npm/cli/issues/9118) — related Node 24.16 allocator bug (already mitigated in OSS via the 24.15.0 pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)