### PR TITLE
fix(settings): show real on-disk log path instead of hard-coded "ToolHive"

### DIFF
--- a/main/src/ipc-handlers/app.ts
+++ b/main/src/ipc-handlers/app.ts
@@ -80,6 +80,13 @@ export function register() {
     (_e, dismissedAt: string) => setExpertConsultationDismissedAt(dismissedAt)
   )
 
+  // Sync IPC: preload reads this once at load time and exposes it as
+  // `window.electronAPI.mainLogPath`. `sendSync` is acceptable here because
+  // it runs once at preload bootstrap, before any page is rendered.
+  ipcMain.on('get-main-log-path-sync', (event) => {
+    event.returnValue = path.join(app.getPath('logs'), 'main.log')
+  })
+
   ipcMain.handle(
     'get-main-log-content',
     async (): Promise<string | undefined> => {

--- a/preload/src/api/app.ts
+++ b/preload/src/api/app.ts
@@ -1,5 +1,10 @@
 import { ipcRenderer } from 'electron'
 
+// Captured once at preload bootstrap (before the page loads). `sendSync` here
+// is the canonical pattern for static, immutable strings sourced from the main
+// process: zero React Query / useEffect boilerplate in every consumer.
+const mainLogPath = ipcRenderer.sendSync('get-main-log-path-sync') as string
+
 export const appApi = {
   getAutoLaunchStatus: () => ipcRenderer.invoke('get-auto-launch-status'),
   setAutoLaunch: (enabled: boolean) =>
@@ -32,6 +37,7 @@ export const appApi = {
   setExpertConsultationDismissedAt: (dismissedAt: string): Promise<void> =>
     ipcRenderer.invoke('set-expert-consultation-dismissed-at', dismissedAt),
 
+  mainLogPath,
   getMainLogContent: () => ipcRenderer.invoke('get-main-log-content'),
 
   isMac: process.platform === 'darwin',
@@ -60,6 +66,7 @@ export interface AppAPI {
   }>
   setExpertConsultationSubmitted: (submitted: boolean) => Promise<void>
   setExpertConsultationDismissedAt: (dismissedAt: string) => Promise<void>
+  mainLogPath: string
   getMainLogContent: () => Promise<string>
   isMac: boolean
   isWindows: boolean

--- a/renderer/src/common/components/settings/tabs/__tests__/logs-tab.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/logs-tab.test.tsx
@@ -24,6 +24,11 @@ describe('LogsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
+    // Preload exposes `mainLogPath` synchronously via `ipcRenderer.sendSync`
+    // at bootstrap time. In tests, the global `resetElectronAPI` runs first
+    // and re-creates `window.electronAPI`, so this assignment must live here.
+    window.electronAPI.mainLogPath =
+      '/Users/test/Library/Logs/ToolHive/main.log'
     window.electronAPI.platform = 'darwin'
     window.electronAPI.getMainLogContent = mockGetMainLogContent
 
@@ -33,51 +38,22 @@ describe('LogsTab', () => {
     document.querySelectorAll('a').forEach((link) => link.remove())
   })
 
-  it('renders logs tab heading and description', async () => {
+  it('renders logs tab heading and description', () => {
     render(<LogsTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText('Logs')).toBeVisible()
-    })
-
+    expect(screen.getByText('Logs')).toBeVisible()
     expect(
       screen.getByText(/Application logs are stored locally/)
     ).toBeVisible()
     expect(screen.getByRole('button', { name: 'Save log file' })).toBeVisible()
   })
 
-  it('displays correct log path for macOS', async () => {
-    window.electronAPI.platform = 'darwin'
-
+  it('displays the log path exposed by preload', () => {
     render(<LogsTab />)
 
-    await waitFor(() => {
-      expect(screen.getByText('~/Library/Logs/ToolHive/main.log')).toBeVisible()
-    })
-  })
-
-  it('displays correct log path for Windows', async () => {
-    window.electronAPI.platform = 'win32'
-
-    render(<LogsTab />)
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          '%USERPROFILE%\\AppData\\Roaming\\ToolHive\\logs\\main.log'
-        )
-      ).toBeVisible()
-    })
-  })
-
-  it('displays correct log path for Linux', async () => {
-    window.electronAPI.platform = 'linux'
-
-    render(<LogsTab />)
-
-    await waitFor(() => {
-      expect(screen.getByText('~/.config/ToolHive/logs/main.log')).toBeVisible()
-    })
+    expect(
+      screen.getByText('/Users/test/Library/Logs/ToolHive/main.log')
+    ).toBeVisible()
   })
 
   it('copies log path to clipboard when copy button is clicked', async () => {
@@ -88,19 +64,13 @@ describe('LogsTab', () => {
 
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-        '~/Library/Logs/ToolHive/main.log'
+        '/Users/test/Library/Logs/ToolHive/main.log'
       )
     })
   })
 
   it('downloads log file when download button is clicked', async () => {
     render(<LogsTab />)
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Save log file' })
-      ).toBeVisible()
-    })
 
     const downloadButton = screen.getByRole('button', {
       name: 'Save log file',
@@ -119,12 +89,6 @@ describe('LogsTab', () => {
     mockGetMainLogContent.mockRejectedValue(mockError)
 
     render(<LogsTab />)
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Save log file' })
-      ).toBeVisible()
-    })
 
     const downloadButton = screen.getByRole('button', {
       name: 'Save log file',

--- a/renderer/src/common/components/settings/tabs/logs-tab.tsx
+++ b/renderer/src/common/components/settings/tabs/logs-tab.tsx
@@ -5,16 +5,15 @@ import { CodeBlockWithCopy } from '../../code-block-with-copy'
 import { Separator } from '../../ui/separator'
 import { SettingsSectionTitle } from './components/settings-section-title'
 
-const LOG_PATHS = {
-  darwin: '~/Library/Logs/ToolHive/main.log',
-  win32: '%USERPROFILE%\\AppData\\Roaming\\ToolHive\\logs\\main.log',
-  linux: '~/.config/ToolHive/logs/main.log',
-} as const
-
 export function LogsTab() {
   const { isDownloading, downloadFile } = useDownloadFile()
-  const platform = window.electronAPI.platform
-  const logPath = LOG_PATHS[platform as keyof typeof LOG_PATHS] ?? null
+
+  // Sync property captured at preload bootstrap from the main process.
+  // Reflects `path.join(app.getPath('logs'), 'main.log')`, which Electron
+  // derives from `app.getName()` (i.e. `productName` in package.json).
+  // A hard-coded string would go stale for any branded build whose
+  // productName is not "ToolHive".
+  const logPath = window.electronAPI.mainLogPath
 
   const handleDownloadLog = async () => {
     await downloadFile(


### PR DESCRIPTION
## Summary
<img width="1249" height="777" alt="Screenshot 2026-05-29 at 12 31 36" src="https://github.com/user-attachments/assets/a234d64e-43ee-42d3-b84a-b25dd4b13983" />

Replaces the hard-coded `LOG_PATHS` map in `renderer/src/common/components/settings/tabs/logs-tab.tsx` with a value sourced from the main process at preload bootstrap. The hard-coded path was stale for any branded build because `app.getPath('logs')` follows `app.getName()` (i.e. `productName`).

## Scope (minimal, 4 files)

- **New sync IPC** `get-main-log-path-sync` in `main/src/ipc-handlers/app.ts` — returns `path.join(app.getPath('logs'), 'main.log')`
- **Preload bootstrap** in `preload/src/api/app.ts` — captures the value once at load time via `ipcRenderer.sendSync` and exposes it as `electronAPI.mainLogPath` (sync string, no Promise)
- **TypeScript interface** — `mainLogPath: string` added to `AppAPI`
- **`logs-tab.tsx`** — drops `LOG_PATHS` map, reads `window.electronAPI.mainLogPath` directly inside the component (no `useQuery`, no async, no loading state)
- **Tests** — `window.electronAPI.mainLogPath` is set in `beforeEach`, assertions verify the rendered value matches

## Why this approach (`sendSync` at preload, not `useQuery`)

The log path is a stable string that never changes during a session. Pulling it via `useQuery` (or any async path that needs a React Query / `useEffect` dance) is unnecessary overhead and boilerplate at every call site. The cleanest pattern is:

1. `ipcMain.on('get-main-log-path-sync', e => { e.returnValue = ... })` — sync IPC handler in main
2. `const mainLogPath = ipcRenderer.sendSync('get-main-log-path-sync')` — runs ONCE at preload bootstrap, before the page is rendered
3. `contextBridge.exposeInMainWorld(..., { mainLogPath })` — sync string available on `window.electronAPI.mainLogPath` from the first React render

`sendSync` is normally discouraged because it blocks the renderer, but here it runs at preload time before any page logic exists. One-shot bootstrap cost, near-zero impact.

## Canonical precedent for a broader strategy

This PR is the canonical precedent for parameterizing other user-visible `ToolHive` literals in OSS. The companion follow-up will expose the runtime app name via the same one-shot preload pattern:

```
package.json `productName` → main `app.getName()` → IPC `get-app-display-name` → preload `electronAPI.appDisplayName` → renderer
```

The OSS `productName` stays `"ToolHive"` (no rebrand). Branded builds — e.g. our enterprise distro setting `productName="Stacklok Desktop"` — get the rebrand for free. ~45 strings tracked in stacklok/toolhive-studio#2296.

## Why

The displayed Settings → Logs path becomes wrong for any build where productName differs from the OSS default "ToolHive" (e.g. forks, custom branded distributions, our enterprise distro). Replacing hard-coded literals with a runtime-sourced value makes the UI honest regardless of branding.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run type-check`
- [x] `pnpm run format`
- [x] `pnpm run test:nonInteractive` — 2448/2448 passing
- [ ] Manual: open Settings → Logs in a packaged OSS build, confirm the path matches `app.getPath('logs')`