### PR TITLE
chore: remove --experimental-mcp flag and internal ToolHive MCP server

### DIFF
--- a/.claude/skills/devcontainer-dev/SKILL.md
+++ b/.claude/skills/devcontainer-dev/SKILL.md
@@ -233,7 +233,7 @@ The Electron main window's `WM_CLASS` is `ToolHive`, **not** `Electron`. The `~/
 
 ### Readiness false-positive (transient processes)
 
-`pgrep -x thv` would match the short-lived `thv version` / `thv --version` invocation that Electron runs during startup to verify the binary is present. The long-running backend is always `thv serve --openapi --experimental-mcp ... --port=N`, so use `pgrep -f "thv serve"` to gate on that specifically.
+`pgrep -x thv` would match the short-lived `thv version` / `thv --version` invocation that Electron runs during startup to verify the binary is present. The long-running backend is always `thv serve --openapi ... --port=N`, so use `pgrep -f "thv serve"` to gate on that specifically.
 
 ### Readiness false-positive (pgrep self-match)
 

--- a/.codex/skills/devcontainer-dev/SKILL.md
+++ b/.codex/skills/devcontainer-dev/SKILL.md
@@ -233,7 +233,7 @@ The Electron main window's `WM_CLASS` is `ToolHive`, **not** `Electron`. The `~/
 
 ### Readiness false-positive (transient processes)
 
-`pgrep -x thv` would match the short-lived `thv version` / `thv --version` invocation that Electron runs during startup to verify the binary is present. The long-running backend is always `thv serve --openapi --experimental-mcp ... --port=N`, so use `pgrep -f "thv serve"` to gate on that specifically.
+`pgrep -x thv` would match the short-lived `thv version` / `thv --version` invocation that Electron runs during startup to verify the binary is present. The long-running backend is always `thv serve --openapi ... --port=N`, so use `pgrep -f "thv serve"` to gate on that specifically.
 
 ### Readiness false-positive (pgrep self-match)
 

--- a/.cursor/skills/devcontainer-dev/SKILL.md
+++ b/.cursor/skills/devcontainer-dev/SKILL.md
@@ -233,7 +233,7 @@ The Electron main window's `WM_CLASS` is `ToolHive`, **not** `Electron`. The `~/
 
 ### Readiness false-positive (transient processes)
 
-`pgrep -x thv` would match the short-lived `thv version` / `thv --version` invocation that Electron runs during startup to verify the binary is present. The long-running backend is always `thv serve --openapi --experimental-mcp ... --port=N`, so use `pgrep -f "thv serve"` to gate on that specifically.
+`pgrep -x thv` would match the short-lived `thv version` / `thv --version` invocation that Electron runs during startup to verify the binary is present. The long-running backend is always `thv serve --openapi ... --port=N`, so use `pgrep -f "thv serve"` to gate on that specifically.
 
 ### Readiness false-positive (pgrep self-match)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,10 +190,7 @@ point the studio at it via `THV_SOCKET`:
    ```bash
    thv serve \
      --openapi \
-     --socket=/tmp/thv-dev.sock \
-     --experimental-mcp \
-     --experimental-mcp-host=127.0.0.1 \
-     --experimental-mcp-port=50001
+     --socket=/tmp/thv-dev.sock
    ```
 
    **Windows (PowerShell)**
@@ -201,23 +198,19 @@ point the studio at it via `THV_SOCKET`:
    ```powershell
    thv.exe serve `
      --openapi `
-     --socket='\\.\pipe\thv-dev' `
-     --experimental-mcp `
-     --experimental-mcp-host=127.0.0.1 `
-     --experimental-mcp-port=50001
+     --socket='\\.\pipe\thv-dev'
    ```
 
-2. Set `THV_SOCKET` (and `THV_MCP_PORT` if you also need the experimental MCP
-   backend) and start the dev server:
+2. Set `THV_SOCKET` and start the dev server:
 
    ```bash
-   THV_SOCKET=/tmp/thv-dev.sock THV_MCP_PORT=50001 pnpm start
+   THV_SOCKET=/tmp/thv-dev.sock pnpm start
    ```
 
    On Windows:
 
    ```powershell
