### PR TITLE
fix(cli): parse commit-hash version strings from dev builds

### DIFF
--- a/main/src/cli/__tests__/cli-detection.test.ts
+++ b/main/src/cli/__tests__/cli-detection.test.ts
@@ -216,6 +216,26 @@ describe('cli-detection', () => {
       })
     })
 
+    it('parses dev builds stamped with a commit hash as version', async () => {
+      vol.fromJSON({
+        '/path/to/thv': 'binary content',
+      })
+
+      mockExecFileAsync.mockResolvedValue({
+        stdout:
+          'ToolHive 493d030\nCommit: 493d030ed24b8c012db4c5717475a2386f5b72ce\nBuilt: unknown',
+        stderr: '',
+      })
+
+      const result = await getCliInfo('/path/to/thv')
+
+      expect(result).toEqual({
+        exists: true,
+        version: '493d030',
+        isExecutable: true,
+      })
+    })
+
     it('parses prerelease versions with and without the "v" prefix', async () => {
       vol.fromJSON({
         '/path/to/thv': 'binary content',

--- a/main/src/cli/cli-detection.ts
+++ b/main/src/cli/cli-detection.ts
@@ -20,7 +20,7 @@ const execFileAsync = promisify(execFile)
  * The "v" prefix is optional: enterprise builds stamp the version without it.
  */
 const parseVersionOutput = (stdout: string): string | null => {
-  const match = stdout.match(/^ToolHive v?(\d+\.\d+\.\d+(?:-[\w.]+)?)/m)
+  const match = stdout.match(/^ToolHive v?([\w.-]+)/m)
   return match?.[1] ?? null
 }
 


### PR DESCRIPTION
## Summary

- `parseVersionOutput` used a strict semver regex (`\d+\.\d+\.\d+`) that returned `null` when the binary version is a commit hash (e.g. `493d030`), causing the Settings page to display "Unknown" for the ToolHive binary version in dev and CI builds
- Relaxes the capture group from the semver pattern to `[\w.-]+`, which still accepts semver, prerelease tags (`1.5.0-rc.1`), and enterprise no-`v` builds (`0.1.39`), while also accepting commit hashes — without opening up to arbitrary punctuation like colons or slashes
- Adds a unit test covering the commit-hash case

This extends the fix from #2314 (which made the `v` prefix optional) to also handle non-semver version strings stamped in dev/CI builds.

## Test plan

- [x] Existing unit tests pass (`parses version without the "v" prefix`, `parses prerelease versions`)
- [x] New unit test passes: `parses dev builds stamped with a commit hash as version`
- [x] E2E test `settings-displays-correct-ToolHive-binary-version` should now pass in CI where `THV_VERSION=<commit-hash>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)