### PR TITLE
fix(chat): hollow assistant messages and session-tied auto-titles

### DIFF
--- a/common/chat/thread-title.ts
+++ b/common/chat/thread-title.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared contract for optimistic / fallback thread titles.
+ *
+ * Main (`TitleService`) and the renderer (`useChatStreaming`) both derive
+ * the user-message fallback from the same slice length so
+ * `shouldAutoTitleThread` can recognize the optimistic title by equality
+ * and still upgrade it to an LLM title.
+ */
+export const FALLBACK_TITLE_MAX_CHARS = 60
+
+export function extractThreadTitleText(
+  parts: ReadonlyArray<{
+    type: string
+    text?: string
+  }>
+): string {
+  return parts
+    .filter(
+      (part): part is { type: 'text'; text: string } =>
+        part.type === 'text' && typeof part.text === 'string'
+    )
+    .map((part) => part.text)
+    .join(' ')
+    .trim()
+}
+
+export function fallbackTitleFromParts(
+  parts: ReadonlyArray<{ type: string; text?: string }>
+): string {
+  return extractThreadTitleText(parts).slice(0, FALLBACK_TITLE_MAX_CHARS)
+}

--- a/main/src/chat/__tests__/generate-thread-title.test.ts
+++ b/main/src/chat/__tests__/generate-thread-title.test.ts
@@ -428,20 +428,74 @@ describe('generateThreadTitle', () => {
       expect(result).toMatchObject({
         success: true,
         title: 'Manual Title',
+        updated: false,
       })
       expect(mockGenerateText).not.toHaveBeenCalled()
+      expect(mockWriteThread).not.toHaveBeenCalled()
     })
 
-    it('persists the user-message fallback before calling the LLM', async () => {
+    it('writes once with the LLM title', async () => {
+      mockGenerateText.mockResolvedValue({ text: 'Great Title' })
       await generateThreadTitle('thread-1')
 
+      expect(mockWriteThread).toHaveBeenCalledTimes(1)
       expect(mockWriteThread).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'thread-1',
+          title: 'Great Title',
+          titleEditedByUser: false,
+        })
+      )
+    })
+
+    it('does not write when the renderer already persisted the fallback title', async () => {
+      mockGetThread.mockReturnValue(
+        makeThread({
           title: 'Hello',
           titleEditedByUser: false,
         })
       )
+      mockGenerateText.mockResolvedValue({ text: 'Hello' })
+
+      const result = await generateThreadTitle('thread-1')
+
+      expect(result).toMatchObject({
+        success: true,
+        title: 'Hello',
+        updated: false,
+      })
+      expect(mockWriteThread).not.toHaveBeenCalled()
+    })
+
+    it('still auto-titles when a legacy hollow assistant is present', async () => {
+      mockGetThread.mockReturnValue(
+        makeThread({
+          title: undefined,
+          messages: [
+            {
+              id: 'm1',
+              role: 'user',
+              parts: [{ type: 'text', text: 'Hello' }],
+            },
+            { id: 'm-hollow', role: 'assistant', parts: [] },
+            {
+              id: 'm2',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Hi there' }],
+            },
+          ],
+        })
+      )
+      mockGenerateText.mockResolvedValue({ text: 'Legacy Hollow Thread' })
+
+      const result = await generateThreadTitle('thread-1')
+
+      expect(result).toMatchObject({
+        success: true,
+        title: 'Legacy Hollow Thread',
+        updated: true,
+      })
+      expect(mockGenerateText).toHaveBeenCalled()
     })
   })
 

--- a/main/src/chat/__tests__/generate-thread-title.test.ts
+++ b/main/src/chat/__tests__/generate-thread-title.test.ts
@@ -225,6 +225,7 @@ describe('generateThreadTitle', () => {
       expect(result).toMatchObject({
         success: true,
         title: 'Patching Security Vulnerabilities',
+        updated: true,
       })
     })
 
@@ -373,6 +374,7 @@ describe('generateThreadTitle', () => {
       expect(result).toMatchObject({
         success: true,
         title: 'Existing Custom Title',
+        updated: false,
       })
       expect(mockGenerateText).not.toHaveBeenCalled()
       expect(mockWriteThread).not.toHaveBeenCalled()

--- a/main/src/chat/__tests__/generate-thread-title.test.ts
+++ b/main/src/chat/__tests__/generate-thread-title.test.ts
@@ -11,6 +11,9 @@ const mockGetThread = vi.hoisted(() => vi.fn())
 const mockWriteThread = vi.hoisted(() => vi.fn())
 const mockReadSelectedModel = vi.hoisted(() => vi.fn())
 const mockReadChatProvider = vi.hoisted(() => vi.fn())
+const mockReadThreadSelectedModel = vi.hoisted(() =>
+  vi.fn<() => { provider: string; model: string } | null>(() => null)
+)
 const mockCreateModelFromRequest = vi.hoisted(() => vi.fn())
 
 // ---------------------------------------------------------------------------
@@ -27,7 +30,7 @@ vi.mock('../../db/readers/threads-reader', () => ({
   readAllThreads: vi.fn(() => []),
   readActiveThreadId: vi.fn(),
   readThreadCount: vi.fn(() => 0),
-  readThreadSelectedModel: vi.fn(() => null),
+  readThreadSelectedModel: mockReadThreadSelectedModel,
   readThreadEnabledMcpTools: vi.fn(() => ({})),
   readThreadEnabledSkills: vi.fn(() => []),
 }))
@@ -80,7 +83,7 @@ const fakeConvertedMessages = [{ role: 'user', content: 'hello' }]
 function makeThread(overrides: Record<string, unknown> = {}) {
   return {
     id: 'thread-1',
-    title: 'Old title',
+    title: undefined,
     titleEditedByUser: false,
     messages: [
       { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
@@ -102,6 +105,7 @@ describe('generateThreadTitle', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetThread.mockReturnValue(makeThread())
+    mockReadThreadSelectedModel.mockReturnValue(null)
     mockReadSelectedModel.mockReturnValue({
       provider: 'openai',
       model: 'gpt-4o',
@@ -160,32 +164,55 @@ describe('generateThreadTitle', () => {
       })
     })
 
-    it('returns failure when LLM returns only whitespace', async () => {
+    it('falls back to the first user message when LLM returns only whitespace', async () => {
       mockGenerateText.mockResolvedValue({ text: '   ' })
+      const result = await generateThreadTitle('thread-1')
+      expect(result).toMatchObject({
+        success: true,
+        title: 'Hello',
+      })
+      expect(mockWriteThread).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'thread-1',
+          title: 'Hello',
+          titleEditedByUser: false,
+        })
+      )
+    })
+
+    it('falls back to the first user message when generateText throws', async () => {
+      mockGenerateText.mockRejectedValue(new Error('API timeout'))
+      const result = await generateThreadTitle('thread-1')
+      expect(result).toMatchObject({
+        success: true,
+        title: 'Hello',
+      })
+    })
+
+    it('falls back when generateText throws a non-Error value', async () => {
+      mockGenerateText.mockRejectedValue('some string error')
+      const result = await generateThreadTitle('thread-1')
+      expect(result).toMatchObject({
+        success: true,
+        title: 'Hello',
+      })
+    })
+
+    it('returns failure when LLM and user-message fallback are both empty', async () => {
+      mockGetThread.mockReturnValue(
+        makeThread({
+          messages: [
+            { id: 'm1', role: 'user', parts: [{ type: 'text', text: '   ' }] },
+          ],
+        })
+      )
+      mockGenerateText.mockResolvedValue({ text: '' })
       const result = await generateThreadTitle('thread-1')
       expect(result).toMatchObject({
         success: false,
         error: 'Empty title generated',
       })
       expect(mockWriteThread).not.toHaveBeenCalled()
-    })
-
-    it('returns failure with error message when generateText throws', async () => {
-      mockGenerateText.mockRejectedValue(new Error('API timeout'))
-      const result = await generateThreadTitle('thread-1')
-      expect(result).toMatchObject({
-        success: false,
-        error: 'Failed to generate thread title.',
-      })
-    })
-
-    it('returns failure with "Unknown error" for non-Error throws', async () => {
-      mockGenerateText.mockRejectedValue('some string error')
-      const result = await generateThreadTitle('thread-1')
-      expect(result).toMatchObject({
-        success: false,
-        error: 'Failed to generate thread title.',
-      })
     })
   })
 
@@ -238,10 +265,58 @@ describe('generateThreadTitle', () => {
         expect.objectContaining({
           model: fakeModel,
           messages: fakeConvertedMessages,
-          maxOutputTokens: 20,
+          maxOutputTokens: 64,
           instructions: expect.stringContaining('6 words or fewer'),
         })
       )
+    })
+
+    it('disables OpenRouter reasoning for title generation', async () => {
+      mockReadSelectedModel.mockReturnValue({
+        provider: 'openrouter',
+        model: 'moonshotai/kimi-k3',
+      })
+      mockReadChatProvider.mockReturnValue({
+        apiKey: 'sk-or-v1-test-key',
+      })
+
+      await generateThreadTitle('thread-1')
+
+      expect(mockGenerateText).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerOptions: {
+            openrouter: {
+              reasoning: { enabled: false, effort: 'none' },
+            },
+          },
+        })
+      )
+    })
+
+    it('does not pass OpenRouter reasoning options for other providers', async () => {
+      await generateThreadTitle('thread-1')
+      const call = mockGenerateText.mock.calls[0]?.[0] as
+        { providerOptions?: unknown } | undefined
+      expect(call?.providerOptions).toBeUndefined()
+    })
+
+    it('omits hollow assistant messages from the title context', async () => {
+      mockGetThread.mockReturnValue(
+        makeThread({
+          messages: [
+            {
+              id: 'm1',
+              role: 'user',
+              parts: [{ type: 'text', text: 'Hello' }],
+            },
+            { id: 'm2', role: 'assistant', parts: [] },
+          ],
+        })
+      )
+      await generateThreadTitle('thread-1')
+      expect(mockConvertToModelMessages).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'm1', role: 'user' }),
+      ])
     })
 
     it('works when thread has only a user message (no assistant reply yet)', async () => {
@@ -262,6 +337,109 @@ describe('generateThreadTitle', () => {
         success: true,
         title: 'Solo User Message',
       })
+    })
+
+    it('prefers the thread selected model over the global default', async () => {
+      mockReadThreadSelectedModel.mockReturnValue({
+        provider: 'openrouter',
+        model: 'moonshotai/kimi-k3',
+      })
+      mockReadSelectedModel.mockReturnValue({
+        provider: 'openai',
+        model: 'gpt-4o',
+      })
+      mockReadChatProvider.mockReturnValue({
+        apiKey: 'sk-or-v1-test-key',
+      })
+
+      await generateThreadTitle('thread-1')
+
+      expect(mockCreateModelFromRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'openrouter' }),
+        expect.objectContaining({
+          provider: 'openrouter',
+          model: 'moonshotai/kimi-k3',
+        })
+      )
+    })
+
+    it('skips LLM when the thread already has a non-fallback title', async () => {
+      mockGetThread.mockReturnValue(
+        makeThread({ title: 'Existing Custom Title' })
+      )
+
+      const result = await generateThreadTitle('thread-1')
+
+      expect(result).toMatchObject({
+        success: true,
+        title: 'Existing Custom Title',
+      })
+      expect(mockGenerateText).not.toHaveBeenCalled()
+      expect(mockWriteThread).not.toHaveBeenCalled()
+    })
+
+    it('skips LLM after the first assistant exchange', async () => {
+      mockGetThread.mockReturnValue(
+        makeThread({
+          title: undefined,
+          messages: [
+            {
+              id: 'm1',
+              role: 'user',
+              parts: [{ type: 'text', text: 'Hello' }],
+            },
+            {
+              id: 'm2',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Hi' }],
+            },
+            {
+              id: 'm3',
+              role: 'user',
+              parts: [{ type: 'text', text: 'Follow up' }],
+            },
+            {
+              id: 'm4',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Sure' }],
+            },
+          ],
+        })
+      )
+
+      const result = await generateThreadTitle('thread-1')
+
+      expect(result).toMatchObject({ success: true, title: 'Hello' })
+      expect(mockGenerateText).not.toHaveBeenCalled()
+    })
+
+    it('returns the existing title when titleEditedByUser is true', async () => {
+      mockGetThread.mockReturnValue(
+        makeThread({
+          title: 'Manual Title',
+          titleEditedByUser: true,
+        })
+      )
+
+      const result = await generateThreadTitle('thread-1')
+
+      expect(result).toMatchObject({
+        success: true,
+        title: 'Manual Title',
+      })
+      expect(mockGenerateText).not.toHaveBeenCalled()
+    })
+
+    it('persists the user-message fallback before calling the LLM', async () => {
+      await generateThreadTitle('thread-1')
+
+      expect(mockWriteThread).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'thread-1',
+          title: 'Hello',
+          titleEditedByUser: false,
+        })
+      )
     })
   })
 

