### PR TITLE
feat(playground): update providers models

### DIFF
--- a/main/src/chat/constants.ts
+++ b/main/src/chat/constants.ts
@@ -18,7 +18,10 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
     id: 'openai',
     name: 'OpenAI',
     models: [
-      // GPT-5.4 (newest)
+      // GPT-5.5 (newest)
+      'gpt-5.5',
+
+      // GPT-5.4
       'gpt-5.4',
       'gpt-5.4-pro',
       'gpt-5.4-mini',
@@ -26,26 +29,19 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
 
       // GPT-5.3
       'gpt-5.3-chat-latest',
-      'gpt-5.3-codex',
 
       // GPT-5.2
       'gpt-5.2',
       'gpt-5.2-chat-latest',
       'gpt-5.2-pro',
-      'gpt-5.2-codex',
 
       // GPT-5.1
       'gpt-5.1',
       'gpt-5.1-chat-latest',
-      'gpt-5.1-codex',
-      'gpt-5.1-codex-mini',
-      'gpt-5.1-codex-max',
 
       // GPT-5
       'gpt-5',
       'gpt-5-chat-latest',
-      'gpt-5-codex',
-      'gpt-5-pro',
       'gpt-5-mini',
       'gpt-5-nano',
 
@@ -57,9 +53,16 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
       // GPT-4o
       'gpt-4o',
       'gpt-4o-mini',
+      'gpt-4o-audio-preview',
+      'gpt-4o-mini-audio-preview',
+      'gpt-4o-search-preview',
+      'gpt-4o-mini-search-preview',
 
       // GPT-3.5 (legacy)
       'gpt-3.5-turbo',
+      'gpt-3.5-turbo-0125',
+      'gpt-3.5-turbo-1106',
+      'gpt-3.5-turbo-16k',
 
       // O-series reasoning models
       'o4-mini',
@@ -72,7 +75,12 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
     id: 'anthropic',
     name: 'Anthropic',
     models: [
-      // Claude 4.7 (newest)
+      // Claude 5 / 4.8 (newest)
+      'claude-opus-4-8',
+      'claude-sonnet-5',
+      'claude-fable-5',
+
+      // Claude 4.7
       'claude-opus-4-7',
 
       // Claude 4.6
@@ -104,12 +112,18 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
       'gemini-flash-latest',
       'gemini-flash-lite-latest',
 
-      // Gemini 3.1 (newest)
+      // Gemini 3.5 (newest)
+      'gemini-3.5-flash',
+
+      // Gemini 3.1
       'gemini-3.1-pro-preview',
+      'gemini-3.1-pro-preview-customtools',
       'gemini-3.1-flash-image-preview',
       'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-tts-preview',
 
       // Gemini 3
+      'gemini-3-pro-preview',
       'gemini-3-pro-image-preview',
       'gemini-3-flash-preview',
 
@@ -118,11 +132,32 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
       'gemini-2.5-flash',
       'gemini-2.5-flash-image',
       'gemini-2.5-flash-lite',
+      'gemini-2.5-flash-preview-tts',
+      'gemini-2.5-pro-preview-tts',
+      'gemini-2.5-flash-native-audio-latest',
       'gemini-2.5-computer-use-preview-10-2025',
 
-      // Gemma 4
-      'gemma-4-31b-it',
-      'gemma-4-26b-a4b-it',
+      // Gemini 2.0
+      'gemini-2.0-flash',
+      'gemini-2.0-flash-lite',
+
+      // Deep research
+      'deep-research-pro-preview-12-2025',
+      'deep-research-max-preview-04-2026',
+      'deep-research-preview-04-2026',
+
+      // Specialty
+      'nano-banana-pro-preview',
+      'gemini-robotics-er-1.5-preview',
+      'aqa',
+
+      // Gemma 3
+      'gemma-3-27b-it',
+      'gemma-3-12b-it',
+      'gemma-3-4b-it',
+      'gemma-3-1b-it',
+      'gemma-3n-e4b-it',
+      'gemma-3n-e2b-it',
     ],
   },
   {
@@ -130,30 +165,14 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
     name: 'xAI',
     models: [
       // Grok 4.20 (newest)
-      'grok-4.20-0309-reasoning',
-      'grok-4.20-0309-non-reasoning',
-      'grok-4.20-multi-agent-0309',
+      'grok-4.20-reasoning',
+      'grok-4.20-non-reasoning',
 
-      // Grok 4.1
-      'grok-4-1-fast-reasoning',
-      'grok-4-1-fast-non-reasoning',
+      // Grok 4.3
+      'grok-4.3',
 
-      // Grok 4
-      'grok-4',
-      'grok-4-latest',
-      'grok-4-fast-reasoning',
-      'grok-4-fast-non-reasoning',
-
-      // Grok Code
-      'grok-code-fast-1',
-
-      // Grok 3
-      'grok-3',
-      'grok-3-latest',
-
-      // Grok 3 Mini
-      'grok-3-mini',
-      'grok-3-mini-latest',
+      // Latest alias
+      'grok-latest',
     ],
   },
   {
@@ -174,27 +193,44 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
       // Fallback models for when API is unavailable:
 
       // OpenAI models via OpenRouter
+      'openai/gpt-5.5',
       'openai/gpt-5.4',
       'openai/gpt-5.4-pro',
-      'openai/gpt-5.3-codex',
+      'openai/gpt-5.4-mini',
+      'openai/gpt-5.4-nano',
+      'openai/gpt-5.3-chat-latest',
       'openai/gpt-5.2',
+      'openai/gpt-5.2-chat-latest',
       'openai/gpt-5.2-pro',
-      'openai/gpt-5.2-codex',
       'openai/gpt-5.1',
-      'openai/gpt-5.1-codex',
+      'openai/gpt-5.1-chat-latest',
       'openai/gpt-5',
-      'openai/gpt-5-pro',
+      'openai/gpt-5-chat-latest',
       'openai/gpt-5-mini',
+      'openai/gpt-5-nano',
       'openai/gpt-4.1',
       'openai/gpt-4.1-mini',
+      'openai/gpt-4.1-nano',
       'openai/gpt-4o',
       'openai/gpt-4o-mini',
+      'openai/gpt-4o-audio-preview',
+      'openai/gpt-4o-mini-audio-preview',
+      'openai/gpt-4o-search-preview',
+      'openai/gpt-4o-mini-search-preview',
+      'openai/gpt-3.5-turbo',
+      'openai/gpt-3.5-turbo-0125',
+      'openai/gpt-3.5-turbo-1106',
+      'openai/gpt-3.5-turbo-16k',
       'openai/o4-mini',
       'openai/o3',
       'openai/o3-mini',
       'openai/o1',
 
       // Anthropic models via OpenRouter
+      'anthropic/claude-opus-4-8',
+      'anthropic/claude-sonnet-5',
+      'anthropic/claude-fable-5',
+      'anthropic/claude-opus-4-7',
       'anthropic/claude-opus-4-6',
       'anthropic/claude-sonnet-4-6',
       'anthropic/claude-opus-4-5',
@@ -206,22 +242,46 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
       'anthropic/claude-3-haiku-20240307',
 
       // Google models via OpenRouter
+      'google/gemini-pro-latest',
+      'google/gemini-flash-latest',
+      'google/gemini-flash-lite-latest',
+      'google/gemini-3.5-flash',
       'google/gemini-3.1-pro-preview',
+      'google/gemini-3.1-pro-preview-customtools',
+      'google/gemini-3.1-flash-image-preview',
+      'google/gemini-3.1-flash-lite-preview',
+      'google/gemini-3.1-flash-tts-preview',
       'google/gemini-3-pro-preview',
+      'google/gemini-3-pro-image-preview',
       'google/gemini-3-flash-preview',
       'google/gemini-2.5-pro',
       'google/gemini-2.5-flash',
+      'google/gemini-2.5-flash-image',
       'google/gemini-2.5-flash-lite',
+      'google/gemini-2.5-flash-preview-tts',
+      'google/gemini-2.5-pro-preview-tts',
+      'google/gemini-2.5-flash-native-audio-latest',
+      'google/gemini-2.5-computer-use-preview-10-2025',
       'google/gemini-2.0-flash',
       'google/gemini-2.0-flash-lite',
+      'google/deep-research-pro-preview-12-2025',
+      'google/deep-research-max-preview-04-2026',
+      'google/deep-research-preview-04-2026',
+      'google/nano-banana-pro-preview',
+      'google/gemini-robotics-er-1.5-preview',
+      'google/aqa',
+      'google/gemma-3-27b-it',
+      'google/gemma-3-12b-it',
+      'google/gemma-3-4b-it',
+      'google/gemma-3-1b-it',
+      'google/gemma-3n-e4b-it',
+      'google/gemma-3n-e2b-it',
 
       // xAI models via OpenRouter
-      'xai/grok-4-1-fast-reasoning',
-      'xai/grok-4',
-      'xai/grok-4-fast-reasoning',
-      'xai/grok-code-fast-1',
-      'xai/grok-3',
-      'xai/grok-3-mini',
+      'xai/grok-4.20-reasoning',
+      'xai/grok-4.20-non-reasoning',
+      'xai/grok-4.3',
+      'xai/grok-latest',
 
       // Meta (Llama) models
       'meta-llama/llama-3.3-70b-instruct',


### PR DESCRIPTION
Refresh CHAT_PROVIDER_INFO model lists in `main/src/chat/constants.ts` to match the model IDs declared in each `@ai-sdk/*` provider's TypeScript types.

- OpenAI: add gpt-5.5 and audio/search/3.5 variants; remove non-typed codex/pro entries
- Anthropic: add claude-opus-4-8, claude-sonnet-5, claude-fable-5
- Google: add Gemini 3.5, deep-research, and Gemma 3 models; remove invalid gemma-4-* entries
- xAI: align to SDK-typed IDs (grok-4.20-*, grok-4.3, grok-latest)
- OpenRouter: sync first-party fallback entries to the updated alias lists