### PR TITLE
fix(registry-servers): tag registry installs with registry+server fields

### DIFF
--- a/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
+++ b/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
@@ -67,6 +67,8 @@ describe('prepareCreateWorkloadData', () => {
       target_port: 8080,
       network_isolation: false,
       volumes: [],
+      registry: 'default',
+      server: 'test-server',
     })
   })
 
@@ -97,7 +99,33 @@ describe('prepareCreateWorkloadData', () => {
       target_port: 8080,
       network_isolation: false,
       volumes: [],
+      registry: 'default',
+      server: 'test-server',
     })
+  })
+
+  it('tags the request with the registry source so the API runs the registry-resolution path', () => {
+    const data: FormSchemaRegistryMcp = {
+      proxy_mode: 'streamable-http',
+      name: 'My Custom github',
+      group: 'default',
+      envVars: [],
+      secrets: [],
+      networkIsolation: false,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+    }
+
+    const result = prepareCreateWorkloadData(SERVER, data)
+
+    // Workload name comes from the form (user-editable); registry entry name
+    // comes from the canonical server metadata. They are deliberately distinct
+    // so the API can resolve registry defaults even when the user renames the
+    // workload at install time.
+    expect(result.name).toBe('My Custom github')
+    expect(result.registry).toBe('default')
+    expect(result.server).toBe('test-server')
   })
 
   it('handles empty cmd_arguments', () => {

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
@@ -51,5 +51,14 @@ export function prepareCreateWorkloadData(
     network_isolation: networkIsolation,
     permission_profile,
     volumes,
+    // Tag the request as a registry install so the API records the source
+    // registry on the workload. `name` is the workload name (user-editable
+    // and may diverge from the registry entry name when the user installs
+    // the same server twice into different groups), so the canonical
+    // registry entry name from `server.name` is sent separately. Without
+    // these fields the API treats the request as a direct image install
+    // and policy gates that allow only registry servers reject it.
+    registry: 'default',
+    server: server.name,
   }
 }


### PR DESCRIPTION
## Summary

The registry-install path currently sends only `req.image` to the workloads API. The API then treats the request as a direct image install — `req.Registry` and `req.Server` are both empty, so `workload_service.go` skips `resolveRegistryServer` and falls into the image-retriever path. That path tries to look the image up in the registry by name (`provider.GetServer(serverOrImage)`), which misses because the registry is keyed by server name, not by image URL. The result is that `RegistryServerName` and `RegistryAPIURL` come back empty on the resulting `RunConfig`.

Policy gates that allow only "registry servers" (e.g. the enterprise `non_registry_servers` directive) then reject the install with `errNonRegistryBlocked`, even though the image is the exact one listed in the registry. Users hit this whenever the enterprise enforces `non_registry_servers: false`, including the canonical setup that pairs it with a `registry` directive.

This change tags the request so the API takes the `resolveRegistryServer` path end-to-end:

- `registry: 'default'` — the registry name token the API understands
- `server: server.name` — the canonical registry entry name (e.g. `"github"`), kept separate from the user-editable workload `name` which may diverge when the user renames the workload at install time or installs the same server twice into different groups

User-provided fields (`image`, `transport`, `target_port`, etc.) still take precedence — `applyRegistryDefaults` only fills in missing values.

## Test plan

- [x] Updated `prepareCreateWorkloadData` unit tests to assert `registry: 'default'` and `server: <server.name>` are emitted
- [x] Added a focused test documenting that workload `name` and registry entry `server` are deliberately distinct
- [x] `pnpm vitest run renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx` — 17 tests pass
- [x] `pnpm run type-check` — clean
- [x] `pnpm eslint` on the two changed files — clean
- [ ] Manual install of a registry server from the UI with `non_registry_servers: false` enforced — needs follow-up verification by the bug-bash reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)