--- a/main/src/chat/__tests__/streaming.test.ts
+++ b/main/src/chat/__tests__/streaming.test.ts
@@ -29,8 +29,12 @@ const mockCreateBuiltinAgentTools = vi.hoisted(() =>
 )
 const mockRunManagedStream = vi.hoisted(() =>
   vi.fn().mockImplementation(async (args: unknown) => {
-    const options = args as { onComplete?: () => void | Promise<void> }
-    await options.onComplete?.()
+    const options = args as {
+      onComplete?: (info: {
+        status: 'finished' | 'error'
+      }) => void | Promise<void>
+    }
+    await options.onComplete?.({ status: 'finished' })
   })
 )
 const mockGetAgent = vi.hoisted(() => vi.fn())
@@ -38,6 +42,7 @@ const mockResolveAgentForThread = vi.hoisted(() => vi.fn())
 const mockGenerateThreadTitle = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ success: true, title: 'Generated Title' })
 )
+const mockBroadcastThreadUpdated = vi.hoisted(() => vi.fn())
 
 vi.mock('ai', () => ({
   ToolLoopAgent: class {
@@ -66,6 +71,13 @@ vi.mock('../agents/builtin-agent-tools', () => ({
 
 vi.mock('../generate-thread-title', () => ({
   generateThreadTitle: mockGenerateThreadTitle,
+}))
+
+vi.mock('../streaming/stream-registry-broadcast', () => ({
+  broadcastThreadUpdated: mockBroadcastThreadUpdated,
+  broadcastState: vi.fn(),
+  broadcast: vi.fn(),
+  safeSend: vi.fn(),
 }))
 
 import { handleChatStreamRealtime as handleChatStreamRealtimeImpl } from '../streaming/chat-stream-service-impl'
@@ -483,7 +495,7 @@ describe('handleChatStreamRealtime — AI SDK v7 UI stream wiring', () => {
 })
 
 describe('handleChatStreamRealtime — auto-title on stream complete', () => {
-  it('calls generateThreadTitle for the chat when the managed stream completes', async () => {
+  it('calls generateThreadTitle and broadcasts thread updated on success', async () => {
     mockResolveAgentForThread.mockReturnValue(
       fakeAgent('builtin.toolhive-assistant', 'DEFAULT INSTRUCTIONS')
     )
@@ -491,5 +503,25 @@ describe('handleChatStreamRealtime — auto-title on stream complete', () => {
     await handleChatStreamRealtime(makeRequest(), 'stream-title', fakeSender)
 
     expect(mockGenerateThreadTitle).toHaveBeenCalledWith('thread-1')
+    expect(mockBroadcastThreadUpdated).toHaveBeenCalledWith('thread-1')
+  })
+
+  it('skips title generation when the stream ends in error', async () => {
+    mockRunManagedStream.mockImplementationOnce(async (args: unknown) => {
+      const options = args as {
+        onComplete?: (info: {
+          status: 'finished' | 'error'
+        }) => void | Promise<void>
+      }
+      await options.onComplete?.({ status: 'error' })
+    })
+    mockResolveAgentForThread.mockReturnValue(
+      fakeAgent('builtin.toolhive-assistant', 'DEFAULT INSTRUCTIONS')
+    )
+
+    await handleChatStreamRealtime(makeRequest(), 'stream-error', fakeSender)
+
+    expect(mockGenerateThreadTitle).not.toHaveBeenCalled()
+    expect(mockBroadcastThreadUpdated).not.toHaveBeenCalled()
   })
 })

--- a/main/src/chat/__tests__/streaming.test.ts
+++ b/main/src/chat/__tests__/streaming.test.ts
@@ -40,7 +40,11 @@ const mockRunManagedStream = vi.hoisted(() =>
 const mockGetAgent = vi.hoisted(() => vi.fn())
 const mockResolveAgentForThread = vi.hoisted(() => vi.fn())
 const mockGenerateThreadTitle = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({ success: true, title: 'Generated Title' })
+  vi.fn().mockResolvedValue({
+    success: true,
+    title: 'Generated Title',
+    updated: true,
+  })
 )
 const mockBroadcastThreadUpdated = vi.hoisted(() => vi.fn())
 
@@ -504,6 +508,22 @@ describe('handleChatStreamRealtime — auto-title on stream complete', () => {
 
     expect(mockGenerateThreadTitle).toHaveBeenCalledWith('thread-1')
     expect(mockBroadcastThreadUpdated).toHaveBeenCalledWith('thread-1')
+  })
+
+  it('skips thread-updated broadcast when title generation is a no-op', async () => {
+    mockGenerateThreadTitle.mockResolvedValueOnce({
+      success: true,
+      title: 'Existing Title',
+      updated: false,
+    })
+    mockResolveAgentForThread.mockReturnValue(
+      fakeAgent('builtin.toolhive-assistant', 'DEFAULT INSTRUCTIONS')
+    )
+
+    await handleChatStreamRealtime(makeRequest(), 'stream-noop', fakeSender)
+
+    expect(mockGenerateThreadTitle).toHaveBeenCalledWith('thread-1')
+    expect(mockBroadcastThreadUpdated).not.toHaveBeenCalled()
   })
 
   it('skips title generation when the stream ends in error', async () => {

--- a/main/src/chat/__tests__/streaming.test.ts
+++ b/main/src/chat/__tests__/streaming.test.ts
@@ -545,3 +545,46 @@ describe('handleChatStreamRealtime — auto-title on stream complete', () => {
     expect(mockBroadcastThreadUpdated).not.toHaveBeenCalled()
   })
 })
+
+describe('handleChatStreamRealtime — message sanitization', () => {
+  it('passes sanitized messages to convertToModelMessages', async () => {
+    mockResolveAgentForThread.mockReturnValue(
+      fakeAgent('builtin.toolhive-assistant', 'DEFAULT INSTRUCTIONS')
+    )
+
+    await handleChatStreamRealtime(
+      makeRequest({
+        messages: [
+          {
+            id: 'u1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'hi' }],
+          },
+          {
+            id: 'a-hollow',
+            role: 'assistant',
+            parts: [],
+          },
+          {
+            id: 'u2',
+            role: 'user',
+            parts: [{ type: 'text', text: 'again' }],
+          },
+        ],
+      }),
+      'stream-sanitize',
+      fakeSender
+    )
+
+    expect(mockConvertToModelMessages).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'u1',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'hi' },
+          { type: 'text', text: 'again' },
+        ],
+      }),
+    ])
+  })
+})

--- a/main/src/chat/__tests__/streaming.test.ts
+++ b/main/src/chat/__tests__/streaming.test.ts
@@ -28,10 +28,16 @@ const mockCreateBuiltinAgentTools = vi.hoisted(() =>
   >(() => ({ tools: {}, cleanup: vi.fn() }))
 )
 const mockRunManagedStream = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(undefined)
+  vi.fn().mockImplementation(async (args: unknown) => {
+    const options = args as { onComplete?: () => void | Promise<void> }
+    await options.onComplete?.()
+  })
 )
 const mockGetAgent = vi.hoisted(() => vi.fn())
 const mockResolveAgentForThread = vi.hoisted(() => vi.fn())
+const mockGenerateThreadTitle = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ success: true, title: 'Generated Title' })
+)
 
 vi.mock('ai', () => ({
   ToolLoopAgent: class {
@@ -56,6 +62,10 @@ vi.mock('../utils', () => ({
 
 vi.mock('../agents/builtin-agent-tools', () => ({
   createBuiltinAgentTools: mockCreateBuiltinAgentTools,
+}))
+
+vi.mock('../generate-thread-title', () => ({
+  generateThreadTitle: mockGenerateThreadTitle,
 }))
 
 import { handleChatStreamRealtime as handleChatStreamRealtimeImpl } from '../streaming/chat-stream-service-impl'
@@ -469,5 +479,17 @@ describe('handleChatStreamRealtime — AI SDK v7 UI stream wiring', () => {
     expect(mockCreateMcpTools).toHaveBeenCalledWith('thread-1', {
       sanitizeSchemas: true,
     })
+  })
+})
+
+describe('handleChatStreamRealtime — auto-title on stream complete', () => {
+  it('calls generateThreadTitle for the chat when the managed stream completes', async () => {
+    mockResolveAgentForThread.mockReturnValue(
+      fakeAgent('builtin.toolhive-assistant', 'DEFAULT INSTRUCTIONS')
+    )
+
+    await handleChatStreamRealtime(makeRequest(), 'stream-title', fakeSender)
+
+    expect(mockGenerateThreadTitle).toHaveBeenCalledWith('thread-1')
   })
 })

--- a/main/src/chat/generate-thread-title.ts
+++ b/main/src/chat/generate-thread-title.ts
@@ -2,12 +2,16 @@ import { Effect } from 'effect'
 import { runChatToResult } from './runtime'
 import { TitleService } from './streaming/title-service'
 
-export async function generateThreadTitle(
-  threadId: string
-): Promise<{ success: boolean; title?: string; error?: string }> {
+export async function generateThreadTitle(threadId: string): Promise<{
+  success: boolean
+  title?: string
+  /** True when this call wrote a new title to SQLite. */
+  updated?: boolean
+  error?: string
+}> {
   return runChatToResult(
     TitleService.generateThreadTitle(threadId).pipe(
-      Effect.map(({ title }) => ({ title }))
+      Effect.map(({ title, updated }) => ({ title, updated }))
     )
   )
 }

--- a/main/src/chat/streaming/__tests__/build-snapshot.test.ts
+++ b/main/src/chat/streaming/__tests__/build-snapshot.test.ts
@@ -1,0 +1,109 @@
+import '../../runtime/__tests__/setup'
+import { describe, expect, it } from 'vitest'
+import type { ChatUIMessage } from '../../types'
+import { buildSnapshot } from '../stream-registry-persist'
+import type { ActiveStream } from '../stream-registry-types'
+
+function msg(
+  partial: Pick<ChatUIMessage, 'id' | 'role' | 'parts'>
+): ChatUIMessage {
+  return partial as ChatUIMessage
+}
+
+function makeStream(
+  overrides: Partial<ActiveStream> &
+    Pick<ActiveStream, 'originalMessages' | 'runningMessage'>
+): ActiveStream {
+  return {
+    chatId: 'thread-1',
+    streamId: 'stream-1',
+    subscribers: new Set(),
+    persistTimer: null,
+    pendingWrite: false,
+    abortController: new AbortController(),
+    status: 'streaming',
+    toolUiMetadata: null,
+    persistFailed: false,
+    messageId: undefined,
+    blockOrder: [],
+    textParts: new Map(),
+    reasoningParts: new Map(),
+    toolParts: new Map(),
+    ...overrides,
+  }
+}
+
+describe('buildSnapshot', () => {
+  it('skips a hollow running assistant placeholder', () => {
+    const user = msg({
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'hi' }],
+    })
+    const hollow = msg({ id: 'a1', role: 'assistant', parts: [] })
+    const snapshot = buildSnapshot(
+      makeStream({
+        originalMessages: [user],
+        runningMessage: hollow,
+      })
+    )
+    expect(snapshot).toEqual([user])
+  })
+
+  it('includes a running assistant that has text', () => {
+    const user = msg({
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'hi' }],
+    })
+    const assistant = msg({
+      id: 'a1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'hello' }],
+    })
+    const snapshot = buildSnapshot(
+      makeStream({
+        originalMessages: [user],
+        runningMessage: assistant,
+      })
+    )
+    expect(snapshot).toEqual([user, assistant])
+  })
+
+  it('heals legacy hollow assistants already in originalMessages', () => {
+    const user = msg({
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'hi' }],
+    })
+    const hollow = msg({ id: 'a-hollow', role: 'assistant', parts: [] })
+    const assistant = msg({
+      id: 'a1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'hello' }],
+    })
+    const snapshot = buildSnapshot(
+      makeStream({
+        originalMessages: [user, hollow],
+        runningMessage: assistant,
+      })
+    )
+    expect(snapshot.map((m) => m.id)).toEqual(['u1', 'a1'])
+  })
+
+  it('returns originalMessages when there is no running message, minus hollows', () => {
+    const user = msg({
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'hi' }],
+    })
+    const hollow = msg({ id: 'a-hollow', role: 'assistant', parts: [] })
+    const snapshot = buildSnapshot(
+      makeStream({
+        originalMessages: [user, hollow],
+        runningMessage: undefined,
+      })
+    )
+    expect(snapshot).toEqual([user])
+  })
+})

