### PR TITLE
feat: remove hardcoded app names

### DIFF
--- a/common/app-info.ts
+++ b/common/app-info.ts
@@ -17,8 +17,7 @@ export const DEPRECATED_APP_NAME_FOR_BUILD = 'ToolHive'
 const electronBridge = (
   globalThis as unknown as { electronAPI?: { appDisplayName?: string } }
 ).electronAPI
-export const APP_DISPLAY_NAME =
-  electronBridge?.appDisplayName ?? 'ToolHive Studio'
+export const APP_DISPLAY_NAME = electronBridge?.appDisplayName ?? 'ToolHive'
 export const APP_IDENTIFIER = 'toolhive-studio'
 
 // Display name of the bundled ToolHive CLI / backend engine (the `thv` process).

--- a/common/app-info.ts
+++ b/common/app-info.ts
@@ -16,6 +16,11 @@ const electronBridge = (
 ).electronAPI
 export const APP_DISPLAY_NAME = electronBridge?.appDisplayName ?? 'ToolHive Studio'
 export const APP_IDENTIFIER = 'toolhive-studio'
+
+// Display name of the bundled ToolHive CLI / backend engine (the `thv` process).
+// Distinct from APP_DISPLAY_NAME: this names the engine the app manages, not the
+// desktop product brand — so it stays "ToolHive" even in rebranded builds.
+export const THV_DISPLAY_NAME = 'ToolHive'
 export const EXECUTABLE_NAME = 'ToolHive'
 export const COMPANY_NAME = 'Stacklok'
 export const DEVELOPER_ID = 'com.stacklok'

--- a/common/app-info.ts
+++ b/common/app-info.ts
@@ -14,7 +14,8 @@ export const APP_NAME = 'ToolHive'
 const electronBridge = (
   globalThis as unknown as { electronAPI?: { appDisplayName?: string } }
 ).electronAPI
-export const APP_DISPLAY_NAME = electronBridge?.appDisplayName ?? 'ToolHive Studio'
+export const APP_DISPLAY_NAME =
+  electronBridge?.appDisplayName ?? 'ToolHive Studio'
 export const APP_IDENTIFIER = 'toolhive-studio'
 
 // Display name of the bundled ToolHive CLI / backend engine (the `thv` process).

--- a/common/app-info.ts
+++ b/common/app-info.ts
@@ -5,7 +5,11 @@
 
 // ── Core identity ────────────────────────────────────────────────────────────
 
-export const APP_NAME = 'ToolHive'
+// Derives from package.json so branded builds (enterprise) get the correct
+// artifact names in forge without any overlay changes.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pkg = require('../package.json') as { productName?: string; name: string }
+export const APP_NAME: string = pkg.productName ?? pkg.name
 
 // In the renderer, derive from the live Electron app name (productName) via the
 // preload bridge, so branded builds rebrand with no code change. Falls back to

--- a/common/app-info.ts
+++ b/common/app-info.ts
@@ -6,7 +6,15 @@
 // ── Core identity ────────────────────────────────────────────────────────────
 
 export const APP_NAME = 'ToolHive'
-export const APP_DISPLAY_NAME = 'ToolHive Studio'
+
+// In the renderer, derive from the live Electron app name (productName) via the
+// preload bridge, so branded builds rebrand with no code change. Falls back to
+// the literal where the bridge is absent (main process, forge build-time).
+// `globalThis` (not `window`) keeps it valid under the node tsconfig.
+const electronBridge = (
+  globalThis as unknown as { electronAPI?: { appDisplayName?: string } }
+).electronAPI
+export const APP_DISPLAY_NAME = electronBridge?.appDisplayName ?? 'ToolHive Studio'
 export const APP_IDENTIFIER = 'toolhive-studio'
 export const EXECUTABLE_NAME = 'ToolHive'
 export const COMPANY_NAME = 'Stacklok'

--- a/common/app-info.ts
+++ b/common/app-info.ts
@@ -5,11 +5,10 @@
 
 // ── Core identity ────────────────────────────────────────────────────────────
 
-// Derives from package.json so branded builds (enterprise) get the correct
-// artifact names in forge without any overlay changes.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const pkg = require('../package.json') as { productName?: string; name: string }
-export const APP_NAME: string = pkg.productName ?? pkg.name
+// TODO: forge.config.ts and generate-flatpak-assets.ts should read directly
+// from package.json. Needs careful audit — some values allow spaces (display
+// names), others must be identifiers (package names, binary names).
+export const APP_NAME_BUILD = 'ToolHive'
 
 // In the renderer, derive from the live Electron app name (productName) via the
 // preload bridge, so branded builds rebrand with no code change. Falls back to

--- a/common/app-info.ts
+++ b/common/app-info.ts
@@ -18,6 +18,7 @@ const electronBridge = (
   globalThis as unknown as { electronAPI?: { appDisplayName?: string } }
 ).electronAPI
 export const APP_DISPLAY_NAME = electronBridge?.appDisplayName ?? 'ToolHive'
+export const APP_ASSISTANT_NAME = `${APP_DISPLAY_NAME} Assistant`
 export const APP_IDENTIFIER = 'toolhive-studio'
 
 // Display name of the bundled ToolHive CLI / backend engine (the `thv` process).

--- a/common/app-info.ts
+++ b/common/app-info.ts
@@ -8,7 +8,7 @@
 // TODO: forge.config.ts and generate-flatpak-assets.ts should read directly
 // from package.json. Needs careful audit — some values allow spaces (display
 // names), others must be identifiers (package names, binary names).
