### PR TITLE
fix(ci): merge multi-arch flatpak bundle artifacts before publishing

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -273,6 +273,7 @@ jobs:
         with:
           pattern: flatpak-bundle-*
           path: _bundles
+          merge-multiple: true
 
       - name: Push Flatpak OCI to GHCR
         uses: aetherpak/actions/publish-oci@d2112669ceaa09afb7c2b96e9e9844866a6c8e78


### PR DESCRIPTION
## Summary

`publish-flatpak` downloads both `flatpak-bundle-x86_64` and `flatpak-bundle-aarch64` via `pattern: flatpak-bundle-*`, but without `merge-multiple`, `actions/download-artifact` puts each match in its own `<artifact-name>/` subdirectory. That adds a directory level the existing `bundle-path` glob (`_bundles/**/*.flatpak`) doesn't account for — `aetherpak import`'s glob expansion (Go's `filepath.Glob`, non-recursive) needs exactly one directory level between `_bundles` and the file.

This caused the real `v0.37.0-rc.0` prerelease's Publish Flatpak job to fail: https://github.com/stacklok/toolhive-studio/actions/runs/28872921555/job/85644431830 (`Failed to open file ".../_bundles/**/*.flatpak": No such file or directory`).

`merge-multiple: true` flattens both artifacts into `_bundles/<arch>/*.flatpak` directly, matching what the glob already expects.

## Test plan
- [x] YAML validated, prettier-formatted
- [ ] Verify on the next prerelease/release that `Publish Flatpak` succeeds

Fully or partially written by an AI agent.