--- a/main/src/chat/streaming/__tests__/sanitize-messages-for-model.test.ts
+++ b/main/src/chat/streaming/__tests__/sanitize-messages-for-model.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatUIMessage } from '../../types'
+import {
+  isHollowAssistantMessage,
+  sanitizeMessagesForModel,
+} from '../sanitize-messages-for-model'
+
+function msg(
+  partial: Pick<ChatUIMessage, 'id' | 'role' | 'parts'>
+): ChatUIMessage {
+  return partial as ChatUIMessage
+}
+
+describe('sanitizeMessagesForModel', () => {
+  it('detects assistants with no parts as hollow', () => {
+    expect(
+      isHollowAssistantMessage(msg({ id: 'a1', role: 'assistant', parts: [] }))
+    ).toBe(true)
+  })
+
+  it('detects step-start-only assistants as hollow', () => {
+    expect(
+      isHollowAssistantMessage(
+        msg({
+          id: 'a1',
+          role: 'assistant',
+          parts: [{ type: 'step-start' }],
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('keeps assistants with text, tools, or reasoning', () => {
+    expect(
+      isHollowAssistantMessage(
+        msg({
+          id: 'a1',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'hi' }],
+        })
+      )
+    ).toBe(false)
+    expect(
+      isHollowAssistantMessage(
+        msg({
+          id: 'a2',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'dynamic-tool',
+              toolName: 'x',
+              toolCallId: 'c1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        })
+      )
+    ).toBe(false)
+    expect(
+      isHollowAssistantMessage(
+        msg({
+          id: 'a3',
+          role: 'assistant',
+          parts: [{ type: 'reasoning', text: 'think' }],
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('strips hollow assistants from the transcript', () => {
+    const result = sanitizeMessagesForModel([
+      msg({ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }),
+      msg({ id: 'a1', role: 'assistant', parts: [] }),
+      msg({ id: 'u2', role: 'user', parts: [{ type: 'text', text: 'again' }] }),
+    ])
+    expect(result.map((m) => m.id)).toEqual(['u1', 'u2'])
+  })
+
+  it('adds a space text part to tool-only assistants', () => {
+    const result = sanitizeMessagesForModel([
+      msg({
+        id: 'a1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolName: 'x',
+            toolCallId: 'c1',
+            state: 'input-available',
+            input: {},
+          },
+        ],
+      }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.parts.at(-1)).toEqual({ type: 'text', text: ' ' })
+  })
+})

--- a/main/src/chat/streaming/__tests__/sanitize-messages-for-model.test.ts
+++ b/main/src/chat/streaming/__tests__/sanitize-messages-for-model.test.ts
@@ -30,6 +30,18 @@ describe('sanitizeMessagesForModel', () => {
     ).toBe(true)
   })
 
+  it('treats whitespace-only text as hollow', () => {
+    expect(
+      isHollowAssistantMessage(
+        msg({
+          id: 'a1',
+          role: 'assistant',
+          parts: [{ type: 'text', text: '   ' }],
+        })
+      )
+    ).toBe(true)
+  })
+
   it('keeps assistants with text, tools, or reasoning', () => {
     expect(
       isHollowAssistantMessage(
@@ -68,32 +80,123 @@ describe('sanitizeMessagesForModel', () => {
     ).toBe(false)
   })
 
-  it('strips hollow assistants from the transcript', () => {
+  it('coalesces adjacent users after removing a middle hollow assistant', () => {
     const result = sanitizeMessagesForModel([
       msg({ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }),
       msg({ id: 'a1', role: 'assistant', parts: [] }),
       msg({ id: 'u2', role: 'user', parts: [{ type: 'text', text: 'again' }] }),
     ])
-    expect(result.map((m) => m.id)).toEqual(['u1', 'u2'])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.id).toBe('u1')
+    expect(result[0]?.parts).toEqual([
+      { type: 'text', text: 'hi' },
+      { type: 'text', text: 'again' },
+    ])
   })
 
-  it('adds a space text part to tool-only assistants', () => {
+  it('coalesces pre-existing adjacent user turns', () => {
+    const result = sanitizeMessagesForModel([
+      msg({ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'first' }] }),
+      msg({
+        id: 'u2',
+        role: 'user',
+        parts: [{ type: 'text', text: 'second' }],
+      }),
+      msg({
+        id: 'a1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'reply' }],
+      }),
+    ])
+    expect(result.map((m) => m.id)).toEqual(['u1', 'a1'])
+    expect(result[0]?.parts).toEqual([
+      { type: 'text', text: 'first' },
+      { type: 'text', text: 'second' },
+    ])
+  })
+
+  it('preserves a valid transcript unchanged aside from wire padding', () => {
+    const input = [
+      msg({ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }),
+      msg({
+        id: 'a1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'hello' }],
+      }),
+    ]
+    expect(sanitizeMessagesForModel(input)).toEqual(input)
+  })
+
+  it('does not pad tool-only assistants', () => {
+    const toolOnly = msg({
+      id: 'a1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolName: 'x',
+          toolCallId: 'c1',
+          state: 'output-available',
+          input: {},
+          output: 'done',
+        },
+      ],
+    })
+    const result = sanitizeMessagesForModel([toolOnly])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.parts).toEqual(toolOnly.parts)
+  })
+
+  it('preserves incomplete tool-only assistants without wire padding', () => {
+    const incompleteTool = msg({
+      id: 'a1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolName: 'x',
+          toolCallId: 'c1',
+          state: 'input-available',
+          input: {},
+        },
+      ],
+    })
+    const result = sanitizeMessagesForModel([incompleteTool])
+    expect(result[0]?.parts).toEqual(incompleteTool.parts)
+  })
+
+  it('adds wire text to reasoning-only assistants', () => {
     const result = sanitizeMessagesForModel([
       msg({
         id: 'a1',
         role: 'assistant',
-        parts: [
-          {
-            type: 'dynamic-tool',
-            toolName: 'x',
-            toolCallId: 'c1',
-            state: 'input-available',
-            input: {},
-          },
-        ],
+        parts: [{ type: 'reasoning', text: 'think' }],
       }),
     ])
     expect(result).toHaveLength(1)
     expect(result[0]?.parts.at(-1)).toEqual({ type: 'text', text: ' ' })
+    expect(result[0]?.parts[0]).toEqual({ type: 'reasoning', text: 'think' })
+  })
+
+  it('keeps assistant with tool output after hollow removal from middle', () => {
+    const result = sanitizeMessagesForModel([
+      msg({
+        id: 'u1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'run tool' }],
+      }),
+      msg({ id: 'hollow', role: 'assistant', parts: [] }),
+      msg({
+        id: 'a1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'done' }],
+      }),
+      msg({
+        id: 'u2',
+        role: 'user',
+        parts: [{ type: 'text', text: 'thanks' }],
+      }),
+    ])
+    expect(result.map((m) => m.id)).toEqual(['u1', 'a1', 'u2'])
   })
 })

--- a/main/src/chat/streaming/__tests__/title-service.test.ts
+++ b/main/src/chat/streaming/__tests__/title-service.test.ts
@@ -127,4 +127,28 @@ describe('shouldAutoTitleThread', () => {
       )
     ).toBe(true)
   })
+
+  it('ignores legacy hollow assistants when checking the first exchange', () => {
+    expect(
+      shouldAutoTitleThread(
+        {
+          id: 't1',
+          title: undefined,
+          titleEditedByUser: false,
+          messages: [
+            userMsg,
+            msg({ id: 'hollow', role: 'assistant', parts: [] }),
+            msg({
+              id: 'a1',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Use Docker' }],
+            }),
+          ],
+          lastEditTimestamp: 0,
+          createdAt: 0,
+        },
+        userMsg
+      )
+    ).toBe(true)
+  })
 })

--- a/main/src/chat/streaming/__tests__/title-service.test.ts
+++ b/main/src/chat/streaming/__tests__/title-service.test.ts
@@ -1,0 +1,130 @@
+import '../../runtime/__tests__/setup'
+import { describe, expect, it } from 'vitest'
+import type { ChatUIMessage } from '../../types'
+import { fallbackTitleFromUser, shouldAutoTitleThread } from '../title-service'
+
+function msg(
+  partial: Pick<ChatUIMessage, 'id' | 'role' | 'parts'>
+): ChatUIMessage {
+  return partial as ChatUIMessage
+}
+
+describe('shouldAutoTitleThread', () => {
+  const userMsg = msg({
+    id: 'u1',
+    role: 'user',
+    parts: [{ type: 'text', text: 'How do I deploy this app?' }],
+  })
+
+  it('returns false when the user edited the title', () => {
+    expect(
+      shouldAutoTitleThread(
+        {
+          id: 't1',
+          title: 'Manual',
+          titleEditedByUser: true,
+          messages: [userMsg],
+          lastEditTimestamp: 0,
+          createdAt: 0,
+        },
+        userMsg
+      )
+    ).toBe(false)
+  })
+
+  it('returns false when a custom title already exists', () => {
+    expect(
+      shouldAutoTitleThread(
+        {
+          id: 't1',
+          title: 'Deploy Planning',
+          titleEditedByUser: false,
+          messages: [userMsg],
+          lastEditTimestamp: 0,
+          createdAt: 0,
+        },
+        userMsg
+      )
+    ).toBe(false)
+  })
+
+  it('returns false after the first assistant exchange', () => {
+    expect(
+      shouldAutoTitleThread(
+        {
+          id: 't1',
+          title: undefined,
+          titleEditedByUser: false,
+          messages: [
+            userMsg,
+            msg({
+              id: 'a1',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Use Docker' }],
+            }),
+            msg({
+              id: 'u2',
+              role: 'user',
+              parts: [{ type: 'text', text: 'Thanks' }],
+            }),
+            msg({
+              id: 'a2',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Welcome' }],
+            }),
+          ],
+          lastEditTimestamp: 0,
+          createdAt: 0,
+        },
+        userMsg
+      )
+    ).toBe(false)
+  })
+
+  it('returns true for the first exchange with no custom title', () => {
+    expect(
+      shouldAutoTitleThread(
+        {
+          id: 't1',
+          title: undefined,
+          titleEditedByUser: false,
+          messages: [
+            userMsg,
+            msg({
+              id: 'a1',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Use Docker' }],
+            }),
+          ],
+          lastEditTimestamp: 0,
+          createdAt: 0,
+        },
+        userMsg
+      )
+    ).toBe(true)
+  })
+
+  it('returns true when the title matches the user-message fallback', () => {
+    const fallback = fallbackTitleFromUser(userMsg)
+    expect(
+      shouldAutoTitleThread(
+        {
+          id: 't1',
+          title: fallback,
+          titleEditedByUser: false,
+          messages: [
+            userMsg,
+            msg({
+              id: 'a1',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Use Docker' }],
+            }),
+          ],
+          lastEditTimestamp: 0,
+          createdAt: 0,
+        },
+        userMsg
+      )
+    ).toBe(true)
+  })
+})

--- a/main/src/chat/streaming/chat-stream-service-impl.ts
+++ b/main/src/chat/streaming/chat-stream-service-impl.ts
@@ -316,9 +316,11 @@ export async function handleChatStreamRealtime(
                     )
                     return
                   }
-                  // Stream `finished` was broadcast before this async work;
-                  // notify renderers again so the sidebar picks up the title.
-                  broadcastThreadUpdated(request.chatId)
+                  // Only refresh when SQLite actually changed — skip no-ops
+                  // (manual title, unchanged title, second-turn skip).
+                  if (result.updated) {
+                    broadcastThreadUpdated(request.chatId)
+                  }
                 } catch (error) {
                   log.warn(
                     `[CHAT] Auto-title threw for ${request.chatId}:`,

--- a/main/src/chat/streaming/chat-stream-service-impl.ts
+++ b/main/src/chat/streaming/chat-stream-service-impl.ts
@@ -20,6 +20,7 @@ import { McpService } from '../mcp/mcp-service'
 import { StreamRegistryService } from './stream-registry-service'
 import { createBuiltinAgentTools } from '../agents/builtin-agent-tools'
 import { sanitizeMessagesForModel } from './sanitize-messages-for-model'
+import { generateThreadTitle } from '../generate-thread-title'
 
 /** Gemini's function-declaration validator rejects schema constructs other
  * providers accept. True for Google directly or a `google/*` OpenRouter model. */
@@ -302,6 +303,14 @@ export async function handleChatStreamRealtime(
                     error
                   )
                 }
+                void generateThreadTitle(request.chatId).then((result) => {
+                  if (!result.success) {
+                    log.warn(
+                      `[CHAT] Auto-title failed for ${request.chatId}:`,
+                      result.error
+                    )
+                  }
+                })
               },
             })
           )

