### PR TITLE
feat(settings): gate TelemetryField on isEnterprise prop

### DIFF
--- a/renderer/src/common/components/settings/tabs/__tests__/general-tab.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/general-tab.test.tsx
@@ -227,6 +227,20 @@ describe('GeneralTab', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('hides the telemetry toggle when isEnterprise is true', async () => {
+    renderWithProviders(<GeneralTabWrapper isEnterprise={true} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'General' })).toBeVisible()
+    })
+
+    // Error reporting (Sentry) toggle is hidden in branded/enterprise builds
+    // because they typically ship without a Sentry DSN — the toggle would be
+    // a confusing no-op.
+    expect(screen.queryByText('Error reporting')).not.toBeInTheDocument()
+    expect(screen.queryByRole('switch', { name: /telemetry/i })).toBeNull()
+  })
+
   describe('Experimental Features', () => {
     it('displays message when no experimental features are available', async () => {
       // Override the mock to return false for experimental_features flag

--- a/renderer/src/common/components/settings/tabs/components/general-tab-wrapper.tsx
+++ b/renderer/src/common/components/settings/tabs/components/general-tab-wrapper.tsx
@@ -187,8 +187,12 @@ export function GeneralTabWrapper({
         <Separator />
         <AutoLaunchField />
         <Separator />
-        <TelemetryField />
-        <Separator />
+        {!isEnterprise && (
+          <>
+            <TelemetryField />
+            <Separator />
+          </>
+        )}
         <QuitConfirmationField />
         <Separator />
         {children}


### PR DESCRIPTION
## Summary

Extends the existing `isEnterprise` prop in `GeneralTabWrapper` (which already gates `ExperimentalFeatures`) to also gate the Sentry `TelemetryField`. Default behavior unchanged for OSS.

## Why

Rebranded / enterprise builds (e.g. stacklok-enterprise-platform's Stacklok Desktop distro) ship without a Sentry DSN, so `Sentry.init({ enabled: !!import.meta.env.VITE_SENTRY_DSN })` is false. The "Error reporting" toggle in Settings → General is a no-op in those builds and confuses end users.

The enterprise overlay already passes `isEnterprise={true}` to `GeneralTabWrapper` (merged in stacklok/stacklok-enterprise-platform#1317). After this PR ships and the submodule is synced, the toggle will disappear in enterprise without any further changes.

## Pattern

Mirrors the existing gate for `ExperimentalFeatures` in the same component.

```tsx
<AutoLaunchField />
<Separator />
{!isEnterprise && (
  <>
    <TelemetryField />
    <Separator />
  </>
)}
<QuitConfirmationField />
```

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run type-check`
- [x] `pnpm run format`
- [x] `pnpm run test:nonInteractive` — 2451/2451 passing (+1 new test in `general-tab.test.tsx`)
- [ ] Manual: render `<GeneralTabWrapper isEnterprise />` in a story or test app, confirm Error reporting + Experimental Features sections are both hidden, other fields (Theme / Start on login / Quit confirmation) remain visible.