-   $env:THV_SOCKET = '\\.\pipe\thv-dev'; $env:THV_MCP_PORT = '50001'; pnpm start
+   $env:THV_SOCKET = '\\.\pipe\thv-dev'; pnpm start
    ```
 
 The UI displays a banner with the socket / pipe path when `THV_SOCKET` is set.

--- a/main/src/chat/__tests__/mcp-tools.test.ts
+++ b/main/src/chat/__tests__/mcp-tools.test.ts
@@ -4,7 +4,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // Hoisted mock factories — must be defined before vi.mock() calls
 // ---------------------------------------------------------------------------
 
-const mockGetToolhiveMcpPort = vi.hoisted(() => vi.fn().mockReturnValue(3001))
 const mockCreateMainProcessApiClient = vi.hoisted(() =>
   vi.fn().mockReturnValue({})
 )
@@ -29,7 +28,7 @@ const mockSdkClient = vi.hoisted(() => ({
   close: vi.fn().mockResolvedValue(undefined),
 }))
 
-// AI SDK MCP client mock (used by getToolhiveMcpInfo / createMcpTools)
+// AI SDK MCP client mock (used by createMcpTools)
 const mockAiMcpClient = vi.hoisted(() => ({
   tools: vi.fn().mockResolvedValue({}),
   close: vi.fn().mockResolvedValue(undefined),
@@ -47,10 +46,6 @@ const mockReplaceAllMcpAppUiMetadata = vi.hoisted(() => vi.fn())
 // ---------------------------------------------------------------------------
 // Module mocks
 // ---------------------------------------------------------------------------
-
-vi.mock('../../toolhive-manager', () => ({
-  getToolhiveMcpPort: mockGetToolhiveMcpPort,
-}))
 
 vi.mock('../../unix-socket-fetch', () => ({
   createMainProcessApiClient: mockCreateMainProcessApiClient,
@@ -104,10 +99,6 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   },
 }))
 
-vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
-  StreamableHTTPClientTransport: function StreamableHTTPTransportMock() {},
-}))
-
 // The schemas are passed through to the mocked client.request(), so they
 // just need to be non-undefined objects.
 vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
@@ -136,7 +127,6 @@ import {
   getCachedUiMetadata,
   fetchUiResource,
   proxyMcpToolCall,
-  getToolhiveMcpInfo,
   getMcpServerTools,
   createMcpTools,
 } from '../mcp-tools'
@@ -145,8 +135,6 @@ import log from '../../logger'
 // ---------------------------------------------------------------------------
 // Shared fixtures
 // ---------------------------------------------------------------------------
-
-const THV_SERVER = 'toolhive-mcp-internal'
 
 const makeWorkload = (overrides: Record<string, unknown> = {}) => ({
   name: 'test-server',
@@ -171,9 +159,6 @@ const makeToolDef = (overrides: Record<string, unknown> = {}) => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
-
-  // MCP backend port (still TCP)
-  mockGetToolhiveMcpPort.mockReturnValue(3001)
 
   // API client chain (fetchWorkloads)
   mockCreateMainProcessApiClient.mockReturnValue({})
@@ -250,8 +235,11 @@ describe('getCachedUiMetadata', () => {
         ui: { resourceUri: 'res://cached-tool', visibility: ['model'] },
       },
     }
+    mockGetApiV1BetaWorkloads.mockResolvedValue({
+      data: { workloads: [makeWorkload()] },
+    })
     mockGetEnabledMcpTools.mockResolvedValue({
-      [THV_SERVER]: ['cached-tool'],
+      'test-server': ['cached-tool'],
     })
     mockAiMcpClient.tools.mockResolvedValue({ 'cached-tool': toolWithUi })
 
@@ -345,20 +333,6 @@ describe('fetchUiResource', () => {
     expect(mockSdkClient.close).toHaveBeenCalledOnce()
   })
 
-  it('uses the raw ToolHive MCP transport for the internal ToolHive server', async () => {
-    mockSdkClient.request.mockResolvedValue({
-      contents: [{ text: '<html>thv</html>' }],
-    })
-
-    await fetchUiResource(THV_SERVER, 'res://thv')
-
-    // buildRawTransport should NOT be called for the internal server
-    expect(mockBuildRawTransport).not.toHaveBeenCalled()
-    // StreamableHTTPClientTransport is newed up inside
-    // createToolhiveRawMcpTransport
-    expect(mockSdkClient.connect).toHaveBeenCalledOnce()
-  })
-
   it('uses buildRawTransport for external servers', async () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [makeWorkload()] },
@@ -424,88 +398,6 @@ describe('proxyMcpToolCall', () => {
 })
 
 // ---------------------------------------------------------------------------
-// getToolhiveMcpInfo
-// ---------------------------------------------------------------------------
-
-describe('getToolhiveMcpInfo', () => {
-  it('returns isRunning: false when port is not available', async () => {
-    mockGetToolhiveMcpPort.mockReturnValue(null)
-
-    const result = await getToolhiveMcpInfo()
-
-    expect(result.isRunning).toBe(false)
-    expect(result.serverName).toBe(THV_SERVER)
-    expect(mockCreateMCPClient).not.toHaveBeenCalled()
-  })
-
-  it('returns tools with correct enabled flags', async () => {
-    mockAiMcpClient.tools.mockResolvedValue({
-      'tool-enabled': makeToolDef({ description: 'enabled' }),
-      'tool-disabled': makeToolDef({ description: 'disabled' }),
-    })
-
-    const result = await getToolhiveMcpInfo(['tool-enabled'])
-
-    expect(result.isRunning).toBe(true)
-    expect(result.tools).toHaveLength(2)
-    const enabled = result.tools.find((t) => t.name === 'tool-enabled')
-    const disabled = result.tools.find((t) => t.name === 'tool-disabled')
-    expect(enabled?.enabled).toBe(true)
-    expect(disabled?.enabled).toBe(false)
-  })
-
-  it('advertises MCP_UI_EXTENSION_CAPABILITY when creating the client', async () => {
-    await getToolhiveMcpInfo()
-
-    expect(mockCreateMCPClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        capabilities: expect.objectContaining({
-          extensions: expect.objectContaining({
-            'io.modelcontextprotocol/ui': expect.anything(),
-          }),
-        }),
-      })
-    )
-  })
-
-  it('closes the AI SDK client after listing tools', async () => {
-    await getToolhiveMcpInfo()
-
-    expect(mockAiMcpClient.close).toHaveBeenCalledOnce()
-  })
-
-  it('returns isRunning: false and logs when createMCPClient throws', async () => {
-    mockCreateMCPClient.mockRejectedValue(new Error('connection refused'))
-
-    const result = await getToolhiveMcpInfo()
-
-    expect(result.isRunning).toBe(false)
-    expect(log.error).toHaveBeenCalledWith(
-      'Failed to get Toolhive MCP info:',
-      expect.any(Error)
-    )
-  })
-
-  it('extracts tool parameters from inputSchema', async () => {
-    mockAiMcpClient.tools.mockResolvedValue({
-      'draw-tool': {
-        description: 'Draw something',
-        inputSchema: {
-          type: 'object',
-          properties: { canvas: { type: 'string' } },
-        },
-      },
-    })
-
-    const result = await getToolhiveMcpInfo()
-
-    expect(result.tools[0]?.parameters).toEqual({
-      canvas: { type: 'string' },
-    })
-  })
-})
-
-// ---------------------------------------------------------------------------
 // getMcpServerTools
 // ---------------------------------------------------------------------------
 
@@ -557,19 +449,6 @@ describe('getMcpServerTools', () => {
     expect(mockGetWorkloadAvailableTools).not.toHaveBeenCalled()
   })
 
-  it('falls back to getToolhiveMcpInfo for the internal ToolHive server', async () => {
-    mockGetApiV1BetaWorkloads.mockResolvedValue({ data: { workloads: [] } })
-    mockGetEnabledMcpTools.mockResolvedValue({ [THV_SERVER]: ['thv-tool'] })
-    mockAiMcpClient.tools.mockResolvedValue({
-      'thv-tool': makeToolDef(),
-    })
-
-    const result = await getMcpServerTools(THV_SERVER)
-
-    expect(result?.serverName).toBe(THV_SERVER)
-    expect(mockCreateMCPClient).toHaveBeenCalled()
-  })
-
   it('throws when a regular server workload is not found', async () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({ data: { workloads: [] } })
 
@@ -612,7 +491,10 @@ describe('createMcpTools', () => {
       ...makeToolDef(),
       _meta: { ui: { resourceUri: 'res://reset-test', visibility: ['model'] } },
     }
-    mockGetEnabledMcpTools.mockResolvedValue({ [THV_SERVER]: ['cached'] })
+    mockGetApiV1BetaWorkloads.mockResolvedValue({
+      data: { workloads: [makeWorkload()] },
+    })
+    mockGetEnabledMcpTools.mockResolvedValue({ 'test-server': ['cached'] })
     mockAiMcpClient.tools.mockResolvedValue({ cached: toolWithUi })
     await createMcpTools()
     expect(getCachedUiMetadata()).toHaveProperty('cached')
@@ -716,35 +598,6 @@ describe('createMcpTools', () => {
     await createMcpTools()
 
     expect(mockCreateMCPClient).not.toHaveBeenCalled()
-  })
-
-  it('registers ToolHive MCP tools when port is available', async () => {
-    mockGetEnabledMcpTools.mockResolvedValue({ [THV_SERVER]: ['thv-draw'] })
-    mockAiMcpClient.tools.mockResolvedValue({ 'thv-draw': makeToolDef() })
-
-    const { tools, clients } = await createMcpTools()
-
-    expect(tools).toHaveProperty('thv-draw')
-    expect(clients).toHaveLength(1)
-    expect(mockCreateMCPClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'toolhive-mcp',
-        capabilities: expect.objectContaining({
-          extensions: expect.objectContaining({
-            'io.modelcontextprotocol/ui': expect.anything(),
-          }),
-        }),
-      })
-    )
-  })
-
-  it('skips ToolHive MCP tools when port is not available', async () => {
-    mockGetToolhiveMcpPort.mockReturnValue(null)
-    mockGetEnabledMcpTools.mockResolvedValue({ [THV_SERVER]: ['thv-draw'] })
-
-    const { tools } = await createMcpTools()
-
-    expect(tools).toEqual({})
   })
 
   it('registers per-server tools using createTransport', async () => {

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/electron/main'
 import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp'
 import type { ToolSet } from 'ai'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import {
   ReadResourceResultSchema,
   CallToolResultSchema,
@@ -12,7 +11,6 @@ import type {
   McpUiResourcePermissions,
 } from '@modelcontextprotocol/ext-apps/app-bridge'
 import { getApiV1BetaWorkloads } from '@common/api/generated/sdk.gen'
-import { getToolhiveMcpPort } from '../toolhive-manager'
 import { createMainProcessApiClient } from '../unix-socket-fetch'
 import log from '../logger'
 import type { AvailableServer } from './types'
@@ -25,7 +23,6 @@ import {
   getWorkloadAvailableTools,
   isMcpToolDefinition,
 } from '../utils/mcp-tools'
-import { TOOLHIVE_MCP_SERVER_NAME } from '../utils/constants'
 import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
 import { readAllMcpAppUiMetadata } from '../db/readers/mcp-app-ui-metadata-reader'
 import { replaceAllMcpAppUiMetadata } from '../db/writers/mcp-app-ui-metadata-writer'
@@ -75,39 +72,6 @@ export function getCachedUiMetadata(): Record<string, ToolUiMetadataEntry> {
 // Private helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Returns the ToolHive-internal MCP URL.
- * Centralizes the port lookup + URL shape used by both AI SDK and raw
- * MCP SDK consumers.
- */
-function getToolhiveMcpUrl(): string {
-  const port = getToolhiveMcpPort()
-  if (!port) throw new Error('Toolhive MCP port not available')
-  return `http://localhost:${port}/mcp`
-}
-
-/**
- * Returns a `MCPClientConfig.transport` for the ToolHive-internal MCP server,
- * suitable for `@ai-sdk/mcp`'s `createMCPClient`.
- *
- * We pass the AI SDK's transport config form (not a transport instance)
- * because `@ai-sdk/mcp` >=1.0.42 assigns to `transport.protocolVersion`
- * after `initialize`, and `StreamableHTTPClientTransport` from
- * `@modelcontextprotocol/sdk` exposes that as a getter-only property
- * which throws on assignment in strict mode.
- */
-function createToolhiveAiSdkTransportConfig(): {
-  type: 'http'
-  url: string
-} {
-  return { type: 'http', url: getToolhiveMcpUrl() }
-}
-
-/** Returns a raw SDK transport for the ToolHive-internal MCP server. */
-function createToolhiveRawMcpTransport(): StreamableHTTPClientTransport {
-  return new StreamableHTTPClientTransport(new URL(getToolhiveMcpUrl()))
-}
-
 /** Fetches all workloads from the ToolHive API. */
 async function fetchWorkloads(): Promise<CoreWorkload[]> {
   const client = createMainProcessApiClient()
@@ -137,12 +101,6 @@ async function createRawMcpClientForServer(
   const clientInfo = { name: 'toolhive-studio-mcp-apps', version: '1.0.0' }
   const clientOptions = {
     capabilities: { extensions: MCP_UI_EXTENSION_CAPABILITY },
-  }
-
-  if (serverName === TOOLHIVE_MCP_SERVER_NAME) {
-    const client = new Client(clientInfo, clientOptions)
-    await client.connect(createToolhiveRawMcpTransport())
-    return { client, close: () => client.close() }
   }
 
   const workload = (await fetchWorkloads()).find((w) => w.name === serverName)
@@ -222,61 +180,6 @@ function getToolParameters(inputSchema: unknown): Record<string, unknown> {
   return {}
 }
 
-// Check if Toolhive MCP is available and get its tools info
-export async function getToolhiveMcpInfo(
-  enabledToolNames: string[] = []
-): Promise<AvailableServer> {
-  const base = {
-    serverName: TOOLHIVE_MCP_SERVER_NAME,
-    serverPackage: 'toolhive-mcp',
-    tools: [],
-    isRunning: false,
-  }
-
-  if (!getToolhiveMcpPort()) {
-    return { ...base, isRunning: false }
-  }
-
-  try {
-    const toolhiveMcpClient = await createMCPClient({
-      name: 'mcp_toolhive',
-      transport: createToolhiveAiSdkTransportConfig(),
-      capabilities: { extensions: MCP_UI_EXTENSION_CAPABILITY },
-    })
-    const toolhiveMcpTools = await toolhiveMcpClient.tools()
-    await toolhiveMcpClient.close()
-
-    const tools = Object.keys(toolhiveMcpTools).map((toolName) => {
-      const toolDef = toolhiveMcpTools[toolName]
-      let description = ''
-
-      if (toolDef && typeof toolDef === 'object') {
-        const tool = toolDef as Record<string, unknown>
-        if (tool.description && typeof tool.description === 'string') {
-          description = tool.description
-        }
-      }
-
-      return {
-        name: toolName,
-        description,
-        parameters: getToolParameters(toolDef?.inputSchema),
-        enabled: enabledToolNames.includes(toolName),
-      }
-    })
-
-    return {
-      serverName: TOOLHIVE_MCP_SERVER_NAME,
-      serverPackage: 'toolhive-mcp',
-      tools,
-      isRunning: true,
-    }
-  } catch (error) {
-    log.error('Failed to get Toolhive MCP info:', error)
-    return { ...base, isRunning: false }
-  }
-}
-
 // Get MCP server tools information
 export async function getMcpServerTools(
   serverName: string,
@@ -295,11 +198,6 @@ export async function getMcpServerTools(
     ? getThreadEnabledMcpTools(threadId)
     : await getEnabledMcpTools()
   const enabledToolNames = enabledTools[serverName] || []
-
-  if (!workload && serverName === TOOLHIVE_MCP_SERVER_NAME) {
-    const toolhiveMcpResult = await getToolhiveMcpInfo(enabledToolNames)
-    return toolhiveMcpResult
-  }
 
   if (!workload) {
     throw new Error('Server not in the workload list')
@@ -377,24 +275,6 @@ export async function createMcpTools(threadId?: string): Promise<{
     return true
   }
 
-  const addToolhiveMcpTools = async () => {
-    if (!getToolhiveMcpPort()) return
-    try {
-      const toolhiveMcpClient = await createMCPClient({
-        name: 'toolhive-mcp',
-        transport: createToolhiveAiSdkTransportConfig(),
-        capabilities: { extensions: MCP_UI_EXTENSION_CAPABILITY },
-      })
-      mcpClients.push(toolhiveMcpClient)
-      const toolhiveMcpTools = await toolhiveMcpClient.tools()
-      for (const [toolName, toolDef] of Object.entries(toolhiveMcpTools)) {
-        registerTool(toolName, toolDef, TOOLHIVE_MCP_SERVER_NAME)
-      }
-    } catch (error) {
-      log.error('Failed to create Toolhive MCP client:', error)
-    }
-  }
-
   try {
     const [workloads, resolvedEnabledTools] = await Promise.all([
       fetchWorkloads(),
@@ -411,11 +291,6 @@ export async function createMcpTools(threadId?: string): Promise<{
       if (toolNames.length === 0) continue
 
       const workload = workloads.find((w) => w.name === serverName)
-
-      if (!workload && serverName === TOOLHIVE_MCP_SERVER_NAME) {
-        await addToolhiveMcpTools()
-        continue
-      }
 
       if (!workload) {
         log.debug(`Skipping ${serverName}: workload not found`)

--- a/main/src/chat/settings-storage.ts
+++ b/main/src/chat/settings-storage.ts
@@ -5,8 +5,6 @@ import { getApiV1BetaWorkloads } from '@common/api/generated/sdk.gen'
 import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
 import { createMainProcessApiClient } from '../unix-socket-fetch'
 import { getTearingDownState } from '../app-state'
-import { getToolhiveMcpInfo } from './mcp-tools'
-import { TOOLHIVE_MCP_SERVER_NAME } from '../utils/constants'
 import {
   CHAT_PROVIDER_INFO,
   LOCAL_PROVIDER_IDS,
@@ -259,25 +257,16 @@ export async function getEnabledMcpTools(): Promise<
         query: { all: true },
       })
 
-      const toolHiveMcpInfo = await getToolhiveMcpInfo()
-
       const runningServerNames = (data?.workloads || [])
         .filter((w: CoreWorkload) => w.status === 'running')
         .map((w: CoreWorkload) => w.name)
-
-      const internalMcpServerName = toolHiveMcpInfo.isRunning
-        ? [TOOLHIVE_MCP_SERVER_NAME]
-        : []
 
       // Filter enabled tools to only include tools from running servers
       const filteredTools: ChatSettings['enabledMcpTools'] = {}
       const serversToRemove: string[] = []
 
       for (const [serverName, tools] of Object.entries(enabledMcpTools)) {
-        if (
-          runningServerNames.includes(serverName) ||
-          internalMcpServerName.includes(serverName)
-        ) {
+        if (runningServerNames.includes(serverName)) {
           filteredTools[serverName] = tools
         } else if (tools.length > 0) {
           // Only log if server actually had tools to clean up

--- a/main/src/ipc-handlers/__tests__/toolhive.test.ts
+++ b/main/src/ipc-handlers/__tests__/toolhive.test.ts
@@ -11,7 +11,6 @@ vi.mock('../../toolhive-manager', () => ({
   getToolhiveSocketPath: vi.fn(),
   isToolhiveRunning: vi.fn(),
   getToolhiveStatus: vi.fn(),
-  getToolhiveMcpPort: vi.fn(),
   isUsingCustomSocket: vi.fn(),
 }))
 
@@ -43,7 +42,6 @@ import {
   getToolhiveSocketPath,
   isToolhiveRunning,
   getToolhiveStatus,
-  getToolhiveMcpPort,
   isUsingCustomSocket,
 } from '../../toolhive-manager'
 import { checkContainerEngine } from '../../container-engine'
@@ -61,7 +59,6 @@ const mockRestartToolhive = vi.mocked(restartToolhive)
 const mockGetSocketPath = vi.mocked(getToolhiveSocketPath)
 const mockIsRunning = vi.mocked(isToolhiveRunning)
 const mockGetStatus = vi.mocked(getToolhiveStatus)
-const mockGetMcpPort = vi.mocked(getToolhiveMcpPort)
 const mockIsUsingCustomSocket = vi.mocked(isUsingCustomSocket)
 const mockCheckContainerEngine = vi.mocked(checkContainerEngine)
 const mockGetLastShutdownServers = vi.mocked(getLastShutdownServers)
@@ -87,7 +84,6 @@ describe('ipc-handlers/toolhive register()', () => {
     const channels = mockHandle.mock.calls.map(([c]) => c)
     expect(channels.sort()).toEqual(
       [
-        'get-toolhive-mcp-port',
         'get-toolhive-socket-path',
         'is-toolhive-running',
         'get-toolhive-status',
@@ -104,13 +100,6 @@ describe('ipc-handlers/toolhive register()', () => {
     register()
 
     expect(mockRegisterApiFetchHandlers).toHaveBeenCalledTimes(1)
-  })
-
-  it('get-toolhive-mcp-port returns the value from the manager', () => {
-    mockGetMcpPort.mockReturnValue(12345)
-    register()
-
-    expect(getHandler('get-toolhive-mcp-port')({})).toBe(12345)
   })
 
   it('get-toolhive-socket-path returns the value from the manager', () => {

--- a/main/src/ipc-handlers/chat/mcp-tools.ts
+++ b/main/src/ipc-handlers/chat/mcp-tools.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron'
-import { getMcpServerTools, getToolhiveMcpInfo } from '../../chat'
+import { getMcpServerTools } from '../../chat'
 import {
   getEnabledMcpTools,
   getEnabledMcpServersFromTools,
@@ -21,5 +21,4 @@ export function register() {
     (_, serverName: string, enabledTools: string[]) =>
       saveEnabledMcpTools(serverName, enabledTools)
   )
-  ipcMain.handle('chat:get-toolhive-mcp-info', () => getToolhiveMcpInfo())
 }

--- a/main/src/ipc-handlers/toolhive.ts
+++ b/main/src/ipc-handlers/toolhive.ts
@@ -4,7 +4,6 @@ import {
   getToolhiveSocketPath,
   isToolhiveRunning,
   getToolhiveStatus,
-  getToolhiveMcpPort,
   isUsingCustomSocket,
 } from '../toolhive-manager'
 import { checkContainerEngine } from '../container-engine'
@@ -13,7 +12,6 @@ import { registerApiFetchHandlers } from '../unix-socket-fetch'
 import log from '../logger'
 
 export function register() {
-  ipcMain.handle('get-toolhive-mcp-port', () => getToolhiveMcpPort())
   ipcMain.handle('get-toolhive-socket-path', () => getToolhiveSocketPath())
   ipcMain.handle('is-toolhive-running', () => isToolhiveRunning())
   ipcMain.handle('get-toolhive-status', () => getToolhiveStatus())

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -2,12 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EventEmitter } from 'node:events'
 import { vol } from 'memfs'
 import { spawn } from 'node:child_process'
-import net from 'node:net'
 import { platform } from 'node:os'
 import { app } from 'electron'
 import {
   startToolhive,
-  getToolhiveMcpPort,
   getToolhiveSocketPath,
   getToolhiveStatus,
   isToolhiveRunning,
@@ -46,18 +44,6 @@ vi.mock('node:os', async (importOriginal) => {
   }
 })
 vi.mock('node:fs')
-vi.mock('node:net', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:net')>()
-  const mockCreateServerFn = vi.fn()
-  return {
-    ...actual,
-    createServer: mockCreateServerFn,
-    default: {
-      ...actual,
-      createServer: mockCreateServerFn,
-    },
-  }
-})
 vi.mock('electron', () => ({
   app: {
     isPackaged: false,
@@ -101,7 +87,6 @@ vi.mock('electron-store', () => {
 
 // Get mocked functions
 const mockSpawn = vi.mocked(spawn)
-const mockNet = vi.mocked(net)
 const mockApp = vi.mocked(app)
 const mockUpdateTrayStatus = vi.mocked(updateTrayStatus)
 const mockLog = vi.mocked(log)
@@ -119,34 +104,6 @@ class MockProcess extends EventEmitter {
     // Don't automatically set killed - let tests control this
     // This allows testing delayed SIGKILL scenarios
     return true
-  }
-}
-
-// Mock server for net.createServer
-class MockServer extends EventEmitter {
-  private _port: number | null = null
-
-  listen(port: number, callback?: () => void) {
-    // Use fake timers - will be controlled by vi.advanceTimersByTime()
-    setTimeout(() => {
-      if (port === 0) {
-        // Simulate OS assigning a random port
-        this._port = Math.floor(Math.random() * 10000) + 10000
-      } else {
-        this._port = port
-      }
-      callback?.()
-    }, 10)
-  }
-
-  address() {
-    return { port: this._port }
-  }
-
-  close(callback?: () => void) {
-    setTimeout(() => {
-      callback?.()
-    }, 10)
   }
 }
 
@@ -181,11 +138,6 @@ describe('toolhive-manager', () => {
       configurable: true,
     })
     vi.mocked(mockApp.getPath).mockReturnValue('/test/userData')
-
-    // Mock net.createServer to return a new MockServer instance each time
-    mockNet.createServer.mockImplementation(function createServer() {
-      return new MockServer() as unknown as net.Server
-    })
 
     // Mock logger methods
     mockLog.info = vi.fn()
@@ -226,9 +178,6 @@ describe('toolhive-manager', () => {
         expect.arrayContaining([
           'serve',
           '--openapi',
-          '--experimental-mcp',
-          '--experimental-mcp-host=127.0.0.1',
-          expect.stringMatching(/--experimental-mcp-port=\d+/),
           expect.stringMatching(/--socket=.+/),
         ]),
         {
@@ -246,7 +195,6 @@ describe('toolhive-manager', () => {
       )
       expect(isToolhiveRunning()).toBe(true)
       expect(getToolhiveSocketPath()).toBeTypeOf('string')
-      expect(getToolhiveMcpPort()).toBeTypeOf('number')
     })
 
     it('updates tray status after starting', async () => {
@@ -388,11 +336,9 @@ describe('toolhive-manager', () => {
         await startPromise
 
         const socketPath = getToolhiveSocketPath()
-        const mcpPort = getToolhiveMcpPort()
 
         expect(socketPath).toBeTypeOf('string')
         expect(socketPath).toMatch(/toolhive-\d+\.sock$/)
-        expect(mcpPort).toBeTypeOf('number')
 
         const spawnArgs = mockSpawn.mock.calls[0]![1] as string[]
         expect(spawnArgs).toEqual(
@@ -425,7 +371,6 @@ describe('toolhive-manager', () => {
         expect(socketPath).toBeTypeOf('string')
         // Named pipe shape: \\.\pipe\toolhive-<pid>
         expect(socketPath).toMatch(/^\\\\\.\\pipe\\toolhive-\d+$/)
-        expect(getToolhiveMcpPort()).toBeTypeOf('number')
 
         const spawnArgs = mockSpawn.mock.calls[0]![1] as string[]
         expect(spawnArgs).toEqual(
@@ -441,20 +386,17 @@ describe('toolhive-manager', () => {
       }
     })
 
-    it('logs socket path and MCP port on startup', async () => {
+    it('logs socket path on startup', async () => {
       const startPromise = startToolhive()
 
       await vi.advanceTimersByTimeAsync(50)
       await startPromise
 
       expect(getToolhiveSocketPath()).toBeTypeOf('string')
-      expect(getToolhiveMcpPort()).toBeTypeOf('number')
 
-      // Verify the log message includes the socket path and MCP port
+      // Verify the log message includes the socket path
       expect(mockLog.info).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /Starting ToolHive from: .+ on socket .+, MCP on port \d+/
-        )
+        expect.stringMatching(/Starting ToolHive from: .+ on socket .+/)
       )
     })
 
@@ -469,9 +411,6 @@ describe('toolhive-manager', () => {
         expect.arrayContaining([
           'serve',
           '--openapi',
-          '--experimental-mcp',
-          '--experimental-mcp-host=127.0.0.1',
-          expect.stringMatching(/--experimental-mcp-port=\d+/),
           expect.stringMatching(/--socket=.+/),
         ]),
         {
@@ -592,24 +531,6 @@ describe('toolhive-manager', () => {
       await vi.advanceTimersByTimeAsync(5000)
 
       expect(getToolhiveStatus().processError).toBeUndefined()
-    })
-  })
-
-  describe('port finding', () => {
-    it('uses an OS-assigned random port for the MCP service', async () => {
-      const startPromise = startToolhive()
-
-      await vi.advanceTimersByTimeAsync(50)
-      await startPromise
-
-      // findFreePort() is called without a range, so it uses OS assignment
-      // (server.listen(0, ...)) which always succeeds. No fallback warning is
-      // expected on the happy path.
-      expect(mockLog.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining('falling back to random port')
-      )
-      expect(isToolhiveRunning()).toBe(true)
-      expect(getToolhiveMcpPort()).toBeTypeOf('number')
     })
   })
 
@@ -778,7 +699,6 @@ describe('toolhive-manager', () => {
 
       expect(isToolhiveRunning()).toBe(false)
       expect(getToolhiveSocketPath()).toBeUndefined()
-      expect(getToolhiveMcpPort()).toBeUndefined()
       expect(mockLog.info).toHaveBeenCalledWith(
         '[stopToolhive] Process cleanup completed'
       )
@@ -892,69 +812,30 @@ describe('toolhive-manager', () => {
 
   describe('external thv via THV_SOCKET', () => {
     const originalSocket = process.env.THV_SOCKET
-    const originalMcpPort = process.env.THV_MCP_PORT
 
     afterEach(() => {
       if (originalSocket === undefined) delete process.env.THV_SOCKET
       else process.env.THV_SOCKET = originalSocket
-      if (originalMcpPort === undefined) delete process.env.THV_MCP_PORT
-      else process.env.THV_MCP_PORT = originalMcpPort
     })
 
     it('reports running and exposes the socket without spawning thv', async () => {
       process.env.THV_SOCKET = '/tmp/external-thv.sock'
-      delete process.env.THV_MCP_PORT
 
       await startToolhive()
 
       expect(mockSpawn).not.toHaveBeenCalled()
       expect(isToolhiveRunning()).toBe(true)
       expect(getToolhiveSocketPath()).toBe('/tmp/external-thv.sock')
-      expect(getToolhiveMcpPort()).toBeUndefined()
     })
 
     it('does not clear THV_SOCKET path when stopToolhive has no child to stop', async () => {
       process.env.THV_SOCKET = '/tmp/external-thv.sock'
-      delete process.env.THV_MCP_PORT
 
       await startToolhive()
       stopToolhive()
 
       expect(getToolhiveSocketPath()).toBe('/tmp/external-thv.sock')
       expect(isToolhiveRunning()).toBe(true)
-    })
-
-    it('parses a valid THV_MCP_PORT', async () => {
-      process.env.THV_SOCKET = '/tmp/external-thv.sock'
-      process.env.THV_MCP_PORT = '40000'
-
-      await startToolhive()
-
-      expect(getToolhiveMcpPort()).toBe(40000)
-    })
-
-    it('falls back to undefined and warns on a non-numeric THV_MCP_PORT', async () => {
-      process.env.THV_SOCKET = '/tmp/external-thv.sock'
-      process.env.THV_MCP_PORT = 'not-a-port'
-
-      await startToolhive()
-
-      expect(getToolhiveMcpPort()).toBeUndefined()
-      expect(mockLog.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Ignoring invalid THV_MCP_PORT=not-a-port')
-      )
-    })
-
-    it('rejects out-of-range THV_MCP_PORT values', async () => {
-      process.env.THV_SOCKET = '/tmp/external-thv.sock'
-      process.env.THV_MCP_PORT = '70000'
-
-      await startToolhive()
-
-      expect(getToolhiveMcpPort()).toBeUndefined()
-      expect(mockLog.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Ignoring invalid THV_MCP_PORT=70000')
-      )
     })
   })
 })

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -1,7 +1,6 @@
 import { spawn } from 'node:child_process'
 import { existsSync, unlinkSync } from 'node:fs'
 import path from 'node:path'
-import net from 'node:net'
 import { app } from 'electron'
 import { updateTrayStatus } from './system-tray'
 import log from './logger'
@@ -35,16 +34,11 @@ const binPath = app.isPackaged
     )
 
 let toolhiveProcess: ReturnType<typeof spawn> | undefined
-let toolhiveMcpPort: number | undefined
 let toolhiveSocketPath: string | undefined
 let isRestarting = false
 let isStopping = false
 let killTimer: NodeJS.Timeout | undefined
 let processError: ToolhiveProcessError | undefined
-
-export function getToolhiveMcpPort(): number | undefined {
-  return toolhiveMcpPort
-}
 
 export function getToolhiveSocketPath(): string | undefined {
   return toolhiveSocketPath
@@ -81,80 +75,6 @@ export function isUsingCustomSocket(): boolean {
   return !app.isPackaged && !!process.env.THV_SOCKET
 }
 
-/**
- * Parses THV_MCP_PORT into a positive integer. Returns `undefined` for
- * unset / blank / non-numeric / out-of-range values and logs a warning so
- * a typo doesn't silently turn into NaN being treated as a real port.
- */
-function parseMcpPortEnv(raw: string | undefined): number | undefined {
-  if (!raw) return undefined
-  const port = Number(raw)
-  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
-    log.warn(
-      `Ignoring invalid THV_MCP_PORT=${raw}; expected an integer in 1..65535`
-    )
-    return undefined
-  }
-  return port
-}
-
-async function findFreePort(
-  minPort?: number,
-  maxPort?: number
-): Promise<number> {
-  const checkPort = (port: number): Promise<boolean> => {
-    return new Promise((resolve) => {
-      const server = net.createServer()
-      server.listen(port, () => {
-        server.close(() => resolve(true))
-      })
-      server.on('error', () => resolve(false))
-    })
-  }
-
-  const getRandomPort = (): Promise<number> => {
-    return new Promise((resolve, reject) => {
-      const server = net.createServer()
-      server.listen(0, () => {
-        const address = server.address()
-        if (typeof address === 'object' && address && address.port) {
-          const port = address.port
-          server.close(() => resolve(port))
-        } else {
-          reject(new Error('Failed to get random port'))
-        }
-      })
-      server.on('error', reject)
-    })
-  }
-
-  // If no range specified, use OS assignment directly
-  if (!minPort || !maxPort) {
-    return await getRandomPort()
-  }
-
-  // Try random ports within range for better distribution
-  const attempts = Math.min(20, maxPort - minPort + 1)
-  const triedPorts = new Set<number>()
-
-  for (let i = 0; i < attempts; i++) {
-    const port = Math.floor(Math.random() * (maxPort - minPort + 1)) + minPort
-
-    if (triedPorts.has(port)) continue
-    triedPorts.add(port)
-
-    if (await checkPort(port)) {
-      return port
-    }
-  }
-
-  // Fallback to OS-assigned random port
-  log.warn(
-    `No free port found in range ${minPort}-${maxPort}, falling back to random port`
-  )
-  return await getRandomPort()
-}
-
 function generateSocketPath(): string {
   // Windows AF_UNIX sockets created in %TEMP% hit EACCES on connect due to
   // DACL handling. Named pipes are the canonical Windows IPC and are
@@ -184,7 +104,6 @@ export async function startToolhive(): Promise<void> {
   Sentry.withScope<Promise<void>>(async (scope) => {
     if (isUsingCustomSocket()) {
       toolhiveSocketPath = process.env.THV_SOCKET!
-      toolhiveMcpPort = parseMcpPortEnv(process.env.THV_MCP_PORT)
       // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
       log.info(`Using external ToolHive on socket ${toolhiveSocketPath}`)
       return
@@ -197,22 +116,14 @@ export async function startToolhive(): Promise<void> {
     }
 
     processError = undefined
-    toolhiveMcpPort = await findFreePort()
     toolhiveSocketPath = generateSocketPath()
     cleanupSocketFile(toolhiveSocketPath)
 
     log.info(
-      `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}, MCP on port ${toolhiveMcpPort}`
+      `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}`
     )
 
-    const serveArgs = [
-      'serve',
-      '--openapi',
-      '--experimental-mcp',
-      '--experimental-mcp-host=127.0.0.1',
-      `--experimental-mcp-port=${toolhiveMcpPort}`,
-      `--socket=${toolhiveSocketPath}`,
-    ]
+    const serveArgs = ['serve', '--openapi', `--socket=${toolhiveSocketPath}`]
 
     const isE2E = process.env.TOOLHIVE_E2E === 'true'
     const sentryDsn = isE2E ? undefined : import.meta.env.VITE_SENTRY_THV_DSN
@@ -244,7 +155,7 @@ export async function startToolhive(): Promise<void> {
 
     scope.addBreadcrumb({
       category: 'debug',
-      message: `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}, MCP on port ${toolhiveMcpPort}, PID: ${child.pid}`,
+      message: `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}, PID: ${child.pid}`,
     })
 
     updateTrayStatus(!!child)
@@ -297,7 +208,6 @@ export async function startToolhive(): Promise<void> {
       if (toolhiveProcess === child) {
         toolhiveProcess = undefined
         toolhiveSocketPath = undefined
-        toolhiveMcpPort = undefined
         isStopping = false
         // Drop the pending SIGKILL timer - the child is already gone and a
         // live setTimeout would keep the event loop alive during shutdown.
@@ -408,7 +318,6 @@ export function stopToolhive(options?: { force?: boolean }): void {
     // THV_SOCKET — that path is not owned by this process and must stay visible.
     if ((!toolhiveProcess || hasExited) && !isUsingCustomSocket()) {
       toolhiveSocketPath = undefined
-      toolhiveMcpPort = undefined
     }
     return
   }
@@ -436,7 +345,6 @@ export function stopToolhive(options?: { force?: boolean }): void {
     // bridge until the real `exit` handler runs (mock tests may not emit exit).
     if (!isUsingCustomSocket()) {
       toolhiveSocketPath = undefined
-      toolhiveMcpPort = undefined
     }
     log.info(`[stopToolhive] Process cleanup completed`)
     return
@@ -451,7 +359,6 @@ export function stopToolhive(options?: { force?: boolean }): void {
     cleanupSocketFile(toolhiveSocketPath)
   }
   toolhiveSocketPath = undefined
-  toolhiveMcpPort = undefined
 
   log.info(`[stopToolhive] Process cleanup completed`)
 }

--- a/main/src/utils/constants.ts
+++ b/main/src/utils/constants.ts
@@ -1,1 +1,0 @@
-export const TOOLHIVE_MCP_SERVER_NAME = 'toolhive-mcp-internal'

--- a/preload/src/api/chat.ts
+++ b/preload/src/api/chat.ts
@@ -81,7 +81,6 @@ export const chatApi = {
         serverName,
         enabledTools
       ),
-    getToolhiveMcpInfo: () => ipcRenderer.invoke('chat:get-toolhive-mcp-info'),
     getEnabledSkills: (installedNames?: readonly string[]) =>
       ipcRenderer.invoke('chat:get-enabled-skills', installedNames) as Promise<
         string[]
@@ -314,7 +313,6 @@ export interface ChatAPI {
       serverName: string,
       enabledTools: string[]
     ) => Promise<{ success: boolean; error?: string }>
-    getToolhiveMcpInfo: () => Promise<AvailableServer>
     getEnabledSkills: (installedNames?: readonly string[]) => Promise<string[]>
     setEnabledSkill: (
       name: string,

--- a/preload/src/api/toolhive.ts
+++ b/preload/src/api/toolhive.ts
@@ -3,7 +3,6 @@ import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@
 import type { ToolhiveStatus } from '../../../common/types/toolhive-status'
 
 export const toolhiveApi = {
-  getToolhiveMcpPort: () => ipcRenderer.invoke('get-toolhive-mcp-port'),
   getToolhiveSocketPath: () => ipcRenderer.invoke('get-toolhive-socket-path'),
   isToolhiveRunning: () => ipcRenderer.invoke('is-toolhive-running'),
   getToolhiveStatus: () => ipcRenderer.invoke('get-toolhive-status'),
@@ -30,7 +29,6 @@ export const toolhiveApi = {
 }
 
 export interface ToolhiveAPI {
-  getToolhiveMcpPort: () => Promise<number | undefined>
   getToolhiveSocketPath: () => Promise<string | undefined>
   isToolhiveRunning: () => Promise<boolean>
   getToolhiveStatus: () => Promise<ToolhiveStatus>

--- a/renderer/src/features/chat/components/mcp-server-badge.tsx
+++ b/renderer/src/features/chat/components/mcp-server-badge.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query'
 import { Badge } from '@/common/components/ui/badge'
 import { Settings2 } from 'lucide-react'
 import { McpToolsModal } from './mcp-tools-modal'
-import { getNormalizedServerName } from '../lib/utils'
 import { trackEvent } from '@/common/lib/analytics'
 
 interface McpServerBadgeProps {
@@ -48,7 +47,7 @@ export function McpServerBadge({
         className="group h-auto max-w-48 cursor-pointer"
         onClick={handleBadgeClick}
       >
-        <span className="truncate">{getNormalizedServerName(serverName)}</span>
+        <span className="truncate">{serverName}</span>
         <Badge variant="outline" className="bg-background/90 font-light">
           {getEnabledToolsCount()} tools
         </Badge>

--- a/renderer/src/features/chat/components/mcp-server-selector.tsx
+++ b/renderer/src/features/chat/components/mcp-server-selector.tsx
@@ -15,7 +15,6 @@ import { ChevronDown, Loader2, ServerIcon, Settings2 } from 'lucide-react'
 import { Badge } from '@/common/components/ui/badge'
 import { ScrollArea } from '@/common/components/ui/scroll-area'
 import { useAvailableServers } from '../hooks/use-available-servers'
-import { getNormalizedServerName } from '../lib/utils'
 import { McpToolsModal } from './mcp-tools-modal'
 import { cn } from '@/common/lib/utils'
 import {
@@ -215,12 +214,10 @@ export function McpServerSelector({ threadId }: McpServerSelectorProps) {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span className="max-w-30 truncate font-normal">
-                          {getNormalizedServerName(server.name)}
+                          {server.name}
                         </span>
                       </TooltipTrigger>
-                      <TooltipContent>
-                        {getNormalizedServerName(server.name)}
-                      </TooltipContent>
+                      <TooltipContent>{server.name}</TooltipContent>
                     </Tooltip>
                   </div>
                   {backendEnabledTools.includes(server.name) && (

--- a/renderer/src/features/chat/components/mcp-tools-modal.tsx
+++ b/renderer/src/features/chat/components/mcp-tools-modal.tsx
@@ -16,7 +16,6 @@ import { Input } from '@/common/components/ui/input'
 
 import { Search, Wrench, AlertCircle, CheckCheck, ListX } from 'lucide-react'
 import { cn } from '@/common/lib/utils'
-import { getNormalizedServerName } from '../lib/utils'
 import { ScrollArea } from '@/common/components/ui/scroll-area'
 import { trackEvent } from '@/common/lib/analytics'
 
@@ -179,10 +178,10 @@ export function McpToolsModal({
             Manage tools
           </DialogTitle>
           <DialogDescription
-            aria-describedby={`Manage the tools for ${getNormalizedServerName(serverName)}`}
+            aria-describedby={`Manage the tools for ${serverName}`}
           />
           <div className="flex items-center gap-1">
-            {getNormalizedServerName(serverName)}
+            {serverName}
             <Badge variant="secondary" className="text-muted-foreground">
               {enabledCount} tools enabled
             </Badge>

--- a/renderer/src/features/chat/hooks/use-available-servers.ts
+++ b/renderer/src/features/chat/hooks/use-available-servers.ts
@@ -3,7 +3,6 @@ import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import type { ChatMcpServer } from '../types'
-import { TOOLHIVE_MCP_SERVER_NAME } from '../lib/constants'
 
 /**
  * Pass `threadId` to scope the enabled-servers view to that thread; omit it
@@ -38,14 +37,6 @@ export function useAvailableServers(threadId?: string | null) {
     [enabledMcpTools]
   )
 
-  const { data: toolhiveMcpInfo } = useQuery({
-    queryKey: ['toolhive-mcp-info'],
-    queryFn: () => window.electronAPI.chat.getToolhiveMcpInfo(),
-    refetchInterval: 5000, // Refresh every 5 seconds
-    staleTime: 0,
-    refetchOnMount: true,
-  })
-
   // Process workloads data to get running MCP servers
   const installedMcpServers: ChatMcpServer[] = (workloadsData?.workloads || [])
     .filter((w: CoreWorkload) => w.status === 'running' && w.url)
@@ -56,21 +47,9 @@ export function useAvailableServers(threadId?: string | null) {
       package: w.package,
     }))
 
-  const internalMcpServers: ChatMcpServer[] = toolhiveMcpInfo?.isRunning
-    ? [
-        {
-          id: 'mcp_toolhive',
-          name: TOOLHIVE_MCP_SERVER_NAME,
-          status: 'running',
-          package: 'toolhive-mcp',
-        },
-      ]
-    : []
-
-  const allAvailableMcpServer = [
-    ...installedMcpServers,
-    ...internalMcpServers,
-  ].sort((a, b) => a.name.localeCompare(b.name))
+  const allAvailableMcpServer = [...installedMcpServers].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  )
 
   const enabledMcpServers = allAvailableMcpServer.filter((server) =>
     backendEnabledTools.includes(server.name)

--- a/renderer/src/features/chat/lib/constants.ts
+++ b/renderer/src/features/chat/lib/constants.ts
@@ -1,1 +1,0 @@
-export const TOOLHIVE_MCP_SERVER_NAME = 'toolhive-mcp-internal'

--- a/renderer/src/features/chat/lib/utils.ts
+++ b/renderer/src/features/chat/lib/utils.ts
@@ -1,12 +1,4 @@
-import { TOOLHIVE_MCP_SERVER_NAME } from './constants'
 import type { ChatSettings } from '../types'
-
-export const getNormalizedServerName = (serverName: string) => {
-  if (serverName === TOOLHIVE_MCP_SERVER_NAME) {
-    return 'toolhive mcp'
-  }
-  return serverName
-}
 
 type ProviderSettings =
   | {


### PR DESCRIPTION
## Summary

Removes the experimental MCP backend — previously spawned via `thv serve --experimental-mcp*` and surfaced in the playground as the internal `toolhive-mcp-internal` server. The feature is removed end-to-end across the main process, IPC/preload, renderer, and docs.

## Migration note: orphaned settings self-heal

Existing users may have enabled-tool entries persisted under `toolhive-mcp-internal`. These self-heal automatically — `getEnabledMcpTools()` no longer matches the internal name against running servers, so the orphaned key is cleaned up on next read (emitting a one-time `Cleaning up tools for stopped server` info log). No migration or manual cleanup needed.

## Testing

- `pnpm run type-check` ✅
- `pnpm run lint` ✅
- `pnpm run knip` ✅
- Affected unit tests (mcp-tools, toolhive-manager, ipc toolhive) ✅
- Manually verified that other MCP servers can still be enabled in the playground, and that the ToolHive MCP server is no longer present by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)