--- a/main/src/chat/streaming/chat-stream-service-impl.ts
+++ b/main/src/chat/streaming/chat-stream-service-impl.ts
@@ -19,6 +19,7 @@ import { AgentsService } from '../agents/agents-service'
 import { McpService } from '../mcp/mcp-service'
 import { StreamRegistryService } from './stream-registry-service'
 import { createBuiltinAgentTools } from '../agents/builtin-agent-tools'
+import { sanitizeMessagesForModel } from './sanitize-messages-for-model'
 
 /** Gemini's function-declaration validator rejects schema constructs other
  * providers accept. True for Google directly or a `google/*` OpenRouter model. */
@@ -126,7 +127,9 @@ export async function handleChatStreamRealtime(
           })
 
           const result = await agent.stream({
-            messages: await convertToModelMessages(request.messages),
+            messages: await convertToModelMessages(
+              sanitizeMessagesForModel(request.messages)
+            ),
             abortSignal: abortController.signal,
           })
 

--- a/main/src/chat/streaming/chat-stream-service-impl.ts
+++ b/main/src/chat/streaming/chat-stream-service-impl.ts
@@ -21,6 +21,7 @@ import { StreamRegistryService } from './stream-registry-service'
 import { createBuiltinAgentTools } from '../agents/builtin-agent-tools'
 import { sanitizeMessagesForModel } from './sanitize-messages-for-model'
 import { generateThreadTitle } from '../generate-thread-title'
+import { broadcastThreadUpdated } from './stream-registry-broadcast'
 
 /** Gemini's function-declaration validator rejects schema constructs other
  * providers accept. True for Google directly or a `google/*` OpenRouter model. */
@@ -287,7 +288,7 @@ export async function handleChatStreamRealtime(
               initialToolUiMetadata: Effect.runSync(
                 deps.mcp.getCachedUiMetadata()
               ),
-              onComplete: async () => {
+              onComplete: async ({ status }) => {
                 for (const client of mcpClients) {
                   try {
                     await client.close()
@@ -303,14 +304,27 @@ export async function handleChatStreamRealtime(
                     error
                   )
                 }
-                void generateThreadTitle(request.chatId).then((result) => {
+                // Only auto-title successful finishes — aborted/errored
+                // streams would waste tokens on a user-only transcript.
+                if (status !== 'finished') return
+                try {
+                  const result = await generateThreadTitle(request.chatId)
                   if (!result.success) {
                     log.warn(
                       `[CHAT] Auto-title failed for ${request.chatId}:`,
                       result.error
                     )
+                    return
                   }
-                })
+                  // Stream `finished` was broadcast before this async work;
+                  // notify renderers again so the sidebar picks up the title.
+                  broadcastThreadUpdated(request.chatId)
+                } catch (error) {
+                  log.warn(
+                    `[CHAT] Auto-title threw for ${request.chatId}:`,
+                    error
+                  )
+                }
               },
             })
           )

--- a/main/src/chat/streaming/sanitize-messages-for-model.ts
+++ b/main/src/chat/streaming/sanitize-messages-for-model.ts
@@ -1,0 +1,73 @@
+import type { ChatUIMessage } from '../types'
+
+type AssistantPartFlags = {
+  hasText: boolean
+  hasTool: boolean
+  hasReasoning: boolean
+}
+
+function getAssistantPartFlags(message: ChatUIMessage): AssistantPartFlags {
+  let hasText = false
+  let hasTool = false
+  let hasReasoning = false
+
+  for (const part of message.parts ?? []) {
+    if (part.type === 'text' && 'text' in part && part.text.trim()) {
+      hasText = true
+      continue
+    }
+    if (part.type.startsWith('tool-') || part.type === 'dynamic-tool') {
+      hasTool = true
+      continue
+    }
+    if (
+      part.type === 'reasoning' &&
+      'text' in part &&
+      typeof part.text === 'string' &&
+      part.text.trim()
+    ) {
+      hasReasoning = true
+    }
+  }
+
+  return { hasText, hasTool, hasReasoning }
+}
+
+/**
+ * Assistant turns with no text, tools, or reasoning — e.g. a stream that
+ * aborted after `start` and left `parts: []` in SQLite. Moonshot (and
+ * similar providers) reject these as empty assistant messages.
+ */
+export function isHollowAssistantMessage(message: ChatUIMessage): boolean {
+  if (message.role !== 'assistant') return false
+  const { hasText, hasTool, hasReasoning } = getAssistantPartFlags(message)
+  return !hasText && !hasTool && !hasReasoning
+}
+
+/**
+ * OpenRouter serializes assistant `content` as `text || null`. Tool- or
+ * reasoning-only turns therefore arrive at providers as an empty assistant
+ * message. A single space keeps the wire payload non-empty without changing
+ * the visible reply.
+ */
+function ensureAssistantWireText(message: ChatUIMessage): ChatUIMessage {
+  if (message.role !== 'assistant') return message
+  const { hasText, hasTool, hasReasoning } = getAssistantPartFlags(message)
+  if (hasText || (!hasTool && !hasReasoning)) return message
+  return {
+    ...message,
+    parts: [...(message.parts ?? []), { type: 'text', text: ' ' }],
+  }
+}
+
+/**
+ * Drop hollow assistants and ensure tool/reasoning-only turns have non-empty
+ * text so providers like Moonshot accept the request.
+ */
+export function sanitizeMessagesForModel(
+  messages: ChatUIMessage[]
+): ChatUIMessage[] {
+  return messages
+    .filter((message) => !isHollowAssistantMessage(message))
+    .map(ensureAssistantWireText)
+}

--- a/main/src/chat/streaming/sanitize-messages-for-model.ts
+++ b/main/src/chat/streaming/sanitize-messages-for-model.ts
@@ -45,29 +45,50 @@ export function isHollowAssistantMessage(message: ChatUIMessage): boolean {
 }
 
 /**
- * OpenRouter serializes assistant `content` as `text || null`. Tool- or
- * reasoning-only turns therefore arrive at providers as an empty assistant
- * message. A single space keeps the wire payload non-empty without changing
- * the visible reply.
+ * Reasoning-only turns serialize to empty assistant `content` on some
+ * providers. Tool-only turns must stay unpadded so adapters can emit
+ * null/omitted content alongside tool_calls (whitespace-only text is
+ * rejected by strict Kimi-compatible gateways).
  */
 function ensureAssistantWireText(message: ChatUIMessage): ChatUIMessage {
   if (message.role !== 'assistant') return message
   const { hasText, hasTool, hasReasoning } = getAssistantPartFlags(message)
-  if (hasText || (!hasTool && !hasReasoning)) return message
+  if (hasText || hasTool || !hasReasoning) return message
   return {
     ...message,
     parts: [...(message.parts ?? []), { type: 'text', text: ' ' }],
   }
 }
 
