### PR TITLE
fix(settings): show detected CLI version instead of build-time constant

### DIFF
--- a/e2e-tests/settings.spec.ts
+++ b/e2e-tests/settings.spec.ts
@@ -8,5 +8,7 @@ test('displays correct ToolHive binary version', async ({ window }) => {
   const versionRow = window
     .locator('text=ToolHive binary version')
     .locator('..')
-  await expect(versionRow).toContainText(TOOLHIVE_VERSION)
+  // The row shows the version detected from the bundled binary, which prints
+  // it without the "v" prefix the build-time constant carries.
+  await expect(versionRow).toContainText(TOOLHIVE_VERSION.replace(/^v/, ''))
 })

--- a/main/src/cli/__tests__/cli-detection.test.ts
+++ b/main/src/cli/__tests__/cli-detection.test.ts
@@ -196,5 +196,44 @@ describe('cli-detection', () => {
         isExecutable: false,
       })
     })
+
+    it('parses version without the "v" prefix (enterprise builds)', async () => {
+      vol.fromJSON({
+        '/path/to/thv': 'binary content',
+      })
+
+      mockExecFileAsync.mockResolvedValue({
+        stdout: 'ToolHive 0.1.39\nCommit: be1357a\nBuilt: 2026-05-19',
+        stderr: '',
+      })
+
+      const result = await getCliInfo('/path/to/thv')
+
+      expect(result).toEqual({
+        exists: true,
+        version: '0.1.39',
+        isExecutable: true,
+      })
+    })
+
+    it('parses prerelease versions with and without the "v" prefix', async () => {
+      vol.fromJSON({
+        '/path/to/thv': 'binary content',
+      })
+
+      mockExecFileAsync.mockResolvedValue({
+        stdout: 'ToolHive v1.5.0-rc.1',
+        stderr: '',
+      })
+
+      expect((await getCliInfo('/path/to/thv')).version).toBe('1.5.0-rc.1')
+
+      mockExecFileAsync.mockResolvedValue({
+        stdout: 'ToolHive 1.5.0-rc.1',
+        stderr: '',
+      })
+
+      expect((await getCliInfo('/path/to/thv')).version).toBe('1.5.0-rc.1')
+    })
   })
 })

--- a/main/src/cli/cli-detection.ts
+++ b/main/src/cli/cli-detection.ts
@@ -15,9 +15,12 @@ import log from '../logger'
 
 const execFileAsync = promisify(execFile)
 
-/** Extracts version from "ToolHive v0.X.X" line in `thv version` output */
+/**
+ * Extracts version from the "ToolHive v0.X.X" line in `thv version` output.
+ * The "v" prefix is optional: enterprise builds stamp the version without it.
+ */
 const parseVersionOutput = (stdout: string): string | null => {
-  const match = stdout.match(/^ToolHive v(\d+\.\d+\.\d+(?:-[\w.]+)?)/m)
+  const match = stdout.match(/^ToolHive v?(\d+\.\d+\.\d+(?:-[\w.]+)?)/m)
   return match?.[1] ?? null
 }
 

--- a/preload/src/api/toolhive.ts
+++ b/preload/src/api/toolhive.ts
@@ -1,12 +1,10 @@
 import { ipcRenderer } from 'electron'
 import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
