### PR TITLE
fix(playground): surface streaming errors and sanitize Gemini MCP schemas

### DIFF
--- a/main/src/chat/__tests__/mcp-tools.test.ts
+++ b/main/src/chat/__tests__/mcp-tools.test.ts
@@ -74,6 +74,8 @@ vi.mock('../../utils/mcp-tools', async (importOriginal) => {
   return {
     // Keep the real validator so fixtures need to be shaped correctly
     isMcpToolDefinition: original.isMcpToolDefinition,
+    // Keep the real sanitizer so registerTool can normalize schemas
+    sanitizeToolInputSchema: original.sanitizeToolInputSchema,
     buildRawTransport: mockBuildRawTransport,
     createTransport: mockCreateTransport,
     getWorkloadAvailableTools: mockGetWorkloadAvailableTools,

--- a/main/src/chat/__tests__/streaming.test.ts
+++ b/main/src/chat/__tests__/streaming.test.ts
@@ -310,5 +310,11 @@ describe('handleChatStreamRealtime — error message mapping', () => {
       'high demand, try later'
     )
     expect(opts.onError(new Error('Overloaded'))).toContain('overloaded')
+    expect(
+      opts.onError({
+        message: 'This model is currently experiencing high demand.',
+      })
+    ).toBe('This model is currently experiencing high demand.')
+    expect(opts.onError({ code: 'UNKNOWN' })).toBe('An error occurred.')
   })
 })

--- a/main/src/chat/__tests__/streaming.test.ts
+++ b/main/src/chat/__tests__/streaming.test.ts
@@ -287,3 +287,28 @@ describe('handleChatStreamRealtime — agent resolution', () => {
     expect(ctorArg.toolChoice).toBeUndefined()
   })
 })
+
+describe('handleChatStreamRealtime — error message mapping', () => {
+  it('passes onError to toUIMessageStream so provider errors reach the UI', async () => {
+    mockGetAgent.mockReturnValue(
+      fakeAgent('builtin.toolhive-assistant', 'TOOLHIVE INSTRUCTIONS')
+    )
+    const toUIMessageStream = vi.fn().mockReturnValue({})
+    mockAgentStream.mockResolvedValue({ toUIMessageStream })
+
+    await handleChatStreamRealtime(
+      makeRequest({ agentId: 'builtin.toolhive-assistant' }),
+      'stream-err',
+      fakeSender
+    )
+
+    expect(toUIMessageStream).toHaveBeenCalled()
+    const opts = toUIMessageStream.mock.calls[0]![0] as {
+      onError: (error: unknown) => string
+    }
+    expect(opts.onError(new Error('high demand, try later'))).toBe(
+      'high demand, try later'
+    )
+    expect(opts.onError(new Error('Overloaded'))).toContain('overloaded')
+  })
+})

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -22,6 +22,7 @@ import {
   createTransport,
   getWorkloadAvailableTools,
   isMcpToolDefinition,
+  sanitizeToolInputSchema,
 } from '../utils/mcp-tools'
 import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
 import { readAllMcpAppUiMetadata } from '../db/readers/mcp-app-ui-metadata-reader'
@@ -240,7 +241,10 @@ export async function getMcpServerTools(
 }
 
 // Create MCP tools for AI SDK