-export const APP_NAME_BUILD = 'ToolHive'
+export const DEPRECATED_APP_NAME_FOR_BUILD = 'ToolHive'
 
 // In the renderer, derive from the live Electron app name (productName) via the
 // preload bridge, so branded builds rebrand with no code change. Falls back to

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,6 +64,7 @@ export default defineConfig([
     ignores: [
       '**/__tests__/**',
       '**/*.test.{ts,tsx}',
+      '**/mocks/**',
       'common/app-info.ts',
     ],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,4 +53,38 @@ export default defineConfig([
       globals: globals.node,
     },
   },
+  // EXPERIMENT (issue #2296): ban hardcoded brand literals; enumerate sites.
+  {
+    files: [
+      'renderer/**/*.{ts,tsx}',
+      'main/**/*.{ts,tsx}',
+      'common/**/*.{ts,tsx}',
+      'preload/**/*.{ts,tsx}',
+    ],
+    ignores: [
+      '**/__tests__/**',
+      '**/*.test.{ts,tsx}',
+      'common/app-info.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Literal[value=/ToolHive/]',
+          message:
+            "Hardcoded 'ToolHive' brand string — import from @common/app-info instead.",
+        },
+        {
+          selector: 'JSXText[value=/ToolHive/]',
+          message:
+            "Hardcoded 'ToolHive' brand string — import from @common/app-info instead.",
+        },
+        {
+          selector: 'TemplateElement[value.cooked=/ToolHive/]',
+          message:
+            "Hardcoded 'ToolHive' brand string — import from @common/app-info instead.",
+        },
+      ],
+    },
+  },
 ])

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -4,7 +4,7 @@ import { MakerDeb } from '@electron-forge/maker-deb'
 import { MakerRpm } from '@electron-forge/maker-rpm'
 import {
   APP_DISPLAY_NAME,
-  APP_NAME,
+  APP_NAME_BUILD,
   COMPANY_NAME,
   DEEP_LINK_PROTOCOL,
   EXECUTABLE_NAME,
@@ -74,9 +74,9 @@ const config: ForgeConfig = {
     // Windows specific options
     win32metadata: {
       CompanyName: COMPANY_NAME,
-      FileDescription: APP_NAME,
+      FileDescription: APP_NAME_BUILD,
       OriginalFilename: `${EXECUTABLE_NAME}.exe`,
-      ProductName: APP_NAME,
+      ProductName: APP_NAME_BUILD,
       InternalName: EXECUTABLE_NAME,
     },
 
@@ -152,19 +152,19 @@ const config: ForgeConfig = {
       name: '@electron-forge/maker-squirrel',
       config: () => ({
         setupIcon: './icons/icon.ico',
-        setupExe: `${APP_NAME} Setup.exe`,
+        setupExe: `${APP_NAME_BUILD} Setup.exe`,
         noMsi: true,
         authors: COMPANY_NAME,
         exe: `${EXECUTABLE_NAME}.exe`,
-        name: APP_NAME,
+        name: APP_NAME_BUILD,
         noDelta: true,
         windowsSign: getWindowsSignConfig(),
       }),
     },
     new MakerDMGWithArch(
       {
-        name: APP_NAME,
-        title: APP_NAME,
+        name: APP_NAME_BUILD,
+        title: APP_NAME_BUILD,
         icon: './icons/icon.icns',
         overwrite: true,
         background: './assets/dmg-installer-background.png',
@@ -189,9 +189,9 @@ const config: ForgeConfig = {
     new MakerTarGz({}, ['linux']),
     new MakerRpm({
       options: {
-        name: APP_NAME,
-        productName: APP_NAME,
-        genericName: APP_NAME,
+        name: APP_NAME_BUILD,
+        productName: APP_NAME_BUILD,
+        genericName: APP_NAME_BUILD,
         icon: './icons/icon.png',
         license: 'Apache-2.0',
         bin: EXECUTABLE_NAME,
@@ -200,9 +200,9 @@ const config: ForgeConfig = {
     }),
     new MakerDeb({
       options: {
-        name: APP_NAME,
-        productName: APP_NAME,
-        genericName: APP_NAME,
+        name: APP_NAME_BUILD,
+        productName: APP_NAME_BUILD,
+        genericName: APP_NAME_BUILD,
         icon: './icons/icon.png',
         depends: [],
         maintainer: COMPANY_NAME,

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -4,7 +4,7 @@ import { MakerDeb } from '@electron-forge/maker-deb'
 import { MakerRpm } from '@electron-forge/maker-rpm'
 import {
   APP_DISPLAY_NAME,
-  APP_NAME_BUILD,
+  DEPRECATED_APP_NAME_FOR_BUILD,
   COMPANY_NAME,
   DEEP_LINK_PROTOCOL,
   EXECUTABLE_NAME,
@@ -74,9 +74,9 @@ const config: ForgeConfig = {
     // Windows specific options
     win32metadata: {
       CompanyName: COMPANY_NAME,
-      FileDescription: APP_NAME_BUILD,
+      FileDescription: DEPRECATED_APP_NAME_FOR_BUILD,
       OriginalFilename: `${EXECUTABLE_NAME}.exe`,
-      ProductName: APP_NAME_BUILD,
+      ProductName: DEPRECATED_APP_NAME_FOR_BUILD,
       InternalName: EXECUTABLE_NAME,
     },
 
@@ -152,19 +152,19 @@ const config: ForgeConfig = {
       name: '@electron-forge/maker-squirrel',
       config: () => ({
         setupIcon: './icons/icon.ico',
-        setupExe: `${APP_NAME_BUILD} Setup.exe`,
+        setupExe: `${DEPRECATED_APP_NAME_FOR_BUILD} Setup.exe`,
         noMsi: true,
         authors: COMPANY_NAME,
         exe: `${EXECUTABLE_NAME}.exe`,
-        name: APP_NAME_BUILD,
+        name: DEPRECATED_APP_NAME_FOR_BUILD,
         noDelta: true,
         windowsSign: getWindowsSignConfig(),
       }),
     },
     new MakerDMGWithArch(
       {
-        name: APP_NAME_BUILD,
-        title: APP_NAME_BUILD,
+        name: DEPRECATED_APP_NAME_FOR_BUILD,
+        title: DEPRECATED_APP_NAME_FOR_BUILD,
         icon: './icons/icon.icns',
         overwrite: true,
         background: './assets/dmg-installer-background.png',
@@ -189,9 +189,9 @@ const config: ForgeConfig = {
     new MakerTarGz({}, ['linux']),
     new MakerRpm({
       options: {
-        name: APP_NAME_BUILD,
-        productName: APP_NAME_BUILD,
-        genericName: APP_NAME_BUILD,
+        name: DEPRECATED_APP_NAME_FOR_BUILD,
+        productName: DEPRECATED_APP_NAME_FOR_BUILD,
+        genericName: DEPRECATED_APP_NAME_FOR_BUILD,
         icon: './icons/icon.png',
         license: 'Apache-2.0',
         bin: EXECUTABLE_NAME,
@@ -200,9 +200,9 @@ const config: ForgeConfig = {
     }),
     new MakerDeb({
       options: {
-        name: APP_NAME_BUILD,
-        productName: APP_NAME_BUILD,
-        genericName: APP_NAME_BUILD,
+        name: DEPRECATED_APP_NAME_FOR_BUILD,
+        productName: DEPRECATED_APP_NAME_FOR_BUILD,
+        genericName: DEPRECATED_APP_NAME_FOR_BUILD,
         icon: './icons/icon.png',
         depends: [],
         maintainer: COMPANY_NAME,

--- a/main/src/app-events/process-exit.ts
+++ b/main/src/app-events/process-exit.ts
@@ -3,6 +3,7 @@ import log from '../logger'
 
 export function register() {
   process.on('exit', (code) => {
+    // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.info(`[process exit] code=${code}, ensuring ToolHive is stopped...`)
     // Note: Only synchronous operations work here, so we force immediate SIGKILL
     stopToolhive({ force: true })

--- a/main/src/app-events/quit.ts
+++ b/main/src/app-events/quit.ts
@@ -7,6 +7,7 @@ import log from '../logger'
 
 export function register() {
   app.on('quit', () => {
+    // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.info('[quit event] Ensuring ToolHive cleanup...')
     // Only cleanup if not already tearing down to avoid double cleanup
     if (!getTearingDownState()) {

--- a/main/src/auto-launch.ts
+++ b/main/src/auto-launch.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { existsSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import log from './logger'
-import { APP_NAME, AUTO_LAUNCH_DESKTOP_FILENAME } from '@common/app-info'
+import { AUTO_LAUNCH_DESKTOP_FILENAME } from '@common/app-info'
 
 interface DesktopEntry {
   Type: string
@@ -18,12 +18,12 @@ interface DesktopEntry {
 export function createDesktopEntry(execPath: string): string {
   const entry: DesktopEntry = {
     Type: 'Application',
-    Name: APP_NAME,
+    Name: app.getName(),
     Exec: `"${execPath}" --hidden`,
     Hidden: 'false',
     NoDisplay: 'false',
     'X-GNOME-Autostart-enabled': 'true',
-    Comment: `${APP_NAME} Auto-Launch`,
+    Comment: `${app.getName()} Auto-Launch`,
   }
 
   return Object.entries(entry)

--- a/main/src/auto-update.ts
+++ b/main/src/auto-update.ts
@@ -450,8 +450,10 @@ async function performUpdateInstallation({
 
         try {
           stopToolhive()
+          // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
           log.info('[update] ToolHive stopped')
         } catch (error) {
+          // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
           log.error('[update] Error stopping ToolHive: ', error)
         }
 
@@ -715,6 +717,7 @@ export async function getLatestAvailableVersion() {
           isNewVersionAvailable,
         }
       } catch (error) {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         log.error('[update] Failed to check for ToolHive update: ', error)
         span.setStatus({
           code: 2,

--- a/main/src/chat/agents/__tests__/registry.test.ts
+++ b/main/src/chat/agents/__tests__/registry.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../../logger', () => ({
 }))
 
 vi.mock('electron', () => ({
-  app: { getPath: vi.fn(() => ':memory:') },
+  app: { getPath: vi.fn(() => ':memory:'), getName: vi.fn(() => 'ToolHive') },
 }))
 
 import {

--- a/main/src/chat/agents/builtin-agent-tools/skills.ts
+++ b/main/src/chat/agents/builtin-agent-tools/skills.ts
@@ -378,6 +378,7 @@ function renderInstructionsSuffix(
 
   if (enabledSkills.length === 0) {
     if (ctx.loadFailureReason) {
+      // eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
       return `${header}\n\nCould not load installed skills: ${ctx.loadFailureReason}. Ask the user to retry once ToolHive is reachable.`
     }
     if (ctx.installedCount === 0) {
@@ -483,6 +484,7 @@ export async function createSkillsAgentTools(
       return {
         skills: [],
         error:
+          // eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
           'ToolHive is not running locally. Ask the user to start it and try again.',
       }
     }
@@ -580,6 +582,7 @@ export async function createSkillsAgentTools(
 
     [BUILD_SKILL_TOOL]: tool({
       description:
+        // eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
         'Builds the skill that lives at `workdir` using the local ToolHive API. Pass the exact `workdir` returned by `write_skill_files`. On success returns an object with: `reference` (canonical artifact reference in `name:tag` form, derived from the SKILL.md frontmatter), `apiReference` (raw reference returned by the build endpoint), `tag` (local build tag for install / navigation), `workdir`, and `build` (full LocalBuild metadata: name, description, tag, version, digest).',
       inputSchema: z.object({
         workdir: z
@@ -606,6 +609,7 @@ export async function createSkillsAgentTools(
           if (!apiClient) {
             return {
               error:
+                // eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
                 'ToolHive is not running locally. Ask the user to start it and try again.',
             }
           }
@@ -697,6 +701,7 @@ export async function createSkillsAgentTools(
 
     [LIST_SKILLS_TOOL]: tool({
       description:
+        // eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
         "Re-fetches the list of skills installed via ToolHive **and enabled for this chat via the Skills picker in the toolbar**. Covers both user-scope (installed under `~/.<client>/skills/`) and project-scope (installed under `<project_root>/.<client>/skills/`) installs. Entries are deduplicated by `name`: if the same skill is installed in both the user home and one or more projects, it appears once with a `variants` array listing every installation site (`{ scope, projectRoot?, clients }`). Returns `{ skills: [{ name, description, reference, version, variants }] }`. The list is already filtered by the user's selection, so an empty list means the user has not enabled any skills yet.",
       inputSchema: z.object({}),
       execute: async () => {
@@ -766,6 +771,7 @@ export async function createSkillsAgentTools(
 
         if (summary.variants.every((v) => v.clients.length === 0)) {
           return {
+            // eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
             error: `Skill "${trimmed}" has no associated clients on any InstalledSkill record. Re-install it via the Skills page so ToolHive materializes it for at least one client.`,
           }
         }
@@ -799,6 +805,7 @@ export async function createSkillsAgentTools(
           return {
             error: `Could not find an on-disk install for skill "${trimmed}". Looked under: ${candidates.join(
               ', '
+              // eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
             )}. Re-install the skill so ToolHive materializes its files.`,
           }
         }

--- a/main/src/chat/agents/builtin-prompts.ts
+++ b/main/src/chat/agents/builtin-prompts.ts
@@ -1,3 +1,4 @@
+import { app } from 'electron'
 import { BUILTIN_AGENT_IDS, type AgentConfig } from '@common/types/agents'
 
 // eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
@@ -216,7 +217,7 @@ export function getBuiltinAgentSeeds(now: number): AgentConfig[] {
     {
       id: BUILTIN_AGENT_IDS.toolhiveAssistant,
       kind: 'builtin',
-      name: 'ToolHive Assistant',
+      name: `${app.getName()} Assistant`,
       description:
         'General-purpose assistant with access to all enabled MCP tools.',
       instructions: TOOLHIVE_ASSISTANT_INSTRUCTIONS,

--- a/main/src/chat/agents/builtin-prompts.ts
+++ b/main/src/chat/agents/builtin-prompts.ts
@@ -1,5 +1,6 @@
 import { BUILTIN_AGENT_IDS, type AgentConfig } from '@common/types/agents'
 
+// eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
 const TOOLHIVE_ASSISTANT_INSTRUCTIONS = `You are a helpful assistant with access to MCP (Model Context Protocol) servers from ToolHive.
 
     You have access to various specialized tools from enabled MCP servers. Each tool is prefixed with the server name (e.g., github-stats-mcp_get_repository_info).
@@ -65,6 +66,7 @@ const TOOLHIVE_ASSISTANT_INSTRUCTIONS = `You are a helpful assistant with access
 
     Remember: Always interpret and format tool results beautifully. Never show raw data!`
 
+// eslint-disable-next-line no-restricted-syntax -- agent prompt/tool copy — refers to the OSS thv project/API
 const SKILLS_AGENT_INSTRUCTIONS = `You are a Skill Engineer for ToolHive. You help users **build** new skills and **audit** installed ones.
 
 A "skill" is a packaged capability whose instructions live in a file named exactly \`SKILL.md\` at the root of a directory, plus optional bundled resources (references, scripts, templates, assets). ToolHive builds skills into OCI artifacts and materializes installed ones either in the user's home directory (\`~/.<client>/skills/<name>/\`, scope=user) or inside a specific project (\`<projectRoot>/.<client>/skills/<name>/\`, scope=project).

--- a/main/src/chat/agents/registry.ts
+++ b/main/src/chat/agents/registry.ts
@@ -1,3 +1,4 @@
+import { app } from 'electron'
 import { nanoid } from 'nanoid'
 import log from '../../logger'
 import {
@@ -111,7 +112,7 @@ export function resolveAgentForThread(
   return {
     id: DEFAULT_AGENT_ID,
     kind: 'builtin',
-    name: 'ToolHive Assistant',
+    name: `${app.getName()} Assistant`,
     description: '',
     instructions: 'You are a helpful assistant.',
     builtinToolsKey: null,

--- a/main/src/chat/agents/registry.ts
+++ b/main/src/chat/agents/registry.ts
@@ -1,4 +1,3 @@
-import { app } from 'electron'
 import { nanoid } from 'nanoid'
 import log from '../../logger'
 import {
@@ -20,6 +19,7 @@ import {
   DEFAULT_AGENT_ID,
   LEGACY_BUILTIN_AGENT_IDS,
 } from '@common/types/agents'
+import { APP_ASSISTANT_NAME } from '@common/app-info'
 import { getBuiltinAgentSeeds } from './builtin-prompts'
 
 /**
@@ -112,7 +112,7 @@ export function resolveAgentForThread(
   return {
     id: DEFAULT_AGENT_ID,
     kind: 'builtin',
-    name: `${app.getName()} Assistant`,
+    name: APP_ASSISTANT_NAME,
     description: '',
     instructions: 'You are a helpful assistant.',
     builtinToolsKey: null,

--- a/main/src/cli/constants.ts
+++ b/main/src/cli/constants.ts
@@ -41,6 +41,7 @@ export function getDesktopCliPath(
     case 'win32':
       return path.join(
         process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'),
+        // eslint-disable-next-line no-restricted-syntax -- CLI install path segment; stays "ToolHive".
         'ToolHive',
         'bin',
         'thv.exe'
@@ -69,10 +70,12 @@ export const LEGACY_BASH_PROFILE_PATH = path.join(homedir(), '.bash_profile')
 
 export const SHELL_PATH_ENTRY = 'export PATH="$HOME/.toolhive/bin:$PATH"'
 
+/* eslint-disable no-restricted-syntax -- CLI marker written to shell rc; stays "ToolHive". */
 export const SHELL_PATH_MARKERS = {
   start: '# Added by ToolHive UI - do not modify this block',
   end: '# End ToolHive UI',
 }
+/* eslint-enable no-restricted-syntax */
 
 export const FISH_PATH_ENTRY = 'fish_add_path -g $HOME/.toolhive/bin'
 
@@ -128,6 +131,7 @@ export function getUninstallInstructions(
     case 'winget':
       return 'To uninstall, run:\n  winget uninstall thv'
     case 'manual':
+      // eslint-disable-next-line no-restricted-syntax -- external CLI message; stays "ToolHive".
       return 'Please manually remove the external ToolHive CLI installation.'
   }
 }

--- a/main/src/cli/path-configurator.ts
+++ b/main/src/cli/path-configurator.ts
@@ -140,6 +140,7 @@ async function configureWindowsPath(): Promise<{
 }> {
   const toolhiveBinPath = path.join(
     process.env.LOCALAPPDATA ?? path.join(homedir(), 'AppData', 'Local'),
+    // eslint-disable-next-line no-restricted-syntax -- CLI install path segment — thv-owned directory
     'ToolHive',
     'bin'
   )
@@ -262,6 +263,7 @@ async function removeWindowsPath(): Promise<{
 }> {
   const toolhiveBinPath = path.join(
     process.env.LOCALAPPDATA ?? path.join(homedir(), 'AppData', 'Local'),
+    // eslint-disable-next-line no-restricted-syntax -- CLI install path segment — thv-owned directory
     'ToolHive',
     'bin'
   )
@@ -311,6 +313,7 @@ export async function checkPathConfiguration(): Promise<PathConfigStatus> {
   if (process.platform === 'win32') {
     const toolhiveBinPath = path.join(
       process.env.LOCALAPPDATA ?? path.join(homedir(), 'AppData', 'Local'),
+      // eslint-disable-next-line no-restricted-syntax -- CLI install path segment — thv-owned directory
       'ToolHive',
       'bin'
     )

--- a/main/src/ipc-handlers/app.ts
+++ b/main/src/ipc-handlers/app.ts
@@ -25,6 +25,13 @@ import { updateTrayStatus } from '../system-tray'
 import { isToolhiveRunning } from '../toolhive-manager'
 
 export function register() {
+  // Synchronous one-shot bootstrap: returns app.getName() (= productName from
+  // package.json), the single source of truth the renderer reads at preload
+  // load time. Sync is fine here — fires once, before the page renders.
+  ipcMain.on('get-app-display-name', (event) => {
+    event.returnValue = app.getName()
+  })
+
   ipcMain.handle('get-auto-launch-status', () => getAutoLaunchStatus())
 
   ipcMain.handle('set-auto-launch', (_event, enabled: boolean) => {

--- a/main/src/ipc-handlers/toolhive.ts
+++ b/main/src/ipc-handlers/toolhive.ts
@@ -28,6 +28,7 @@ export function register() {
       await restartToolhive()
       return { success: true }
     } catch (error) {
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.error('Failed to restart ToolHive: ', error)
       return {
         success: false,

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -13,6 +13,7 @@ initSentry()
 
 // Environment variables are now handled in mainWindow.ts
 
+// eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
 log.info(`ToolHive binary path: ${binPath}`)
 log.info(`Binary file exists: ${existsSync(binPath)}`)
 

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -1,5 +1,4 @@
 import { Menu, app } from 'electron'
-import { APP_NAME } from '@common/app-info'
 import { getAutoLaunchStatus, setAutoLaunch } from './auto-launch'
 import { updateTrayStatus } from './system-tray'
 import { handleCheckForUpdates } from './utils/update-dialogs'
@@ -51,7 +50,7 @@ export function createApplicationMenu() {
   const isProduction = app.isPackaged
   const template: Electron.MenuItemConstructorOptions[] = [
     {
-      label: APP_NAME,
+      label: app.getName(),
       submenu: [
         { role: 'about' as const },
         { type: 'separator' as const },

--- a/main/src/quit-confirmation.ts
+++ b/main/src/quit-confirmation.ts
@@ -1,9 +1,8 @@
-import { dialog } from 'electron'
+import { app, dialog } from 'electron'
 import Store from 'electron-store'
 import log from './logger'
 import { writeSetting } from './db/writers/settings-writer'
 import { readSetting } from './db/readers/settings-reader'
-import { THV_DISPLAY_NAME } from '@common/app-info'
 
 interface QuitConfirmationStore {
   skipQuitConfirmation: boolean
@@ -56,9 +55,9 @@ export async function showNativeQuitConfirmation(): Promise<boolean> {
   try {
     const { response, checkboxChecked } = await dialog.showMessageBox({
       type: 'warning',
-      title: `Quit ${THV_DISPLAY_NAME}`,
-      message: `Quit ${THV_DISPLAY_NAME}?`,
-      detail: `Shutting down ${THV_DISPLAY_NAME} stops all MCP servers.`,
+      title: `Quit ${app.getName()}`,
+      message: `Quit ${app.getName()}?`,
+      detail: `Shutting down ${app.getName()} stops all MCP servers.`,
       buttons: ['Quit', 'Cancel'],
       defaultId: 0,
       cancelId: 1,

--- a/main/src/quit-confirmation.ts
+++ b/main/src/quit-confirmation.ts
@@ -3,6 +3,7 @@ import Store from 'electron-store'
 import log from './logger'
 import { writeSetting } from './db/writers/settings-writer'
 import { readSetting } from './db/readers/settings-reader'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 
 interface QuitConfirmationStore {
   skipQuitConfirmation: boolean
@@ -55,9 +56,9 @@ export async function showNativeQuitConfirmation(): Promise<boolean> {
   try {
     const { response, checkboxChecked } = await dialog.showMessageBox({
       type: 'warning',
-      title: 'Quit ToolHive',
-      message: 'Quit ToolHive?',
-      detail: 'Shutting down ToolHive stops all MCP servers.',
+      title: `Quit ${THV_DISPLAY_NAME}`,
+      message: `Quit ${THV_DISPLAY_NAME}?`,
+      detail: `Shutting down ${THV_DISPLAY_NAME} stops all MCP servers.`,
       buttons: ['Quit', 'Cancel'],
       defaultId: 0,
       cancelId: 1,

--- a/main/src/system-tray.ts
+++ b/main/src/system-tray.ts
@@ -1,5 +1,4 @@
 import { Menu, Tray, app, nativeImage, BrowserWindow } from 'electron'
-import { APP_NAME } from '@common/app-info'
 import path from 'node:path'
 import { getAutoLaunchStatus, setAutoLaunch } from './auto-launch'
 import { createApplicationMenu } from './menu'
@@ -135,8 +134,8 @@ const handleStartOnLogin = async (toolHiveIsRunning: boolean) => {
 
 const createStatusMenuItem = (toolHiveIsRunning: boolean) => ({
   label: toolHiveIsRunning
-    ? `🟢 ${APP_NAME} is running`
-    : `🔴 ${APP_NAME} is stopped`,
+    ? `🟢 ${app.getName()} is running`
+    : `🔴 ${app.getName()} is stopped`,
   type: 'normal' as const,
   enabled: false,
 })
@@ -188,7 +187,7 @@ const createHideMenuItem = () => ({
 })
 
 const createQuitMenuItem = () => ({
-  label: `Quit ${APP_NAME}`,
+  label: `Quit ${app.getName()}`,
   type: 'normal' as const,
   click: () => {
     // Triggers the 'before-quit' event, which shows the native
@@ -249,7 +248,7 @@ function setupTrayMenu(toolHiveIsRunning: boolean) {
   const menuTemplate = createMenuTemplate(toolHiveIsRunning)
   const contextMenu = Menu.buildFromTemplate(menuTemplate)
 
-  tray.setToolTip(APP_NAME)
+  tray.setToolTip(app.getName())
   tray.setContextMenu(contextMenu)
 
   // Windows-specific click handling

--- a/main/src/tests/auto-launch.test.ts
+++ b/main/src/tests/auto-launch.test.ts
@@ -4,6 +4,7 @@ import { createDesktopEntry } from '../auto-launch'
 vi.mock('electron', () => ({
   app: {
     isPackaged: false,
+    getName: vi.fn(() => 'ToolHive'),
   },
 }))
 

--- a/main/src/tests/quit-confirmation.test.ts
+++ b/main/src/tests/quit-confirmation.test.ts
@@ -21,6 +21,7 @@ vi.mock('electron-store', () => ({
 }))
 
 vi.mock('electron', () => ({
+  app: { getName: vi.fn(() => 'ToolHive') },
   dialog: {
     showMessageBox: mockShowMessageBox,
   },

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -256,14 +256,14 @@ export async function startToolhive(): Promise<void> {
       child.stderr.on('data', (data) => {
         const output = data.toString().trim()
         if (!output) return
-        // eslint-disable-next-line no-restricted-syntax -- matches thv CLI stdout — must stay literal
+        // eslint-disable-next-line no-restricted-syntax -- matches thv stderr output — must stay literal
         if (output.includes('A new version of ToolHive is available')) {
           return
         }
         if (output.includes('registry authentication required')) {
           processError = REGISTRY_AUTH_REQUIRED
         }
-        // eslint-disable-next-line no-restricted-syntax -- matches thv CLI stdout — must stay literal
+        // eslint-disable-next-line no-restricted-syntax -- matches thv stderr output — must stay literal
         if (output.includes('another ToolHive server is already running')) {
           processError = ALREADY_RUNNING
         }

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -184,11 +184,13 @@ export async function startToolhive(): Promise<void> {
     if (isUsingCustomSocket()) {
       toolhiveSocketPath = process.env.THV_SOCKET!
       toolhiveMcpPort = parseMcpPortEnv(process.env.THV_MCP_PORT)
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.info(`Using external ToolHive on socket ${toolhiveSocketPath}`)
       return
     }
 
     if (!existsSync(binPath)) {
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.error(`ToolHive binary not found at: ${binPath}`)
       return
     }
@@ -248,6 +250,7 @@ export async function startToolhive(): Promise<void> {
 
     // Capture and log stderr
     if (child.stderr) {
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.info(`[ToolHive] Capturing stderr enabled`)
       child.stderr.on('data', (data) => {
         const output = data.toString().trim()
@@ -261,6 +264,7 @@ export async function startToolhive(): Promise<void> {
         if (output.includes('another ToolHive server is already running')) {
           processError = ALREADY_RUNNING
         }
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         log.info(`[ToolHive stderr] ${output}`)
         scope.addBreadcrumb({
           category: 'debug',
@@ -271,6 +275,7 @@ export async function startToolhive(): Promise<void> {
     }
 
     child.on('error', (error) => {
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.error('Failed to start ToolHive: ', error)
       Sentry.captureMessage(
         `Failed to start ToolHive: ${JSON.stringify(error)}`,
@@ -280,6 +285,7 @@ export async function startToolhive(): Promise<void> {
     })
 
     child.on('exit', (code) => {
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.warn(`ToolHive process exited with code: ${code}`)
       // Only clear globals if this exit is for the currently tracked child.
       // Otherwise a prior child's exit can run after restart has spawned a
@@ -314,19 +320,23 @@ export async function restartToolhive(): Promise<void> {
   }
 
   isRestarting = true
+  // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
   log.info('Restarting ToolHive...')
 
   try {
     // Stop existing process if running
     if (toolhiveProcess && !toolhiveProcess.killed) {
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.info('Stopping existing ToolHive process...')
       toolhiveProcess.kill()
     }
 
     // Start new process
     await startToolhive()
+    // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.info('ToolHive restarted successfully')
   } catch (error) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.error('Failed to restart ToolHive: ', error)
     Sentry.captureMessage(
       `Failed to restart ToolHive: ${JSON.stringify(error)}`,
@@ -408,6 +418,7 @@ export function stopToolhive(options?: { force?: boolean }): void {
   const pidToKill = toolhiveProcess.pid
   const processToKill = toolhiveProcess
   isStopping = true
+  // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
   log.info(`Stopping ToolHive process (PID: ${pidToKill})...`)
 
   // Attempt to kill the process

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -5,6 +5,7 @@ import net from 'node:net'
 import { app } from 'electron'
 import { updateTrayStatus } from './system-tray'
 import log from './logger'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import * as Sentry from '@sentry/electron/main'
 import { getQuittingState } from './app-state'
 import { readSetting } from './db/readers/settings-reader'
@@ -201,7 +202,7 @@ export async function startToolhive(): Promise<void> {
     cleanupSocketFile(toolhiveSocketPath)
 
     log.info(
-      `Starting ToolHive from: ${binPath} on socket ${toolhiveSocketPath}, MCP on port ${toolhiveMcpPort}`
+      `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}, MCP on port ${toolhiveMcpPort}`
     )
 
     const serveArgs = [
@@ -243,7 +244,7 @@ export async function startToolhive(): Promise<void> {
 
     scope.addBreadcrumb({
       category: 'debug',
-      message: `Starting ToolHive from: ${binPath} on socket ${toolhiveSocketPath}, MCP on port ${toolhiveMcpPort}, PID: ${child.pid}`,
+      message: `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}, MCP on port ${toolhiveMcpPort}, PID: ${child.pid}`,
     })
 
     updateTrayStatus(!!child)
@@ -278,7 +279,7 @@ export async function startToolhive(): Promise<void> {
       // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.error('Failed to start ToolHive: ', error)
       Sentry.captureMessage(
-        `Failed to start ToolHive: ${JSON.stringify(error)}`,
+        `Failed to start ${THV_DISPLAY_NAME}: ${JSON.stringify(error)}`,
         'fatal'
       )
       updateTrayStatus(false)
@@ -305,7 +306,7 @@ export async function startToolhive(): Promise<void> {
       if (!isRestarting && !getQuittingState()) {
         updateTrayStatus(false)
         Sentry.captureMessage(
-          `ToolHive process exited with code: ${code}`,
+          `${THV_DISPLAY_NAME} process exited with code: ${code}`,
           'fatal'
         )
       }
@@ -339,7 +340,7 @@ export async function restartToolhive(): Promise<void> {
     // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.error('Failed to restart ToolHive: ', error)
     Sentry.captureMessage(
-      `Failed to restart ToolHive: ${JSON.stringify(error)}`,
+      `Failed to restart ${THV_DISPLAY_NAME}: ${JSON.stringify(error)}`,
       'fatal'
     )
   } finally {

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -256,12 +256,14 @@ export async function startToolhive(): Promise<void> {
       child.stderr.on('data', (data) => {
         const output = data.toString().trim()
         if (!output) return
+        // eslint-disable-next-line no-restricted-syntax -- matches thv CLI stdout — must stay literal
         if (output.includes('A new version of ToolHive is available')) {
           return
         }
         if (output.includes('registry authentication required')) {
           processError = REGISTRY_AUTH_REQUIRED
         }
+        // eslint-disable-next-line no-restricted-syntax -- matches thv CLI stdout — must stay literal
         if (output.includes('another ToolHive server is already running')) {
           processError = ALREADY_RUNNING
         }
@@ -269,6 +271,7 @@ export async function startToolhive(): Promise<void> {
         log.info(`[ToolHive stderr] ${output}`)
         scope.addBreadcrumb({
           category: 'debug',
+          // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
           message: `[ToolHive stderr] ${output}`,
           level: 'log',
         })

--- a/main/src/unix-socket-fetch.ts
+++ b/main/src/unix-socket-fetch.ts
@@ -3,6 +3,7 @@ import { ipcMain } from 'electron'
 import * as Sentry from '@sentry/electron/main'
 import log from './logger'
 import { getToolhiveSocketPath } from './toolhive-manager'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import { getHeaders } from './headers'
 import { createClient, type Client } from '@common/api/generated/client'
 
@@ -86,7 +87,7 @@ function performRequest(
 function requireSocketPath(): string {
   const socketPath = getToolhiveSocketPath()
   if (!socketPath) {
-    throw new Error('No ToolHive socket available')
+    throw new Error(`No ${THV_DISPLAY_NAME} socket available`)
   }
   return socketPath
 }

--- a/main/src/utils/toolhive-version.ts
+++ b/main/src/utils/toolhive-version.ts
@@ -78,11 +78,13 @@ export async function fetchLatestRelease(span: Sentry.Span) {
   const currentVersion = getAppVersion()
   const url = getManifestUrl(currentVersion)
 
+  // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
   log.info('[update] checking for latest ToolHive release...')
 
   const latestTag = await fetchLatestVersionFromUrl(url)
 
   if (!latestTag) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.error('[update] Failed to check for ToolHive update from: ', url)
     span.setStatus({
       code: 2,

--- a/main/src/utils/update-dialogs.ts
+++ b/main/src/utils/update-dialogs.ts
@@ -1,8 +1,8 @@
-import { dialog, shell } from 'electron'
+import { app, dialog, shell } from 'electron'
 import log from '../logger'
 import { getAppVersion } from '../util'
 import { getLatestAvailableVersion, manualUpdate } from '../auto-update'
-import { APP_NAME, GITHUB_RELEASES_URL } from '@common/app-info'
+import { GITHUB_RELEASES_URL } from '@common/app-info'
 
 /**
  * Check for updates and show appropriate dialogs to the user
@@ -45,7 +45,7 @@ export async function handleCheckForUpdates(): Promise<boolean> {
         type: 'info',
         title: 'No Update Available',
         message: 'You are already using the latest version.',
-        detail: `Current version: ${currentVersion}\n\nYou have the latest version of ${APP_NAME} installed.`,
+        detail: `Current version: ${currentVersion}\n\nYou have the latest version of ${app.getName()} installed.`,
         buttons: ['OK'],
         defaultId: 0,
       })

--- a/preload/src/api/__tests__/app.test.ts
+++ b/preload/src/api/__tests__/app.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Spike (issue #2296): prove the renderer derives appDisplayName from the
+// synchronous IPC bootstrap (which the main process backs with app.getName()).
+const sendSync = vi.fn().mockReturnValue('Stacklok Desktop')
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    sendSync,
+    invoke: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}))
+
+describe('appApi.appDisplayName (dynamic derivation spike)', () => {
+  it('reads the value returned by the get-app-display-name sync IPC', async () => {
+    const { appApi } = await import('../app')
+
+    expect(sendSync).toHaveBeenCalledWith('get-app-display-name')
+    expect(appApi.appDisplayName).toBe('Stacklok Desktop')
+  })
+})

--- a/preload/src/api/app.ts
+++ b/preload/src/api/app.ts
@@ -5,7 +5,13 @@ import { ipcRenderer } from 'electron'
 // process: zero React Query / useEffect boilerplate in every consumer.
 const mainLogPath = ipcRenderer.sendSync('get-main-log-path-sync') as string
 
+// Resolved once at preload load time (sync) → a plain string available
+// immediately to the renderer, no async/Suspense. Source of truth: app.getName().
+const appDisplayName: string = ipcRenderer.sendSync('get-app-display-name')
+
 export const appApi = {
+  appDisplayName,
+
   getAutoLaunchStatus: () => ipcRenderer.invoke('get-auto-launch-status'),
   setAutoLaunch: (enabled: boolean) =>
     ipcRenderer.invoke('set-auto-launch', enabled),
@@ -47,6 +53,7 @@ export const appApi = {
 }
 
 export interface AppAPI {
+  appDisplayName: string
   getAutoLaunchStatus: () => Promise<boolean>
   setAutoLaunch: (enabled: boolean) => Promise<boolean>
   showApp: () => Promise<void>

--- a/renderer/src/common/components/__tests__/newsletter-modal.test.tsx
+++ b/renderer/src/common/components/__tests__/newsletter-modal.test.tsx
@@ -75,7 +75,9 @@ describe('NewsletterModal', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Stay up to date with improvements to ToolHive')
+          screen.getByText(
+            `Stay up to date with improvements to ${APP_DISPLAY_NAME}`
+          )
         ).toBeVisible()
       })
     })
@@ -91,7 +93,9 @@ describe('NewsletterModal', () => {
         expect(window.electronAPI.getNewsletterState).toHaveBeenCalled()
       })
       expect(
-        screen.queryByText('Stay up to date with improvements to ToolHive')
+        screen.queryByText(
+          `Stay up to date with improvements to ${APP_DISPLAY_NAME}`
+        )
       ).not.toBeInTheDocument()
     })
 
@@ -109,7 +113,9 @@ describe('NewsletterModal', () => {
         expect(window.electronAPI.getNewsletterState).toHaveBeenCalled()
       })
       expect(
-        screen.queryByText('Stay up to date with improvements to ToolHive')
+        screen.queryByText(
+          `Stay up to date with improvements to ${APP_DISPLAY_NAME}`
+        )
       ).not.toBeInTheDocument()
     })
 
@@ -125,7 +131,9 @@ describe('NewsletterModal', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Stay up to date with improvements to ToolHive')
+          screen.getByText(
+            `Stay up to date with improvements to ${APP_DISPLAY_NAME}`
+          )
         ).toBeVisible()
       })
     })
@@ -267,7 +275,9 @@ describe('NewsletterModal', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText('Stay up to date with improvements to ToolHive')
+          screen.getByText(
+            `Stay up to date with improvements to ${APP_DISPLAY_NAME}`
+          )
         ).toBeVisible()
       })
 

--- a/renderer/src/common/components/custom-socket-banner.tsx
+++ b/renderer/src/common/components/custom-socket-banner.tsx
@@ -39,6 +39,7 @@ export function CustomSocketBanner() {
       <AlertTriangle />
       <AlertDescription className="flex items-start gap-2">
         <div className="whitespace-nowrap">
+          {/* eslint-disable-next-line no-restricted-syntax -- external thv CLI reference */}
           <span>Using external ToolHive at </span>
           <span
             className="rounded bg-yellow-100 px-1 py-0.5 font-mono text-xs

--- a/renderer/src/common/components/error/__tests__/technical-details.test.tsx
+++ b/renderer/src/common/components/error/__tests__/technical-details.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TechnicalDetails } from '../technical-details'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 
 vi.mock('../../layout/top-nav/minimal', () => ({
   TopNavMinimal: () => <div />,
@@ -97,7 +98,7 @@ describe('TechnicalDetails', () => {
 
     expect(writeText).toHaveBeenCalledTimes(1)
     const reportText = writeText.mock.calls[0]?.[0] as string
-    expect(reportText).toContain('ToolHive Crash Report')
+    expect(reportText).toContain(`${APP_DISPLAY_NAME} Crash Report`)
     expect(reportText).toContain('Error: Crash error')
     expect(reportText).toContain('Desktop Version:')
     expect(reportText).toContain('CLI Version:')

--- a/renderer/src/common/components/error/already-running-error.tsx
+++ b/renderer/src/common/components/error/already-running-error.tsx
@@ -1,18 +1,22 @@
 import { AlertCircle } from 'lucide-react'
 import { BaseErrorScreen } from './base-error-screen'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 
 export function AlreadyRunningError() {
   return (
     <BaseErrorScreen
-      title="ToolHive Is Already Running"
+      title={`${THV_DISPLAY_NAME} Is Already Running`}
       icon={<AlertCircle className="text-destructive size-12" />}
     >
       <p>
-        Another ToolHive HTTP server (
+        Another {THV_DISPLAY_NAME} HTTP server (
         <code className="bg-background rounded px-1 py-0.5">thv serve</code>) is
         already running on this machine. Only one instance can run at a time.
       </p>
-      <p>Please close the other ToolHive instance and click "Try Again".</p>
+      <p>
+        Please close the other {THV_DISPLAY_NAME} instance and click "Try
+        Again".
+      </p>
     </BaseErrorScreen>
   )
 }

--- a/renderer/src/common/components/error/base-error-screen.tsx
+++ b/renderer/src/common/components/error/base-error-screen.tsx
@@ -29,6 +29,7 @@ export function BaseErrorScreen({
         await withMinimumDelay(window.electronAPI.restartToolhive, 1200)
         window.location.reload()
       } catch (error) {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         log.error('Error restarting ToolHive: ', error)
       }
     }

--- a/renderer/src/common/components/error/connection-refused-error.tsx
+++ b/renderer/src/common/components/error/connection-refused-error.tsx
@@ -44,6 +44,7 @@ export function ConnectionRefusedError() {
     isError: isRestartError,
   } = useMutation({
     mutationFn: async () => {
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.info('Container engines are now available, restarting ToolHive...')
       const result = await withMinimumDelay(
         window.electronAPI.restartToolhive,
@@ -53,13 +54,16 @@ export function ConnectionRefusedError() {
     },
     onSuccess: (result) => {
       if (result.success) {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         log.info('ToolHive restarted successfully')
         window.location.reload()
       } else {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         log.error('Failed to restart ToolHive: ', result.error)
       }
     },
     onError: (error) => {
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.error('Error restarting ToolHive: ', error)
     },
   })

--- a/renderer/src/common/components/error/connection-refused-error.tsx
+++ b/renderer/src/common/components/error/connection-refused-error.tsx
@@ -7,7 +7,7 @@ import { BaseErrorScreen } from './base-error-screen'
 import { IllustrationPackage } from '../illustrations/illustration-package'
 import { withMinimumDelay } from './utils'
 import log from 'electron-log/renderer'
-import { DISCORD_URL } from '@common/app-info'
+import { DISCORD_URL, THV_DISPLAY_NAME } from '@common/app-info'
 
 interface ExternalLinkButtonProps {
   href: string
@@ -80,8 +80,8 @@ export function ConnectionRefusedError() {
         icon={<AlertCircle className="text-destructive size-12" />}
       >
         <p>
-          We're having trouble connecting to ToolHive. This is unexpected and
-          may indicate a service issue.
+          We're having trouble connecting to {THV_DISPLAY_NAME}. This is
+          unexpected and may indicate a service issue.
         </p>
 
         <div className="bg-muted rounded-md p-3 text-sm">
@@ -109,7 +109,7 @@ export function ConnectionRefusedError() {
           <RefreshCw className="mx-auto mb-2 size-6 animate-spin" />
           <p>
             {isRestarting
-              ? 'Restarting ToolHive...'
+              ? `Restarting ${THV_DISPLAY_NAME}...`
               : 'Checking container engines...'}
           </p>
         </div>
@@ -123,8 +123,8 @@ export function ConnectionRefusedError() {
       icon={<IllustrationPackage className="size-20" />}
     >
       <p>
-        ToolHive requires a container engine to be installed and running to
-        manage containerized tools and services. We support{' '}
+        {THV_DISPLAY_NAME} requires a container engine to be installed and
+        running to manage containerized tools and services. We support{' '}
         <strong>Docker</strong>, <strong>Podman</strong> or{' '}
         <strong>Rancher Desktop</strong> (with dockerd - moby).
       </p>

--- a/renderer/src/common/components/error/generic-error.tsx
+++ b/renderer/src/common/components/error/generic-error.tsx
@@ -2,6 +2,7 @@ import { AlertCircle } from 'lucide-react'
 import { LinkErrorDiscord } from '../workloads/link-error-discord'
 import { BaseErrorScreen } from './base-error-screen'
 import { TechnicalDetails } from './technical-details'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 
 interface GenericErrorProps {
   error?: Error
@@ -18,7 +19,8 @@ export function GenericError({ error }: GenericErrorProps) {
         app.
       </p>
       <p>
-        If issues persist, contact the ToolHive team via <LinkErrorDiscord />
+        If issues persist, contact the {APP_DISPLAY_NAME} team via{' '}
+        <LinkErrorDiscord />
       </p>
       {error && (
         <div className="-mt-2 pb-4">

--- a/renderer/src/common/components/error/generic-error.tsx
+++ b/renderer/src/common/components/error/generic-error.tsx
@@ -2,7 +2,7 @@ import { AlertCircle } from 'lucide-react'
 import { LinkErrorDiscord } from '../workloads/link-error-discord'
 import { BaseErrorScreen } from './base-error-screen'
 import { TechnicalDetails } from './technical-details'
-import { APP_DISPLAY_NAME } from '@common/app-info'
+import { COMPANY_NAME } from '@common/app-info'
 
 interface GenericErrorProps {
   error?: Error
@@ -19,7 +19,7 @@ export function GenericError({ error }: GenericErrorProps) {
         app.
       </p>
       <p>
-        If issues persist, contact the {APP_DISPLAY_NAME} team via{' '}
+        If issues persist, contact the {COMPANY_NAME} team via{' '}
         <LinkErrorDiscord />
       </p>
       {error && (

--- a/renderer/src/common/components/error/keyring-error.tsx
+++ b/renderer/src/common/components/error/keyring-error.tsx
@@ -1,5 +1,6 @@
 import { FolderKey } from 'lucide-react'
 import { BaseErrorScreen } from './base-error-screen'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 
 export function KeyringError() {
   return (
@@ -8,8 +9,8 @@ export function KeyringError() {
       icon={<FolderKey className="text-destructive size-12" />}
     >
       <p>
-        ToolHive needs to access your system keyring in order to securely store
-        and manage secrets.
+        {THV_DISPLAY_NAME} needs to access your system keyring in order to
+        securely store and manage secrets.
       </p>
 
       <p>Most Linux distributions have a system keyring out of the box.</p>

--- a/renderer/src/common/components/error/registry-error.tsx
+++ b/renderer/src/common/components/error/registry-error.tsx
@@ -1,4 +1,5 @@
 import { LinkErrorDiscord } from '../workloads/link-error-discord'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 import { Button } from '../ui/button'
 import { EmptyState } from '../empty-state'
 import { Link } from '@tanstack/react-router'
@@ -67,7 +68,7 @@ export function RegistryError({ error }: { error: unknown }) {
         >
           <div className="mt-8 flex flex-col items-center gap-4">
             <p className="text-muted-foreground text-sm">
-              If issues persist, contact the ToolHive team via{' '}
+              If issues persist, contact the {APP_DISPLAY_NAME} team via{' '}
               <LinkErrorDiscord />
             </p>
             {registrySettingsButton}

--- a/renderer/src/common/components/error/registry-error.tsx
+++ b/renderer/src/common/components/error/registry-error.tsx
@@ -1,5 +1,5 @@
 import { LinkErrorDiscord } from '../workloads/link-error-discord'
-import { APP_DISPLAY_NAME } from '@common/app-info'
+import { COMPANY_NAME } from '@common/app-info'
 import { Button } from '../ui/button'
 import { EmptyState } from '../empty-state'
 import { Link } from '@tanstack/react-router'
@@ -68,7 +68,7 @@ export function RegistryError({ error }: { error: unknown }) {
         >
           <div className="mt-8 flex flex-col items-center gap-4">
             <p className="text-muted-foreground text-sm">
-              If issues persist, contact the {APP_DISPLAY_NAME} team via{' '}
+              If issues persist, contact the {COMPANY_NAME} team via{' '}
               <LinkErrorDiscord />
             </p>
             {registrySettingsButton}

--- a/renderer/src/common/components/error/utils.ts
+++ b/renderer/src/common/components/error/utils.ts
@@ -1,4 +1,4 @@
-import { APP_DISPLAY_NAME } from '@common/app-info'
+import { APP_DISPLAY_NAME, THV_DISPLAY_NAME } from '@common/app-info'
 
 export interface EnvironmentInfo {
   desktopVersion: string
@@ -16,7 +16,7 @@ export const METADATA_FIELDS: {
   { label: 'Desktop', key: 'desktopVersion' },
   { label: 'CLI', key: 'cliVersion' },
   { label: 'Platform', key: 'platform' },
-  { label: 'ToolHive', key: 'toolhiveRunning' },
+  { label: THV_DISPLAY_NAME, key: 'toolhiveRunning' },
   { label: 'Engine', key: 'containerEngine' },
 ]
 
@@ -29,7 +29,7 @@ export function buildCrashReport(error: Error, env: EnvironmentInfo): string {
     `Desktop Version: ${env.desktopVersion}`,
     `CLI Version: ${env.cliVersion}`,
     `Platform: ${env.platform}`,
-    `ToolHive Running: ${env.toolhiveRunning}`,
+    `${THV_DISPLAY_NAME} Running: ${env.toolhiveRunning}`,
     `Container Engine: ${env.containerEngine}`,
     `User Agent: ${env.userAgent}`,
     '',

--- a/renderer/src/common/components/error/utils.ts
+++ b/renderer/src/common/components/error/utils.ts
@@ -1,3 +1,5 @@
+import { APP_DISPLAY_NAME } from '@common/app-info'
+
 export interface EnvironmentInfo {
   desktopVersion: string
   cliVersion: string
@@ -21,7 +23,7 @@ export const METADATA_FIELDS: {
 export function buildCrashReport(error: Error, env: EnvironmentInfo): string {
   const timestamp = new Date().toISOString()
   return [
-    'ToolHive Crash Report',
+    `${APP_DISPLAY_NAME} Crash Report`,
     '=====================',
     `Timestamp: ${timestamp}`,
     `Desktop Version: ${env.desktopVersion}`,

--- a/renderer/src/common/components/newsletter-modal.tsx
+++ b/renderer/src/common/components/newsletter-modal.tsx
@@ -22,11 +22,7 @@ import {
   ConsentCheckbox,
   PrivacyFooter,
 } from './hubspot-form-parts'
-import {
-  APP_NAME,
-  APP_DISPLAY_NAME,
-  HUBSPOT_NEWSLETTER_FORM_ID,
-} from '@common/app-info'
+import { APP_DISPLAY_NAME, HUBSPOT_NEWSLETTER_FORM_ID } from '@common/app-info'
 const DISMISS_DAYS = 15
 
 const emailSchema = z.email('Please enter a valid email address')
@@ -121,11 +117,11 @@ function NewsletterDialog({
               <DialogTitle
                 className="text-brand-blue-mid font-serif text-3xl font-light"
               >
-                Stay up to date with improvements to {APP_NAME}
+                Stay up to date with improvements to {APP_DISPLAY_NAME}
               </DialogTitle>
               <DialogDescription className="text-primary">
                 Subscribe to our quarterly email showing you all the new product
-                improvements to {APP_NAME}
+                improvements to {APP_DISPLAY_NAME}
               </DialogDescription>
             </DialogHeader>
             <form

--- a/renderer/src/common/components/settings/registry/registry-source-field.tsx
+++ b/renderer/src/common/components/settings/registry/registry-source-field.tsx
@@ -40,7 +40,9 @@ const REGISTRY_INPUT_CONFIG = {
             target="_blank"
             rel="noopener noreferrer"
           >
+            {/* eslint-disable no-restricted-syntax -- OSS thv registry */}
             official ToolHive registry
+            {/* eslint-enable no-restricted-syntax */}
           </a>
         </Button>
         ).

--- a/renderer/src/common/components/settings/registry/registry-tab.tsx
+++ b/renderer/src/common/components/settings/registry/registry-tab.tsx
@@ -22,11 +22,13 @@ export function RegistryTab() {
     <div className="space-y-3">
       <div className="flex flex-col gap-2">
         <SettingsSectionTitle>Registry</SettingsSectionTitle>
+        {/* eslint-disable no-restricted-syntax -- OSS thv registry */}
         <p className="text-muted-foreground text-sm leading-5.5">
           Choose between ToolHive default registry, a custom remote registry
           JSON URL, a custom local registry JSON file, or a custom registry
           server API URL.
         </p>
+        {/* eslint-enable no-restricted-syntax */}
       </div>
       <RegistryForm
         form={form}

--- a/renderer/src/common/components/settings/tabs/components/external-cli-alert.tsx
+++ b/renderer/src/common/components/settings/tabs/components/external-cli-alert.tsx
@@ -16,10 +16,12 @@ export function ExternalCliAlert({ path, source }: ExternalCliAlertProps) {
       <AlertTriangle className="size-4" />
       <AlertTitle>External CLI Installation Detected</AlertTitle>
       <AlertDescription className="space-y-2">
+        {/* eslint-disable no-restricted-syntax -- external thv CLI reference */}
         <p>
           An external ToolHive CLI was found at{' '}
           <code className="bg-muted rounded px-1 text-xs">{path}</code>
         </p>
+        {/* eslint-enable no-restricted-syntax */}
         <p>
           {uninstallCommand ? (
             <>

--- a/renderer/src/common/components/settings/tabs/components/general-tab-wrapper.tsx
+++ b/renderer/src/common/components/settings/tabs/components/general-tab-wrapper.tsx
@@ -1,4 +1,5 @@
 import { trackEvent } from '@/common/lib/analytics'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 import {
   useAutoLaunchStatus,
   useSetAutoLaunch,
@@ -34,7 +35,7 @@ function ThemeField() {
   return (
     <WrapperField
       label="Theme"
-      description="Choose how ToolHive looks to you"
+      description={`Choose how ${APP_DISPLAY_NAME} looks to you`}
       htmlFor="theme-select"
     >
       <Select value={theme} onValueChange={handleThemeChange}>
@@ -95,7 +96,7 @@ function TelemetryField() {
   return (
     <WrapperField
       label="Error reporting"
-      description="Help improve ToolHive by sending error reports to Sentry"
+      description={`Help improve ${APP_DISPLAY_NAME} by sending error reports to Sentry`}
       htmlFor="telemetry"
     >
       <Switch
@@ -123,7 +124,7 @@ function AutoLaunchField() {
   return (
     <WrapperField
       label="Start on login"
-      description="Automatically start ToolHive when you log in to your computer"
+      description={`Automatically start ${APP_DISPLAY_NAME} when you log in to your computer`}
       htmlFor="auto-launch"
     >
       <Switch
@@ -159,7 +160,7 @@ function QuitConfirmationField() {
   return (
     <WrapperField
       label="Quit confirmation"
-      description="Skip the confirmation dialog when quitting ToolHive"
+      description={`Skip the confirmation dialog when quitting ${APP_DISPLAY_NAME}`}
       htmlFor="quit-confirmation"
     >
       <Switch

--- a/renderer/src/common/components/settings/tabs/version-tab.tsx
+++ b/renderer/src/common/components/settings/tabs/version-tab.tsx
@@ -128,6 +128,7 @@ export function VersionTab({ appInfo, isLoading, error }: VersionTabProps) {
           />
         </SettingsRow>
         <Separator />
+        {/* eslint-disable-next-line no-restricted-syntax -- thv CLI binary version label */}
         <SettingsRow label="ToolHive binary version">
           <VersionBadge
             version={appInfo.toolhiveVersion}

--- a/renderer/src/common/components/settings/tabs/version-tab.tsx
+++ b/renderer/src/common/components/settings/tabs/version-tab.tsx
@@ -18,7 +18,7 @@ import { SettingsRow } from './components/settings-row'
 import { WrapperField } from './components/wrapper-field'
 import { usePermissions } from '@/common/contexts/permissions'
 import { PERMISSION_KEYS } from '@/common/contexts/permissions/permission-keys'
-import { APP_NAME, GITHUB_RELEASES_URL } from '@common/app-info'
+import { APP_DISPLAY_NAME, GITHUB_RELEASES_URL } from '@common/app-info'
 
 interface VersionTabProps {
   appInfo: AppVersionInfo | undefined
@@ -150,7 +150,7 @@ export function VersionTab({ appInfo, isLoading, error }: VersionTabProps) {
           <div className="flex flex-col gap-3 py-1">
             <WrapperField
               label="Downloads"
-              description={`Automatically download and install ${APP_NAME} updates when a new release is available.`}
+              description={`Automatically download and install ${APP_DISPLAY_NAME} updates when a new release is available.`}
               htmlFor="auto-update"
             >
               <Switch

--- a/renderer/src/common/components/starting-toolhive.tsx
+++ b/renderer/src/common/components/starting-toolhive.tsx
@@ -25,6 +25,7 @@ export function StartingToolHive() {
   useEffect(() => {
     if (!error && !isChecking) {
       log.info(
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         '[StartingToolHive] Health check successful, navigating to default group'
       )
       navigate({ to: '/group/$groupName', params: { groupName: 'default' } })
@@ -32,6 +33,7 @@ export function StartingToolHive() {
 
     if (hasError) {
       log.error(
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         '[StartingToolHive] Error checking health:',
         JSON.stringify(error)
       )

--- a/renderer/src/common/components/starting-toolhive.tsx
+++ b/renderer/src/common/components/starting-toolhive.tsx
@@ -5,7 +5,7 @@ import { getHealthOptions } from '@common/api/generated/@tanstack/react-query.ge
 import { useQuery } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import log from 'electron-log/renderer'
-import { APP_NAME } from '@common/app-info'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import { useNavigate } from '@tanstack/react-router'
 import { GenericError } from './error/generic-error'
 
@@ -56,7 +56,7 @@ export function StartingToolHive() {
           </div>
 
           <CardTitle className="text-xl font-semibold">
-            Starting {APP_NAME} configuration
+            Starting {THV_DISPLAY_NAME} configuration
           </CardTitle>
         </CardHeader>
 
@@ -65,8 +65,8 @@ export function StartingToolHive() {
             items-center justify-center space-y-4 overflow-y-auto px-8"
         >
           <div className="text-muted-foreground text-center">
-            We're checking your {APP_NAME} configuration to ensure it's set up
-            correctly.
+            We're checking your {THV_DISPLAY_NAME} configuration to ensure it's
+            set up correctly.
           </div>
           <Loader className="size-10 animate-spin [animation-duration:1.5s]" />
         </CardContent>

--- a/renderer/src/common/components/workloads/alert-error-fetching-editing-data.tsx
+++ b/renderer/src/common/components/workloads/alert-error-fetching-editing-data.tsx
@@ -4,7 +4,7 @@ import {
   AlertDescription,
 } from '@/common/components/ui/alert'
 import { LinkErrorDiscord } from './link-error-discord'
-import { APP_DISPLAY_NAME } from '@common/app-info'
+import { COMPANY_NAME } from '@common/app-info'
 
 export function AlertErrorFetchingEditingData() {
   return (
@@ -15,7 +15,7 @@ export function AlertErrorFetchingEditingData() {
       <AlertDescription>
         <p className="text-red-300">
           Close the dialog and try again. <br />
-          If issues persist, contact the {APP_DISPLAY_NAME} team via{' '}
+          If issues persist, contact the {COMPANY_NAME} team via{' '}
           <LinkErrorDiscord />.
         </p>
       </AlertDescription>

--- a/renderer/src/common/components/workloads/alert-error-fetching-editing-data.tsx
+++ b/renderer/src/common/components/workloads/alert-error-fetching-editing-data.tsx
@@ -4,6 +4,7 @@ import {
   AlertDescription,
 } from '@/common/components/ui/alert'
 import { LinkErrorDiscord } from './link-error-discord'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 
 export function AlertErrorFetchingEditingData() {
   return (
@@ -14,7 +15,8 @@ export function AlertErrorFetchingEditingData() {
       <AlertDescription>
         <p className="text-red-300">
           Close the dialog and try again. <br />
-          If issues persist, contact the ToolHive team via <LinkErrorDiscord />.
+          If issues persist, contact the {APP_DISPLAY_NAME} team via{' '}
+          <LinkErrorDiscord />.
         </p>
       </AlertDescription>
     </Alert>

--- a/renderer/src/common/components/workloads/alert-error-form-submission.tsx
+++ b/renderer/src/common/components/workloads/alert-error-form-submission.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/common/components/ui/button'
 import { Separator } from '@/common/components/ui/separator'
 import { X } from 'lucide-react'
 import { LinkErrorDiscord } from './link-error-discord'
+import { APP_DISPLAY_NAME, THV_DISPLAY_NAME } from '@common/app-info'
 
 interface AlertErrorFormSubmissionProps {
   error: string
@@ -16,7 +17,7 @@ interface AlertErrorFormSubmissionProps {
 
 function getErrorTitle(error: string): string {
   if (error.includes('Failed to retrieve MCP server image')) {
-    return 'ToolHive could not download the server image'
+    return `${THV_DISPLAY_NAME} could not download the server image`
   }
   return 'Something went wrong'
 }
@@ -45,7 +46,8 @@ export function AlertErrorFormSubmission({
         <p className="text-red-300">
           {isErrorSecrets && 'Failed to create secrets for the server. '}
           Check the configuration and try again. <br />
-          If issues persist, contact the ToolHive team via <LinkErrorDiscord />.
+          If issues persist, contact the {APP_DISPLAY_NAME} team via{' '}
+          <LinkErrorDiscord />.
         </p>
         {!isErrorSecrets && (
           <>

--- a/renderer/src/common/components/workloads/alert-error-form-submission.tsx
+++ b/renderer/src/common/components/workloads/alert-error-form-submission.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/common/components/ui/button'
 import { Separator } from '@/common/components/ui/separator'
 import { X } from 'lucide-react'
 import { LinkErrorDiscord } from './link-error-discord'
-import { APP_DISPLAY_NAME, THV_DISPLAY_NAME } from '@common/app-info'
+import { COMPANY_NAME, THV_DISPLAY_NAME } from '@common/app-info'
 
 interface AlertErrorFormSubmissionProps {
   error: string
@@ -46,7 +46,7 @@ export function AlertErrorFormSubmission({
         <p className="text-red-300">
           {isErrorSecrets && 'Failed to create secrets for the server. '}
           Check the configuration and try again. <br />
-          If issues persist, contact the {APP_DISPLAY_NAME} team via{' '}
+          If issues persist, contact the {COMPANY_NAME} team via{' '}
           <LinkErrorDiscord />.
         </p>
         {!isErrorSecrets && (

--- a/renderer/src/common/components/workloads/dialog-workload-form-wrapper.tsx
+++ b/renderer/src/common/components/workloads/dialog-workload-form-wrapper.tsx
@@ -1,4 +1,5 @@
 import { type FieldValues, type UseFormReturn } from 'react-hook-form'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import { Button } from '../ui/button'
 import { Form } from '@/common/components/ui/form'
 import {
@@ -58,9 +59,9 @@ export function DialogWorkloadFormWrapper<T extends FieldValues = FieldValues>({
                   <DialogDescription>{description}</DialogDescription>
                 ) : (
                   <DialogDescription className="sr-only">
-                    ToolHive allows you to securely run a remote MCP server or a
-                    custom local MCP server from a Docker image or a package
-                    manager.
+                    {THV_DISPLAY_NAME} allows you to securely run a remote MCP
+                    server or a custom local MCP server from a Docker image or a
+                    package manager.
                   </DialogDescription>
                 )}
               </DialogHeader>

--- a/renderer/src/common/components/workloads/form-fields-proxy.tsx
+++ b/renderer/src/common/components/workloads/form-fields-proxy.tsx
@@ -6,6 +6,7 @@ import {
   FormMessage,
 } from '@/common/components/ui/form'
 import { Input } from '@/common/components/ui/input'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import {
   Select,
   SelectContent,
@@ -89,8 +90,8 @@ export function FormFieldsProxy<T extends FieldValues & ProxyFields>({
             <div className="flex items-center gap-1">
               <FormLabel htmlFor={field.name}>Proxy port</FormLabel>
               <TooltipInfoIcon className="max-w-72">
-                Port for the HTTP proxy to listen on. If not specified, ToolHive
-                will automatically assign a random port.
+                Port for the HTTP proxy to listen on. If not specified,{' '}
+                {THV_DISPLAY_NAME} will automatically assign a random port.
               </TooltipInfoIcon>
             </div>
             <FormControl>

--- a/renderer/src/common/components/workloads/form-fields-remote-mcp.tsx
+++ b/renderer/src/common/components/workloads/form-fields-remote-mcp.tsx
@@ -22,7 +22,7 @@ import { REMOTE_MCP_AUTH_TYPES } from '@/common/lib/form-schema-mcp'
 import { FormFieldsProxy } from './form-fields-proxy'
 import { Button } from '../ui/button'
 import { SecretStoreCombobox } from '../secrets/secret-store-combobox'
-import { DOCS_BASE_URL } from '@common/app-info'
+import { DOCS_BASE_URL, THV_DISPLAY_NAME } from '@common/app-info'
 
 function FormFieldRemoteAuthType({
   control,
@@ -363,8 +363,8 @@ function FormFieldsCustomHeaders({
                 Headers from Secrets
               </FormLabel>
               <TooltipInfoIcon className="max-w-72">
-                Header values are retrieved from ToolHive&apos;s secrets
-                manager. Use this for sensitive data like API keys.
+                Header values are retrieved from {THV_DISPLAY_NAME}&apos;s
+                secrets manager. Use this for sensitive data like API keys.
               </TooltipInfoIcon>
             </div>
 

--- a/renderer/src/common/hooks/use-auto-launch.ts
+++ b/renderer/src/common/hooks/use-auto-launch.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useToastMutation } from './use-toast-mutation'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 
 export function useAutoLaunchStatus() {
   return useQuery({
@@ -19,7 +20,7 @@ export function useSetAutoLaunch() {
     },
     successMsg: (enabled) =>
       enabled
-        ? 'Auto-launch enabled - ToolHive will start when you log into your system'
+        ? `Auto-launch enabled - ${APP_DISPLAY_NAME} will start when you log into your system`
         : 'Auto-launch disabled',
     errorMsg: 'Failed to update auto-launch setting',
   })

--- a/renderer/src/common/hooks/use-auto-update.ts
+++ b/renderer/src/common/hooks/use-auto-update.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useToastMutation } from './use-toast-mutation'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 
 export function useAutoUpdateStatus() {
   return useQuery({
@@ -19,7 +20,7 @@ export function useSetAutoUpdate() {
     },
     successMsg: (enabled) =>
       enabled
-        ? 'Auto-update enabled - ToolHive will automatically update to the latest version'
+        ? `Auto-update enabled - ${APP_DISPLAY_NAME} will automatically update to the latest version`
         : 'Auto-update disabled',
     errorMsg: 'Failed to update auto-update setting',
   })

--- a/renderer/src/common/hooks/use-mcp-optimizer-startup-cleanup.ts
+++ b/renderer/src/common/hooks/use-mcp-optimizer-startup-cleanup.ts
@@ -31,6 +31,7 @@ export function useMcpOptimizerStartupCleanup() {
         const ready = await waitForToolhiveReady()
         if (!ready) {
           log.warn(
+            // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
             'MCP Optimizer startup cleanup: ToolHive did not become ready in time, skipping'
           )
           return

--- a/renderer/src/common/mocks/electronAPI.ts
+++ b/renderer/src/common/mocks/electronAPI.ts
@@ -6,6 +6,7 @@ import type { ElectronAPI } from '../../../../preload/src/preload'
  */
 function createElectronStub(): Partial<ElectronAPI> {
   return {
+    appDisplayName: 'ToolHive',
     onServerShutdown: () => () => {},
     onDeepLinkNavigation: () => () => {},
     getSkipQuitConfirmation: vi.fn().mockResolvedValue(false),

--- a/renderer/src/features/agents/components/__tests__/agent-detail-page.test.tsx
+++ b/renderer/src/features/agents/components/__tests__/agent-detail-page.test.tsx
@@ -144,7 +144,9 @@ describe('AgentDetailPage', () => {
     it('shows the curated hint for built-ins', () => {
       renderDetail(builtinAgent)
       expect(
-        screen.getByText(/built-in agents are curated and cannot be edited/i)
+        screen.getByText(
+          /built-in agents are curated by stacklok and cannot be edited/i
+        )
       ).toBeInTheDocument()
     })
 

--- a/renderer/src/features/agents/components/__tests__/agent-detail-page.test.tsx
+++ b/renderer/src/features/agents/components/__tests__/agent-detail-page.test.tsx
@@ -141,12 +141,10 @@ describe('AgentDetailPage', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('shows the "curated by ToolHive" hint for built-ins', () => {
+    it('shows the curated hint for built-ins', () => {
       renderDetail(builtinAgent)
       expect(
-        screen.getByText(
-          /built-in agents are curated by toolhive and cannot be edited/i
-        )
+        screen.getByText(/built-in agents are curated and cannot be edited/i)
       ).toBeInTheDocument()
     })
 

--- a/renderer/src/features/agents/components/agent-detail-page.tsx
+++ b/renderer/src/features/agents/components/agent-detail-page.tsx
@@ -172,8 +172,8 @@ export function AgentDetailPage({ agent }: { agent: AgentConfig }) {
             />
             {isBuiltin && (
               <p className="text-muted-foreground text-xs leading-5">
-                Built-in agents are curated by ToolHive and cannot be edited.
-                Duplicate this agent to create a customisable copy.
+                Built-in agents are curated and cannot be edited. Duplicate this
+                agent to create a customisable copy.
               </p>
             )}
           </div>

--- a/renderer/src/features/agents/components/agent-detail-page.tsx
+++ b/renderer/src/features/agents/components/agent-detail-page.tsx
@@ -1,3 +1,4 @@
+import { COMPANY_NAME } from '@common/app-info'
 import { toast } from 'sonner'
 import { useNavigate } from '@tanstack/react-router'
 import { Streamdown } from 'streamdown'
@@ -172,8 +173,8 @@ export function AgentDetailPage({ agent }: { agent: AgentConfig }) {
             />
             {isBuiltin && (
               <p className="text-muted-foreground text-xs leading-5">
-                Built-in agents are curated and cannot be edited. Duplicate this
-                agent to create a customisable copy.
+                Built-in agents are curated by {COMPANY_NAME} and cannot be
+                edited. Duplicate this agent to create a customisable copy.
               </p>
             )}
           </div>

--- a/renderer/src/features/agents/components/agent-form-page.tsx
+++ b/renderer/src/features/agents/components/agent-form-page.tsx
@@ -1,3 +1,4 @@
+import { COMPANY_NAME } from '@common/app-info'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from '@tanstack/react-router'
@@ -290,8 +291,9 @@ export function AgentFormPage({ mode, agent }: AgentFormPageProps) {
                 />
               </FormControl>
               <FormDescription>
-                Give this agent access to a curated bundle of built-in tools.
-                Leave unselected to use only MCP tools enabled in the chat.
+                Give this agent access to a curated bundle of {COMPANY_NAME}
+                -provided tools. Leave unselected to use only MCP tools enabled
+                in the chat.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/renderer/src/features/agents/components/agent-form-page.tsx
+++ b/renderer/src/features/agents/components/agent-form-page.tsx
@@ -290,9 +290,8 @@ export function AgentFormPage({ mode, agent }: AgentFormPageProps) {
                 />
               </FormControl>
               <FormDescription>
-                Give this agent access to a curated bundle of ToolHive-provided
-                tools. Leave unselected to use only MCP tools enabled in the
-                chat.
+                Give this agent access to a curated bundle of built-in tools.
+                Leave unselected to use only MCP tools enabled in the chat.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/renderer/src/features/chat/components/chat-message/mcp-app-view.tsx
+++ b/renderer/src/features/chat/components/chat-message/mcp-app-view.tsx
@@ -15,6 +15,7 @@ import type {
 import { ThemeProviderContext } from '@/common/contexts/theme-context'
 import { AlertCircle, Loader2, Maximize2, Minimize2, X } from 'lucide-react'
 import { Button } from '@/common/components/ui/button'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 
 interface McpAppViewProps {
   toolName: string
@@ -152,7 +153,7 @@ export function McpAppView({
     const currentTheme = resolveTheme()
     const bridge = new AppBridge(
       null, // no MCP client — proxied through IPC
-      { name: 'ToolHive Studio', version: '1.0.0' },
+      { name: APP_DISPLAY_NAME, version: '1.0.0' },
       HOST_CAPABILITIES,
       {
         hostContext: {
@@ -162,7 +163,7 @@ export function McpAppView({
           platform: 'desktop',
           locale: navigator.language,
           timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          userAgent: 'ToolHive Studio',
+          userAgent: APP_DISPLAY_NAME,
           deviceCapabilities: { hover: true },
         },
       }

--- a/renderer/src/features/cli-issue/components/__tests__/cli-issue-page.test.tsx
+++ b/renderer/src/features/cli-issue/components/__tests__/cli-issue-page.test.tsx
@@ -4,7 +4,7 @@ import { vi, beforeEach, describe, it, expect } from 'vitest'
 import { createTestRouter } from '@/common/test/create-test-router'
 import { renderRoute } from '@/common/test/render-route'
 import { CliIssuePage } from '../cli-issue-page'
-import { APP_NAME } from '@common/app-info'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 
 const mockGetValidationResult = vi.fn()
 const mockValidate = vi.fn()
@@ -64,7 +64,7 @@ describe('CliIssuePage', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(`External ${APP_NAME} CLI Detected`)
+          screen.getByText(`External ${THV_DISPLAY_NAME} CLI Detected`)
         ).toBeVisible()
       })
 
@@ -89,7 +89,7 @@ describe('CliIssuePage', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(`External ${APP_NAME} CLI Detected`)
+          screen.getByText(`External ${THV_DISPLAY_NAME} CLI Detected`)
         ).toBeVisible()
       })
 
@@ -111,14 +111,14 @@ describe('CliIssuePage', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(`External ${APP_NAME} CLI Detected`)
+          screen.getByText(`External ${THV_DISPLAY_NAME} CLI Detected`)
         ).toBeVisible()
       })
 
       expect(screen.getByText('Manual installation')).toBeVisible()
       expect(
         screen.getByText(
-          `Please manually remove the external ${APP_NAME} CLI installation.`
+          `Please manually remove the external ${THV_DISPLAY_NAME} CLI installation.`
         )
       ).toBeVisible()
     })
@@ -166,7 +166,7 @@ describe('CliIssuePage', () => {
       })
 
       expect(
-        screen.getByText(`The ${APP_NAME} CLI symlink is broken.`)
+        screen.getByText(`The ${THV_DISPLAY_NAME} CLI symlink is broken.`)
       ).toBeVisible()
       expect(screen.getByText('Was pointing to:')).toBeVisible()
       expect(screen.getByText('/old/path/to/thv')).toBeVisible()
@@ -231,7 +231,9 @@ describe('CliIssuePage', () => {
       })
 
       expect(
-        screen.getByText(`The ${APP_NAME} CLI has been modified externally.`)
+        screen.getByText(
+          `The ${THV_DISPLAY_NAME} CLI has been modified externally.`
+        )
       ).toBeVisible()
       expect(screen.getByText('Currently pointing to:')).toBeVisible()
       expect(screen.getByText('/wrong/path/to/thv')).toBeVisible()

--- a/renderer/src/features/cli-issue/components/__tests__/external-cli-content.test.tsx
+++ b/renderer/src/features/cli-issue/components/__tests__/external-cli-content.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ExternalCliContent } from '../external-cli-content'
-import { APP_DISPLAY_NAME, APP_NAME } from '@common/app-info'
+import { APP_DISPLAY_NAME, THV_DISPLAY_NAME } from '@common/app-info'
 
 const mockWriteText = vi.fn()
 
@@ -32,7 +32,9 @@ describe('ExternalCliContent', () => {
   it('renders the title and description', () => {
     render(<ExternalCliContent {...defaultProps} />)
 
-    expect(screen.getByText(`External ${APP_NAME} CLI Detected`)).toBeVisible()
+    expect(
+      screen.getByText(`External ${THV_DISPLAY_NAME} CLI Detected`)
+    ).toBeVisible()
     expect(
       screen.getByText(
         `${APP_DISPLAY_NAME} cannot run while an external CLI is installed.`
@@ -104,7 +106,7 @@ describe('ExternalCliContent', () => {
     expect(screen.getByText('Manual installation')).toBeVisible()
     expect(
       screen.getByText(
-        `Please manually remove the external ${APP_NAME} CLI installation.`
+        `Please manually remove the external ${THV_DISPLAY_NAME} CLI installation.`
       )
     ).toBeVisible()
   })

--- a/renderer/src/features/cli-issue/components/__tests__/symlink-issue-content.test.tsx
+++ b/renderer/src/features/cli-issue/components/__tests__/symlink-issue-content.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { SymlinkIssueContent } from '../symlink-issue-content'
-import { APP_DISPLAY_NAME, APP_NAME } from '@common/app-info'
+import { APP_DISPLAY_NAME, THV_DISPLAY_NAME } from '@common/app-info'
 
 describe('SymlinkIssueContent', () => {
   const defaultProps = {
@@ -23,7 +23,7 @@ describe('SymlinkIssueContent', () => {
       render(<SymlinkIssueContent {...defaultProps} type="broken" />)
 
       expect(
-        screen.getByText(`The ${APP_NAME} CLI symlink is broken.`)
+        screen.getByText(`The ${THV_DISPLAY_NAME} CLI symlink is broken.`)
       ).toBeVisible()
     })
 
@@ -67,7 +67,9 @@ describe('SymlinkIssueContent', () => {
       render(<SymlinkIssueContent {...defaultProps} type="tampered" />)
 
       expect(
-        screen.getByText(`The ${APP_NAME} CLI has been modified externally.`)
+        screen.getByText(
+          `The ${THV_DISPLAY_NAME} CLI has been modified externally.`
+        )
       ).toBeVisible()
     })
 

--- a/renderer/src/features/cli-issue/components/external-cli-content.tsx
+++ b/renderer/src/features/cli-issue/components/external-cli-content.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/common/components/ui/button'
 import { CodeBlockWithCopy } from '@/common/components/code-block-with-copy'
 import { getUninstallCommand, getSourceLabel } from '../lib/cli-issue-utils'
 import type { ExternalCliInfo } from '@common/types/cli'
-import { APP_DISPLAY_NAME, APP_NAME } from '@common/app-info'
+import { APP_DISPLAY_NAME, THV_DISPLAY_NAME } from '@common/app-info'
 
 interface ExternalCliContentProps {
   cli: ExternalCliInfo
@@ -32,7 +32,7 @@ export function ExternalCliContent({
           <AlertTriangle className="text-destructive size-12" />
         </div>
         <CardTitle className="text-2xl font-semibold">
-          External {APP_NAME} CLI Detected
+          External {THV_DISPLAY_NAME} CLI Detected
         </CardTitle>
         <CardDescription>
           {APP_DISPLAY_NAME} cannot run while an external CLI is installed.
@@ -62,7 +62,8 @@ export function ExternalCliContent({
           </>
         ) : (
           <p className="text-muted-foreground text-sm">
-            Please manually remove the external {APP_NAME} CLI installation.
+            Please manually remove the external {THV_DISPLAY_NAME} CLI
+            installation.
           </p>
         )}
         <Button

--- a/renderer/src/features/cli-issue/components/symlink-issue-content.tsx
+++ b/renderer/src/features/cli-issue/components/symlink-issue-content.tsx
@@ -6,7 +6,7 @@ import {
   CardTitle,
 } from '@/common/components/ui/card'
 import { Button } from '@/common/components/ui/button'
-import { APP_DISPLAY_NAME, APP_NAME } from '@common/app-info'
+import { APP_DISPLAY_NAME, THV_DISPLAY_NAME } from '@common/app-info'
 
 interface SymlinkIssueContentProps {
   type: 'broken' | 'tampered'
@@ -26,8 +26,8 @@ export function SymlinkIssueContent({
     ? 'CLI Installation Needs Repair'
     : 'CLI Installation Modified'
   const description = isBroken
-    ? `The ${APP_NAME} CLI symlink is broken.`
-    : `The ${APP_NAME} CLI has been modified externally.`
+    ? `The ${THV_DISPLAY_NAME} CLI symlink is broken.`
+    : `The ${THV_DISPLAY_NAME} CLI has been modified externally.`
   const detail = isBroken
     ? `This can happen if ${APP_DISPLAY_NAME} was moved or updated.`
     : 'This could cause version compatibility issues.'

--- a/renderer/src/features/mcp-servers/components/form-fields-array-custom-secrets.tsx
+++ b/renderer/src/features/mcp-servers/components/form-fields-array-custom-secrets.tsx
@@ -8,6 +8,7 @@ import {
 import type { ChangeEventHandler } from 'react'
 
 import { FormControl, FormField, FormItem } from '@/common/components/ui/form'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import { Input } from '@/common/components/ui/input'
 import { DynamicArrayField } from '@/features/registry-servers/components/dynamic-array-field'
 import { SecretStoreCombobox } from '@/common/components/secrets/secret-store-combobox'
@@ -33,7 +34,7 @@ export function FormFieldsArrayCustomSecrets<T extends FormWithSecrets>({
             label="Secrets"
             inputLabelPrefix="Secret"
             addButtonText="Add secret"
-            description="All secrets are encrypted and securely stored by ToolHive."
+            description={`All secrets are encrypted and securely stored by ${THV_DISPLAY_NAME}.`}
             gridConfig="grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
             columnHeaders={[
               { title: 'Secret name' },

--- a/renderer/src/features/mcp-servers/components/local-mcp/form-fields-base.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/form-fields-base.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/common/components/ui/form'
 import { Input } from '@/common/components/ui/input'
 import { type UseFormReturn } from 'react-hook-form'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import {
   Select,
   SelectContent,
@@ -177,8 +178,8 @@ export function FormFieldsBase({
               <div className="flex items-center gap-1">
                 <FormLabel htmlFor={field.name}>Target port</FormLabel>
                 <TooltipInfoIcon className="max-w-72">
-                  Target port to expose from the container. If not specified,
-                  ToolHive will automatically assign a random port.
+                  Target port to expose from the container. If not specified,{' '}
+                  {THV_DISPLAY_NAME} will automatically assign a random port.
                 </TooltipInfoIcon>
               </div>
               <FormControl>
@@ -238,8 +239,8 @@ export function FormFieldsBase({
               <div className="flex items-center gap-1">
                 <FormLabel htmlFor={field.name}>Protocol</FormLabel>
                 <TooltipInfoIcon>
-                  ToolHive supports running MCP servers directly from supported
-                  package managers.
+                  {THV_DISPLAY_NAME} supports running MCP servers directly from
+                  supported package managers.
                 </TooltipInfoIcon>
               </div>
               <FormControl>

--- a/renderer/src/features/mcp-servers/components/remote-mcp/form-fields-auth.tsx
+++ b/renderer/src/features/mcp-servers/components/remote-mcp/form-fields-auth.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/common/components/ui/form'
 import { Input } from '@/common/components/ui/input'
 import { TooltipInfoIcon } from '@/common/components/ui/tooltip-info-icon'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import { type UseFormReturn, useWatch } from 'react-hook-form'
 import { SecretStoreCombobox } from '@/common/components/secrets/secret-store-combobox'
 import type { FormSchemaRemoteMcp } from '@/common/lib/workloads/remote/form-schema-remote-mcp'
@@ -130,7 +131,7 @@ export function FormFieldsAuth({
                   </TooltipInfoIcon>
                 </div>
                 <p className="text-muted-foreground text-sm">
-                  The bearer token is stored securely by ToolHive.
+                  The bearer token is stored securely by {THV_DISPLAY_NAME}.
                 </p>
                 <FormControl>
                   <div className="grid grid-cols-2 gap-2">
@@ -414,7 +415,8 @@ export function FormFieldsAuth({
                   </TooltipInfoIcon>
                 </div>
                 <p className="text-muted-foreground text-sm">
-                  All secrets are encrypted and securely stored by ToolHive.
+                  All secrets are encrypted and securely stored by{' '}
+                  {THV_DISPLAY_NAME}.
                 </p>
                 <FormControl>
                   <div className="grid grid-cols-2 gap-2">

--- a/renderer/src/features/registry-servers/components/form-run-from-registry/configuration-tab-content.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry/configuration-tab-content.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/common/components/ui/form'
 import { Input } from '@/common/components/ui/input'
 import { Label } from '@/common/components/ui/label'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import { Button } from '@/common/components/ui/button'
 import { useFieldArray, type UseFormReturn } from 'react-hook-form'
 import { Plus, Trash2 } from 'lucide-react'
@@ -282,7 +283,7 @@ export function ConfigurationTabContent({
           Secrets
         </Label>
         <p className="text-muted-foreground mb-6 text-sm">
-          All secrets are encrypted and securely stored by ToolHive.
+          All secrets are encrypted and securely stored by {THV_DISPLAY_NAME}.
         </p>
 
         {groupedEnvVars.secrets.map((secret, index) => (

--- a/renderer/src/lib/client-config.ts
+++ b/renderer/src/lib/client-config.ts
@@ -17,6 +17,7 @@ export async function configureClient() {
       headers: telemetryHeaders,
     })
   } catch (e) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.error('Failed to configure ToolHive API client: ', e)
     throw e
   }

--- a/renderer/src/renderer.tsx
+++ b/renderer/src/renderer.tsx
@@ -21,6 +21,7 @@ import './common/lib/os-design'
 initSentry()
 
 if (!window.electronAPI || !window.electronAPI.apiFetch) {
+  // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
   log.error('ToolHive API bridge not available in renderer')
 }
 

--- a/renderer/src/routes/root/guards/check-health.ts
+++ b/renderer/src/routes/root/guards/check-health.ts
@@ -46,6 +46,7 @@ export async function checkHealth(queryClient: QueryClient): Promise<void> {
       `[beforeLoad] Client baseUrl: ${clientConfig.baseUrl || 'NOT SET'}`
     )
     log.error(
+      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       `[beforeLoad] ToolHive status: running=${freshStatus.isRunning}, processError=${freshStatus.processError ?? 'none'}`
     )
 

--- a/renderer/src/routes/root/guards/ensure-toolhive-running.ts
+++ b/renderer/src/routes/root/guards/ensure-toolhive-running.ts
@@ -15,6 +15,7 @@ export async function ensureToolhiveRunning(
     queryFn: async () => {
       const res = await window.electronAPI.isToolhiveRunning()
       if (!res) {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         log.error('ToolHive is not running')
       }
       return res

--- a/renderer/src/routes/root/root-error.tsx
+++ b/renderer/src/routes/root/root-error.tsx
@@ -16,6 +16,7 @@ export function RootErrorComponent({ error }: { error: unknown }) {
   const cause = errorData instanceof Error ? errorData.cause : undefined
 
   if (cause?.processError === ALREADY_RUNNING) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.info('[HealthCheckError] Another ToolHive server is already running')
     return <AlreadyRunningError />
   }

--- a/renderer/src/routes/shutdown.tsx
+++ b/renderer/src/routes/shutdown.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { Loader2 } from 'lucide-react'
-import { APP_DISPLAY_NAME } from '@common/app-info'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 import {
   Card,
   CardContent,
@@ -26,7 +26,7 @@ function Shutdown() {
         </CardHeader>
         <CardContent className="space-y-4 text-center">
           <p className="text-muted-foreground">
-            Please wait while {APP_DISPLAY_NAME} safely shuts down your MCP
+            Please wait while {THV_DISPLAY_NAME} safely shuts down your MCP
             servers...
           </p>
         </CardContent>

--- a/renderer/src/routes/shutdown.tsx
+++ b/renderer/src/routes/shutdown.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { Loader2 } from 'lucide-react'
+import { APP_DISPLAY_NAME } from '@common/app-info'
 import {
   Card,
   CardContent,
@@ -25,7 +26,8 @@ function Shutdown() {
         </CardHeader>
         <CardContent className="space-y-4 text-center">
           <p className="text-muted-foreground">
-            Please wait while ToolHive safely shuts down your MCP servers...
+            Please wait while {APP_DISPLAY_NAME} safely shuts down your MCP
+            servers...
           </p>
         </CardContent>
       </Card>

--- a/utils/generate-flatpak-assets.ts
+++ b/utils/generate-flatpak-assets.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import {
-  APP_NAME_BUILD,
+  DEPRECATED_APP_NAME_FOR_BUILD,
   COMPANY_NAME,
   DEEP_LINK_PROTOCOL,
   DEVELOPER_ID,
@@ -17,9 +17,9 @@ const FLATPAK_DIR = path.resolve(import.meta.dirname, '..', 'flatpak')
 
 function desktopFileContent(): string {
   return `[Desktop Entry]
-Name=${APP_NAME_BUILD}
+Name=${DEPRECATED_APP_NAME_FOR_BUILD}
 Comment=Install, manage and run MCP servers and connect them to AI agents and clients
-GenericName=${APP_NAME_BUILD}
+GenericName=${DEPRECATED_APP_NAME_FOR_BUILD}
 Exec=${FLATPAK_WRAPPER_NAME} %U
 Icon=${FLATPAK_APP_ID}
 Type=Application
@@ -33,7 +33,7 @@ function metainfoFileContent(): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>${FLATPAK_APP_ID}</id>
-  <name>${APP_NAME_BUILD}</name>
+  <name>${DEPRECATED_APP_NAME_FOR_BUILD}</name>
   <summary>Install, manage and run MCP servers</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>
@@ -43,7 +43,7 @@ function metainfoFileContent(): string {
   </developer>
 
   <description>
-    <p>${APP_NAME_BUILD} is an application that allows you to install, manage and run MCP servers and connect them to AI agents and clients.</p>
+    <p>${DEPRECATED_APP_NAME_FOR_BUILD} is an application that allows you to install, manage and run MCP servers and connect them to AI agents and clients.</p>
   </description>
 
   <launchable type="desktop-id">${FLATPAK_APP_ID}.desktop</launchable>
@@ -64,7 +64,7 @@ function metainfoFileContent(): string {
   <!-- TODO: Add real screenshots before Flathub submission -->
   <screenshots>
     <screenshot type="default">
-      <caption>${APP_NAME_BUILD} main window</caption>
+      <caption>${DEPRECATED_APP_NAME_FOR_BUILD} main window</caption>
       <image>https://raw.githubusercontent.com/${GITHUB_OWNER}/${GITHUB_REPO}/main/assets/screenshot.png</image>
     </screenshot>
   </screenshots>

--- a/utils/generate-flatpak-assets.ts
+++ b/utils/generate-flatpak-assets.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import {
-  APP_NAME,
+  APP_NAME_BUILD,
   COMPANY_NAME,
   DEEP_LINK_PROTOCOL,
   DEVELOPER_ID,
@@ -17,9 +17,9 @@ const FLATPAK_DIR = path.resolve(import.meta.dirname, '..', 'flatpak')
 
 function desktopFileContent(): string {
   return `[Desktop Entry]
-Name=${APP_NAME}
+Name=${APP_NAME_BUILD}
 Comment=Install, manage and run MCP servers and connect them to AI agents and clients
-GenericName=${APP_NAME}
+GenericName=${APP_NAME_BUILD}
 Exec=${FLATPAK_WRAPPER_NAME} %U
 Icon=${FLATPAK_APP_ID}
 Type=Application
@@ -33,7 +33,7 @@ function metainfoFileContent(): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>${FLATPAK_APP_ID}</id>
-  <name>${APP_NAME}</name>
+  <name>${APP_NAME_BUILD}</name>
   <summary>Install, manage and run MCP servers</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>
@@ -43,7 +43,7 @@ function metainfoFileContent(): string {
   </developer>
 
   <description>
-    <p>${APP_NAME} is an application that allows you to install, manage and run MCP servers and connect them to AI agents and clients.</p>
+    <p>${APP_NAME_BUILD} is an application that allows you to install, manage and run MCP servers and connect them to AI agents and clients.</p>
   </description>
 
   <launchable type="desktop-id">${FLATPAK_APP_ID}.desktop</launchable>
@@ -64,7 +64,7 @@ function metainfoFileContent(): string {
   <!-- TODO: Add real screenshots before Flathub submission -->
   <screenshots>
     <screenshot type="default">
-      <caption>${APP_NAME} main window</caption>
+      <caption>${APP_NAME_BUILD} main window</caption>
       <image>https://raw.githubusercontent.com/${GITHUB_OWNER}/${GITHUB_REPO}/main/assets/screenshot.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
see #2296

Notes:

- `APP_NAME` needed to be changed, because it was used for various different things, such as referring to `thv` but also for package configuration. This means that I could not leave this const as it is. I change it's usages that were referring to the desktop app to use `APP_DISPLAY_NAME` (derived from package.json), then I basically renamed it to `THV_DISPLAY_NAME` to avoid confusion. This way the existing correct references to Toolhive (not Toolhive Studio) were kept unchanged, but with a different variable name
- some usages of `APP_NAME` were referring to the desktop app, and explicitly diverging form the `APP_DISPLAY_NAME` format; in such ways that these usages cannot be derived from package.json without a deeper reworking and audit of the entire build process. It's not the right choice to do that here, so for those usages I was forced to create a "legacy const" named `DEPRECATED_APP_NAME_FOR_BUILD` so this issue will not spread.
- In some cases a usage was slightly ambiguous or potentially confusing to the user, but also did not add any informational value. In some such cases I opted for simply removing the brand name, for instance: https://github.com/stacklok/toolhive-studio/pull/2300/changes#diff-78aca5d68c50f753ae7f2b0d719ff08d8a2bde69433349fa0080426147720644