### PR TITLE
chore(deps): remove guardrail pnpm overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,25 +6,11 @@ settings:
 
 overrides:
   '@electron/rebuild': ^4.0.4
-  '@hono/node-server': '>=1.19.14'
-  '@xmldom/xmldom': '>=0.9.10'
-  esbuild: '>=0.28.1'
-  fast-uri: '>=3.1.2'
   fast-xml-builder: '>=1.2.0'
   fast-xml-parser: 5.8.0
-  hono: '>=4.12.25'
-  ip-address: '>=10.2.0'
-  lodash-es: '>=4.18.0'
-  mermaid: '>=11.15.0'
-  '@babel/core': '>=7.29.6 <8.0.0'
-  dompurify: '>=3.4.11'
   js-yaml: '>=4.2.0'
   '@opentelemetry/core': '>=2.8.0'
-  tar: '>=7.5.16'
-  picomatch: '>=4.0.4'
-  qs: '>=6.15.2'
   tmp: '>=0.2.7'
-  uuid: '>=14.0.0'
   jsdom>undici: '>=7.28.0 <8'
   node-gyp>undici: '>=6.27.0 <7'
   brace-expansion@>=4.0.0 <5.0.5: 5.0.6
@@ -388,7 +374,7 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       tar:
-        specifier: '>=7.5.16'
+        specifier: ^7.5.15
         version: 7.5.16
       tsx:
         specifier: ^4.22.4
@@ -705,7 +691,7 @@ packages:
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': '>=7.29.6 <8.0.0'
+      '@babel/core': ^7.0.0
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -1221,11 +1207,11 @@ packages:
   '@hey-api/types@0.1.4':
     resolution: {integrity: sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==}
 
-  '@hono/node-server@2.0.2':
-    resolution: {integrity: sha512-tXlTi1h/4V7sDe7i97IVP+9re9ZU7wXZZggnR5ucCRclf1+AX6YhGStrR5w8bLj+3Mlyl0pKfBh9gqTqqnGKfQ==}
-    engines: {node: '>=20'}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.25'
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4964,7 +4950,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -6508,6 +6494,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -7712,7 +7702,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.3.0
-      esbuild: '>=0.28.1'
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -9368,7 +9358,7 @@ snapshots:
 
   '@hey-api/types@0.1.4': {}
 
-  '@hono/node-server@2.0.2(hono@4.12.25)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
 
@@ -9786,7 +9776,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.2(hono@4.12.25)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -14798,7 +14788,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -15182,6 +15172,8 @@ snapshots:
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,25 +33,11 @@ auditConfig:
 
 overrides:
   '@electron/rebuild': ^4.0.4
-  '@hono/node-server': '>=1.19.14'
-  '@xmldom/xmldom': '>=0.9.10'
-  esbuild: '>=0.28.1'
-  fast-uri: '>=3.1.2'
   fast-xml-builder: '>=1.2.0'
   fast-xml-parser: 5.8.0
-  hono: '>=4.12.25'
-  ip-address: '>=10.2.0'
-  lodash-es: '>=4.18.0'
-  mermaid: '>=11.15.0'
-  '@babel/core': '>=7.29.6 <8.0.0'
-  dompurify: '>=3.4.11'
   js-yaml: '>=4.2.0'
   '@opentelemetry/core': '>=2.8.0'
-  tar: '>=7.5.16'
-  picomatch: '>=4.0.4'
-  qs: '>=6.15.2'
   tmp: '>=0.2.7'
-  uuid: '>=14.0.0'
   'jsdom>undici': '>=7.28.0 <8'
   'node-gyp>undici': '>=6.27.0 <7'
   brace-expansion@>=4.0.0 <5.0.5: 5.0.6


### PR DESCRIPTION
## Summary

- Remove 14 guardrail `pnpm` overrides whose direct/transitive consumers already admit the patched version (hono, qs, esbuild, mermaid, etc.).
- Keep 11 hard-required overrides: exact-pin consumers (`@opentelemetry/core`, `js-yaml`, `tmp`), AWS SDK xml-builder pins, undici scoped overrides, brace-expansion ranges, and `@electron/rebuild`.
- `@hono/node-server` resolves to 1.19.14 (SDK range) instead of override-forced 2.0.2; picomatch 2.x coexists again on the electron-forge path (not flagged by grype).

## Test plan

- [x] `pnpm install`
- [x] Lockfile resolves fixed versions for removed overrides
- [x] `grype . --config .grype.yaml`
- [x] `pnpm audit --prod --audit-level=moderate`


Made with [Cursor](https://cursor.com)