-export async function createMcpTools(threadId?: string): Promise<{
+export async function createMcpTools(
+  threadId?: string,
+  options?: { sanitizeSchemas?: boolean }
+): Promise<{
   tools: ToolSet
   clients: Awaited<ReturnType<typeof createMCPClient>>[]
   enabledTools: Record<string, string[]>
@@ -265,6 +269,9 @@ export async function createMcpTools(threadId?: string): Promise<{
     if (!isMcpToolDefinition(toolDef)) return false
     const ui = extractToolUiMeta(toolDef)
     if (shouldSkipAppOnlyTool(ui)) return false
+    // Only Gemini needs schema normalization; other providers handle the
+    // original schema (and keep richer constructs like union types).
+    if (options?.sanitizeSchemas) sanitizeToolInputSchema(toolDef)
     mcpTools[toolName] = toolDef
     if (ui?.resourceUri) {
       nextCachedUiMetadata[toolName] = {

--- a/main/src/chat/streaming.ts
+++ b/main/src/chat/streaming.ts
@@ -45,6 +45,24 @@ function addUsage(
   } as LanguageModelV2Usage
 }
 
+/** Map provider/SDK errors to user-facing messages for the playground UI. */
+export function toUserFacingErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  if (/overloaded/i.test(message)) {
+    return 'The AI service is currently overloaded. Please try again in a few moments.'
+  }
+  if (/rate limit/i.test(message)) {
+    return 'Rate limit exceeded. Please wait a moment before sending another message.'
+  }
+  if (/insufficient_quota|quota/i.test(message)) {
+    return 'API quota exceeded. Please check your API key billing status.'
+  }
+  if (/invalid_api_key|authentication/i.test(message)) {
+    return 'Invalid API key. Please check your API key configuration.'
+  }
+  return message || 'An error occurred.'
+}
+
 /**
  * Handle chat streaming request using real-time IPC events
  */
@@ -171,6 +189,7 @@ export async function handleChatStreamRealtime(
               prefix: 'msg',
               size: 16,
             }),
+            onError: (error) => toUserFacingErrorMessage(error),
             messageMetadata: ({ part }) => {
               if (part.type === 'start') {
                 const createdAt = Date.now()
@@ -354,43 +373,7 @@ export async function handleChatStreamRealtime(
             )
           }
 
-          // Improve error messages for common API issues
-          if (error instanceof Error) {
-            if (
-              error.message.includes('overloaded') ||
-              error.message.includes('Overloaded')
-            ) {
-              throw new Error(
-                'The AI service is currently overloaded. Please try again in a few moments.'
-              )
-            }
-            if (
-              error.message.includes('rate limit') ||
-              error.message.includes('Rate limit')
-            ) {
-              throw new Error(
-                'Rate limit exceeded. Please wait a moment before sending another message.'
-              )
-            }
-            if (
-              error.message.includes('insufficient_quota') ||
-              error.message.includes('quota')
-            ) {
-              throw new Error(
-                'API quota exceeded. Please check your API key billing status.'
-              )
-            }
-            if (
-              error.message.includes('invalid_api_key') ||
-              error.message.includes('authentication')
-            ) {
-              throw new Error(
-                'Invalid API key. Please check your API key configuration.'
-              )
-            }
-          }
-
-          throw error
+          throw new Error(toUserFacingErrorMessage(error))
         }
       } catch (error) {
         log.error('[CHAT] Chat stream error:', error)

--- a/main/src/chat/streaming.ts
+++ b/main/src/chat/streaming.ts
@@ -45,6 +45,12 @@ function addUsage(
   } as LanguageModelV2Usage
 }
 
+/** Gemini's function-declaration validator rejects schema constructs other
+ * providers accept. True for Google directly or a `google/*` OpenRouter model. */
+function requiresGeminiSchemaCompat(provider: string, model: string): boolean {
+  return provider === 'google' || model.toLowerCase().startsWith('google/')
+}
+
 /** Map provider/SDK errors to user-facing messages for the playground UI. */
 export function toUserFacingErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error)
@@ -109,7 +115,12 @@ export async function handleChatStreamRealtime(
           tools: mcpTools,
           clients: mcpClients,
           enabledTools,
-        } = await createMcpTools(request.chatId)
+        } = await createMcpTools(request.chatId, {
+          sanitizeSchemas: requiresGeminiSchemaCompat(
+            request.provider,
+            request.model
+          ),
+        })
 
         // Agent-specific built-in tools (e.g. Skills Builder, Skill Tester).
         // Pass the threadId so per-thread skill enablement is honoured.

--- a/main/src/chat/streaming.ts
+++ b/main/src/chat/streaming.ts
@@ -51,9 +51,19 @@ function requiresGeminiSchemaCompat(provider: string, model: string): boolean {
   return provider === 'google' || model.toLowerCase().startsWith('google/')
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message: unknown }).message
+    if (typeof message === 'string') return message
+  }
+  return ''
+}
+
 /** Map provider/SDK errors to user-facing messages for the playground UI. */
-export function toUserFacingErrorMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error)
+function toUserFacingErrorMessage(error: unknown): string {
+  const message = getErrorMessage(error)
   if (/overloaded/i.test(message)) {
     return 'The AI service is currently overloaded. Please try again in a few moments.'
   }

--- a/main/src/utils/__tests__/mcp-tools.test.ts
+++ b/main/src/utils/__tests__/mcp-tools.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createTransport } from '../mcp-tools'
+import {
+  createTransport,
+  sanitizeMcpJsonSchema,
+  sanitizeToolInputSchema,
+} from '../mcp-tools'
 import type { GithubComStacklokToolhivePkgCoreWorkload as CoreWorkload } from '@common/api/generated/types.gen'
 import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
 
