### PR TITLE
fix(registry): sort group servers alphabetically

### DIFF
--- a/renderer/src/routes/(registry)/registry-group_.$name.tsx
+++ b/renderer/src/routes/(registry)/registry-group_.$name.tsx
@@ -43,6 +43,20 @@ function RegistryGroupDetail() {
   const hasServers =
     Object.keys(group?.servers ?? {}).length > 0 ||
     Object.keys(group?.remote_servers ?? {}).length > 0
+  const groupServers = [
+    ...Object.entries(group?.servers ?? {}).map(([key, srv]) => ({
+      key: `local-${key}`,
+      server: srv as RegistryImageMetadata,
+    })),
+    ...Object.entries(group?.remote_servers ?? {}).map(([key, srv]) => ({
+      key: `remote-${key}`,
+      server: srv as RegistryRemoteServerMetadata,
+    })),
+  ].sort((a, b) =>
+    (a.server.name ?? '').localeCompare(b.server.name ?? '', undefined, {
+      sensitivity: 'base',
+    })
+  )
 
   return (
     <div className="flex max-h-full w-full flex-1 flex-col">
@@ -73,26 +87,14 @@ function RegistryGroupDetail() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {Object.entries(group?.servers ?? {}).map(
-                  ([key, srv]: [string, RegistryImageMetadata]) => (
-                    <TableRow key={`local-${key}`}>
-                      <TableCell className="text-foreground">
-                        {srv.name}
-                      </TableCell>
-                      <TableCell>{srv.description}</TableCell>
-                    </TableRow>
-                  )
-                )}
-                {Object.entries(group?.remote_servers ?? {}).map(
-                  ([key, srv]: [string, RegistryRemoteServerMetadata]) => (
-                    <TableRow key={`remote-${key}`}>
-                      <TableCell className="text-foreground">
-                        {srv.name}
-                      </TableCell>
-                      <TableCell>{srv.description}</TableCell>
-                    </TableRow>
-                  )
-                )}
+                {groupServers.map(({ key, server }) => (
+                  <TableRow key={key}>
+                    <TableCell className="text-foreground">
+                      {server.name}
+                    </TableCell>
+                    <TableCell>{server.description}</TableCell>
+                  </TableRow>
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/renderer/src/routes/__tests__/registry-group_.$name.test.tsx
+++ b/renderer/src/routes/__tests__/registry-group_.$name.test.tsx
@@ -255,6 +255,9 @@ describe('Registry Group Detail Route', () => {
     const bodyRows = allRows.slice(1) // skip header row
 
     expect(bodyRows).toHaveLength(3)
+    expect(
+      bodyRows.map((row) => within(row).getAllByRole('cell')[0]?.textContent)
+    ).toEqual(['anthropic-server', 'huggingface-remote', 'openai-server'])
 
     expect(screen.getByText('openai-server')).toBeVisible()
     expect(screen.getByText('OpenAI API integration for Claude')).toBeVisible()


### PR DESCRIPTION
## Summary
- Sort registry group detail rows alphabetically after combining local and remote servers.
- Add a regression assertion that mixed local/remote group servers render in one unified alphabetical order.

Fixes #1956

## Validation
- `pnpm exec vitest run 'renderer/src/routes/__tests__/registry-group_.$name.test.tsx'`
- `pnpm run prettier`
- `pnpm run lint`
- `pnpm run type-check`
- `git diff --check`
