### PR TITLE
fix(settings): hide auto-update controls on Linux

### DIFF
--- a/renderer/src/common/components/settings/tabs/__tests__/version-tab.test.tsx
+++ b/renderer/src/common/components/settings/tabs/__tests__/version-tab.test.tsx
@@ -354,6 +354,19 @@ describe('VersionTab', () => {
       expect(screen.queryByText('Updates')).not.toBeInTheDocument()
     })
 
+    it('hides the auto-update controls on Linux', () => {
+      window.electronAPI.isLinux = true
+
+      renderWithProviders(
+        <VersionTab appInfo={mockAppInfo} isLoading={false} error={null} />
+      )
+
+      expect(screen.queryByText('Updates')).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('switch', { name: /downloads/i })
+      ).not.toBeInTheDocument()
+    })
+
     it('hides the update-available banner when auto-update permission is false', () => {
       import.meta.env.MODE = 'production'
 

--- a/renderer/src/common/components/settings/tabs/version-tab.tsx
+++ b/renderer/src/common/components/settings/tabs/version-tab.tsx
@@ -55,7 +55,9 @@ export function VersionTab({ appInfo, isLoading, error }: VersionTabProps) {
     useAutoUpdateStatus()
   const { mutateAsync: setAutoUpdate, isPending: isSetAutoUpdatePending } =
     useSetAutoUpdate()
+  const isLinux = window.electronAPI?.isLinux
   const canShowAutoUpdate = canShow(PERMISSION_KEYS.AUTO_UPDATE)
+  const canShowAutoUpdateControls = canShowAutoUpdate && !isLinux
   const canShowUpdateAlert =
     canShowAutoUpdate && appInfo?.isNewVersionAvailable && isProduction
 
@@ -82,7 +84,6 @@ export function VersionTab({ appInfo, isLoading, error }: VersionTabProps) {
   }
 
   const handleManualUpdate = () => {
-    const isLinux = window.electronAPI?.isLinux
     if (isLinux) {
       window.open(GITHUB_RELEASES_URL)
 
@@ -144,7 +145,7 @@ export function VersionTab({ appInfo, isLoading, error }: VersionTabProps) {
         <Separator />
       </div>
 
-      {canShowAutoUpdate && (
+      {canShowAutoUpdateControls && (
         <>
           <SettingsSectionTitle>Updates</SettingsSectionTitle>
           <div className="flex flex-col gap-3 py-1">


### PR DESCRIPTION
## Summary

- hide the auto-update toggle/controls on Linux, where Electron auto-update is not supported
- keep the existing Linux manual download path that opens GitHub Releases when an update banner is shown
- add a Version tab regression test for the Linux controls state

## Why

Fixes #2266. The Version tab already redirects Linux users to GitHub Releases for manual downloads, but the automatic update controls were still visible and could be toggled even though Linux builds do not support that auto-update flow.

## Validation

- `pnpm exec vitest run renderer/src/common/components/settings/tabs/__tests__/version-tab.test.tsx`
- `pnpm run prettier`
- `pnpm run lint`
- `pnpm run type-check`
- `git diff --check`