@@ -208,5 +212,92 @@ describe('createTransport', () => {
       expect(config.name).toBe('pure-stdio')
       expect(config.transport).toBeInstanceOf(Experimental_StdioMCPTransport)
     })
+  })
+})
+
+describe('sanitizeMcpJsonSchema', () => {
+  it('drops non-string enums (e.g. boolean) while keeping the property', () => {
+    // Mirrors the GitHub `issue_write` schema Gemini rejected:
+    // issue_fields.items.properties.delete = { type: 'boolean', enum: [true] }
+    const schema = {
+      type: 'object',
+      properties: {
+        issue_fields: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              delete: { type: 'boolean', enum: [true] },
+            },
+            required: ['delete'],
+          },
+        },
+      },
+    }
+
+    sanitizeMcpJsonSchema(schema)
+
+    const del = schema.properties.issue_fields.items.properties.delete
+    expect('enum' in del).toBe(false)
+    // The property and any `required` reference to it remain intact.
+    expect(del.type).toBe('boolean')
+    expect(schema.properties.issue_fields.items.required).toEqual(['delete'])
+  })
+
+  it('preserves string enums', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        state: { type: 'string', enum: ['open', 'closed'] },
+      },
+    }
+
+    sanitizeMcpJsonSchema(schema)
+
+    expect(schema.properties.state.enum).toEqual(['open', 'closed'])
+  })
+
+  it('collapses union type arrays to the first concrete type', () => {
+    // Mirrors the GitHub `issue_write` schema Gemini rejected:
+    // issue_fields.items.properties.value = { type: ['string','number','boolean'] }
+    const value: Record<string, unknown> = {
+      type: ['string', 'number', 'boolean'],
+      description: 'v',
+    }
+    sanitizeMcpJsonSchema({ type: 'object', properties: { value } })
+
+    expect(value.type).toBe('string')
+    expect('nullable' in value).toBe(false)
+  })
+
+  it('maps a "null" union member to nullable', () => {
+    const value: Record<string, unknown> = { type: ['null', 'number'] }
+    sanitizeMcpJsonSchema({ type: 'object', properties: { value } })
+
+    expect(value.type).toBe('number')
+    expect(value.nullable).toBe(true)
+  })
+
+  it('falls back to "string" when a union has no concrete type', () => {
+    const value: Record<string, unknown> = { type: ['null'] }
+    sanitizeMcpJsonSchema({ type: 'object', properties: { value } })
+
+    expect(value.type).toBe('string')
+    expect(value.nullable).toBe(true)
+  })
+
+  it('sanitizes through jsonSchema()-wrapped tool inputSchema', () => {
+    const tool = {
+      inputSchema: {
+        jsonSchema: {
+          type: 'object',
+          properties: { flag: { type: 'boolean', enum: [true] } },
+        },
+      },
+    }
+
+    sanitizeToolInputSchema(tool)
+
+    expect('enum' in tool.inputSchema.jsonSchema.properties.flag).toBe(false)
   })
 })

--- a/main/src/utils/mcp-tools.ts
+++ b/main/src/utils/mcp-tools.ts
@@ -15,6 +15,49 @@ export interface McpToolDefinition {
   inputSchema: Tool['inputSchema']
 }
 