+/** Merge consecutive user turns after hollow removal heals role alternation. */
+function coalesceAdjacentUserMessages(
+  messages: ChatUIMessage[]
+): ChatUIMessage[] {
+  const result: ChatUIMessage[] = []
+  for (const message of messages) {
+    const previous = result.at(-1)
+    if (message.role === 'user' && previous?.role === 'user') {
+      result[result.length - 1] = {
+        ...previous,
+        parts: [...(previous.parts ?? []), ...(message.parts ?? [])],
+      }
+      continue
+    }
+    result.push(message)
+  }
+  return result
+}
+
 /**
- * Drop hollow assistants and ensure tool/reasoning-only turns have non-empty
- * text so providers like Moonshot accept the request.
+ * Drop hollow assistants, coalesce adjacent user turns for strict role
+ * alternation, and pad reasoning-only turns for wire compatibility.
  */
 export function sanitizeMessagesForModel(
   messages: ChatUIMessage[]
 ): ChatUIMessage[] {
-  return messages
-    .filter((message) => !isHollowAssistantMessage(message))
-    .map(ensureAssistantWireText)
+  return coalesceAdjacentUserMessages(
+    messages
+      .filter((message) => !isHollowAssistantMessage(message))
+      .map(ensureAssistantWireText)
+  )
 }

--- a/main/src/chat/streaming/stream-registry-broadcast.ts
+++ b/main/src/chat/streaming/stream-registry-broadcast.ts
@@ -36,6 +36,20 @@ export function broadcastState(
   }
 }
 
+/** Notify every renderer that thread metadata (e.g. title) changed so
+ * sidebars can refresh after async work that finished after stream end. */
+export function broadcastThreadUpdated(threadId: string): void {
+  let allContents: WebContents[]
+  try {
+    allContents = webContentsApi.getAllWebContents()
+  } catch {
+    return
+  }
+  for (const wc of allContents) {
+    safeSend(wc, 'chat:thread:updated', { threadId })
+  }
+}
+
 export function broadcast(
   stream: ActiveStream,
   channel: string,

--- a/main/src/chat/streaming/stream-registry-broadcast.ts
+++ b/main/src/chat/streaming/stream-registry-broadcast.ts
@@ -18,6 +18,18 @@ export function safeSend(
   }
 }
 
+function broadcastToAllRenderers(channel: string, payload: unknown): void {
+  let allContents: WebContents[]
+  try {
+    allContents = webContentsApi.getAllWebContents()
+  } catch {
+    return
+  }
+  for (const wc of allContents) {
+    safeSend(wc, channel, payload)
+  }
+}
+
 /** Broadcast a stream-state change to every renderer window so UI
  * surfaces (e.g. the sidebar) can reflect activity for threads they
  * aren't currently subscribed to. */
@@ -25,29 +37,13 @@ export function broadcastState(
   chatId: string,
   status: 'streaming' | 'finished' | 'error'
 ): void {
-  let allContents: WebContents[]
-  try {
-    allContents = webContentsApi.getAllWebContents()
-  } catch {
-    return
-  }
-  for (const wc of allContents) {
-    safeSend(wc, 'chat:stream:state', { chatId, status })
-  }
+  broadcastToAllRenderers('chat:stream:state', { chatId, status })
 }
 
 /** Notify every renderer that thread metadata (e.g. title) changed so
  * sidebars can refresh after async work that finished after stream end. */
 export function broadcastThreadUpdated(threadId: string): void {
-  let allContents: WebContents[]
-  try {
-    allContents = webContentsApi.getAllWebContents()
-  } catch {
-    return
-  }
-  for (const wc of allContents) {
-    safeSend(wc, 'chat:thread:updated', { threadId })
-  }
+  broadcastToAllRenderers('chat:thread:updated', { threadId })
 }
 
 export function broadcast(

--- a/main/src/chat/streaming/stream-registry-engine.ts
+++ b/main/src/chat/streaming/stream-registry-engine.ts
@@ -148,12 +148,13 @@ function finalizeError(stream: ActiveStream, error: unknown): void {
 
 async function teardownStream(
   stream: ActiveStream,
-  onComplete: (() => void | Promise<void>) | undefined
+  onComplete: RunStreamOptions['onComplete']
 ): Promise<void> {
   getStreams().delete(stream.chatId)
   if (!onComplete) return
+  const status = stream.status === 'finished' ? 'finished' : 'error'
   try {
-    await onComplete()
+    await onComplete({ status })
   } catch (cleanupError) {
     log.error(
       `[ACTIVE_STREAMS] onComplete threw for ${stream.chatId}:`,

--- a/main/src/chat/streaming/stream-registry-persist.ts
+++ b/main/src/chat/streaming/stream-registry-persist.ts
@@ -16,6 +16,7 @@ import type {
   ChatUIMessageChunk,
   PersistMessagesSync,
 } from './stream-registry-types'
+import { isHollowAssistantMessage } from './sanitize-messages-for-model'
 
 /**
  * Throttled DB persistence cadence (ms).
@@ -43,12 +44,26 @@ export function isPersistenceBoundary(chunk: ChatUIMessageChunk): boolean {
 }
 
 function buildSnapshot(stream: ActiveStream): ChatUIMessage[] {
-  if (!stream.runningMessage) return stream.originalMessages
-  const tail = stream.originalMessages[stream.originalMessages.length - 1]
-  if (tail && tail.id === stream.runningMessage.id) {
-    return [...stream.originalMessages.slice(0, -1), stream.runningMessage]
+  let messages: ChatUIMessage[]
+  if (!stream.runningMessage) {
+    messages = stream.originalMessages
+  } else if (isHollowAssistantMessage(stream.runningMessage)) {
+    // Never persist a hollow assistant placeholder (stream start / abort
+    // before any text, tools, or reasoning).
+    messages = stream.originalMessages
+  } else {
+    const tail = stream.originalMessages[stream.originalMessages.length - 1]
+    if (tail && tail.id === stream.runningMessage.id) {
+      messages = [
+        ...stream.originalMessages.slice(0, -1),
+        stream.runningMessage,
+      ]
+    } else {
+      messages = [...stream.originalMessages, stream.runningMessage]
+    }
   }
-  return [...stream.originalMessages, stream.runningMessage]
+  // Heal threads that already stored hollow assistants from earlier aborts.
+  return messages.filter((message) => !isHollowAssistantMessage(message))
 }
 
 function reportPersistFailure(stream: ActiveStream, error: string): void {

--- a/main/src/chat/streaming/stream-registry-persist.ts
+++ b/main/src/chat/streaming/stream-registry-persist.ts
@@ -43,7 +43,8 @@ export function isPersistenceBoundary(chunk: ChatUIMessageChunk): boolean {
   return PERSISTENCE_BOUNDARIES.has(chunk.type)
 }
 
-function buildSnapshot(stream: ActiveStream): ChatUIMessage[] {
+/** Exported for unit tests covering hollow-assistant persist rules. */
+export function buildSnapshot(stream: ActiveStream): ChatUIMessage[] {
   let messages: ChatUIMessage[]
   if (!stream.runningMessage) {
     messages = stream.originalMessages

--- a/main/src/chat/streaming/stream-registry-types.ts
+++ b/main/src/chat/streaming/stream-registry-types.ts
@@ -106,5 +106,5 @@ export interface RunStreamOptions {
   /** Tool UI metadata broadcast on first chunk so late-attaching
    * subscribers can identify MCP App tools. */
   initialToolUiMetadata?: Record<string, unknown>
-  onComplete?: () => void | Promise<void>
+  onComplete?: (info: { status: 'finished' | 'error' }) => void | Promise<void>
 }

--- a/main/src/chat/streaming/title-service.ts
+++ b/main/src/chat/streaming/title-service.ts
@@ -15,7 +15,7 @@ const TITLE_SYSTEM_PROMPT =
   'You are a concise assistant. Summarize the following conversation in 6 words or fewer using title case. Reply with only the title — no punctuation, no quotes, no explanation.'
 
 /** Max chars for the non-LLM fallback title (first user message). */
-export const FALLBACK_TITLE_MAX_CHARS = 60
+const FALLBACK_TITLE_MAX_CHARS = 60
 
 /**
  * Reasoning models (e.g. Moonshot Kimi via OpenRouter) spend max_tokens on
@@ -35,7 +35,7 @@ function isLocalProvider(providerId: string): boolean {
   )
 }
 
-export function extractMessageText(message: ChatUIMessage): string {
+function extractMessageText(message: ChatUIMessage): string {
   return (message.parts ?? [])
     .filter(
       (part): part is { type: 'text'; text: string } =>

--- a/main/src/chat/streaming/title-service.ts
+++ b/main/src/chat/streaming/title-service.ts
@@ -1,5 +1,10 @@
 import { generateText, convertToModelMessages } from 'ai'
 import { Effect } from 'effect'
+import {
+  extractThreadTitleText,
+  fallbackTitleFromParts,
+} from '@common/chat/thread-title'
+import log from '../../logger'
 import { LOCAL_PROVIDER_IDS } from '../constants'
 import { CHAT_PROVIDERS } from '../providers/providers-catalog'
 import { createModelFromRequest } from '../utils'
@@ -13,9 +18,6 @@ import { sanitizeMessagesForModel } from './sanitize-messages-for-model'
 
 const TITLE_SYSTEM_PROMPT =
   'You are a concise assistant. Summarize the following conversation in 6 words or fewer using title case. Reply with only the title — no punctuation, no quotes, no explanation.'
-
-/** Max chars for the non-LLM fallback title (first user message). */
-const FALLBACK_TITLE_MAX_CHARS = 60
 
 /**
  * Reasoning models (e.g. Moonshot Kimi via OpenRouter) spend max_tokens on
@@ -36,14 +38,7 @@ function isLocalProvider(providerId: string): boolean {
 }
 
 function extractMessageText(message: ChatUIMessage): string {
-  return (message.parts ?? [])
-    .filter(
-      (part): part is { type: 'text'; text: string } =>
-        part.type === 'text' && 'text' in part
-    )
-    .map((part) => part.text)
-    .join(' ')
-    .trim()
+  return extractThreadTitleText(message.parts ?? [])
 }
 
 function normalizeTitle(text: string): string {
@@ -54,7 +49,7 @@ function normalizeTitle(text: string): string {
 }
 
 export function fallbackTitleFromUser(userMsg: ChatUIMessage): string {
-  return extractMessageText(userMsg).slice(0, FALLBACK_TITLE_MAX_CHARS)
+  return fallbackTitleFromParts(userMsg.parts ?? [])
 }
 
 /** Only auto-title the first assistant exchange in a thread. */
@@ -218,12 +213,24 @@ export class TitleService extends Effect.Service<TitleService>()(
                 })
                 return text
               },
-              catch: () =>
+              catch: (cause) =>
                 new ProviderError({
                   providerId: selected.provider,
+                  cause,
                   userMessage: 'Failed to generate thread title.',
                 }),
-            }).pipe(Effect.catchTag('ProviderError', () => Effect.succeed('')))
+            }).pipe(
+              Effect.tapError((error) =>
+                Effect.sync(() => {
+                  log.warn(
+                    `[TITLE] LLM title generation failed for ${threadId}:`,
+                    error.userMessage,
+                    error.cause ?? ''
+                  )
+                })
+              ),
+              Effect.catchTag('ProviderError', () => Effect.succeed(''))
+            )
 
             const title = normalizeTitle(llmText) || userFallback
             if (!title) {

--- a/main/src/chat/streaming/title-service.ts
+++ b/main/src/chat/streaming/title-service.ts
@@ -109,12 +109,14 @@ export class TitleService extends Effect.Service<TitleService>()(
             const userFallback = fallbackTitleFromUser(userMsg)
 
             if (thread.titleEditedByUser) {
-              return { title: thread.title }
+              return { title: thread.title, updated: false }
             }
 
             if (!shouldAutoTitleThread(thread, userMsg)) {
-              return { title: thread.title ?? userFallback }
+              return { title: thread.title ?? userFallback, updated: false }
             }
+
+            let updated = false
 
             // Skip empty/hollow assistants — some providers reject them, and
             // they add no signal for a short title summary.
@@ -174,6 +176,7 @@ export class TitleService extends Effect.Service<TitleService>()(
                 title: userFallback,
                 titleEditedByUser: false,
               })
+              updated = true
             }
 
             const request = (
@@ -244,18 +247,18 @@ export class TitleService extends Effect.Service<TitleService>()(
 
             const latestThread = yield* threads.getThread(threadId)
             if (latestThread?.titleEditedByUser) {
-              return { title: latestThread.title }
+              return { title: latestThread.title, updated }
             }
 
             if (latestThread?.title?.trim() === title) {
-              return { title }
+              return { title, updated }
             }
 
             yield* threads.updateThread(threadId, {
               title,
               titleEditedByUser: false,
             })
-            return { title }
+            return { title, updated: true }
           }),
       }
     }),

