### PR TITLE
fix: default network isolation to enabled for new workloads

### DIFF
--- a/renderer/src/features/mcp-servers/components/__tests__/network-isolation-tab-content.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/network-isolation-tab-content.test.tsx
@@ -101,7 +101,7 @@ describe('NetworkIsolationTabContent', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            'This configuration blocks all outbound network traffic from the MCP server.'
+            'All outbound traffic is permitted. Add specific hosts or ports below to restrict network access.'
           )
         ).toBeInTheDocument()
       })
@@ -130,7 +130,7 @@ describe('NetworkIsolationTabContent', () => {
 
       expect(
         screen.queryByText(
-          'This configuration blocks all outbound network traffic from the MCP server.'
+          'All outbound traffic is permitted. Add specific hosts or ports below to restrict network access.'
         )
       ).not.toBeInTheDocument()
     })
@@ -156,7 +156,7 @@ describe('NetworkIsolationTabContent', () => {
 
       expect(
         screen.queryByText(
-          'This configuration blocks all outbound network traffic from the MCP server.'
+          'All outbound traffic is permitted. Add specific hosts or ports below to restrict network access.'
         )
       ).not.toBeInTheDocument()
     })
@@ -182,7 +182,7 @@ describe('NetworkIsolationTabContent', () => {
 
       expect(
         screen.queryByText(
-          'This configuration blocks all outbound network traffic from the MCP server.'
+          'All outbound traffic is permitted. Add specific hosts or ports below to restrict network access.'
         )
       ).not.toBeInTheDocument()
     })

--- a/renderer/src/features/mcp-servers/components/local-mcp/__tests__/dialog-form-local-mcp.test.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/__tests__/dialog-form-local-mcp.test.tsx
@@ -329,6 +329,52 @@ describe('DialogFormLocalMcp', () => {
     })
   })
 