+/**
+ * Normalize a JSON Schema in place for Gemini's stricter validator. Drops
+ * non-string `enum`s (Gemini allows `enum` only on strings) and collapses
+ * union `type` arrays to a single type (`'null'` becomes `nullable: true`),
+ * both of which Gemini otherwise rejects.
+ */
+export function sanitizeMcpJsonSchema(node: unknown): void {
+  if (!node || typeof node !== 'object') return
+  if (Array.isArray(node)) {
+    for (const item of node) sanitizeMcpJsonSchema(item)
+    return
+  }
+  const obj = node as Record<string, unknown>
+  if (
+    Array.isArray(obj.enum) &&
+    !obj.enum.every((value) => typeof value === 'string')
+  ) {
+    delete obj.enum
+  }
+  if (Array.isArray(obj.type)) {
+    const types = obj.type.filter(
+      (t): t is string => typeof t === 'string' && t !== 'null'
+    )
+    if (obj.type.includes('null')) obj.nullable = true
+    obj.type = types[0] ?? 'string'
+  }
+  for (const key of Object.keys(obj)) sanitizeMcpJsonSchema(obj[key])
+}
+
+/** Sanitize a tool's JSON Schema, whether wrapped (`inputSchema.jsonSchema`)
+ * or bare (`inputSchema`). Mutates in place; safe on any tool. */
+export function sanitizeToolInputSchema(tool: unknown): void {
+  if (!tool || typeof tool !== 'object') return
+  const inputSchema = (tool as { inputSchema?: unknown }).inputSchema
+  if (!inputSchema || typeof inputSchema !== 'object') return
+  const wrapped = (inputSchema as { jsonSchema?: unknown }).jsonSchema
+  if (wrapped && typeof wrapped === 'object') {
+    sanitizeMcpJsonSchema(wrapped)
+  } else {
+    sanitizeMcpJsonSchema(inputSchema)
+  }
+}
+
 export function isMcpToolDefinition(obj: unknown): obj is McpToolDefinition {
   if (!obj || typeof obj !== 'object' || obj === null) return false
 


### PR DESCRIPTION
After the AI SDK bump, Google models surfaced two playground issues: provider failures (e.g. `AI_RetryError` high-demand messages) showed a generic "An error occurred." in the UI, and MCP tool calls failed schema validation on Gemini (direct Google API or `google/*` via OpenRouter).

Two atomic commits — error surfacing first, then Gemini schema normalization.

## Summary

- **Provider errors now reach the UI.** `toUIMessageStream` gets an `onError` callback wired through a shared `toUserFacingErrorMessage` helper, so the playground shows the actual provider message (with friendly mapping for common cases like overload/rate-limit/quota/auth).
- **Gemini MCP tool schemas are normalized before the model sees them.** MCP servers sometimes emit JSON Schema constructs Gemini rejects: non-string `enum`s (e.g. `{ type: 'boolean', enum: [true] }`) and union `type` arrays (e.g. `{ type: ['string','number','boolean'] }`). A recursive sanitizer strips or collapses these in place; sanitization runs only for Google directly or `google/*` OpenRouter models so other providers keep richer schemas.

## Changes

### Commit 1 — `fix(playground): surface provider errors in streaming UI`

- **[`main/src/chat/streaming.ts`](main/src/chat/streaming.ts)** — extract `toUserFacingErrorMessage`, pass `onError` to `result.toUIMessageStream(...)`, reuse the helper in the outer catch block (replaces duplicated inline mapping).
- **[`main/src/chat/__tests__/streaming.test.ts`](main/src/chat/__tests__/streaming.test.ts)** — regression test asserting `onError` maps provider errors through the helper.

### Commit 2 — `fix(chat): sanitize MCP tool schemas for Gemini`

- **[`main/src/utils/mcp-tools.ts`](main/src/utils/mcp-tools.ts)** — add `sanitizeMcpJsonSchema` / `sanitizeToolInputSchema` (drop non-string enums; collapse union `type` arrays, mapping `'null'` to `nullable: true`).
- **[`main/src/chat/mcp-tools.ts`](main/src/chat/mcp-tools.ts)** — opt-in sanitization via `createMcpTools(..., { sanitizeSchemas })` inside `registerTool`.
- **[`main/src/chat/streaming.ts`](main/src/chat/streaming.ts)** — `requiresGeminiSchemaCompat(provider, model)` gates sanitization to Google / `google/*` OpenRouter routes.
- **Tests** — unit coverage in [`main/src/utils/__tests__/mcp-tools.test.ts`](main/src/utils/__tests__/mcp-tools.test.ts); mock fix in [`main/src/chat/__tests__/mcp-tools.test.ts`](main/src/chat/__tests__/mcp-tools.test.ts) to expose the real sanitizer.

## Test plan

- [x] `pnpm run test:nonInteractive run main/src/chat/__tests__/streaming.test.ts main/src/utils/__tests__/mcp-tools.test.ts main/src/chat/__tests__/mcp-tools.test.ts`
- [x] `pnpm run type-check` clean
- [ ] **Error surfacing**: trigger a Google high-demand / retry error → playground shows the provider message, not "An error occurred."
- [ ] **Gemini + GitHub MCP**: send a message with GitHub tools enabled on Google API or OpenRouter `google/gemini-*` → stream completes without `enum[0] (TYPE_STRING)` or `required[n]: property is not defined` schema errors
- [ ] **Other providers**: confirm OpenAI/Anthropic MCP tool calls still work with unsanitized schemas (union types preserved)

Made with [Cursor](https://cursor.com)