### PR TITLE
chore(main): export tray menu helpers for downstream composition

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -25,6 +25,7 @@ export default {
     'renderer/src/vite-env.d.ts',
     'renderer/src/types/global.d.ts',
     'main/src/vite-env.d.ts',
+    'main/src/system-tray.ts',
   ],
   ignoreDependencies: [
     '@electron-forge/maker-dmg', // Used indirectly in MakerDMGWithArch

--- a/main/src/system-tray.ts
+++ b/main/src/system-tray.ts
@@ -132,7 +132,7 @@ const handleStartOnLogin = async (toolHiveIsRunning: boolean) => {
   }
 }
 
-const createStatusMenuItem = (toolHiveIsRunning: boolean) => ({
+export const createStatusMenuItem = (toolHiveIsRunning: boolean) => ({
   label: toolHiveIsRunning
     ? `🟢 ${app.getName()} is running`
     : `🔴 ${app.getName()} is stopped`,
@@ -140,7 +140,7 @@ const createStatusMenuItem = (toolHiveIsRunning: boolean) => ({
   enabled: false,
 })
 
-const getCurrentAppVersion = () => {
+export const getCurrentAppVersion = () => {
   const appVersion = getAppVersion()
   return {
     label: `Current version: v${appVersion}`,
@@ -149,7 +149,7 @@ const getCurrentAppVersion = () => {
   }
 }
 
-const createUpdateMenuItem = () => {
+export const createUpdateMenuItem = () => {
   const isProduction = app.isPackaged
   return {
     label: 'Check for Updates...',
@@ -161,7 +161,7 @@ const createUpdateMenuItem = () => {
   }
 }
 
-const startOnLoginMenu = (toolHiveIsRunning: boolean) => {
+export const startOnLoginMenu = (toolHiveIsRunning: boolean) => {
   const isStartOnLogin = getAutoLaunchStatus()
   return {
     label: 'Start on login',
@@ -172,21 +172,21 @@ const startOnLoginMenu = (toolHiveIsRunning: boolean) => {
   }
 }
 
-const createShowMenuItem = () => ({
+export const createShowMenuItem = () => ({
   label: 'Show Window',
   accelerator: 'CmdOrCtrl+S',
   type: 'normal' as const,
   click: withWindow(showWindowWithFocus),
 })
 
-const createHideMenuItem = () => ({
+export const createHideMenuItem = () => ({
   label: 'Hide Window',
   accelerator: 'CmdOrCtrl+H',
   type: 'normal' as const,
   click: withWindow(hideWindow),
 })
 
-const createQuitMenuItem = () => ({
+export const createQuitMenuItem = () => ({
   label: `Quit ${app.getName()}`,
   type: 'normal' as const,
   click: () => {
@@ -196,9 +196,9 @@ const createQuitMenuItem = () => ({
   },
 })
 
-const createSeparator = () => ({ type: 'separator' as const })
+export const createSeparator = () => ({ type: 'separator' as const })
 
-const createMenuTemplate = (toolHiveIsRunning: boolean) => [
+export const createMenuTemplate = (toolHiveIsRunning: boolean) => [
   createStatusMenuItem(toolHiveIsRunning),
   getCurrentAppVersion(),
   createUpdateMenuItem(),


### PR DESCRIPTION
Closes #2302

## Summary

Mechanical change. Promote 9 helper factories in `main/src/system-tray.ts` from `const` to `export const` so external composers can recompose the tray menu template. Zero runtime behavior change.

Promoted symbols:

- `createStatusMenuItem`
- `getCurrentAppVersion`
- `createUpdateMenuItem`
- `startOnLoginMenu`
- `createShowMenuItem`
- `createHideMenuItem`
- `createQuitMenuItem`
- `createSeparator`
- `createMenuTemplate`

Existing exports (`safeTrayDestroy`, `initTray`, `updateTrayStatus`) are untouched.

## Test plan

- [x] Diff scope verified: exactly 9 lines changed in 1 file, each just adding the `export` keyword (`git diff --stat` → `main/src/system-tray.ts | 18 +++++++++---------` / `1 file changed, 9 insertions(+), 9 deletions(-)`)
- [x] `pnpm format` clean (no incidental rewrites)
- [x] `pnpm lint` passes
- [x] `pnpm type-check` passes
- [x] `pnpm test:nonInteractive` passes (217 files / 2450 tests)