+  it('defaults networkIsolation to true for a new server', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunCustomServer.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    renderWithProviders(
+      <Wrapper>
+        <DialogFormLocalMcp isOpen closeDialog={vi.fn()} groupName="default" />
+      </Wrapper>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Fill minimal required fields and submit
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /name/i }),
+      'test-server'
+    )
+    await userEvent.click(screen.getByLabelText('Transport'))
+    await userEvent.click(screen.getByRole('option', { name: 'stdio' }))
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Docker image' }),
+      'ghcr.io/test/server'
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install server' })
+    )
+
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalledWith(
+        {
+          data: expect.objectContaining({
+            networkIsolation: true,
+          }),
+        },
+        expect.any(Object)
+      )
+    })
+  })
+
   it('submits package manager form with all fields', async () => {
     const mockInstallServerMutation = vi.fn()
     mockUseRunCustomServer.mockReturnValue({

--- a/renderer/src/features/mcp-servers/components/local-mcp/__tests__/dialog-form-local-mcp.test.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/__tests__/dialog-form-local-mcp.test.tsx
@@ -1039,7 +1039,7 @@ describe('DialogFormLocalMcp', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            'This configuration blocks all outbound network traffic from the MCP server.'
+            'All outbound traffic is permitted. Add specific hosts or ports below to restrict network access.'
           )
         ).toBeInTheDocument()
       })
@@ -1052,7 +1052,7 @@ describe('DialogFormLocalMcp', () => {
       await waitFor(() => {
         expect(
           screen.queryByText(
-            'This configuration blocks all outbound network traffic from the MCP server.'
+            'All outbound traffic is permitted. Add specific hosts or ports below to restrict network access.'
           )
         ).not.toBeInTheDocument()
       })

--- a/renderer/src/features/mcp-servers/components/local-mcp/__tests__/dialog-form-local-mcp.test.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/__tests__/dialog-form-local-mcp.test.tsx
@@ -806,7 +806,6 @@ describe('DialogFormLocalMcp', () => {
       const networkTab = screen.getByRole('tab', { name: /network isolation/i })
       await userEvent.click(networkTab)
 
-      // Network isolation is enabled by default; no need to toggle the switch
       const addHostBtn = screen.getByRole('button', { name: /add a host/i })
       await userEvent.click(addHostBtn)
       const hostInput = screen.getByLabelText('Host 1')
@@ -971,7 +970,6 @@ describe('DialogFormLocalMcp', () => {
       const networkTab = screen.getByRole('tab', { name: /network isolation/i })
       await userEvent.click(networkTab)
 
-      // Network isolation is enabled by default; no need to toggle the switch
       const addHostBtn = screen.getByRole('button', { name: /add a host/i })
       await userEvent.click(addHostBtn)
       const hostInput = screen.getByLabelText('Host 1')
@@ -1035,7 +1033,6 @@ describe('DialogFormLocalMcp', () => {
       const networkTab = screen.getByRole('tab', { name: /network isolation/i })
       await userEvent.click(networkTab)
 
-      // Network isolation is enabled by default; no need to toggle the switch
       await waitFor(() => {
         expect(
           screen.getByText(
@@ -1094,7 +1091,6 @@ describe('DialogFormLocalMcp', () => {
       const networkTab = screen.getByRole('tab', { name: /network isolation/i })
       await userEvent.click(networkTab)
 
-      // Network isolation is enabled by default
       const switchLabel = screen.getByLabelText(
         'Enable outbound network filtering'
       )

--- a/renderer/src/features/mcp-servers/components/local-mcp/__tests__/dialog-form-local-mcp.test.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/__tests__/dialog-form-local-mcp.test.tsx
@@ -318,7 +318,7 @@ describe('DialogFormLocalMcp', () => {
             envVars: [],
             secrets: [],
             cmd_arguments: [],
-            networkIsolation: false,
+            networkIsolation: true,
             allowedHosts: [],
             allowedPorts: [],
             target_port: 0,
@@ -806,11 +806,7 @@ describe('DialogFormLocalMcp', () => {
       const networkTab = screen.getByRole('tab', { name: /network isolation/i })
       await userEvent.click(networkTab)
 
-      const switchLabel = screen.getByLabelText(
-        'Enable outbound network filtering'
-      )
-      await userEvent.click(switchLabel)
-
+      // Network isolation is enabled by default; no need to toggle the switch
       const addHostBtn = screen.getByRole('button', { name: /add a host/i })
       await userEvent.click(addHostBtn)
       const hostInput = screen.getByLabelText('Host 1')
@@ -873,6 +869,14 @@ describe('DialogFormLocalMcp', () => {
         screen.getByRole('textbox', { name: 'Docker image' }),
         'ghcr.io/test/server'
       )
+
+      // Network isolation is enabled by default; toggle it off
+      const networkTab = screen.getByRole('tab', { name: /network isolation/i })
+      await userEvent.click(networkTab)
+      const switchLabel = screen.getByLabelText(
+        'Enable outbound network filtering'
+      )
+      await userEvent.click(switchLabel)
 
       await userEvent.click(
         screen.getByRole('button', { name: 'Install server' })
@@ -966,11 +970,8 @@ describe('DialogFormLocalMcp', () => {
 
       const networkTab = screen.getByRole('tab', { name: /network isolation/i })
       await userEvent.click(networkTab)
-      const switchLabel = screen.getByLabelText(
-        'Enable outbound network filtering'
-      )
-      await userEvent.click(switchLabel)
 
+      // Network isolation is enabled by default; no need to toggle the switch
       const addHostBtn = screen.getByRole('button', { name: /add a host/i })
       await userEvent.click(addHostBtn)
       const hostInput = screen.getByLabelText('Host 1')
@@ -1034,11 +1035,7 @@ describe('DialogFormLocalMcp', () => {
       const networkTab = screen.getByRole('tab', { name: /network isolation/i })
       await userEvent.click(networkTab)
 
-      const switchLabel = screen.getByLabelText(
-        'Enable outbound network filtering'
-      )
-      await userEvent.click(switchLabel)
-
+      // Network isolation is enabled by default; no need to toggle the switch
       await waitFor(() => {
         expect(
           screen.getByText(
@@ -1097,11 +1094,10 @@ describe('DialogFormLocalMcp', () => {
       const networkTab = screen.getByRole('tab', { name: /network isolation/i })
       await userEvent.click(networkTab)
 
-      // Enable network isolation first
+      // Network isolation is enabled by default
       const switchLabel = screen.getByLabelText(
         'Enable outbound network filtering'
       )
-      await userEvent.click(switchLabel)
 
       const addHostBtn = screen.getByRole('button', { name: /add a host/i })
       await userEvent.click(addHostBtn)

--- a/renderer/src/features/mcp-servers/components/local-mcp/dialog-form-local-mcp.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/dialog-form-local-mcp.tsx
@@ -72,7 +72,7 @@ const DEFAULT_FORM_VALUES = {
   protocol: '',
   package_name: '',
   target_port: 0,
-  networkIsolation: false,
+  networkIsolation: true,
   allowedHosts: [],
   allowedPorts: [],
   volumes: [{ host: '', container: '', accessMode: 'rw' as const }],

--- a/renderer/src/features/mcp-servers/components/network-isolation-tab-content.tsx
+++ b/renderer/src/features/mcp-servers/components/network-isolation-tab-content.tsx
@@ -50,8 +50,8 @@ export function NetworkIsolationTabContent({
                   <Alert className="mt-2">
                     <AlertTriangle className="mt-0.5" />
                     <AlertDescription>
-                      This configuration blocks all outbound network traffic
-                      from the MCP server.
+                      All outbound traffic is permitted. Add specific hosts or
+                      ports below to restrict network access.
                     </AlertDescription>
                   </Alert>
                 )}

--- a/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-local-server.test.tsx
+++ b/renderer/src/features/mcp-servers/lib/__tests__/orchestrate-run-local-server.test.tsx
@@ -279,6 +279,64 @@ describe('prepareCreateWorkloadData', () => {
     expect(result.permission_profile).toBeUndefined()
   })
 
+  it('sets insecure_allow_all to true when networkIsolation is true and both allow lists are empty', () => {
+    const data: FormSchemaLocalMcp = {
+      image: 'test-image',
+      name: 'test-server',
+      transport: 'stdio',
+      proxy_mode: 'streamable-http',
+      type: 'docker_image',
+      group: 'default',
+      envVars: [],
+      secrets: [],
+      cmd_arguments: [],
+      networkIsolation: true,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+    }
+
+    const result = prepareCreateWorkloadData(data)
+
+    expect(result.network_isolation).toBe(true)
+    expect(
+      result.permission_profile?.network?.outbound?.insecure_allow_all
+    ).toBe(true)
+    expect(result.permission_profile?.network?.outbound?.allow_host).toEqual([])
+    expect(result.permission_profile?.network?.outbound?.allow_port).toEqual([])
+  })
+
+  it('keeps insecure_allow_all false when networkIsolation is true and allow lists are populated', () => {
+    const data: FormSchemaLocalMcp = {
+      image: 'test-image',
+      name: 'test-server',
+      transport: 'stdio',
+      proxy_mode: 'streamable-http',
+      type: 'docker_image',
+      group: 'default',
+      envVars: [],
+      secrets: [],
+      cmd_arguments: [],
+      networkIsolation: true,
+      allowedHosts: [{ value: 'api.example.com' }],
+      allowedPorts: [{ value: '443' }],
+      volumes: [],
+    }
+
+    const result = prepareCreateWorkloadData(data)
+
+    expect(result.network_isolation).toBe(true)
+    expect(
+      result.permission_profile?.network?.outbound?.insecure_allow_all
+    ).toBe(false)
+    expect(result.permission_profile?.network?.outbound?.allow_host).toEqual([
+      'api.example.com',
+    ])
+    expect(result.permission_profile?.network?.outbound?.allow_port).toEqual([
+      443,
+    ])
+  })
+
   it('sends proxy mode for stdio transport', () => {
     const data: FormSchemaLocalMcp = {
       image: 'test-image',
@@ -998,6 +1056,33 @@ describe('prepareUpdateLocalWorkloadData', () => {
     const result = prepareUpdateLocalWorkloadData(data)
 
     expect(result.tools).toEqual([])
+  })
+
+  it('sets insecure_allow_all to true when networkIsolation is true and allow lists are empty', () => {
+    const data: FormSchemaLocalMcp = {
+      name: 'test-server',
+      transport: 'stdio',
+      proxy_mode: 'streamable-http',
+      type: 'docker_image',
+      group: 'default',
+      image: 'test-image',
+      cmd_arguments: [],
+      envVars: [],
+      secrets: [],
+      networkIsolation: true,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+    }
+
+    const result = prepareUpdateLocalWorkloadData(data)
+
+    expect(result.network_isolation).toBe(true)
+    expect(
+      result.permission_profile?.network?.outbound?.insecure_allow_all
+    ).toBe(true)
+    expect(result.permission_profile?.network?.outbound?.allow_host).toEqual([])
+    expect(result.permission_profile?.network?.outbound?.allow_port).toEqual([])
   })
 
   it('includes tools for package manager type', () => {

--- a/renderer/src/features/mcp-servers/lib/orchestrate-run-local-server.tsx
+++ b/renderer/src/features/mcp-servers/lib/orchestrate-run-local-server.tsx
@@ -265,6 +265,14 @@ export function prepareUpdateLocalWorkloadData(
       : `${data.protocol}://${data.package_name}`
 
   const sendProxyMode = data.transport === 'stdio'
+  const filteredHosts =
+    data.allowedHosts
+      ?.map((host) => host.value)
+      .filter((h) => h.trim() !== '') ?? []
+  const filteredPorts =
+    data.allowedPorts
+      ?.map((port) => parseInt(port.value, 10))
+      .filter((p) => !isNaN(p)) ?? []
 
   return {
     image,
@@ -278,26 +286,16 @@ export function prepareUpdateLocalWorkloadData(
     secrets,
     network_isolation: data.networkIsolation,
     permission_profile: data.networkIsolation
-      ? (() => {
-          const filteredHosts =
-            data.allowedHosts
-              ?.map((host) => host.value)
-              .filter((h) => h.trim() !== '') ?? []
-          const filteredPorts =
-            data.allowedPorts
-              ?.map((port) => parseInt(port.value, 10))
-              .filter((p) => !isNaN(p)) ?? []
-          return {
-            network: {
-              outbound: {
-                allow_host: filteredHosts,
-                allow_port: filteredPorts,
-                insecure_allow_all:
-                  filteredHosts.length === 0 && filteredPorts.length === 0,
-              } as PermissionsOutboundNetworkPermissions,
-            },
-          }
-        })()
+      ? {
+          network: {
+            outbound: {
+              allow_host: filteredHosts,
+              allow_port: filteredPorts,
+              insecure_allow_all:
+                filteredHosts.length === 0 && filteredPorts.length === 0,
+            } as PermissionsOutboundNetworkPermissions,
+          },
+        }
       : undefined,
     volumes: getVolumes(data.volumes ?? []),
     tools: data.tools || undefined,

--- a/renderer/src/features/mcp-servers/lib/orchestrate-run-local-server.tsx
+++ b/renderer/src/features/mcp-servers/lib/orchestrate-run-local-server.tsx
@@ -65,19 +65,22 @@ export function prepareCreateWorkloadData(
   request.cmd_arguments = cmd_arguments || []
   request.env_vars = mapEnvVars(envVars || [])
   request.secrets = secrets
+  const filteredHosts =
+    allowedHosts
+      ?.map(({ value }: { value: string }) => value)
+      .filter((host: string) => host.trim() !== '') ?? []
+  const filteredPorts =
+    allowedPorts
+      ?.map(({ value }: { value: string }) => parseInt(value, 10))
+      .filter((port: number) => !isNaN(port)) ?? []
   const permission_profile = networkIsolation
     ? {
         network: {
           outbound: {
-            allow_host:
-              allowedHosts
-                ?.map(({ value }: { value: string }) => value)
-                .filter((host: string) => host.trim() !== '') ?? [],
-            allow_port:
-              allowedPorts
-                ?.map(({ value }: { value: string }) => parseInt(value, 10))
-                .filter((port: number) => !isNaN(port)) ?? [],
-            insecure_allow_all: false,
+            allow_host: filteredHosts,
+            allow_port: filteredPorts,
+            insecure_allow_all:
+              filteredHosts.length === 0 && filteredPorts.length === 0,
           } as PermissionsOutboundNetworkPermissions,
         },
       }
@@ -275,17 +278,26 @@ export function prepareUpdateLocalWorkloadData(
     secrets,
     network_isolation: data.networkIsolation,
     permission_profile: data.networkIsolation
-      ? {
-          network: {
-            outbound: {
-              allow_host: data.allowedHosts?.map((host) => host.value),
-              allow_port: data.allowedPorts?.map((port) =>
-                parseInt(port.value, 10)
-              ),
-              insecure_allow_all: false,
-            } as PermissionsOutboundNetworkPermissions,
-          },
-        }
+      ? (() => {
+          const filteredHosts =
+            data.allowedHosts
+              ?.map((host) => host.value)
+              .filter((h) => h.trim() !== '') ?? []
+          const filteredPorts =
+            data.allowedPorts
+              ?.map((port) => parseInt(port.value, 10))
+              .filter((p) => !isNaN(p)) ?? []
+          return {
+            network: {
+              outbound: {
+                allow_host: filteredHosts,
+                allow_port: filteredPorts,
+                insecure_allow_all:
+                  filteredHosts.length === 0 && filteredPorts.length === 0,
+              } as PermissionsOutboundNetworkPermissions,
+            },
+          }
+        })()
       : undefined,
     volumes: getVolumes(data.volumes ?? []),
     tools: data.tools || undefined,

--- a/renderer/src/features/network-isolation/components/network-isolation-tab-content.tsx
+++ b/renderer/src/features/network-isolation/components/network-isolation-tab-content.tsx
@@ -50,8 +50,8 @@ export function NetworkIsolationTabContent({
                   <Alert className="mt-2">
                     <AlertTriangle className="mt-0.5" />
                     <AlertDescription>
-                      This configuration blocks all outbound network traffic
-                      from the MCP server.
+                      All outbound traffic is permitted. Add specific hosts or
+                      ports below to restrict network access.
                     </AlertDescription>
                   </Alert>
                 )}

--- a/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
@@ -289,6 +289,46 @@ describe('FormRunFromRegistry', () => {
     })
   })
 
+  it('defaults networkIsolation to true for a new registry server', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    const server = { ...REGISTRY_SERVER, env_vars: ENV_VARS_OPTIONAL }
+
+    renderWithProviders(
+      <FormRunFromRegistry
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        server={server}
+        actionsSubmitLabel="Install server"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Replace pre-filled server name and submit
+    await userEvent.type(screen.getByLabelText('Server name'), 'my-server', {
+      initialSelectionStart: 0,
+      initialSelectionEnd: REGISTRY_SERVER.name?.length,
+    })
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install server' })
+    )
+
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalled()
+    })
+    expect(
+      mockInstallServerMutation.mock.calls[0]?.[0]?.data?.networkIsolation
+    ).toBe(true)
+  })
+
   it('should not submit the form if the server name is not valid', async () => {
     const mockInstallServerMutation = vi.fn()
     mockUseRunFromRegistry.mockReturnValue({

--- a/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
@@ -279,6 +279,15 @@ describe('FormRunFromRegistry', () => {
       screen.getByLabelText('ENV_VAR value'),
       'my-awesome-env-var'
     )
+    // Network isolation is enabled by default; toggle it off for this scenario
+    const networkTab = screen.getByRole('tab', { name: /network isolation/i })
+    await userEvent.click(networkTab)
+    const switchLabel = screen.getByLabelText(
+      'Enable outbound network filtering'
+    )
+    await userEvent.click(switchLabel)
+    const configTab = screen.getByRole('tab', { name: /configuration/i })
+    await userEvent.click(configTab)
     await userEvent.click(
       screen.getByRole('button', { name: 'Install server' })
     )
@@ -431,7 +440,7 @@ describe('FormRunFromRegistry', () => {
             secrets: [
               { name: 'SECRET', value: { isFromStore: false, secret: '' } },
             ],
-            networkIsolation: false,
+            networkIsolation: true,
             allowedHosts: [],
             allowedPorts: [],
             volumes: [
@@ -494,7 +503,7 @@ describe('FormRunFromRegistry', () => {
             secrets: [
               { name: 'SECRET', value: { isFromStore: false, secret: '' } },
             ],
-            networkIsolation: false,
+            networkIsolation: true,
             allowedHosts: [],
             allowedPorts: [],
           }),
@@ -1022,11 +1031,7 @@ describe('FormRunFromRegistry', () => {
     // Switch to Network Isolation tab
     const networkTab = screen.getByRole('tab', { name: /network isolation/i })
     await userEvent.click(networkTab)
-    // Enable network isolation
-    const switchLabel = screen.getByLabelText(
-      'Enable outbound network filtering'
-    )
-    await userEvent.click(switchLabel)
+    // Network isolation is enabled by default
     // Do not add any ports
     // Submit
     const configTab = screen.getByRole('tab', { name: /configuration/i })
@@ -1068,11 +1073,7 @@ describe('Allowed Hosts field', () => {
     // Switch to the Network Isolation tab
     const networkTab = screen.getByRole('tab', { name: /network isolation/i })
     await userEvent.click(networkTab)
-    // Enable network isolation
-    const switchLabel = screen.getByLabelText(
-      'Enable outbound network filtering'
-    )
-    await userEvent.click(switchLabel)
+    // Network isolation is enabled by default
     // Add a host so the input and label are rendered
     await userEvent.click(screen.getByRole('button', { name: /add a host/i }))
     // Allowed Hosts field should be present
@@ -1099,10 +1100,7 @@ describe('Allowed Hosts field', () => {
     })
     const networkTab = screen.getByRole('tab', { name: /network isolation/i })
     await userEvent.click(networkTab)
-    const switchLabel = screen.getByLabelText(
-      'Enable outbound network filtering'
-    )
-    await userEvent.click(switchLabel)
+    // Network isolation is enabled by default
     // Add a host
     const addHostButton = screen.getByRole('button', { name: /add a host/i })
     await userEvent.click(addHostButton)
@@ -1138,10 +1136,7 @@ describe('Allowed Hosts field', () => {
     })
     const networkTab = screen.getByRole('tab', { name: /network isolation/i })
     await userEvent.click(networkTab)
-    const switchLabel = screen.getByLabelText(
-      'Enable outbound network filtering'
-    )
-    await userEvent.click(switchLabel)
+    // Network isolation is enabled by default
     const addHostButton = screen.getByRole('button', { name: /add a host/i })
     await userEvent.click(addHostButton)
     const hostInput = screen.getByLabelText('Host 1')
@@ -1215,10 +1210,7 @@ describe('Allowed Hosts field', () => {
     )
     const networkTab = screen.getByRole('tab', { name: /network isolation/i })
     await userEvent.click(networkTab)
-    const switchLabel = screen.getByLabelText(
-      'Enable outbound network filtering'
-    )
-    await userEvent.click(switchLabel)
+    // Network isolation is enabled by default
     const addHostButton = screen.getByRole('button', { name: /add a host/i })
     await userEvent.click(addHostButton)
     const hostInput = screen.getByLabelText('Host 1')
@@ -1260,10 +1252,7 @@ describe('Allowed Hosts field', () => {
     })
     const networkTab = screen.getByRole('tab', { name: /network isolation/i })
     await userEvent.click(networkTab)
-    const switchLabel = screen.getByLabelText(
-      'Enable outbound network filtering'
-    )
-    await userEvent.click(switchLabel)
+    // Network isolation is enabled by default
     // Should be empty by default
     expect(screen.queryByLabelText('Host 1')).not.toBeInTheDocument()
     // Add two hosts
@@ -1311,10 +1300,10 @@ describe('Allowed Hosts field', () => {
     const networkTab = screen.getByRole('tab', { name: /network isolation/i })
     await userEvent.click(networkTab)
 
+    // Network isolation is enabled by default
     const switchLabel = screen.getByLabelText(
       'Enable outbound network filtering'
     )
-    await userEvent.click(switchLabel)
 
     const addHostButton = screen.getByRole('button', { name: /add a host/i })
     await userEvent.click(addHostButton)
@@ -1391,13 +1380,9 @@ describe('Network Isolation Tab Activation', () => {
     // Ensure we are on the configuration tab
     const configTab = screen.getByRole('tab', { name: /configuration/i })
     expect(configTab).toHaveAttribute('aria-selected', 'true')
-    // Enable network isolation and add an invalid host
+    // Network isolation is enabled by default; add an invalid host
     const networkTab = screen.getByRole('tab', { name: /network isolation/i })
     await userEvent.click(networkTab)
-    const switchLabel = screen.getByLabelText(
-      'Enable outbound network filtering'
-    )
-    await userEvent.click(switchLabel)
     // Add a host and enter an invalid value
     const addHostBtn = screen.getByRole('button', { name: /add a host/i })
     await userEvent.click(addHostBtn)
@@ -1686,7 +1671,7 @@ describe('Storage Volumes', () => {
                 },
               },
             ],
-            networkIsolation: false,
+            networkIsolation: true,
             allowedHosts: [],
             allowedPorts: [],
             volumes: [

--- a/renderer/src/features/registry-servers/components/form-run-from-registry/index.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry/index.tsx
@@ -133,7 +133,7 @@ export function FormRunFromRegistry({
         name: e.name || '',
         value: e.default || '',
       })),
-      networkIsolation: false,
+      networkIsolation: true,
       allowedHosts: server?.permissions?.network?.outbound?.allow_host
         ? server.permissions.network.outbound.allow_host.map((host) => ({
             value: host,

--- a/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
+++ b/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
@@ -268,4 +268,68 @@ describe('prepareCreateWorkloadData', () => {
     expect(result.network_isolation).toBe(false)
     expect(result.permission_profile).toBeUndefined()
   })
+
+  it('keeps insecure_allow_all false when networkIsolation is true and allow lists are populated from registry server permissions', () => {
+    const serverWithPermissions: RegistryImageMetadata = {
+      ...REGISTRY_SERVER,
+      permissions: {
+        network: {
+          outbound: {
+            allow_host: ['api.github.com'],
+            allow_port: [443],
+          },
+        },
+      },
+    }
+
+    const data: FormSchemaRegistryMcp = {
+      proxy_mode: 'streamable-http',
+      name: 'test-server',
+      group: 'default',
+      cmd_arguments: [],
+      secrets: [],
+      envVars: [],
+      networkIsolation: true,
+      allowedHosts: [{ value: 'api.github.com' }],
+      allowedPorts: [{ value: '443' }],
+      volumes: [],
+    }
+
+    const result = prepareCreateWorkloadData(serverWithPermissions, data)
+
+    expect(result.network_isolation).toBe(true)
+    expect(result.permission_profile?.network?.outbound?.allow_host).toEqual([
+      'api.github.com',
+    ])
+    expect(result.permission_profile?.network?.outbound?.allow_port).toEqual([
+      443,
+    ])
+    expect(
+      result.permission_profile?.network?.outbound?.insecure_allow_all
+    ).toBe(false)
+  })
+
+  it('sets insecure_allow_all to true when networkIsolation is true and both allow lists are empty', () => {
+    const data: FormSchemaRegistryMcp = {
+      proxy_mode: 'streamable-http',
+      name: 'test-server',
+      group: 'default',
+      cmd_arguments: [],
+      secrets: [],
+      envVars: [],
+      networkIsolation: true,
+      allowedHosts: [],
+      allowedPorts: [],
+      volumes: [],
+    }
+
+    const result = prepareCreateWorkloadData(REGISTRY_SERVER, data)
+
+    expect(result.network_isolation).toBe(true)
+    expect(
+      result.permission_profile?.network?.outbound?.insecure_allow_all
+    ).toBe(true)
+    expect(result.permission_profile?.network?.outbound?.allow_host).toEqual([])
+    expect(result.permission_profile?.network?.outbound?.allow_port).toEqual([])
+  })
 })

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
@@ -18,19 +18,22 @@ export function prepareCreateWorkloadData(
 ): V1CreateRequest {
   // Extract and transform network isolation fields
   const { allowedHosts, allowedPorts, networkIsolation } = data
+  const filteredHosts =
+    allowedHosts
+      ?.map(({ value }: { value: string }) => value)
+      .filter((host: string) => host.trim() !== '') ?? []
+  const filteredPorts =
+    allowedPorts
+      ?.map(({ value }: { value: string }) => parseInt(value, 10))
+      .filter((port: number) => !isNaN(port)) ?? []
   const permission_profile = networkIsolation
     ? {
         network: {
           outbound: {
-            allow_host:
-              allowedHosts
-                ?.map(({ value }: { value: string }) => value)
-                .filter((host: string) => host.trim() !== '') ?? [],
-            allow_port:
-              allowedPorts
-                ?.map(({ value }: { value: string }) => parseInt(value, 10))
-                .filter((port: number) => !isNaN(port)) ?? [],
-            insecure_allow_all: false,
+            allow_host: filteredHosts,
+            allow_port: filteredPorts,
+            insecure_allow_all:
+              filteredHosts.length === 0 && filteredPorts.length === 0,
           } as PermissionsOutboundNetworkPermissions,
         },
       }


### PR DESCRIPTION
## Summary
<img width="1720" height="1045" alt="Screenshot 2026-06-25 at 16 15 44" src="https://github.com/user-attachments/assets/ae1f8cb1-2ba2-430c-abde-e9f8fa52309a" />

Aligns Studio with the ToolHive backend default: network isolation is now **enabled by default** for all new MCP server workloads.

- Default `networkIsolation` form value flipped from `false` → `true` in both the local-server and registry-server create dialogs
- `insecure_allow_all` is now computed dynamically: `true` when isolation is on but no allow-list is configured (prevents silently blocking all egress for custom servers), `false` when an explicit allow-list is provided
- Applied consistently across all three code paths: create-local, update-local, create-registry

Closes #2326

## Background

The backend now defaults `network_isolation: true` when the field is omitted from `POST /api/v1beta/workloads`. Studio was overriding this by always sending `network_isolation: false`, so users never benefited from the hardened default.

The `insecure_allow_all: true` case (isolation on, all outbound permitted except Docker gateway) maps directly to the backend's built-in `"network"` permission profile. Custom/local servers that have no declared allow-list get this profile by default, preserving general internet connectivity while still blocking the Docker gateway.

Registry servers retain their declared outbound permissions automatically — the form already pre-fills `allowedHosts`/`allowedPorts` from the registry entry's `permissions.network.outbound` metadata, so flipping the default is sufficient.

The MCP Optimizer referenced in the issue (`use-create-optimizer-workload.ts`) no longer exists in the codebase — that feature was previously removed. No action needed there.

## Test plan

- [x] `prepareCreateWorkloadData` with isolation on + empty allow-lists → `insecure_allow_all: true`
- [x] `prepareCreateWorkloadData` with isolation on + populated allow-lists → `insecure_allow_all: false`
- [x] `prepareUpdateLocalWorkloadData` with isolation on + empty allow-lists → `insecure_allow_all: true`
- [x] Local server form defaults `networkIsolation` to `true`
- [x] Registry server form defaults `networkIsolation` to `true`
- [x] Full test suite: 2454 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)