-import { TOOLHIVE_VERSION } from '../../../utils/constants'
 import type { ToolhiveStatus } from '../../../common/types/toolhive-status'
 
 export const toolhiveApi = {
   getToolhiveMcpPort: () => ipcRenderer.invoke('get-toolhive-mcp-port'),
   getToolhiveSocketPath: () => ipcRenderer.invoke('get-toolhive-socket-path'),
-  getToolhiveVersion: () => TOOLHIVE_VERSION,
   isToolhiveRunning: () => ipcRenderer.invoke('is-toolhive-running'),
   getToolhiveStatus: () => ipcRenderer.invoke('get-toolhive-status'),
   isUsingCustomSocket: () => ipcRenderer.invoke('is-using-custom-socket'),
@@ -34,7 +32,6 @@ export const toolhiveApi = {
 export interface ToolhiveAPI {
   getToolhiveMcpPort: () => Promise<number | undefined>
   getToolhiveSocketPath: () => Promise<string | undefined>
-  getToolhiveVersion: () => string
   isToolhiveRunning: () => Promise<boolean>
   getToolhiveStatus: () => Promise<ToolhiveStatus>
   isUsingCustomSocket: () => Promise<boolean>

--- a/renderer/src/common/components/error/__tests__/technical-details.test.tsx
+++ b/renderer/src/common/components/error/__tests__/technical-details.test.tsx
@@ -28,7 +28,9 @@ describe('TechnicalDetails', () => {
       latestVersion: '0.34.0',
       isNewVersionAvailable: false,
     })
-    window.electronAPI.getToolhiveVersion = vi.fn().mockReturnValue('0.8.0')
+    window.electronAPI.cliAlignment = {
+      getStatus: vi.fn().mockResolvedValue({ cliVersion: '0.8.0' }),
+    } as unknown as typeof window.electronAPI.cliAlignment
     window.electronAPI.isOfficialReleaseBuild = vi.fn().mockResolvedValue(false)
     window.electronAPI.getToolhiveStatus = vi
       .fn()

--- a/renderer/src/common/components/settings/tabs/__tests__/settings-tabs.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/settings-tabs.test.tsx
@@ -12,7 +12,7 @@ import { Suspense } from 'react'
 const mockGetMainLogContent = vi.fn()
 const mockGetAppVersion = vi.fn()
 const mockIsOfficialReleaseBuild = vi.fn()
-const mockGetToolhiveVersion = vi.fn()
+const mockGetCliStatus = vi.fn()
 const mockIsAutoUpdateEnabled = vi.fn()
 const mockSetAutoUpdate = vi.fn()
 const mockGetUpdateState = vi.fn()
@@ -89,7 +89,9 @@ describe('SettingsTabs', () => {
     window.electronAPI.getMainLogContent = mockGetMainLogContent
     window.electronAPI.getAppVersion = mockGetAppVersion
     window.electronAPI.isOfficialReleaseBuild = mockIsOfficialReleaseBuild
-    window.electronAPI.getToolhiveVersion = mockGetToolhiveVersion
+    window.electronAPI.cliAlignment = {
+      getStatus: mockGetCliStatus,
+    } as unknown as typeof window.electronAPI.cliAlignment
     window.electronAPI.isAutoUpdateEnabled = mockIsAutoUpdateEnabled
     window.electronAPI.setAutoUpdate = mockSetAutoUpdate
     window.electronAPI.getUpdateState = mockGetUpdateState
@@ -108,7 +110,7 @@ describe('SettingsTabs', () => {
     mockGetMainLogContent.mockResolvedValue('Mock log content')
     mockGetAppVersion.mockResolvedValue('1.0.0')
     mockIsOfficialReleaseBuild.mockResolvedValue(true)
-    mockGetToolhiveVersion.mockResolvedValue('0.9.0')
+    mockGetCliStatus.mockResolvedValue({ cliVersion: '0.9.0' })
     mockIsAutoUpdateEnabled.mockResolvedValue(false)
     mockGetUpdateState.mockResolvedValue('none')
     mockSentryIsEnabled.mockResolvedValue(true)

--- a/renderer/src/common/hooks/__tests__/use-app-version.test.ts
+++ b/renderer/src/common/hooks/__tests__/use-app-version.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React, { type ReactNode } from 'react'
+import { useAppVersion } from '../use-app-version'
+
+const mockGetAppVersion = vi.fn()
+const mockIsOfficialReleaseBuild = vi.fn()
+const mockGetCliStatus = vi.fn()
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    )
+  }
+}
+
+function mockCliStatus(cliVersion: string | null) {
+  return {
+    isManaged: true,
+    cliPath: '/home/user/.toolhive/bin/thv',
+    cliVersion,
+    installMethod: 'symlink' as const,
+    symlinkTarget: '/app/resources/bin/thv',
+    isValid: true,
+    lastValidated: new Date().toISOString(),
+  }
+}
+
+describe('useAppVersion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    window.electronAPI.getAppVersion = mockGetAppVersion
+    window.electronAPI.isOfficialReleaseBuild = mockIsOfficialReleaseBuild
+    window.electronAPI.cliAlignment = {
+      getStatus: mockGetCliStatus,
+    } as unknown as typeof window.electronAPI.cliAlignment
+
+    mockGetAppVersion.mockResolvedValue({
+      currentVersion: '1.0.0',
+      latestVersion: '1.0.0',
+      isNewVersionAvailable: false,
+    })
+    mockIsOfficialReleaseBuild.mockResolvedValue(true)
+  })
+
+  it('sources toolhiveVersion from the detected CLI version', async () => {
+    mockGetCliStatus.mockResolvedValue(mockCliStatus('0.1.39'))
+
+    const { result } = renderHook(() => useAppVersion(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.toolhiveVersion).toBe('0.1.39')
+  })
+
+  it('falls back to "Unknown" when the CLI version cannot be detected', async () => {
+    mockGetCliStatus.mockResolvedValue(mockCliStatus(null))
+
+    const { result } = renderHook(() => useAppVersion(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.toolhiveVersion).toBe('Unknown')
+  })
+
+  it('falls back to "Unknown" when the CLI status query fails', async () => {
+    mockGetCliStatus.mockRejectedValue(new Error('IPC failure'))
+
+    const { result } = renderHook(() => useAppVersion(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.toolhiveVersion).toBe('Unknown')
+  })
+})

--- a/renderer/src/common/hooks/use-app-version.ts
+++ b/renderer/src/common/hooks/use-app-version.ts
@@ -15,10 +15,10 @@ export function useAppVersion() {
     queryKey: ['app-version'],
     queryFn: async (): Promise<AppVersionInfo> => {
       try {
-        const [version, release, toolhiveVersion] = await Promise.allSettled([
+        const [version, release, cliStatus] = await Promise.allSettled([
           window.electronAPI.getAppVersion(),
           window.electronAPI.isOfficialReleaseBuild(),
-          window.electronAPI.getToolhiveVersion(),
+          window.electronAPI.cliAlignment.getStatus(),
         ])
 
         return {
@@ -36,10 +36,12 @@ export function useAppVersion() {
               : false,
           isReleaseBuild:
             release.status === 'fulfilled' ? release.value : false,
+          // Same value the CLI tab shows (detected from the actual binary),
+          // so the two settings tabs can never disagree.
           toolhiveVersion:
-            toolhiveVersion.status === 'fulfilled'
-              ? toolhiveVersion.value
-              : 'N/A',
+            cliStatus.status === 'fulfilled'
+              ? (cliStatus.value.cliVersion ?? 'Unknown')
+              : 'Unknown',
         }
       } catch (error) {
         toast.error('Failed to fetch version info')


### PR DESCRIPTION
The Settings → Version tab showed the build-time `TOOLHIVE_VERSION` constant, while the Settings → CLI tab showed the version detected from the actual binary. This makes both tabs use the same detected value, so they always agree and always reflect the binary that's really installed.

Also makes the `v` prefix optional when parsing `thv version` output, so builds that stamp the version without it (e.g. downstream distributions) don't show "Unknown".

- Version tab now reads `cliAlignment.getStatus().cliVersion` (same source as the CLI tab); falls back to "Unknown" when detection fails
- Removed the now-unused `getToolhiveVersion` preload method — the renovate-managed constant keeps its build-time role (thv download) but is no longer in the display path
- Tests added for both changes

*Fully or partially written by an AI agent.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)