### PR TITLE
fix(ci): don't fail unit tests job on Coveralls upload errors

### DIFF
--- a/.github/workflows/_unit-tests.yml
+++ b/.github/workflows/_unit-tests.yml
@@ -18,6 +18,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Upload coverage to Coveralls
+        continue-on-error: true
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           file: ./coverage/lcov.info


### PR DESCRIPTION
## Summary
- Coveralls occasionally returns transient errors (e.g. a 504 Gateway Timeout was hit on #2463) which failed the whole `Unit Tests / Vitest` job even though the tests themselves passed.
- Add `continue-on-error: true` to the "Upload coverage to Coveralls" step so a flaky Coveralls upload no longer blocks CI.

## Test plan
- [x] Confirm the Vitest job passes even if the Coveralls upload step is forced to fail
- [x] Confirm coverage still uploads to Coveralls normally when the service is healthy