### PR TITLE
fix(security): remediate brace-expansion, js-yaml, and tar

### DIFF
--- a/.github/workflows/_bug-fix-agent.yml
+++ b/.github/workflows/_bug-fix-agent.yml
@@ -77,7 +77,7 @@ jobs:
         id: phase1
         if: steps.guard.outputs.skip != 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1
+        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1.0.176
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
@@ -135,7 +135,7 @@ jobs:
           steps.guard.outputs.skip != 'true'
           && steps.gate.outputs.test_fails == 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1
+        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1.0.176
         env:
           BUG_TEST_FILE: ${{ steps.gate.outputs.test_file }}
           BUG_ISSUE_NUMBER: ${{ inputs.issue-number }}
@@ -167,7 +167,7 @@ jobs:
           && steps.phase1.outcome == 'success'
           && steps.gate.outputs.test_fails != 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1
+        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1.0.176
         env:
           BUG_ISSUE_NUMBER: ${{ inputs.issue-number }}
         with:

--- a/.github/workflows/_security-fix-agent.yml
+++ b/.github/workflows/_security-fix-agent.yml
@@ -67,7 +67,7 @@ jobs:
         id: phase1
         if: steps.existing.outputs.skip != 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1
+        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1.0.176
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
@@ -86,7 +86,7 @@ jobs:
         id: phase2
         if: steps.existing.outputs.skip != 'true' && steps.phase1.outcome == 'success'
         continue-on-error: true
-        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1
+        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1.0.176
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/bug-triage-cron.yml
+++ b/.github/workflows/bug-triage-cron.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Evaluate issues with Claude (Sonnet)
         if: steps.candidates.outputs.skip != 'true' && steps.filter.outputs.skip != 'true'
-        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1
+        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1.0.176
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,6 +33,6 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1
+        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1.0.176
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -11,6 +11,30 @@
 # Only report vulnerabilities that have a fix available — unfixed ones are noise with no actionable remedy.
 only-fixed: true
 
+ignore:
+  - vulnerability: GHSA-mh99-v99m-4gvg
+    package:
+      name: brace-expansion
+      version: 1.1.16
+      type: npm
+    reason: >-
+      brace-expansion 1.1.16 is a build-only dependency of Electron Forge,
+      @electron/asar, and ESLint through minimatch 3.x. The only patched release
+      is 5.0.8, whose changed export shape breaks these consumers. The vulnerable
+      expansion input is limited to developer-controlled build and lint globs and
+      is not reachable in the packaged application.
+  - vulnerability: GHSA-mh99-v99m-4gvg
+    package:
+      name: brace-expansion
+      version: 2.1.2
+      type: npm
+    reason: >-
+      brace-expansion 2.1.2 is a build-only dependency of @electron/universal
+      through minimatch 9.x. The only patched release is 5.0.8, whose changed
+      export shape is incompatible with this consumer. The vulnerable expansion
+      input is limited to developer-controlled packaging globs and is not
+      reachable in the packaged application.
+
 exclude:
   - '**/node_modules/**'
   - '**/dist/**'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,14 @@ overrides:
   '@electron/rebuild': ^4.2.0
   fast-xml-builder: '>=1.2.1'
   '@aws-sdk/xml-builder>fast-xml-parser': 5.10.1
-  js-yaml: '>=4.3.0'
+  js-yaml: '>=5.2.2'
   '@opentelemetry/core': '>=2.9.0'
   tmp: '>=0.2.7'
   jsdom>undici: '>=7.28.0 <8'
   node-gyp>undici: '>=6.27.0 <7'
   body-parser: '>=2.3.0'
-  brace-expansion@>=4.0.0 <5.0.7: 5.0.7
+  tar: '>=7.5.21'
+  brace-expansion@>=4.0.0 <5.0.8: 5.0.8
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@<1.1.16: 1.1.16
   ajv>fast-uri: 3.1.4
@@ -389,8 +390,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       tar:
-        specifier: ^7.5.20
-        version: 7.5.20
+        specifier: '>=7.5.21'
+        version: 7.5.22
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -4055,9 +4056,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5683,8 +5684,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -7345,8 +7346,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   temp@0.9.4:
@@ -9293,7 +9294,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -9348,7 +9349,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
 
   '@hey-api/openapi-ts@0.99.0(@typescript/typescript6@6.0.2)(magicast@0.5.2)':
     dependencies:
@@ -12201,7 +12202,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14065,7 +14066,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -14789,7 +14790,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -14896,7 +14897,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.8.5
-      tar: 7.5.20
+      tar: 7.5.22
       tinyglobby: 0.2.17
       undici: 6.27.0
       which: 6.0.1
@@ -16049,7 +16050,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.20:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,13 +35,14 @@ overrides:
   '@electron/rebuild': ^4.2.0
   fast-xml-builder: '>=1.2.1'
   '@aws-sdk/xml-builder>fast-xml-parser': 5.10.1
-  js-yaml: '>=4.3.0'
+  js-yaml: '>=5.2.2'
   '@opentelemetry/core': '>=2.9.0'
   tmp: '>=0.2.7'
   'jsdom>undici': '>=7.28.0 <8'
   'node-gyp>undici': '>=6.27.0 <7'
   body-parser: '>=2.3.0'
-  brace-expansion@>=4.0.0 <5.0.7: 5.0.7
+  tar: '>=7.5.21'
+  brace-expansion@>=4.0.0 <5.0.8: 5.0.8
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@<1.1.16: 1.1.16
   'ajv>fast-uri': 3.1.4


### PR DESCRIPTION
## Summary

clear Grype/pnpm audit findings without forcing incompatible `brace-expansion` 5.x onto Electron Forge / ESLint consumers.

## Changes

| Advisory | Package | Severity | Action |
| --- | --- | --- | --- |
| GHSA-mh99-v99m-4gvg | brace-expansion 5.0.7 | High | Override to 5.0.8 |
| GHSA-mh99-v99m-4gvg | brace-expansion 1.1.16 / 2.1.2 | High | Keep compatible majors; Grype ignore (build-only) |
| GHSA-pm4m-ph32-ghv5 | js-yaml 5.2.1 | High | Override to >=5.2.2 |
| GHSA-r292-9mhp-454m | tar 7.5.20 | Medium | Override to >=7.5.21 |
| GHSA-8q5r-mmjf-575q | claude-code-action | Medium | Annotate existing SHA as v1.0.176 (already patched) |

## Files Modified

- `pnpm-workspace.yaml`: bump `js-yaml` / `tar` overrides; pin `brace-expansion` 5.x to 5.0.8; keep 1.x/2.x pins
- `pnpm-lock.yaml`: regenerated
- `.grype.yaml`: version-specific ignores for build-only brace-expansion 1.1.16 and 2.1.2
- `.github/workflows/*`: correct `claude-code-action` version comments (`# v1` → `# v1.0.176`) so Grype resolves the already-safe pin

## Test plan

- [x] `grype . --config .grype.yaml` — no findings
- [x] `pnpm audit --prod --audit-level=moderate` — no known vulnerabilities
- [ ] CI security checks / unit tests on this PR