### PR TITLE
feat(main): allow tray menu template builder injection

### DIFF
--- a/main/src/system-tray.ts
+++ b/main/src/system-tray.ts
@@ -211,6 +211,20 @@ export const createMenuTemplate = (toolHiveIsRunning: boolean) => [
   createQuitMenuItem(),
 ]
 
+// Module-level template builder. Defaults to createMenuTemplate. Downstream
+// consumers (overlays, packagers, custom distributions) can swap it via
+// setMenuTemplateBuilder before app.whenReady() fires to recompose the tray
+// menu without forking this module.
+type MenuTemplateBuilder = (
+  toolHiveIsRunning: boolean
+) => Electron.MenuItemConstructorOptions[]
+
+let menuTemplateBuilder: MenuTemplateBuilder = createMenuTemplate
+
+export function setMenuTemplateBuilder(builder: MenuTemplateBuilder) {
+  menuTemplateBuilder = builder
+}
+
 const createClickHandler = () => {
   let lastClickTime = 0
 
@@ -245,7 +259,7 @@ function setupTrayMenu(toolHiveIsRunning: boolean) {
     setTray(tray)
   }
 
-  const menuTemplate = createMenuTemplate(toolHiveIsRunning)
+  const menuTemplate = menuTemplateBuilder(toolHiveIsRunning)
   const contextMenu = Menu.buildFromTemplate(menuTemplate)
 
   tray.setToolTip(app.getName())

--- a/main/src/system-tray.ts
+++ b/main/src/system-tray.ts
@@ -215,7 +215,7 @@ export const createMenuTemplate = (toolHiveIsRunning: boolean) => [
 // consumers (overlays, packagers, custom distributions) can swap it via
 // setMenuTemplateBuilder before app.whenReady() fires to recompose the tray
 // menu without forking this module.
-type MenuTemplateBuilder = (
+export type MenuTemplateBuilder = (
   toolHiveIsRunning: boolean
 ) => Electron.MenuItemConstructorOptions[]
 

--- a/main/src/tests/system-tray.test.ts
+++ b/main/src/tests/system-tray.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Shared mock methods so test assertions can read what was called on the Tray
+// instance regardless of which `new Tray(...)` call produced it.
+const trayMethods = {
+  destroy: vi.fn(),
+  isDestroyed: vi.fn(() => false),
+  setToolTip: vi.fn(),
+  setContextMenu: vi.fn(),
+  on: vi.fn(),
+}
+
+// `new Tray(icon)` is called from setupTrayMenu — we need a real constructor,
+// not an arrow function, so a class is the simplest path.
+class TrayMock {
+  destroy = trayMethods.destroy
+  isDestroyed = trayMethods.isDestroyed
+  setToolTip = trayMethods.setToolTip
+  setContextMenu = trayMethods.setContextMenu
+  on = trayMethods.on
+}
+
+const mockMenu = {
+  buildFromTemplate: vi.fn((template: unknown) => ({ __template: template })),
+}
+
+const mockNativeImage = {
+  createFromPath: vi.fn(() => ({
+    setTemplateImage: vi.fn(),
+    resize: vi.fn(() => ({})),
+  })),
+}
+
+const mockApp = {
+  isPackaged: false,
+  getName: vi.fn(() => 'ToolHive'),
+}
+
+vi.mock('electron', () => ({
+  Menu: mockMenu,
+  Tray: TrayMock,
+  app: mockApp,
+  nativeImage: mockNativeImage,
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+  },
+}))
+
+vi.mock('../auto-launch', () => ({
+  getAutoLaunchStatus: vi.fn(() => false),
+  setAutoLaunch: vi.fn(),
+}))
+
+vi.mock('../menu', () => ({
+  createApplicationMenu: vi.fn(),
+}))
+
+vi.mock('../logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+vi.mock('../util', () => ({
+  getAppVersion: vi.fn(() => '1.0.0'),
+}))
+
+vi.mock('../dock-utils', () => ({
+  hideWindow: vi.fn(),
+  showWindow: vi.fn(),
+}))
+
+const trayStore = { current: null as unknown }
+
+vi.mock('../app-state', () => ({
+  getTray: vi.fn(() => trayStore.current),
+  setTray: vi.fn((tray: unknown) => {
+    trayStore.current = tray
+  }),
+}))
+
+vi.mock('../utils/update-dialogs', () => ({
+  handleCheckForUpdates: vi.fn(),
+}))
+
+describe('system-tray template builder injection', () => {
+  beforeEach(async () => {
+    trayStore.current = null
+    mockMenu.buildFromTemplate.mockClear()
+    trayMethods.setContextMenu.mockClear()
+    trayMethods.isDestroyed.mockClear()
+    trayMethods.isDestroyed.mockReturnValue(false)
+    // Reset the module's internal state (menuTemplateBuilder) between tests.
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses createMenuTemplate by default when no custom builder is set', async () => {
+    const systemTray = await import('../system-tray')
+
+    systemTray.initTray({ toolHiveIsRunning: true })
+
+    expect(mockMenu.buildFromTemplate).toHaveBeenCalledTimes(1)
+    const template = mockMenu.buildFromTemplate.mock.calls[0]?.[0] as Array<{
+      label?: string
+    }>
+    // The default template includes the "Check for Updates..." entry.
+    expect(template.some((item) => item.label === 'Check for Updates...')).toBe(
+      true
+    )
+  })
+
+  it('routes setupTrayMenu through a custom template builder when set', async () => {
+    const systemTray = await import('../system-tray')
+
+    const customBuilder = vi.fn(() => [
+      { label: 'custom-status', type: 'normal' as const, enabled: false },
+      { type: 'separator' as const },
+      { label: 'custom-quit', type: 'normal' as const },
+    ])
+
+    systemTray.setMenuTemplateBuilder(customBuilder)
+    systemTray.initTray({ toolHiveIsRunning: true })
+
+    expect(customBuilder).toHaveBeenCalledTimes(1)
+    expect(customBuilder).toHaveBeenCalledWith(true)
+
+    expect(mockMenu.buildFromTemplate).toHaveBeenCalledTimes(1)
+    const passedTemplate = mockMenu.buildFromTemplate.mock
+      .calls[0]?.[0] as Array<{
+      label?: string
+    }>
+    expect(passedTemplate).toHaveLength(3)
+    expect(passedTemplate[0]?.label).toBe('custom-status')
+    expect(passedTemplate[2]?.label).toBe('custom-quit')
+  })
+
+  it('propagates toolHiveIsRunning to the custom builder on updateTrayStatus', async () => {
+    const systemTray = await import('../system-tray')
+
+    const customBuilder = vi.fn(() => [
+      { label: 'placeholder', type: 'normal' as const },
+    ])
+    systemTray.setMenuTemplateBuilder(customBuilder)
+
+    // initTray creates the tray and triggers a first call.
+    systemTray.initTray({ toolHiveIsRunning: false })
+    expect(customBuilder).toHaveBeenLastCalledWith(false)
+
+    // updateTrayStatus should re-invoke the same custom builder with the new flag.
+    systemTray.updateTrayStatus(true)
+    expect(customBuilder).toHaveBeenLastCalledWith(true)
+    expect(customBuilder).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Closes #2310
<img width="317" height="251" alt="Screenshot 2026-06-08 at 12 58 54" src="https://github.com/user-attachments/assets/15303337-35bf-4a84-b47a-187a10aa7add" />

## Summary

Add a module-level template builder slot and a `setMenuTemplateBuilder` setter so downstream consumers (overlays, packagers, custom distributions) can recompose the tray menu without forking `main/src/system-tray.ts`.

The default `createMenuTemplate` is unchanged; callers that do not invoke the setter get the exact same tray menu as today. `setupTrayMenu` now invokes `menuTemplateBuilder(running)` instead of `createMenuTemplate(running)` directly so an injected builder actually reaches `Menu.buildFromTemplate`.

## Why

#2302 promoted the helper factories (`createStatusMenuItem`, `getCurrentAppVersion`, `createUpdateMenuItem`, etc.) to `export const`. Exposing the building blocks alone, however, is not sufficient to recompose the menu from outside this module: the reference to `createMenuTemplate` inside `setupTrayMenu` is captured by closure at module-load time, and ES module bindings are read-only on the consumer side.

This PR closes that gap with a minimal dependency-injection seam:

```ts
import { setMenuTemplateBuilder, createStatusMenuItem, getCurrentAppVersion, createSeparator } from './system-tray'

setMenuTemplateBuilder((running) => [
  createStatusMenuItem(running),
  getCurrentAppVersion(),
  // omit or add entries as needed
  createSeparator(),
])
```

Upstream stays "consumer-agnostic" — no awareness of any specific downstream distribution leaks in — and any future overlay can compose the menu freely.

## API

```ts
type MenuTemplateBuilder = (
  toolHiveIsRunning: boolean
) => Electron.MenuItemConstructorOptions[]

export function setMenuTemplateBuilder(builder: MenuTemplateBuilder): void
```

The parameter type is `Electron.MenuItemConstructorOptions[]` — broader than the default's inferred type — so consumers are free to mix any valid Electron menu item shape. The default `createMenuTemplate`'s narrower return is still assignable to it.

## Files

- **`main/src/system-tray.ts`** — adds `MenuTemplateBuilder` type, `menuTemplateBuilder` slot (default = `createMenuTemplate`), exported `setMenuTemplateBuilder`; switches `setupTrayMenu` to call the slot.
- **`main/src/tests/system-tray.test.ts`** (new) — three tests covering:
  - Default template (no setter call) still produces a template that includes the "Check for Updates..." entry.
  - Custom builder is routed through `Menu.buildFromTemplate` (custom items reach the OS).
  - `toolHiveIsRunning` propagates through `updateTrayStatus` to the same custom builder.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm type-check` clean
- [x] `pnpm test:nonInteractive` — 218 files / 2453 tests passing (was 2450; +3 new tests in `system-tray.test.ts`)
- [x] Diff scope verified: 2 files (`main/src/system-tray.ts` +14 / -1, `main/src/tests/system-tray.test.ts` new)
- [x] Backward compatibility: existing call sites of `initTray`, `updateTrayStatus`, `safeTrayDestroy` and the default tray menu rendering are byte-identical when no setter is invoked.

## Out of scope

- Changing the default `createMenuTemplate` contents or ordering.
- Adding new menu items.
- Exposing additional internals (`setupTrayMenu`, `getIcon`, `createClickHandler`).
- Any awareness of specific downstream distributions in this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)