### PR TITLE
feat(network-isolation): show isolation status badge on tab trigger

### DIFF
--- a/renderer/src/common/hooks/use-stable-tab-panel-height.ts
+++ b/renderer/src/common/hooks/use-stable-tab-panel-height.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * Tracks the tallest height ever measured across a set of tab panels that
+ * take turns being mounted one at a time (e.g. toggled via the `hidden`
+ * attribute). Applying the returned `minHeight` to whichever panel is
+ * currently shown keeps the container from growing/shrinking every time the
+ * user switches tabs, once every panel has been visited at least once.
+ */
+export function useStableTabPanelMinHeight() {
+  const [element, setElement] = useState<HTMLElement | null>(null)
+  const [minHeight, setMinHeight] = useState(0)
+
+  useEffect(() => {
+    if (!element || typeof ResizeObserver === 'undefined') return
+
+    const measure = () => {
+      setMinHeight((prev) => Math.max(prev, element.scrollHeight))
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [element])
+
+  const measureRef = useCallback((node: HTMLElement | null) => {
+    setElement(node)
+  }, [])
+
+  return { measureRef, minHeight }
+}

--- a/renderer/src/features/mcp-servers/components/local-mcp/dialog-form-local-mcp.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/dialog-form-local-mcp.tsx
@@ -22,6 +22,7 @@ import {
   type FieldTabMapping,
 } from '@/common/hooks/use-form-tab-state'
 import { NetworkAccessTabContent } from '@/features/network-isolation/components/network-access-tab-content'
+import { NetworkAccessTabTriggerLabel } from '@/features/network-isolation/components/network-access-tab-trigger-label'
 import { FormFieldsArrayVolumes } from '../form-fields-array-custom-volumes'
 import { FormFieldsBase } from './form-fields-base'
 import {
@@ -324,7 +325,7 @@ export function DialogFormLocalMcp({
               <TabsList className="grid w-full grid-cols-2">
                 <TabsTrigger value="configuration">Configuration</TabsTrigger>
                 <TabsTrigger value="network-isolation">
-                  Network access
+                  <NetworkAccessTabTriggerLabel form={form} />
                 </TabsTrigger>
               </TabsList>
             </Tabs>

--- a/renderer/src/features/mcp-servers/components/local-mcp/dialog-form-local-mcp.tsx
+++ b/renderer/src/features/mcp-servers/components/local-mcp/dialog-form-local-mcp.tsx
@@ -10,7 +10,6 @@ import {
 import { convertCreateRequestToFormData } from '../../lib/orchestrate-run-local-server'
 import { useUpdateServer } from '../../hooks/use-update-server'
 import { zodV4Resolver } from '@/common/lib/zod-v4-resolver'
-import { cn } from '@/common/lib/utils'
 import { FormFieldsArrayCustomEnvVars } from '../form-fields-array-custom-env-vars'
 import { FormFieldsArrayCustomSecrets } from '../form-fields-array-custom-secrets'
 import { useRunCustomServer } from '../../hooks/use-run-custom-server'
@@ -21,6 +20,7 @@ import {
   useFormTabState,
   type FieldTabMapping,
 } from '@/common/hooks/use-form-tab-state'
+import { useStableTabPanelMinHeight } from '@/common/hooks/use-stable-tab-panel-height'
 import { NetworkAccessTabContent } from '@/features/network-isolation/components/network-access-tab-content'
 import { NetworkAccessTabTriggerLabel } from '@/features/network-isolation/components/network-access-tab-trigger-label'
 import { FormFieldsArrayVolumes } from '../form-fields-array-custom-volumes'
@@ -119,6 +119,7 @@ export function DialogFormLocalMcp({
       fieldTabMap: FIELD_TAB_MAP,
       defaultTab: 'configuration',
     })
+  const { measureRef, minHeight } = useStableTabPanelMinHeight()
   const { checkServerStatus } = useCheckServerStatus()
 
   const handleSecrets = (completedCount: number, secretsCount: number) => {
@@ -329,14 +330,12 @@ export function DialogFormLocalMcp({
                 </TabsTrigger>
               </TabsList>
             </Tabs>
-            <div className="grid flex-1 overflow-y-auto">
+            <div className="flex-1 overflow-y-auto">
               <div
-                className={cn(
-                  'col-start-1 row-start-1 space-y-4 px-6',
-                  activeTab === 'configuration'
-                    ? 'visible'
-                    : 'pointer-events-none invisible'
-                )}
+                ref={activeTab === 'configuration' ? measureRef : undefined}
+                className="space-y-4 px-6"
+                style={{ minHeight }}
+                hidden={activeTab !== 'configuration'}
                 inert={activeTab !== 'configuration'}
               >
                 <FormFieldsBase
@@ -349,12 +348,9 @@ export function DialogFormLocalMcp({
                 <FormFieldsArrayVolumes<FormSchemaLocalMcp> form={form} />
               </div>
               <div
-                className={cn(
-                  'col-start-1 row-start-1',
-                  activeTab === 'network-isolation'
-                    ? 'visible'
-                    : 'pointer-events-none invisible'
-                )}
+                ref={activeTab === 'network-isolation' ? measureRef : undefined}
+                style={{ minHeight }}
+                hidden={activeTab !== 'network-isolation'}
                 inert={activeTab !== 'network-isolation'}
               >
                 <NetworkAccessTabContent form={form} />
@@ -377,6 +373,8 @@ export function DialogFormLocalMcp({
     setError,
     activeTab,
     setActiveTab,
+    measureRef,
+    minHeight,
     form,
     groups,
     serverToEdit,

--- a/renderer/src/features/network-isolation/components/__tests__/network-access-tab-trigger-label.test.tsx
+++ b/renderer/src/features/network-isolation/components/__tests__/network-access-tab-trigger-label.test.tsx
@@ -38,33 +38,33 @@ function TestWrapper({
 }
 
 describe('NetworkAccessTabTriggerLabel', () => {
-  it('shows "Not isolated" text when no isolation is selected', async () => {
+  it('shows "Unrestricted" text when no isolation is selected', async () => {
     const router = createTestRouter(() => <TestWrapper networkAccess="none" />)
     renderRoute(router)
 
     await waitFor(() => {
-      expect(screen.getByText('Not isolated')).toBeInTheDocument()
+      expect(screen.getByText('Unrestricted')).toBeInTheDocument()
     })
-    expect(screen.queryByText('Isolated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Restricted')).not.toBeInTheDocument()
   })
 
-  it('shows "Not isolated" text when host networking is selected', async () => {
+  it('shows "Unrestricted" text when host networking is selected', async () => {
     const router = createTestRouter(() => <TestWrapper networkAccess="host" />)
     renderRoute(router)
 
     await waitFor(() => {
-      expect(screen.getByText('Not isolated')).toBeInTheDocument()
+      expect(screen.getByText('Unrestricted')).toBeInTheDocument()
     })
   })
 
-  it('shows "Isolated" text when proxy mode is selected', async () => {
+  it('shows "Restricted" text when proxy mode is selected', async () => {
     const router = createTestRouter(() => <TestWrapper networkAccess="proxy" />)
     renderRoute(router)
 
     await waitFor(() => {
-      expect(screen.getByText('Isolated')).toBeInTheDocument()
+      expect(screen.getByText('Restricted')).toBeInTheDocument()
     })
-    expect(screen.queryByText('Not isolated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Unrestricted')).not.toBeInTheDocument()
   })
 
   it('always renders the "Network access" label alongside the status', async () => {

--- a/renderer/src/features/network-isolation/components/__tests__/network-access-tab-trigger-label.test.tsx
+++ b/renderer/src/features/network-isolation/components/__tests__/network-access-tab-trigger-label.test.tsx
@@ -1,0 +1,78 @@
+import { screen, waitFor } from '@testing-library/react'
+import { expect, it, describe } from 'vitest'
+import { useForm } from 'react-hook-form'
+import { NetworkAccessTabTriggerLabel } from '../network-access-tab-trigger-label'
+import { renderRoute } from '@/common/test/render-route'
+import { createTestRouter } from '@/common/test/create-test-router'
+import { Form } from '@/common/components/ui/form'
+import type { FormSchemaLocalMcp } from '@/features/mcp-servers/lib/form-schema-local-mcp'
+import type { NetworkAccessMode } from '@/common/lib/form-schema-mcp'
+
+function TestWrapper({
+  networkAccess = 'none',
+}: {
+  networkAccess?: NetworkAccessMode
+}) {
+  const form = useForm<FormSchemaLocalMcp>({
+    defaultValues: {
+      name: '',
+      transport: 'stdio',
+      type: 'docker_image',
+      image: '',
+      envVars: [],
+      secrets: [],
+      cmd_arguments: [],
+      networkAccess,
+      allowedDestinations: 'anywhere',
+      allowHostAccess: false,
+      allowedHosts: [],
+      allowedPorts: [],
+    },
+  })
+
+  return (
+    <Form {...form}>
+      <NetworkAccessTabTriggerLabel form={form} />
+    </Form>
+  )
+}
+
+describe('NetworkAccessTabTriggerLabel', () => {
+  it('shows "Not isolated" text when no isolation is selected', async () => {
+    const router = createTestRouter(() => <TestWrapper networkAccess="none" />)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('Not isolated')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Isolated')).not.toBeInTheDocument()
+  })
+
+  it('shows "Not isolated" text when host networking is selected', async () => {
+    const router = createTestRouter(() => <TestWrapper networkAccess="host" />)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('Not isolated')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Isolated" text when proxy mode is selected', async () => {
+    const router = createTestRouter(() => <TestWrapper networkAccess="proxy" />)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('Isolated')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Not isolated')).not.toBeInTheDocument()
+  })
+
+  it('always renders the "Network access" label alongside the status', async () => {
+    const router = createTestRouter(() => <TestWrapper networkAccess="proxy" />)
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.getByText('Network access')).toBeInTheDocument()
+    })
+  })
+})

--- a/renderer/src/features/network-isolation/components/network-access-tab-trigger-label.tsx
+++ b/renderer/src/features/network-isolation/components/network-access-tab-trigger-label.tsx
@@ -16,21 +16,21 @@ export function NetworkAccessTabTriggerLabel<
   const networkAccess = form.watch(
     'networkAccess' as Path<TFieldValues>
   ) as NetworkAccessMode
-  const isIsolated = networkAccess === NETWORK_ACCESS_MODES.Proxy
+  const isRestricted = networkAccess === NETWORK_ACCESS_MODES.Proxy
 
   return (
     <>
       Network access
       <Badge
-        variant={isIsolated ? 'success' : 'outline'}
+        variant={isRestricted ? 'success' : 'outline'}
         className="pointer-events-none font-normal"
       >
-        {isIsolated ? (
+        {isRestricted ? (
           <ShieldCheck className="size-3" />
         ) : (
           <ShieldOff className="size-3" />
         )}
-        {isIsolated ? 'Isolated' : 'Not isolated'}
+        {isRestricted ? 'Restricted' : 'Unrestricted'}
       </Badge>
     </>
   )

--- a/renderer/src/features/network-isolation/components/network-access-tab-trigger-label.tsx
+++ b/renderer/src/features/network-isolation/components/network-access-tab-trigger-label.tsx
@@ -1,0 +1,37 @@
+import type { FieldValues, Path, UseFormReturn } from 'react-hook-form'
+import { ShieldCheck, ShieldOff } from 'lucide-react'
+import { Badge } from '@/common/components/ui/badge'
+import {
+  NETWORK_ACCESS_MODES,
+  type NetworkAccessMode,
+} from '@/common/lib/form-schema-mcp'
+
+type NetworkAccessFormValues = FieldValues & {
+  networkAccess: NetworkAccessMode
+}
+
+export function NetworkAccessTabTriggerLabel<
+  TFieldValues extends NetworkAccessFormValues,
+>({ form }: { form: UseFormReturn<TFieldValues> }) {
+  const networkAccess = form.watch(
+    'networkAccess' as Path<TFieldValues>
+  ) as NetworkAccessMode
+  const isIsolated = networkAccess === NETWORK_ACCESS_MODES.Proxy
+
+  return (
+    <>
+      Network access
+      <Badge
+        variant={isIsolated ? 'success' : 'outline'}
+        className="pointer-events-none font-normal"
+      >
+        {isIsolated ? (
+          <ShieldCheck className="size-3" />
+        ) : (
+          <ShieldOff className="size-3" />
+        )}
+        {isIsolated ? 'Isolated' : 'Not isolated'}
+      </Badge>
+    </>
+  )
+}

--- a/renderer/src/features/registry-servers/components/form-run-from-registry/index.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry/index.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
 import type { RegistryImageMetadata } from '@common/api/registry-types'
 import { zodV4Resolver } from '@/common/lib/zod-v4-resolver'
-import { cn } from '@/common/lib/utils'
 import { groupEnvVars } from '../../lib/group-env-vars'
 import { getApiV1BetaWorkloadsOptions } from '@common/api/generated/@tanstack/react-query.gen'
 import { useRunFromRegistry } from '../../hooks/use-run-from-registry'
@@ -17,6 +16,7 @@ import {
   useFormTabState,
   type FieldTabMapping,
 } from '@/common/hooks/use-form-tab-state'
+import { useStableTabPanelMinHeight } from '@/common/hooks/use-stable-tab-panel-height'
 import {
   getFormSchemaRegistryMcp,
   type FormSchemaRegistryMcp,
@@ -108,6 +108,7 @@ export function FormRunFromRegistry({
       fieldTabMap: FIELD_TAB_MAP,
       defaultTab: 'configuration',
     })
+  const { measureRef, minHeight } = useStableTabPanelMinHeight()
 
   const { data } = useQuery({
     ...getApiV1BetaWorkloadsOptions({ query: { all: true } }),
@@ -266,14 +267,11 @@ export function FormRunFromRegistry({
               </TabsTrigger>
             </TabsList>
           </Tabs>
-          <div className="grid flex-1 overflow-y-auto">
+          <div className="flex-1 overflow-y-auto">
             <div
-              className={cn(
-                'col-start-1 row-start-1',
-                activeTab === 'configuration'
-                  ? 'visible'
-                  : 'pointer-events-none invisible'
-              )}
+              ref={activeTab === 'configuration' ? measureRef : undefined}
+              style={{ minHeight }}
+              hidden={activeTab !== 'configuration'}
               inert={activeTab !== 'configuration'}
             >
               <ConfigurationTabContent
@@ -282,12 +280,9 @@ export function FormRunFromRegistry({
               />
             </div>
             <div
-              className={cn(
-                'col-start-1 row-start-1',
-                activeTab === 'network-isolation'
-                  ? 'visible'
-                  : 'pointer-events-none invisible'
-              )}
+              ref={activeTab === 'network-isolation' ? measureRef : undefined}
+              style={{ minHeight }}
+              hidden={activeTab !== 'network-isolation'}
               inert={activeTab !== 'network-isolation'}
             >
               <NetworkAccessTabContent form={form} />

--- a/renderer/src/features/registry-servers/components/form-run-from-registry/index.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry/index.tsx
@@ -10,6 +10,7 @@ import { getApiV1BetaWorkloadsOptions } from '@common/api/generated/@tanstack/re
 import { useRunFromRegistry } from '../../hooks/use-run-from-registry'
 import { LoadingStateAlert } from '../../../../common/components/secrets/loading-state-alert'
 import { NetworkAccessTabContent } from '@/features/network-isolation/components/network-access-tab-content'
+import { NetworkAccessTabTriggerLabel } from '@/features/network-isolation/components/network-access-tab-trigger-label'
 import { ConfigurationTabContent } from './configuration-tab-content'
 import { Tabs, TabsList, TabsTrigger } from '@/common/components/ui/tabs'
 import {
@@ -261,7 +262,7 @@ export function FormRunFromRegistry({
             <TabsList className="grid w-full grid-cols-2">
               <TabsTrigger value="configuration">Configuration</TabsTrigger>
               <TabsTrigger value="network-isolation">
-                Network access
+                <NetworkAccessTabTriggerLabel form={form} />
               </TabsTrigger>
             </TabsList>
           </Tabs>


### PR DESCRIPTION
## Summary
- Adds a visible "Restricted" / "Unrestricted" badge directly on the "Network access" tab trigger of the local-server and run-from-registry create/edit forms, so the isolation state is discoverable without opening that tab. Wording per feature-owner (Dan Barr) sign-off.
- Status is derived from the same `networkAccess === 'proxy'` logic already used when submitting `network_isolation` to the API, so it always reflects the value that will actually be sent.
- Fixes a related layout bug (also flagged by Dan Barr in review): both tab panels were kept mounted and stacked in the same CSS grid cell, sized by visibility rather than display, so the scroll container's height always matched the taller panel — letting a shorter tab scroll into blank space. Switches to the `hidden` attribute plus a small `useStableTabPanelMinHeight` hook that remembers the tallest panel seen and floors the active one at that height, so switching tabs no longer causes the modal to jump size *or* over-scroll.

<img width="1137" height="794" alt="screenshot-2026-07-24_11-07-33" src="https://github.com/user-attachments/assets/f3cc42ae-bed4-404d-993d-394140b2f5c8" />
<img width="1038" height="860" alt="screenshot-2026-07-24_11-07-24" src="https://github.com/user-attachments/assets/a4022a19-8254-47c5-82d3-f83fd2b65074" />

## Related
Closes stacklok/stacklok-enterprise-platform#2518 (scoped to the "Network access" tab in the create/edit form, per discussion in that issue — the fuller "consolidated install/config page" idea mentioned there is out of scope for this PR).

## Test plan
- [x] `pnpm run test:nonInteractive` for the affected files (network-isolation feature, local-mcp dialog, run-from-registry form) — all passing
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean
- [x] Manually verified in the running app: badge reflects live state on both tabs and updates as the radio selection changes; tab switching no longer resizes the modal or leaves scrollable empty space

---
Fully or partially written by an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)