### PR TITLE
fix(startup): eliminate cold-start window flash by awaiting socket readiness

### DIFF
--- a/main/src/main-window.ts
+++ b/main/src/main-window.ts
@@ -1,9 +1,15 @@
-import { app, BrowserWindow, shell } from 'electron'
+import { app, BrowserWindow, nativeTheme, shell } from 'electron'
 import path from 'node:path'
 import log from './logger'
 import { hideWindow } from './dock-utils'
 import { getQuittingState, getTray } from './app-state'
 import { pollWindowReady } from './util'
+
+// Mirror the Tailwind theme `:root` / `.dark` --background values so that
+// the brief window between BrowserWindow creation and the first paint of
+// index.html doesn't flash white-on-dark (or vice versa).
+const BG_LIGHT = '#f9faf9'
+const BG_DARK = '#2e2e2e'
 
 // Forge environment variables
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined
@@ -160,6 +166,7 @@ export async function createMainWindow(
       height: options.height || DEFAULT_WINDOW_HEIGHT,
       show: options.show ?? !shouldStartHidden,
       autoHideMenuBar: true,
+      backgroundColor: nativeTheme.shouldUseDarkColors ? BG_DARK : BG_LIGHT,
       webPreferences: {
         contextIsolation: true,
         preload: path.join(__dirname, 'preload.js'),

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -14,6 +14,8 @@ import {
   stopToolhive,
   restartToolhive,
   binPath,
+  probeSocket,
+  waitForSocketReady,
 } from '../toolhive-manager'
 import { updateTrayStatus } from '../system-tray'
 import log from '../logger'
@@ -49,12 +51,15 @@ vi.mock('node:fs')
 vi.mock('node:net', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:net')>()
   const mockCreateServerFn = vi.fn()
+  const mockConnectFn = vi.fn()
   return {
     ...actual,
     createServer: mockCreateServerFn,
+    connect: mockConnectFn,
     default: {
       ...actual,
       createServer: mockCreateServerFn,
+      connect: mockConnectFn,
     },
   }
 })
@@ -185,6 +190,25 @@ describe('toolhive-manager', () => {
     // Mock net.createServer to return a new MockServer instance each time
     mockNet.createServer.mockImplementation(function createServer() {
       return new MockServer() as unknown as net.Server
+    })
+
+    // Default `net.connect` stub for tests that exercise `startToolhive`
+    // (which now awaits a real socket-readiness probe in a detached
+    // promise inside the Sentry.withScope mock). The default returns a
+    // socket that errors on next tick, so `probeSocket` resolves false
+    // without throwing — individual probe/wait-for-ready tests override
+    // this with `mockReturnValueOnce` / `mockImplementationOnce`.
+    mockNet.connect.mockImplementation(function connect() {
+      const fakeSock = new EventEmitter() as EventEmitter & {
+        destroy: () => void
+        destroyed: boolean
+      }
+      fakeSock.destroy = () => {
+        fakeSock.destroyed = true
+      }
+      fakeSock.destroyed = false
+      process.nextTick(() => fakeSock.emit('error', new Error('ENOENT')))
+      return fakeSock as unknown as net.Socket
     })
 
     // Mock logger methods
@@ -955,6 +979,104 @@ describe('toolhive-manager', () => {
       expect(mockLog.warn).toHaveBeenCalledWith(
         expect.stringContaining('Ignoring invalid THV_MCP_PORT=70000')
       )
+    })
+  })
+
+  describe('socket readiness probe', () => {
+    // Minimal fake of `net.Socket` exposing the API used by `probeSocket`.
+    class FakeSocket extends EventEmitter {
+      destroyed = false
+      destroy() {
+        this.destroyed = true
+      }
+      // `removeAllListeners` is inherited from EventEmitter and works as-is.
+    }
+
+    beforeEach(() => {
+      // probeSocket / waitForSocketReady use real timers (with `.unref()`)
+      // so the tests for them run faster against real time. Switch back to
+      // fake timers between cases is unnecessary because each test sets up
+      // its own connect mock.
+      vi.useRealTimers()
+    })
+
+    describe('probeSocket', () => {
+      it('resolves true when net.connect emits `connect`', async () => {
+        const sock = new FakeSocket()
+        vi.mocked(net.connect).mockReturnValueOnce(
+          sock as unknown as net.Socket
+        )
+
+        const promise = probeSocket('/tmp/whatever.sock', 1_000)
+        sock.emit('connect')
+        await expect(promise).resolves.toBe(true)
+        expect(sock.destroyed).toBe(true)
+      })
+
+      it('resolves false when net.connect emits `error`', async () => {
+        const sock = new FakeSocket()
+        vi.mocked(net.connect).mockReturnValueOnce(
+          sock as unknown as net.Socket
+        )
+
+        const promise = probeSocket('/tmp/whatever.sock', 1_000)
+        sock.emit('error', new Error('ENOENT'))
+        await expect(promise).resolves.toBe(false)
+        expect(sock.destroyed).toBe(true)
+      })
+
+      it('resolves false when neither connect nor error fires before timeout', async () => {
+        const sock = new FakeSocket()
+        vi.mocked(net.connect).mockReturnValueOnce(
+          sock as unknown as net.Socket
+        )
+
+        await expect(probeSocket('/tmp/whatever.sock', 20)).resolves.toBe(false)
+        expect(sock.destroyed).toBe(true)
+      })
+    })
+
+    describe('waitForSocketReady', () => {
+      it('returns true on the first successful probe', async () => {
+        const sock = new FakeSocket()
+        vi.mocked(net.connect).mockImplementationOnce(() => {
+          // Resolve `connect` on next tick so the listener is attached first.
+          process.nextTick(() => sock.emit('connect'))
+          return sock as unknown as net.Socket
+        })
+
+        const child = { exitCode: null } as ReturnType<typeof spawn>
+        await expect(
+          waitForSocketReady('/tmp/whatever.sock', child)
+        ).resolves.toBe(true)
+      })
+
+      it('returns false immediately when the child has already exited', async () => {
+        const child = { exitCode: 1 } as ReturnType<typeof spawn>
+        await expect(
+          waitForSocketReady('/tmp/whatever.sock', child)
+        ).resolves.toBe(false)
+        expect(net.connect).not.toHaveBeenCalled()
+      })
+
+      it('eventually returns true after initial failed probes', async () => {
+        let attempt = 0
+        vi.mocked(net.connect).mockImplementation(() => {
+          attempt++
+          const sock = new FakeSocket()
+          process.nextTick(() => {
+            if (attempt < 3) sock.emit('error', new Error('ENOENT'))
+            else sock.emit('connect')
+          })
+          return sock as unknown as net.Socket
+        })
+
+        const child = { exitCode: null } as ReturnType<typeof spawn>
+        await expect(
+          waitForSocketReady('/tmp/whatever.sock', child)
+        ).resolves.toBe(true)
+        expect(attempt).toBeGreaterThanOrEqual(3)
+      })
     })
   })
 })

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -192,9 +192,13 @@ const SOCKET_PROBE_INTERVAL_MS = 100
  * Probe the thv socket by attempting a real connection. Works on both Unix
  * sockets and Windows named pipes — `existsSync` is unreliable for the
  * latter and even on Unix the file can appear before the server has called
