### PR TITLE
feat(on-ramp): increase dismiss period to 60 days

### DIFF
--- a/renderer/src/common/components/__tests__/expert-consultation-banner.test.tsx
+++ b/renderer/src/common/components/__tests__/expert-consultation-banner.test.tsx
@@ -108,9 +108,9 @@ describe('ExpertConsultationBanner', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('does not render when dismissed less than 30 days ago', async () => {
+    it('does not render when dismissed less than 60 days ago', async () => {
       const recentDismissal = new Date(
-        Date.now() - 10 * 24 * 60 * 60 * 1000
+        Date.now() - 30 * 24 * 60 * 60 * 1000
       ).toISOString()
       window.electronAPI.getExpertConsultationState = vi
         .fn()
@@ -128,9 +128,9 @@ describe('ExpertConsultationBanner', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('renders when dismissed more than 30 days ago', async () => {
+    it('renders when dismissed more than 60 days ago', async () => {
       const oldDismissal = new Date(
-        Date.now() - 35 * 24 * 60 * 60 * 1000
+        Date.now() - 75 * 24 * 60 * 60 * 1000
       ).toISOString()
       window.electronAPI.getExpertConsultationState = vi
         .fn()

--- a/renderer/src/common/components/__tests__/newsletter-modal.test.tsx
+++ b/renderer/src/common/components/__tests__/newsletter-modal.test.tsx
@@ -99,9 +99,9 @@ describe('NewsletterModal', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('does not render when dismissed less than 15 days ago', async () => {
+    it('does not render when dismissed less than 60 days ago', async () => {
       const recentDismissal = new Date(
-        Date.now() - 10 * 24 * 60 * 60 * 1000
+        Date.now() - 30 * 24 * 60 * 60 * 1000
       ).toISOString()
       window.electronAPI.getNewsletterState = vi
         .fn()
@@ -119,9 +119,9 @@ describe('NewsletterModal', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('renders when dismissed more than 15 days ago', async () => {
+    it('renders when dismissed more than 60 days ago', async () => {
       const oldDismissal = new Date(
-        Date.now() - 20 * 24 * 60 * 60 * 1000
+        Date.now() - 75 * 24 * 60 * 60 * 1000
       ).toISOString()
       window.electronAPI.getNewsletterState = vi
         .fn()

--- a/renderer/src/common/components/expert-consultation-banner.tsx
+++ b/renderer/src/common/components/expert-consultation-banner.tsx
@@ -8,7 +8,10 @@ import log from 'electron-log/renderer'
 import { getApiV1BetaWorkloadsOptions } from '@common/api/generated/@tanstack/react-query.gen'
 import type { GithubComStacklokToolhivePkgCoreWorkload } from '@common/api/generated/types.gen'
 import { trackEvent } from '../lib/analytics'
-import { shouldShowAfterDismissal, DISMISS_DAYS } from '../lib/hubspot'
+import {
+  shouldShowAfterDismissal,
+  HUBSPOT_ON_RAMP_DISMISS_DAYS,
+} from '../lib/hubspot'
 import { useHubSpotForm } from '../hooks/use-hubspot-form'
 import {
   Dialog,
@@ -390,7 +393,7 @@ export function ExpertConsultationBanner() {
     shouldShowAfterDismissal(
       consultationState.submitted,
       consultationState.dismissedAt,
-      DISMISS_DAYS
+      HUBSPOT_ON_RAMP_DISMISS_DAYS
     )
 
   const isNewsletterModalVisible =

--- a/renderer/src/common/components/expert-consultation-banner.tsx
+++ b/renderer/src/common/components/expert-consultation-banner.tsx
@@ -8,7 +8,7 @@ import log from 'electron-log/renderer'
 import { getApiV1BetaWorkloadsOptions } from '@common/api/generated/@tanstack/react-query.gen'
 import type { GithubComStacklokToolhivePkgCoreWorkload } from '@common/api/generated/types.gen'
 import { trackEvent } from '../lib/analytics'
-import { shouldShowAfterDismissal } from '../lib/hubspot'
+import { shouldShowAfterDismissal, DISMISS_DAYS } from '../lib/hubspot'
 import { useHubSpotForm } from '../hooks/use-hubspot-form'
 import {
   Dialog,
@@ -30,7 +30,6 @@ import {
   DEMO_URL,
   HUBSPOT_EXPERT_CONSULTATION_FORM_ID,
 } from '@common/app-info'
-const DISMISS_DAYS = 30
 const MIN_SERVERS_IN_GROUP = 3
 
 function hasGroupWithEnoughServers(

--- a/renderer/src/common/components/newsletter-modal.tsx
+++ b/renderer/src/common/components/newsletter-modal.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod/v4'
 import * as Sentry from '@sentry/electron/renderer'
 import log from 'electron-log/renderer'
 import { trackEvent } from '../lib/analytics'
-import { shouldShowAfterDismissal } from '../lib/hubspot'
+import { shouldShowAfterDismissal, DISMISS_DAYS } from '../lib/hubspot'
 import { useHubSpotForm } from '../hooks/use-hubspot-form'
 import { useNewsletterModal } from '../contexts/newsletter-modal-context'
 import {
@@ -23,7 +23,6 @@ import {
   PrivacyFooter,
 } from './hubspot-form-parts'
 import { APP_DISPLAY_NAME, HUBSPOT_NEWSLETTER_FORM_ID } from '@common/app-info'
-const DISMISS_DAYS = 15
 
 const emailSchema = z.email('Please enter a valid email address')
 

--- a/renderer/src/common/components/newsletter-modal.tsx
+++ b/renderer/src/common/components/newsletter-modal.tsx
@@ -5,7 +5,10 @@ import { z } from 'zod/v4'
 import * as Sentry from '@sentry/electron/renderer'
 import log from 'electron-log/renderer'
 import { trackEvent } from '../lib/analytics'
-import { shouldShowAfterDismissal, DISMISS_DAYS } from '../lib/hubspot'
+import {
+  shouldShowAfterDismissal,
+  HUBSPOT_ON_RAMP_DISMISS_DAYS,
+} from '../lib/hubspot'
 import { useHubSpotForm } from '../hooks/use-hubspot-form'
 import { useNewsletterModal } from '../contexts/newsletter-modal-context'
 import {
@@ -204,7 +207,7 @@ export function NewsletterModal() {
     !shouldShowAfterDismissal(
       newsletterState!.subscribed,
       newsletterState!.dismissedAt,
-      DISMISS_DAYS
+      HUBSPOT_ON_RAMP_DISMISS_DAYS
     )
 
   if (shouldHideBecauseClosed || shouldHideBecauseDismissed) return null

--- a/renderer/src/common/lib/hubspot.ts
+++ b/renderer/src/common/lib/hubspot.ts
@@ -8,6 +8,8 @@ export { HUBSPOT_PORTAL_ID, PRIVACY_POLICY_URL }
 
 export const CONSENT_PROCESSING_TEXT = `I agree to allow ${COMPANY_NAME} to store and process my personal data.`
 
+export const DISMISS_DAYS = 60
+
 export function shouldShowAfterDismissal(
   flag: boolean,
   dismissedAt: string,

--- a/renderer/src/common/lib/hubspot.ts
+++ b/renderer/src/common/lib/hubspot.ts
@@ -8,7 +8,7 @@ export { HUBSPOT_PORTAL_ID, PRIVACY_POLICY_URL }
 
 export const CONSENT_PROCESSING_TEXT = `I agree to allow ${COMPANY_NAME} to store and process my personal data.`
 
-export const DISMISS_DAYS = 60
+export const HUBSPOT_ON_RAMP_DISMISS_DAYS = 60
 
 export function shouldShowAfterDismissal(
   flag: boolean,


### PR DESCRIPTION
The time between one dismissal and the next was too short, and I think that’s probably why we received more fake email addresses. This increases the dismissal period to 60 days.