### PR TITLE
fix: discover proxied stdio tools with raw MCP transport

### DIFF
--- a/main/src/utils/__tests__/mcp-tools.test.ts
+++ b/main/src/utils/__tests__/mcp-tools.test.ts
@@ -1,7 +1,40 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createTransport } from '../mcp-tools'
+import {
+  createTransport,
+  getWorkloadAvailableTools,
+  buildRawTransport,
+} from '../mcp-tools'
 import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
+
+const mockAiMcpClient = vi.hoisted(() => ({
+  tools: vi.fn().mockResolvedValue({}),
+  close: vi.fn().mockResolvedValue(undefined),
+}))
+
+const mockCreateMCPClient = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(mockAiMcpClient)
+)
+
+const mockSdkClient = vi.hoisted(() => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  listTools: vi.fn().mockResolvedValue({ tools: [] }),
+  close: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@ai-sdk/mcp', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@ai-sdk/mcp')>()
+  return {
+    ...original,
+    experimental_createMCPClient: mockCreateMCPClient,
+  }
+})
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: function ClientMock() {
+    return mockSdkClient
+  },
+}))
 
 vi.mock('../../logger', () => ({
   default: {
@@ -15,6 +48,12 @@ vi.mock('../../logger', () => ({
 describe('createTransport', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAiMcpClient.tools.mockResolvedValue({})
+    mockAiMcpClient.close.mockResolvedValue(undefined)
+    mockCreateMCPClient.mockResolvedValue(mockAiMcpClient)
+    mockSdkClient.connect.mockResolvedValue(undefined)
+    mockSdkClient.listTools.mockResolvedValue({ tools: [] })
+    mockSdkClient.close.mockResolvedValue(undefined)
   })
 
   describe('streamable-http transport', () => {
@@ -207,6 +246,44 @@ describe('createTransport', () => {
 
       expect(config.name).toBe('pure-stdio')
       expect(config.transport).toBeInstanceOf(Experimental_StdioMCPTransport)
+    })
+  })
+})
+
+describe('getWorkloadAvailableTools', () => {
+  it('discovers tools for stdio servers proxied through streamable HTTP with the raw SDK transport', async () => {
+    const workload: CoreWorkload = {
+      name: 'context7',
+      port: 40281,
+      transport_type: 'stdio',
+      proxy_mode: 'streamable-http',
+      url: 'http://127.0.0.1:40281/mcp',
+      status: 'running',
+    }
+
+    mockSdkClient.listTools.mockResolvedValue({
+      tools: [
+        {
+          name: 'resolve-library-id',
+          description: 'Resolve a package name',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    })
+
+    const tools = await getWorkloadAvailableTools(workload)
+
+    expect(mockCreateMCPClient).not.toHaveBeenCalled()
+    expect(mockSdkClient.connect).toHaveBeenCalledWith(
+      buildRawTransport(workload)
+    )
+    expect(mockSdkClient.listTools).toHaveBeenCalledOnce()
+    expect(mockSdkClient.close).toHaveBeenCalledOnce()
+    expect(tools).toEqual({
+      'resolve-library-id': {
+        description: 'Resolve a package name',
+        inputSchema: { type: 'object', properties: {} },
+      },
     })
   })
 })

--- a/main/src/utils/mcp-tools.ts
+++ b/main/src/utils/mcp-tools.ts
@@ -4,6 +4,7 @@ import {
 } from '@ai-sdk/mcp'
 import { type Tool } from 'ai'
 import { Experimental_StdioMCPTransport as StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
@@ -153,6 +154,34 @@ export async function getWorkloadAvailableTools(
   if (!workload.name) return null
 
   try {
+    if (
+      workload.transport_type === 'stdio' &&
+      workload.proxy_mode === 'streamable-http'
+    ) {
+      const mcpClient = new Client({
+        name: 'toolhive-studio-tool-discovery',
+        version: '1.0.0',
+      })
+
+      try {
+        await mcpClient.connect(buildRawTransport(workload))
+        const rawTools = await mcpClient.listTools()
+
+        return rawTools.tools
+          .filter((tool) => isMcpToolDefinition(tool))
+          .reduce<Record<string, McpToolDefinition>>((prev, tool) => {
+            if (!tool.name) return prev
+            prev[tool.name] = {
+              description: tool.description,
+              inputSchema: tool.inputSchema as Tool['inputSchema'],
+            }
+            return prev
+          }, {})
+      } finally {
+        await mcpClient.close()
+      }
+    }
+
     // Try to create an MCP client and discover tools
     const config = createTransport(workload)
     if (config) {


### PR DESCRIPTION
## Summary

Fixes #2333.

Fixes Playground tool discovery for stdio workloads that are exposed through the Streamable HTTP proxy.

The existing discovery path uses the AI SDK MCP HTTP client for all streamable-http workloads. For stdio-backed workloads proxied by ToolHive, the proxy can return event-less SSE `data:` frames. The raw MCP SDK transport handles that response shape, but the AI SDK discovery path can hang before returning tools.

## Changes

This change keeps the existing AI SDK discovery path for normal streamable-http workloads, and only switches stdio + streamable-http proxy discovery to the raw MCP SDK client through the existing `buildRawTransport(workload)` helper.

## Verification

```text
pnpm exec vitest run --dir main/src/utils main/src/utils/__tests__/mcp-tools.test.ts
pnpm run type-check
pnpm exec prettier --check main/src/utils/mcp-tools.ts main/src/utils/__tests__/mcp-tools.test.ts
pnpm exec eslint --max-warnings 0 main/src/utils/mcp-tools.ts main/src/utils/__tests__/mcp-tools.test.ts
```