- * Listen().
+ * Listen(). The connect-timeout timer is `unref`'d so it does not keep the
+ * Electron main event loop alive during shutdown.
  */
-function probeSocket(socketPath: string, timeoutMs: number): Promise<boolean> {
+export function probeSocket(
+  socketPath: string,
+  timeoutMs: number
+): Promise<boolean> {
   return new Promise((resolve) => {
     const sock = net.connect({ path: socketPath })
     const done = (ok: boolean) => {
@@ -203,6 +207,7 @@ function probeSocket(socketPath: string, timeoutMs: number): Promise<boolean> {
       resolve(ok)
     }
     const timer = setTimeout(() => done(false), timeoutMs)
+    timer.unref()
     sock.once('connect', () => {
       clearTimeout(timer)
       done(true)
@@ -214,7 +219,7 @@ function probeSocket(socketPath: string, timeoutMs: number): Promise<boolean> {
   })
 }
 
-async function waitForSocketReady(
+export async function waitForSocketReady(
   socketPath: string,
   child: ReturnType<typeof spawn>
 ): Promise<boolean> {
@@ -222,7 +227,10 @@ async function waitForSocketReady(
   while (Date.now() < deadline) {
     if (child.exitCode !== null) return false
     if (await probeSocket(socketPath, 200)) return true
-    await new Promise((r) => setTimeout(r, SOCKET_PROBE_INTERVAL_MS))
+    await new Promise<void>((r) => {
+      const t = setTimeout(r, SOCKET_PROBE_INTERVAL_MS)
+      t.unref()
+    })
   }
   return false
 }
@@ -367,9 +375,20 @@ export async function startToolhive(): Promise<void> {
     // succeeds and the renderer fires its first `getHealth` while thv is
     // still initializing — producing an ENOENT in main logs and a black
     // window flash before retry kicks in.
-    const ready = await waitForSocketReady(toolhiveSocketPath, child)
+    //
+    // Capture the socket path locally — the `child.on('exit')` handler can
+    // clear `toolhiveSocketPath` if the child fast-fails before we get here,
+    // and `net.connect({ path: undefined })` would throw.
+    const probeSocketPath = toolhiveSocketPath
+    if (!probeSocketPath) {
+      log.warn(
+        '[startToolhive] socket path was cleared before readiness probe; child likely exited'
+      )
+      return
+    }
+    const ready = await waitForSocketReady(probeSocketPath, child)
     if (ready) {
-      log.info(`[startToolhive] socket ready: ${toolhiveSocketPath}`)
+      log.info(`[startToolhive] socket ready: ${probeSocketPath}`)
     } else {
       log.warn(
         `[startToolhive] socket did not become ready within ${SOCKET_READY_TIMEOUT_MS}ms`

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -180,8 +180,55 @@ function cleanupSocketFile(socketPath: string): void {
   }
 }
 
+// How long to wait for thv to bind its UNIX socket / named pipe before
+// resolving `startToolhive`. The probe runs every 100ms; on a healthy machine
+// thv binds in <2s, but starting Docker, a slow disk, or AV scanning the
+// binary can extend that. After this deadline we resolve anyway and let the
+// renderer fall back to its retrying `getHealth` query.
+const SOCKET_READY_TIMEOUT_MS = 15_000
+const SOCKET_PROBE_INTERVAL_MS = 100
+
+/**
+ * Probe the thv socket by attempting a real connection. Works on both Unix
+ * sockets and Windows named pipes — `existsSync` is unreliable for the
+ * latter and even on Unix the file can appear before the server has called
+ * Listen().
+ */
+function probeSocket(socketPath: string, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.connect({ path: socketPath })
+    const done = (ok: boolean) => {
+      sock.removeAllListeners()
+      sock.destroy()
+      resolve(ok)
+    }
+    const timer = setTimeout(() => done(false), timeoutMs)
+    sock.once('connect', () => {
+      clearTimeout(timer)
+      done(true)
+    })
+    sock.once('error', () => {
+      clearTimeout(timer)
+      done(false)
+    })
+  })
+}
+
+async function waitForSocketReady(
+  socketPath: string,
+  child: ReturnType<typeof spawn>
+): Promise<boolean> {
+  const deadline = Date.now() + SOCKET_READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) return false
+    if (await probeSocket(socketPath, 200)) return true
+    await new Promise((r) => setTimeout(r, SOCKET_PROBE_INTERVAL_MS))
+  }
+  return false
+}
+
 export async function startToolhive(): Promise<void> {
-  Sentry.withScope<Promise<void>>(async (scope) => {
+  return Sentry.withScope<Promise<void>>(async (scope) => {
     if (isUsingCustomSocket()) {
       toolhiveSocketPath = process.env.THV_SOCKET!
       toolhiveMcpPort = parseMcpPortEnv(process.env.THV_MCP_PORT)
@@ -314,6 +361,20 @@ export async function startToolhive(): Promise<void> {
         )
       }
     })
+
+    // Wait for thv to actually bind its UNIX socket / named pipe before
+    // resolving. Without this, `startToolhive` returns the moment `spawn()`
+    // succeeds and the renderer fires its first `getHealth` while thv is
+    // still initializing — producing an ENOENT in main logs and a black
+    // window flash before retry kicks in.
+    const ready = await waitForSocketReady(toolhiveSocketPath, child)
+    if (ready) {
+      log.info(`[startToolhive] socket ready: ${toolhiveSocketPath}`)
+    } else {
+      log.warn(
+        `[startToolhive] socket did not become ready within ${SOCKET_READY_TIMEOUT_MS}ms`
+      )
+    }
   })
 }
 

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -3,8 +3,98 @@
   <head>
     <meta charset="UTF-8" />
     <title>ToolHive</title>
+    <style>
+      /*
+        Static splash painted from the first parse of index.html, before the
+        Vite bundle loads and React mounts. Covers the ~1–2s cold-start gap
+        that would otherwise show a bare BrowserWindow background. React's
+        createRoot().render() replaces the contents of #root on first commit.
+
+        Colors mirror the Tailwind theme `:root` / `.dark` --background and
+        --foreground so the transition between this static splash and the
+        first React paint is seamless.
+      */
+      :root {
+        color-scheme: light dark;
+        --splash-bg: #f9faf9;
+        --splash-fg: oklch(0.145 0 0);
+        --splash-muted: oklch(0.556 0 0);
+        --splash-border: oklch(0.922 0 0);
+        --splash-spinner-track: oklch(0.922 0 0);
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --splash-bg: oklch(0.1867 0 0);
+          --splash-fg: oklch(0.985 0 0);
+          --splash-muted: oklch(0.708 0 0);
+          --splash-border: oklch(0.269 0 0);
+          --splash-spinner-track: oklch(0.269 0 0);
+        }
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100vh;
+        background: var(--splash-bg);
+        color: var(--splash-fg);
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+      .initial-splash {
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+      }
+      .initial-splash-card {
+        width: 100%;
+        max-width: 32rem;
+        border: 1px solid var(--splash-border);
+        border-radius: 0.75rem;
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1.25rem;
+        text-align: center;
+      }
+      .initial-splash-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+      }
+      .initial-splash-subtitle {
+        color: var(--splash-muted);
+        font-size: 0.9rem;
+        line-height: 1.4;
+      }
+      .initial-splash-spinner {
+        width: 2.5rem;
+        height: 2.5rem;
+        border: 3px solid var(--splash-spinner-track);
+        border-top-color: var(--splash-fg);
+        border-radius: 50%;
+        animation: initial-splash-spin 1.5s linear infinite;
+      }
+      @keyframes initial-splash-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
   </head>
   <body id="root" class="font-sans">
+    <div class="initial-splash">
+      <div class="initial-splash-card">
+        <div class="initial-splash-title">Starting ToolHive</div>
+        <div class="initial-splash-subtitle">
+          We're checking your ToolHive configuration to ensure it's set up
+          correctly.
+        </div>
+        <div class="initial-splash-spinner"></div>
+      </div>
+    </div>
     <script type="module" src="/src/renderer.tsx"></script>
   </body>
 </html>

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -3,6 +3,27 @@
   <head>
     <meta charset="UTF-8" />
     <title>ToolHive</title>
+    <script>
+      // Apply the theme class on <html> before paint, mirroring what
+      // ThemeProvider does in its `useEffect`. Without this the splash
+      // would render with the light `:root` tokens for a frame on
+      // dark-mode systems before React's first commit.
+      ;(function () {
+        try {
+          var stored = localStorage.getItem('toolhive-ui-theme')
+          var theme =
+            stored === 'dark' || stored === 'light'
+              ? stored
+              : window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light'
+          document.documentElement.classList.add(theme)
+        } catch (e) {
+          // localStorage / matchMedia unavailable — fall back to no class,
+          // splash will use `:root` (light) tokens.
+        }
+      })()
+    </script>
     <style>
       /*
         Static splash painted from the first parse of index.html, before the
@@ -10,26 +31,31 @@
         that would otherwise show a bare BrowserWindow background. React's
         createRoot().render() replaces the contents of #root on first commit.
 
-        Colors mirror the Tailwind theme `:root` / `.dark` --background and
-        --foreground so the transition between this static splash and the
-        first React paint is seamless.
+        Token values mirror the Tailwind theme `:root` / `.dark` selectors
+        defined in `src/index.css`. They are inlined rather than pulled in
+        via <link rel="stylesheet" href="/src/index.css"> because Vite's
+        production build emits the bundled CSS at the end of <body>, which
+        would delay first paint by the CSS fetch round-trip. The set of
+        tokens used here is small and rarely changes — `.dark` class is
+        applied by the inline <script> above so the same selectors work as
+        in the rest of the app.
       */
       :root {
         color-scheme: light dark;
         --splash-bg: #f9faf9;
         --splash-fg: oklch(0.145 0 0);
+        --splash-card: oklch(1 0 0);
         --splash-muted: oklch(0.556 0 0);
         --splash-border: oklch(0.922 0 0);
         --splash-spinner-track: oklch(0.922 0 0);
       }
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --splash-bg: oklch(0.1867 0 0);
-          --splash-fg: oklch(0.985 0 0);
-          --splash-muted: oklch(0.708 0 0);
-          --splash-border: oklch(0.269 0 0);
-          --splash-spinner-track: oklch(0.269 0 0);
-        }
+      .dark {
+        --splash-bg: oklch(0.1867 0 0);
+        --splash-fg: oklch(0.985 0 0);
+        --splash-card: oklch(0.1408 0.0044 285.82);
+        --splash-muted: oklch(0.708 0 0);
+        --splash-border: oklch(1 0 0 / 10%);
+        --splash-spinner-track: oklch(0.269 0 0);
       }
       html,
       body {
@@ -51,6 +77,7 @@
       .initial-splash-card {
         width: 100%;
         max-width: 32rem;
+        background: var(--splash-card);
         border: 1px solid var(--splash-border);
         border-radius: 0.75rem;
         padding: 2rem;
@@ -82,17 +109,27 @@
           transform: rotate(360deg);
         }
       }
+      @media (prefers-reduced-motion: reduce) {
+        .initial-splash-spinner {
+          animation: none;
+        }
+      }
     </style>
   </head>
   <body id="root" class="font-sans">
-    <div class="initial-splash">
+    <div
+      class="initial-splash"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
       <div class="initial-splash-card">
         <div class="initial-splash-title">Starting ToolHive</div>
         <div class="initial-splash-subtitle">
           We're checking your ToolHive configuration to ensure it's set up
           correctly.
         </div>
-        <div class="initial-splash-spinner"></div>
+        <div class="initial-splash-spinner" aria-hidden="true"></div>
       </div>
     </div>
     <script type="module" src="/src/renderer.tsx"></script>


### PR DESCRIPTION
## Summary

Three coupled changes that together remove the dark-window flash users see on cold launch, between the app icon being clicked and the first usable UI frame.

### 1. `startToolhive()` actually awaits a real socket connection
`main/src/toolhive-manager.ts`

The current implementation has a missing \`return\` on its \`Sentry.withScope\` wrapper, and even after fixing that it only awaits \`spawn()\` (synchronous). So the renderer could fire its first \`getHealth\` while thv was still binding the socket — producing an ENOENT in main logs and a retry-driven flash on cold start.

The new \`waitForSocketReady()\` polls a real \`net.connect()\` probe (cross-platform: UNIX sockets + Windows named pipes — \`existsSync\` is unreliable for the latter and even on Unix the file can appear before the server has called \`Listen()\`). 15s timeout with 100ms probe interval, graceful resolve-anyway fallback so the renderer's existing retry logic still applies if thv is genuinely slow to start.

### 2. \`BrowserWindow\` opens with a theme-matched background
\`main/src/main-window.ts\`

Adds \`backgroundColor\` to the BrowserWindow constructor, sampling \`nativeTheme.shouldUseDarkColors\` and using values that mirror the Tailwind theme \`--background\` tokens (\`#f9faf9\` light / \`#2e2e2e\` dark, which approximates \`oklch(0.1867 0 0)\` in sRGB). Without this the OS shows a default white/black window for the brief gap between window creation and the first paint of \`index.html\`.

### 3. Static splash painted from the first parse of \`index.html\`
\`renderer/index.html\`

The Vite bundle in dev (and the chunked production bundle) takes ~1s to load and evaluate. During that window, only the bare BrowserWindow background was visible. Now the HTML body contains an inline splash card (\"Starting ToolHive\" + spinner) styled with CSS variables that mirror the Tailwind \`--background\` / \`--foreground\` / \`--border\` tokens for both light and dark via \`prefers-color-scheme\`. \`createRoot().render()\` replaces the splash contents on first commit, so React takes over transparently.

## Why these three together

Each change closes one of three sequential gaps on cold start:

| Gap | Without fix | With fix |
|---|---|---|
| Window opened → \`index.html\` parsed (~50ms) | Default OS bg (white/black) | Theme-matched bg color |
| \`index.html\` parsed → React mounts (~1s) | Bare body color | Static splash card |
| React mounts → first route renders | Existing app skeleton | Existing app skeleton |
| First route → thv socket ready | ENOENT + retry flash | thv already ready (gap moved into \`startToolhive\` await) |

## Test plan

- [ ] \`pnpm test:nonInteractive\` — passes (217 files, 2450 tests)
- [ ] \`pnpm type-check\` — passes
- [ ] \`pnpm lint\` — passes
- [ ] \`pnpm format\` — clean
- [ ] Manual cold-start on macOS: dock bounces, window appears with splash visible, transitions seamlessly to app
- [ ] Manual cold-start on Linux: same behavior
- [ ] Manual cold-start on Windows: same behavior (named-pipe probe path)
- [ ] Verify \`pnpm e2e\` still passes (build awaits socket; downstream UI gates should now find thv ready immediately)