--- a/main/src/chat/streaming/title-service.ts
+++ b/main/src/chat/streaming/title-service.ts
@@ -14,7 +14,10 @@ import { ProviderError, ThreadNotFoundError } from '../runtime/errors'
 import { ThreadsService } from '../threads/threads-service'
 import { SettingsRepository } from '../settings/settings-service'
 import { ThreadSettingsService } from '../settings/thread-settings-service'
-import { sanitizeMessagesForModel } from './sanitize-messages-for-model'
+import {
+  isHollowAssistantMessage,
+  sanitizeMessagesForModel,
+} from './sanitize-messages-for-model'
 
 const TITLE_SYSTEM_PROMPT =
   'You are a concise assistant. Summarize the following conversation in 6 words or fewer using title case. Reply with only the title — no punctuation, no quotes, no explanation.'
@@ -60,7 +63,7 @@ export function shouldAutoTitleThread(
   if (thread.titleEditedByUser) return false
 
   const assistantCount = thread.messages.filter(
-    (m) => m.role === 'assistant'
+    (m) => m.role === 'assistant' && !isHollowAssistantMessage(m)
   ).length
   if (assistantCount > 1) return false
 
@@ -94,9 +97,6 @@ export class TitleService extends Effect.Service<TitleService>()(
             }
 
             const userMsg = thread.messages.find((m) => m.role === 'user')
-            const assistantMsg = thread.messages.find(
-              (m) => m.role === 'assistant'
-            )
             if (!userMsg) {
               return yield* Effect.fail(
                 new ProviderError({
@@ -108,24 +108,23 @@ export class TitleService extends Effect.Service<TitleService>()(
 
             const userFallback = fallbackTitleFromUser(userMsg)
 
-            if (thread.titleEditedByUser) {
-              return { title: thread.title, updated: false }
-            }
-
             if (!shouldAutoTitleThread(thread, userMsg)) {
               return { title: thread.title ?? userFallback, updated: false }
             }
 
-            let updated = false
-
             // Skip empty/hollow assistants — some providers reject them, and
             // they add no signal for a short title summary.
-            const assistantText = assistantMsg
-              ? extractMessageText(assistantMsg)
+            const nonHollowAssistant = thread.messages.find(
+              (m) => m.role === 'assistant' && !isHollowAssistantMessage(m)
+            )
+            const assistantText = nonHollowAssistant
+              ? extractMessageText(nonHollowAssistant)
               : ''
             const contextMessages = sanitizeMessagesForModel([
               userMsg,
-              ...(assistantMsg && assistantText ? [assistantMsg] : []),
+              ...(nonHollowAssistant && assistantText
+                ? [nonHollowAssistant]
+                : []),
             ])
 
             const threadModel =
@@ -169,14 +168,6 @@ export class TitleService extends Effect.Service<TitleService>()(
                   userMessage: 'Provider settings not found',
                 })
               )
-            }
-
-            if (!thread.title?.trim() && userFallback) {
-              yield* threads.updateThread(threadId, {
-                title: userFallback,
-                titleEditedByUser: false,
-              })
-              updated = true
             }
 
             const request = (
@@ -246,12 +237,15 @@ export class TitleService extends Effect.Service<TitleService>()(
             }
 
             const latestThread = yield* threads.getThread(threadId)
-            if (latestThread?.titleEditedByUser) {
-              return { title: latestThread.title, updated }
+            if (latestThread && !shouldAutoTitleThread(latestThread, userMsg)) {
+              return {
+                title: latestThread.title ?? userFallback,
+                updated: false,
+              }
             }
 
             if (latestThread?.title?.trim() === title) {
-              return { title, updated }
+              return { title, updated: false }
             }
 
             yield* threads.updateThread(threadId, {

--- a/main/src/chat/streaming/title-service.ts
+++ b/main/src/chat/streaming/title-service.ts
@@ -3,18 +3,77 @@ import { Effect } from 'effect'
 import { LOCAL_PROVIDER_IDS } from '../constants'
 import { CHAT_PROVIDERS } from '../providers/providers-catalog'
 import { createModelFromRequest } from '../utils'
-import type { ChatRequest } from '../types'
+import type { ChatRequest, ChatUIMessage } from '../types'
+import type { ChatSettingsThread } from '../threads/types'
 import { ProviderError, ThreadNotFoundError } from '../runtime/errors'
 import { ThreadsService } from '../threads/threads-service'
 import { SettingsRepository } from '../settings/settings-service'
+import { ThreadSettingsService } from '../settings/thread-settings-service'
+import { sanitizeMessagesForModel } from './sanitize-messages-for-model'
 
 const TITLE_SYSTEM_PROMPT =
   'You are a concise assistant. Summarize the following conversation in 6 words or fewer using title case. Reply with only the title — no punctuation, no quotes, no explanation.'
+
+/** Max chars for the non-LLM fallback title (first user message). */
+export const FALLBACK_TITLE_MAX_CHARS = 60
+
+/**
+ * Reasoning models (e.g. Moonshot Kimi via OpenRouter) spend max_tokens on
+ * hidden thinking. Title calls are tiny — disable reasoning so the budget
+ * goes to visible text. `effort: 'none'` satisfies the OpenRouter schema
+ * which requires either `max_tokens` or `effort` alongside `enabled`.
+ */
+const OPENROUTER_TITLE_PROVIDER_OPTIONS = {
+  openrouter: {
+    reasoning: { enabled: false, effort: 'none' as const },
+  },
+}
 
 function isLocalProvider(providerId: string): boolean {
   return LOCAL_PROVIDER_IDS.includes(
     providerId as (typeof LOCAL_PROVIDER_IDS)[number]
   )
+}
+
+export function extractMessageText(message: ChatUIMessage): string {
+  return (message.parts ?? [])
+    .filter(
+      (part): part is { type: 'text'; text: string } =>
+        part.type === 'text' && 'text' in part
+    )
+    .map((part) => part.text)
+    .join(' ')
+    .trim()
+}
+
+function normalizeTitle(text: string): string {
+  return text
+    .trim()
+    .replace(/[.!?]+$/, '')
+    .trim()
+}
+
+export function fallbackTitleFromUser(userMsg: ChatUIMessage): string {
+  return extractMessageText(userMsg).slice(0, FALLBACK_TITLE_MAX_CHARS)
+}
+
+/** Only auto-title the first assistant exchange in a thread. */
+export function shouldAutoTitleThread(
+  thread: ChatSettingsThread,
+  userMsg: ChatUIMessage
+): boolean {
+  if (thread.titleEditedByUser) return false
+
+  const assistantCount = thread.messages.filter(
+    (m) => m.role === 'assistant'
+  ).length
+  if (assistantCount > 1) return false
+
+  const userFallback = fallbackTitleFromUser(userMsg)
+  const existingTitle = thread.title?.trim()
+  if (existingTitle && existingTitle !== userFallback) return false
+
+  return true
 }
 
 export class TitleService extends Effect.Service<TitleService>()(
@@ -24,6 +83,7 @@ export class TitleService extends Effect.Service<TitleService>()(
     effect: Effect.gen(function* () {
       const threads = yield* ThreadsService
       const settingsRepo = yield* SettingsRepository
+      const threadSettings = yield* ThreadSettingsService
 
       return {
         generateThreadTitle: (threadId: string) =>
@@ -50,12 +110,35 @@ export class TitleService extends Effect.Service<TitleService>()(
                 })
               )
             }
-            const contextMessages = [
-              userMsg,
-              ...(assistantMsg ? [assistantMsg] : []),
-            ]
 
-            const selected = yield* settingsRepo.readSelectedModel()
+            const userFallback = fallbackTitleFromUser(userMsg)
+
+            if (thread.titleEditedByUser) {
+              return { title: thread.title }
+            }
+
+            if (!shouldAutoTitleThread(thread, userMsg)) {
+              return { title: thread.title ?? userFallback }
+            }
+
+            // Skip empty/hollow assistants — some providers reject them, and
+            // they add no signal for a short title summary.
+            const assistantText = assistantMsg
+              ? extractMessageText(assistantMsg)
+              : ''
+            const contextMessages = sanitizeMessagesForModel([
+              userMsg,
+              ...(assistantMsg && assistantText ? [assistantMsg] : []),
+            ])
+
+            const threadModel =
+              yield* threadSettings.getThreadSelectedModel(threadId)
+            const globalModel = yield* settingsRepo.readSelectedModel()
+            const selected =
+              threadModel?.provider && threadModel?.model
+                ? threadModel
+                : globalModel
+
             if (!selected.provider || !selected.model) {
               return yield* Effect.fail(
                 new ProviderError({
@@ -91,6 +174,13 @@ export class TitleService extends Effect.Service<TitleService>()(
               )
             }
 
+            if (!thread.title?.trim() && userFallback) {
+              yield* threads.updateThread(threadId, {
+                title: userFallback,
+                titleEditedByUser: false,
+              })
+            }
+
             const request = (
               isLocalProvider(selected.provider)
                 ? {
@@ -111,26 +201,31 @@ export class TitleService extends Effect.Service<TitleService>()(
 
             const model = createModelFromRequest(provider, request)
 
-            const { text } = yield* Effect.tryPromise({
-              try: async () =>
-                generateText({
+            // Soft-fail the LLM call: reasoning models / flaky providers often
+            // return empty text. We always prefer a user-message fallback over
+            // leaving the UI stuck on "New chat".
+            const llmText = yield* Effect.tryPromise({
+              try: async () => {
+                const { text } = await generateText({
                   model,
                   instructions: TITLE_SYSTEM_PROMPT,
                   messages: await convertToModelMessages(contextMessages),
-                  maxOutputTokens: 20,
-                }),
-              catch: (cause) =>
+                  // Small but enough for a 6-word title once reasoning is off.
+                  maxOutputTokens: 64,
+                  ...(selected.provider === 'openrouter'
+                    ? { providerOptions: OPENROUTER_TITLE_PROVIDER_OPTIONS }
+                    : {}),
+                })
+                return text
+              },
+              catch: () =>
                 new ProviderError({
                   providerId: selected.provider,
-                  cause,
                   userMessage: 'Failed to generate thread title.',
                 }),
-            })
+            }).pipe(Effect.catchTag('ProviderError', () => Effect.succeed('')))
 
-            const title = text
-              .trim()
-              .replace(/[.!?]+$/, '')
-              .trim()
+            const title = normalizeTitle(llmText) || userFallback
             if (!title) {
               return yield* Effect.fail(
                 new ProviderError({
@@ -145,6 +240,10 @@ export class TitleService extends Effect.Service<TitleService>()(
               return { title: latestThread.title }
             }
 
+            if (latestThread?.title?.trim() === title) {
+              return { title }
+            }
+
             yield* threads.updateThread(threadId, {
               title,
               titleEditedByUser: false,
@@ -153,6 +252,10 @@ export class TitleService extends Effect.Service<TitleService>()(
           }),
       }
     }),
-    dependencies: [ThreadsService.Default, SettingsRepository.Default],
+    dependencies: [
+      ThreadsService.Default,
+      SettingsRepository.Default,
+      ThreadSettingsService.Default,
+    ],
   }
 ) {}

--- a/main/src/ipc-handlers/chat/threads.ts
+++ b/main/src/ipc-handlers/chat/threads.ts
@@ -21,7 +21,6 @@ import {
   getThreadInfo,
   ensureThreadExists,
 } from '../../chat/thread-integration'
-import { generateThreadTitle } from '../../chat/generate-thread-title'
 
 export function register() {
   ipcMain.handle(
@@ -104,9 +103,5 @@ export function register() {
     'chat:ensure-thread-exists',
     (_, threadId?: string, title?: string) =>
       ensureThreadExists(threadId, title)
-  )
-
-  ipcMain.handle('chat:generate-thread-title', (_, threadId: string) =>
-    generateThreadTitle(threadId)
   )
 }

--- a/preload/src/api/chat.ts
+++ b/preload/src/api/chat.ts
@@ -463,6 +463,7 @@ export interface ChatAPI {
     generateThreadTitle: (threadId: string) => Promise<{
       success: boolean
       title?: string
+      updated?: boolean
       error?: string
     }>
 

--- a/preload/src/api/chat.ts
+++ b/preload/src/api/chat.ts
@@ -136,8 +136,6 @@ export const chatApi = {
       ipcRenderer.invoke('chat:get-thread-info', threadId),
     ensureThreadExists: (threadId?: string, title?: string) =>
       ipcRenderer.invoke('chat:ensure-thread-exists', threadId, title),
-    generateThreadTitle: (threadId: string) =>
-      ipcRenderer.invoke('chat:generate-thread-title', threadId),
 
     agents: {
       list: (): Promise<AgentConfig[]> =>
@@ -459,12 +457,6 @@ export interface ChatAPI {
       threadId?: string
       error?: string
       isNew?: boolean
-    }>
-    generateThreadTitle: (threadId: string) => Promise<{
-      success: boolean
-      title?: string
-      updated?: boolean
-      error?: string
     }>
 
     agents: {

--- a/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-streaming.test.ts
@@ -69,6 +69,7 @@ const mockChatAPI = {
   ensureThreadExists: vi.fn(),
   getThread: vi.fn(),
   getThreadMessagesForTransport: vi.fn(),
+  updateThread: vi.fn(),
   updateThreadMessages: vi.fn(),
   getActiveStreamId: vi.fn(),
   unsubscribeStream: vi.fn(),
@@ -141,6 +142,7 @@ describe('useChatStreaming', () => {
     })
     mockChatAPI.getThread.mockResolvedValue(null)
     mockChatAPI.getThreadMessagesForTransport.mockResolvedValue([])
+    mockChatAPI.updateThread.mockResolvedValue({ success: true })
     mockChatAPI.updateThreadMessages.mockResolvedValue({ success: true })
     mockChatAPI.getActiveStreamId.mockResolvedValue(null)
     mockChatAPI.unsubscribeStream.mockResolvedValue(undefined)
@@ -1330,6 +1332,92 @@ describe('useChatStreaming', () => {
         mockChatAPI.getActiveStreamId.mock.calls.length
       ).toBeGreaterThanOrEqual(2)
       expect(mockUseChat.resumeStream).toHaveBeenCalled()
+    })
+  })
+
+  describe('optimistic title on stream completion', () => {
+    it('writes the user-message fallback once when the thread has no title', async () => {
+      mockUseChat.messages = [
+        {
+          id: 'm1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'How do I deploy this app?' }],
+        },
+      ]
+      mockUseChat.status = 'streaming'
+      mockChatAPI.getThread.mockResolvedValue({
+        id: 'toolhive-chat',
+        title: undefined,
+        titleEditedByUser: false,
+        messages: mockUseChat.messages,
+        lastEditTimestamp: 0,
+        createdAt: 0,
+      })
+
+      const { Wrapper } = createTestUtils()
+      const { rerender } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      mockUseChat.status = 'ready'
+      await act(async () => {
+        rerender()
+      })
+
+      await waitFor(() => {
+        expect(mockChatAPI.updateThread).toHaveBeenCalledWith('toolhive-chat', {
+          title: 'How do I deploy this app?',
+          titleEditedByUser: false,
+        })
+      })
+      expect(mockChatAPI.updateThread).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not write the optimistic title twice for the same thread', async () => {
+      mockUseChat.messages = [
+        {
+          id: 'm1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ]
+      mockUseChat.status = 'streaming'
+      mockChatAPI.getThread.mockResolvedValue({
+        id: 'toolhive-chat',
+        title: undefined,
+        titleEditedByUser: false,
+        messages: mockUseChat.messages,
+        lastEditTimestamp: 0,
+        createdAt: 0,
+      })
+
+      const { Wrapper } = createTestUtils()
+      const { rerender } = renderHook(() => useChatStreaming(), {
+        wrapper: Wrapper,
+      })
+
+      mockUseChat.status = 'ready'
+      await act(async () => {
+        rerender()
+      })
+
+      await waitFor(() => {
+        expect(mockChatAPI.updateThread).toHaveBeenCalledTimes(1)
+      })
+
+      mockUseChat.status = 'streaming'
+      await act(async () => {
+        rerender()
+      })
+
+      mockUseChat.status = 'ready'
+      await act(async () => {
+        rerender()
+      })
+
+      await waitFor(() => {
+        expect(mockChatAPI.updateThread).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })

--- a/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
@@ -592,5 +592,36 @@ describe('usePlaygroundThreads', () => {
         expect(mockChatAPI.getThread).toHaveBeenCalledWith('bg-thread')
       )
     })
+
+    it('calls refreshThread when chat:thread:updated is broadcast', async () => {
+      mockChatAPI.getAllThreads.mockResolvedValue([
+        makeDbThread({ id: 'titled-thread', title: 'Old title' }),
+      ])
+      mockChatAPI.getThread.mockResolvedValue(
+        makeDbThread({ id: 'titled-thread', title: 'LLM title' })
+      )
+
+      const { result } = renderHook(
+        () => usePlaygroundThreads('titled-thread'),
+        { wrapper: createWrapper() }
+      )
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      const onCalls = vi.mocked(window.electronAPI.on).mock.calls
+      const threadUpdatedHandler = onCalls.find(
+        (call) => call[0] === 'chat:thread:updated'
+      )?.[1] as ((...args: unknown[]) => void) | undefined
+      expect(threadUpdatedHandler).toBeDefined()
+
+      await act(async () => {
+        threadUpdatedHandler?.({ threadId: 'titled-thread' })
+      })
+
+      await waitFor(() =>
+        expect(
+          result.current.threads.find((t) => t.id === 'titled-thread')?.title
+        ).toBe('LLM title')
+      )
+    })
   })
 })

--- a/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-playground-threads.test.ts
@@ -21,6 +21,8 @@ const mockChatAPI = {
   updateThread: vi.fn(),
 }
 
+const mockUnsubscribeStreamState = vi.fn()
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -44,6 +46,7 @@ beforeEach(() => {
   window.electronAPI = {
     ...window.electronAPI,
     chat: mockChatAPI as unknown as typeof window.electronAPI.chat,
+    on: vi.fn().mockReturnValue(mockUnsubscribeStreamState),
   }
   mockChatAPI.getAllThreads.mockResolvedValue([])
   mockChatAPI.setActiveThreadId.mockResolvedValue(undefined)
@@ -559,6 +562,34 @@ describe('usePlaygroundThreads', () => {
         expect(
           result.current.threads.find((t) => t.id === 'streaming-thread')?.title
         ).toBe('Auto title')
+      )
+    })
+
+    it('calls refreshThread when chat:stream:state reports finished', async () => {
+      mockChatAPI.getAllThreads.mockResolvedValue([
+        makeDbThread({ id: 'bg-thread', title: 'Old title' }),
+      ])
+      mockChatAPI.getThread.mockResolvedValue(
+        makeDbThread({ id: 'bg-thread', title: 'LLM title' })
+      )
+
+      renderHook(() => usePlaygroundThreads('bg-thread'), {
+        wrapper: createWrapper(),
+      })
+      await waitFor(() => expect(mockChatAPI.getAllThreads).toHaveBeenCalled())
+
+      const onCalls = vi.mocked(window.electronAPI.on).mock.calls
+      const streamStateHandler = onCalls.find(
+        (call) => call[0] === 'chat:stream:state'
+      )?.[1] as ((...args: unknown[]) => void) | undefined
+      expect(streamStateHandler).toBeDefined()
+
+      await act(async () => {
+        streamStateHandler?.({ chatId: 'bg-thread', status: 'finished' })
+      })
+
+      await waitFor(() =>
+        expect(mockChatAPI.getThread).toHaveBeenCalledWith('bg-thread')
       )
     })
   })

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -16,6 +16,7 @@ import { useChatSettings } from './use-chat-settings'
 import { useThreadManagement } from './use-thread-management'
 import type { FileUIPart } from 'ai'
 import { trackEvent } from '@/common/lib/analytics'
+import { fallbackTitleFromParts } from '@common/chat/thread-title'
 import { hasValidCredentials } from '../lib/utils'
 import { chatThreadQueryOptions } from '../lib/thread-query'
 
@@ -262,15 +263,6 @@ export function useChatStreaming(externalThreadId?: string | null) {
   // React to streaming completion: publish a signal and set an optimistic title
   const prevStatusRef = useRef(status)
 
-  /** Extracts plain text from a ChatUIMessage's parts */
-  function extractUserText(msg: ChatUIMessage): string {
-    return msg.parts
-      .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-      .map((p) => p.text)
-      .join(' ')
-      .trim()
-  }
-
   /** Emits the streamingComplete cache signal so subscribers refresh the thread */
   function signalStreamingComplete(threadId: string) {
     queryClient.setQueryData(['chat', 'streamingComplete'], {
@@ -301,9 +293,13 @@ export function useChatStreaming(externalThreadId?: string | null) {
 
         // Optimistic placeholder: first user-message text, visible immediately.
         // Main process owns the LLM title upgrade on stream complete.
+        // Must match `fallbackTitleFromParts` so shouldAutoTitleThread
+        // still upgrades this placeholder after the LLM returns.
         const firstUserMsg = messages.find((m) => m.role === 'user')
         if (firstUserMsg && !thread?.title?.trim()) {
-          const optimisticTitle = extractUserText(firstUserMsg).slice(0, 60)
+          const optimisticTitle = fallbackTitleFromParts(
+            firstUserMsg.parts ?? []
+          )
           if (optimisticTitle) {
             await window.electronAPI.chat.updateThread(threadIdAtCompletion, {
               title: optimisticTitle,

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -262,6 +262,7 @@ export function useChatStreaming(externalThreadId?: string | null) {
 
   // React to streaming completion: publish a signal and set an optimistic title
   const prevStatusRef = useRef(status)
+  const titledThreadsRef = useRef<Set<string>>(new Set())
 
   /** Emits the streamingComplete cache signal so subscribers refresh the thread */
   function signalStreamingComplete(threadId: string) {
@@ -283,6 +284,9 @@ export function useChatStreaming(externalThreadId?: string | null) {
 
     // Publish initial signal so message list / loading state updates
     signalStreamingComplete(currentThreadId)
+
+    if (titledThreadsRef.current.has(currentThreadId)) return
+    titledThreadsRef.current.add(currentThreadId)
 
     const threadIdAtCompletion = currentThreadId
 

--- a/renderer/src/features/chat/hooks/use-chat-streaming.ts
+++ b/renderer/src/features/chat/hooks/use-chat-streaming.ts
@@ -259,9 +259,8 @@ export function useChatStreaming(externalThreadId?: string | null) {
     }
   }, [status, currentThreadId, queryClient])
 
-  // React to streaming completion: publish a signal and auto-title the thread via LLM
+  // React to streaming completion: publish a signal and set an optimistic title
   const prevStatusRef = useRef(status)
-  const titledThreadsRef = useRef<Set<string>>(new Set())
 
   /** Extracts plain text from a ChatUIMessage's parts */
   function extractUserText(msg: ChatUIMessage): string {
@@ -293,21 +292,17 @@ export function useChatStreaming(externalThreadId?: string | null) {
     // Publish initial signal so message list / loading state updates
     signalStreamingComplete(currentThreadId)
 
-    // Auto-title: run once per thread per session (guard against concurrent calls)
-    if (titledThreadsRef.current.has(currentThreadId)) return
-    titledThreadsRef.current.add(currentThreadId)
-
     const threadIdAtCompletion = currentThreadId
 
-    window.electronAPI.chat
+    void window.electronAPI.chat
       .getThread(threadIdAtCompletion)
       .then(async (thread) => {
-        // Respect manually-edited titles
         if (thread?.titleEditedByUser) return
 
-        // Optimistic placeholder: first user-message text, visible immediately
+        // Optimistic placeholder: first user-message text, visible immediately.
+        // Main process owns the LLM title upgrade on stream complete.
         const firstUserMsg = messages.find((m) => m.role === 'user')
-        if (firstUserMsg) {
+        if (firstUserMsg && !thread?.title?.trim()) {
           const optimisticTitle = extractUserText(firstUserMsg).slice(0, 60)
           if (optimisticTitle) {
             await window.electronAPI.chat.updateThread(threadIdAtCompletion, {
@@ -317,21 +312,9 @@ export function useChatStreaming(externalThreadId?: string | null) {
             signalStreamingComplete(threadIdAtCompletion)
           }
         }
-
-        return window.electronAPI.chat.generateThreadTitle(threadIdAtCompletion)
-      })
-      .then((result) => {
-        if (result && !result.success) {
-          log.warn('[useChatStreaming] Title generation failed:', result.error)
-          return
-        }
-        // Re-publish after LLM title is written to DB
-        if (result?.success) {
-          signalStreamingComplete(threadIdAtCompletion)
-        }
       })
       .catch((err) =>
-        log.error('[useChatStreaming] Failed to auto-title thread:', err)
+        log.error('[useChatStreaming] Failed to set optimistic title:', err)
       )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status, currentThreadId, queryClient])

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -287,29 +287,38 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
     })
   }, [queryClient, refreshThread])
 
-  // Refresh thread metadata when a background stream finishes in main
-  // (e.g. user switched away before the LLM title was written).
+  // Refresh when a background stream finishes, or when main writes a
+  // title after stream end (title work runs after the `finished` broadcast).
   useEffect(() => {
-    const listener = (...args: unknown[]) => {
+    const onStreamState = (...args: unknown[]) => {
       const event = args[0] as { chatId?: string; status?: string } | undefined
       if (!event?.chatId || event.status !== 'finished') return
-      refreshThread(event.chatId).catch((err) =>
-        log.error('[usePlaygroundThreads] refreshThread failed:', err)
-      )
-      queryClient.invalidateQueries({
-        queryKey: ['chat', 'thread', event.chatId],
-      })
+      // Signal only — the query-cache subscriber above does the refresh.
       queryClient.setQueryData(['chat', 'streamingComplete'], {
         threadId: event.chatId,
         timestamp: Date.now(),
       })
     }
 
-    const unsubscribe = window.electronAPI.on?.('chat:stream:state', listener)
-    return () => {
-      unsubscribe?.()
+    const onThreadUpdated = (...args: unknown[]) => {
+      const event = args[0] as { threadId?: string } | undefined
+      if (!event?.threadId) return
+      queryClient.setQueryData(['chat', 'streamingComplete'], {
+        threadId: event.threadId,
+        timestamp: Date.now(),
+      })
     }
-  }, [queryClient, refreshThread])
+
+    const offState = window.electronAPI.on?.('chat:stream:state', onStreamState)
+    const offUpdated = window.electronAPI.on?.(
+      'chat:thread:updated',
+      onThreadUpdated
+    )
+    return () => {
+      offState?.()
+      offUpdated?.()
+    }
+  }, [queryClient])
 
   return {
     threads,

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -315,8 +315,19 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
       onThreadUpdated
     )
     return () => {
-      offState?.()
-      offUpdated?.()
+      if (typeof offState === 'function') {
+        offState()
+      } else {
+        window.electronAPI.removeListener?.('chat:stream:state', onStreamState)
+      }
+      if (typeof offUpdated === 'function') {
+        offUpdated()
+      } else {
+        window.electronAPI.removeListener?.(
+          'chat:thread:updated',
+          onThreadUpdated
+        )
+      }
     }
   }, [queryClient])
 

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -287,6 +287,30 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
     })
   }, [queryClient, refreshThread])
 
+  // Refresh thread metadata when a background stream finishes in main
+  // (e.g. user switched away before the LLM title was written).
+  useEffect(() => {
+    const listener = (...args: unknown[]) => {
+      const event = args[0] as { chatId?: string; status?: string } | undefined
+      if (!event?.chatId || event.status !== 'finished') return
+      refreshThread(event.chatId).catch((err) =>
+        log.error('[usePlaygroundThreads] refreshThread failed:', err)
+      )
+      queryClient.invalidateQueries({
+        queryKey: ['chat', 'thread', event.chatId],
+      })
+      queryClient.setQueryData(['chat', 'streamingComplete'], {
+        threadId: event.chatId,
+        timestamp: Date.now(),
+      })
+    }
+
+    const unsubscribe = window.electronAPI.on?.('chat:stream:state', listener)
+    return () => {
+      unsubscribe?.()
+    }
+  }, [queryClient, refreshThread])
+
   return {
     threads,
     isLoading,

--- a/renderer/src/features/chat/hooks/use-playground-threads.ts
+++ b/renderer/src/features/chat/hooks/use-playground-threads.ts
@@ -290,23 +290,23 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
   // Refresh when a background stream finishes, or when main writes a
   // title after stream end (title work runs after the `finished` broadcast).
   useEffect(() => {
+    const signalStreamingComplete = (threadId: string) => {
+      queryClient.setQueryData(['chat', 'streamingComplete'], {
+        threadId,
+        timestamp: Date.now(),
+      })
+    }
+
     const onStreamState = (...args: unknown[]) => {
       const event = args[0] as { chatId?: string; status?: string } | undefined
       if (!event?.chatId || event.status !== 'finished') return
-      // Signal only — the query-cache subscriber above does the refresh.
-      queryClient.setQueryData(['chat', 'streamingComplete'], {
-        threadId: event.chatId,
-        timestamp: Date.now(),
-      })
+      signalStreamingComplete(event.chatId)
     }
 
     const onThreadUpdated = (...args: unknown[]) => {
       const event = args[0] as { threadId?: string } | undefined
       if (!event?.threadId) return
-      queryClient.setQueryData(['chat', 'streamingComplete'], {
-        threadId: event.threadId,
-        timestamp: Date.now(),
-      })
+      signalStreamingComplete(event.threadId)
     }
 
     const offState = window.electronAPI.on?.('chat:stream:state', onStreamState)
@@ -315,19 +315,8 @@ export function usePlaygroundThreads(activeThreadId: string | null) {
       onThreadUpdated
     )
     return () => {
-      if (typeof offState === 'function') {
-        offState()
-      } else {
-        window.electronAPI.removeListener?.('chat:stream:state', onStreamState)
-      }
-      if (typeof offUpdated === 'function') {
-        offUpdated()
-      } else {
-        window.electronAPI.removeListener?.(
-          'chat:thread:updated',
-          onThreadUpdated
-        )
-      }
+      offState?.()
+      offUpdated?.()
     }
   }, [queryClient])
 


### PR DESCRIPTION
## Summary

- Drop hollow assistant placeholders from persisted snapshots and from model requests so providers like Moonshot no longer reject multi-thread transcripts with empty assistant turns after switching sessions mid-stream.
- Move auto-title generation to the main process on stream completion, resolve the thread's own provider/model (not the global default), disable OpenRouter reasoning for short title calls, and fall back to the first user message when the LLM returns empty output so threads are not left as "New chat".

## Test plan

- [x] Start two chat threads with OpenRouter + Kimi, switch between them while streaming, then send follow-up messages — no "assistant must not be empty" errors
- [x] Complete a first exchange in a new thread with Kimi — sidebar title updates from "New chat" to user text, then to an LLM title (or stays on user text if the model fails)
- [x] Switch away from a thread before its stream finishes — title still updates when the background stream completes
- [x] Send a second message in an existing titled thread — title is not regenerated
- [x] Manually rename a thread — auto-title does not overwrite the custom title
- [x] `pnpm run test run main/src/chat/__tests__/generate-thread-title.test.ts main/src/chat/streaming/__tests__/sanitize-messages-for-model.test.ts main/src/chat/__tests__/streaming.test.ts`


Made with [Cursor](https://cursor.com)