### PR TITLE
ci(pr-size-labeler): adjust action event target

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Size Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
Use `pull_request_target`, which runs the workflow definition from the default branch (trusted) and grants the declared token permissions for fork PRs. This is the same pattern GitHub recommends for labeler workflows.

- Switch the PR Size Labeler workflow trigger from `pull_request` to `pull_request_target` so it can write size labels on fork PRs
- Fixes `403 Resource not accessible by integration` failures when external contributors open PRs (e.g. [#2425](https://github.com/stacklok/toolhive-studio/pull/2425))
- Safe for this workflow because it only calls the GitHub REST API via `actions/github-script`, no checkout or execution of contributor code