### PR TITLE
fix(renovate): skip cooling-off period for toolhive, fix deprecated fileMatch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,8 @@
       "matchDatasources": ["github-releases"],
       "matchPackageNames": ["stacklok/toolhive"],
       "prPriority": 10,
-      "schedule": []
+      "schedule": [],
+      "minimumReleaseAge": null
     },
     {
       "description": "Group all AI SDK packages into a single PR — they are tightly coupled and should move together",
@@ -36,7 +37,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^utils/constants\\.ts$"],
+      "managerFilePatterns": ["/^utils/constants\\.ts$/"],
       "matchStrings": [
         "renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\*/\\s*export const TOOLHIVE_VERSION = process\\.env\\.THV_VERSION \\?\\? '(?<currentValue>.*?)'"
       ],


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge: null` for the `stacklok/toolhive` package rule — we control those releases directly, so the 3-day cooling-off period just adds lag between backend releases and the UI picking them up
- Replace deprecated `fileMatch` with `managerFilePatterns` in the `customManagers` block (regex now wrapped in `/…/` delimiters as required)

## Test plan
- [x] `renovate-config-validator renovate.json` passes cleanly with no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)