### PR TITLE
fix(registry): sort aggregated MCP servers alphabetically across sources (#1956)

### DIFF
--- a/renderer/src/routes/(registry)/registry-group_.$name.tsx
+++ b/renderer/src/routes/(registry)/registry-group_.$name.tsx
@@ -44,6 +44,28 @@ function RegistryGroupDetail() {
     Object.keys(group?.servers ?? {}).length > 0 ||
     Object.keys(group?.remote_servers ?? {}).length > 0
 
+  // Merge local and remote servers into a single list sorted alphabetically by
+  // name (case-insensitive) so servers from all sources are interleaved rather
+  // than clustered per source. See issue #1956.
+  const sortedGroupServers = [
+    ...Object.entries(group?.servers ?? {}).map(
+      ([key, server]: [string, RegistryImageMetadata]) => ({
+        key: `local-${key}`,
+        server,
+      })
+    ),
+    ...Object.entries(group?.remote_servers ?? {}).map(
+      ([key, server]: [string, RegistryRemoteServerMetadata]) => ({
+        key: `remote-${key}`,
+        server,
+      })
+    ),
+  ].sort((a, b) =>
+    (a.server.name ?? '').localeCompare(b.server.name ?? '', undefined, {
+      sensitivity: 'base',
+    })
+  )
+
   return (
     <div className="flex max-h-full w-full flex-1 flex-col">
       <RegistryDetailHeader
@@ -73,26 +95,14 @@ function RegistryGroupDetail() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {Object.entries(group?.servers ?? {}).map(
-                  ([key, srv]: [string, RegistryImageMetadata]) => (
-                    <TableRow key={`local-${key}`}>
-                      <TableCell className="text-foreground">
-                        {srv.name}
-                      </TableCell>
-                      <TableCell>{srv.description}</TableCell>
-                    </TableRow>
-                  )
-                )}
-                {Object.entries(group?.remote_servers ?? {}).map(
-                  ([key, srv]: [string, RegistryRemoteServerMetadata]) => (
-                    <TableRow key={`remote-${key}`}>
-                      <TableCell className="text-foreground">
-                        {srv.name}
-                      </TableCell>
-                      <TableCell>{srv.description}</TableCell>
-                    </TableRow>
-                  )
-                )}
+                {sortedGroupServers.map(({ key, server }) => (
+                  <TableRow key={key}>
+                    <TableCell className="text-foreground">
+                      {server.name}
+                    </TableCell>
+                    <TableCell>{server.description}</TableCell>
+                  </TableRow>
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/renderer/src/routes/__tests__/registry-group_.$name.test.tsx
+++ b/renderer/src/routes/__tests__/registry-group_.$name.test.tsx
@@ -266,6 +266,70 @@ describe('Registry Group Detail Route', () => {
     expect(screen.getByText('HuggingFace model inference')).toBeVisible()
   })
 
+  it('sorts servers alphabetically across local and remote sources (#1956)', async () => {
+    mockUseParams.mockReturnValue({ name: 'multi-source' })
+
+    // Two sources (local `servers` and remote `remote_servers`) with names
+    // deliberately interleaved and out of order. The rendered table must be a
+    // single alphabetical list across both sources, not clustered per source.
+    mockedGetApiV1BetaRegistryByName.override(
+      () =>
+        ({
+          registry: {
+            servers: {},
+            groups: [
+              {
+                name: 'multi-source',
+                description: 'Servers aggregated from multiple sources',
+                servers: {
+                  zebra: {
+                    name: 'zebra',
+                    description: 'Local server zebra',
+                    image: 'ghcr.io/example/zebra:latest',
+                  },
+                  delta: {
+                    name: 'delta',
+                    description: 'Local server delta',
+                    image: 'ghcr.io/example/delta:latest',
+                  },
+                },
+                remote_servers: {
+                  alpha: {
+                    name: 'alpha',
+                    description: 'Remote server alpha',
+                    url: 'https://example.com/alpha',
+                  },
+                  mango: {
+                    name: 'mango',
+                    description: 'Remote server mango',
+                    url: 'https://example.com/mango',
+                  },
+                },
+              },
+            ],
+          },
+        }) as unknown as V1GetRegistryResponse
+    )
+
+    const router = createTestRouter(WrapperComponent)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'multi-source' })
+      ).toBeVisible()
+    })
+
+    const table = screen.getByRole('table')
+    const bodyRows = within(table).getAllByRole('row').slice(1) // skip header
+    const renderedNames = bodyRows.map((row) =>
+      within(row).getAllByRole('cell')[0]?.textContent?.trim()
+    )
+
+    // Fully alphabetical across both sources, NOT local-then-remote clusters.
+    expect(renderedNames).toEqual(['alpha', 'delta', 'mango', 'zebra'])
+  })
+
   it('opens install wizard when clicking Install group button', async () => {
     const rec = recordRequests()
 


### PR DESCRIPTION
## Summary

When the ToolHive UI connects to a registry that aggregates servers from multiple sources, MCP servers were listed in **source order first, then alphabetically within each source** — producing clusters per source rather than a single unified list.

This was visible on the **registry group detail view** (`/registry-group/$name`): all local servers (`group.servers`) were rendered first, followed by all remote servers (`group.remote_servers`), with alphabetical ordering only applied within each block.

> Note: the main registry list (`/registry`) already sorts globally via `useFilterSort` (case-insensitive `localeCompare`), so it was already correct. The remaining clustering was only on the group detail view, which is what this PR fixes.

## Change

Merge the local and remote servers of a group into a **single list sorted alphabetically by name (case-insensitive)** before rendering, so servers from all sources are interleaved into one unified alphabetical list. Remote vs. local handling is preserved (both kinds are still rendered; row keys keep their `local-`/`remote-` prefixes).

```ts
[...local, ...remote].sort((a, b) =>
  (a.server.name ?? '').localeCompare(b.server.name ?? '', undefined, { sensitivity: 'base' })
)
```

This matches the existing `localeCompare` style already used in `lib/group-env-vars.ts`.

## Testing

- Added a colocated regression test in `renderer/src/routes/__tests__/registry-group_.$name.test.tsx` that mocks a group with two sources whose names are deliberately interleaved/out of order (local: `zebra`, `delta`; remote: `alpha`, `mango`) and asserts the rendered order is fully alphabetical (`alpha, delta, mango, zebra`).
  - Verified red→green: without the fix the order is `zebra, delta, alpha, mango` (source clusters); with the fix it is `alpha, delta, mango, zebra`.
- `pnpm run lint` ✅
- `pnpm run type-check` ✅
- `pnpm run test:nonInteractive` ✅ (132 tests pass, including the new one)

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
