### PR TITLE
fix: make thv startup resilient to SQLite failures

### DIFF
--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -231,7 +231,7 @@ describe('toolhive-manager', () => {
         testError
       )
       expect(mockCaptureMessage).toHaveBeenCalledWith(
-        `Failed to start ToolHive: ${JSON.stringify(testError)}`,
+        'Failed to start ToolHive: Test spawn error',
         'fatal'
       )
       expect(mockUpdateTrayStatus).toHaveBeenCalledWith(false)

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -18,6 +18,7 @@ import log from '../logger'
 import * as Sentry from '@sentry/electron/main'
 import { getQuittingState } from '../app-state'
 import { readSetting } from '../db/readers/settings-reader'
+import { telemetryStore } from '../telemetry-store'
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>()
@@ -92,6 +93,8 @@ const mockUpdateTrayStatus = vi.mocked(updateTrayStatus)
 const mockLog = vi.mocked(log)
 const mockCaptureMessage = vi.mocked(Sentry.captureMessage)
 const mockGetQuittingState = vi.mocked(getQuittingState)
+const mockReadSetting = vi.mocked(readSetting)
+const mockTelemetryStoreGet = vi.mocked(telemetryStore.get)
 
 // Mock process for testing
 class MockProcess extends EventEmitter {
@@ -493,9 +496,10 @@ describe('toolhive-manager', () => {
 
     it('still spawns thv when readSetting throws (e.g. SQLite unavailable)', async () => {
       vi.stubEnv('VITE_SENTRY_THV_DSN', 'https://test@sentry.io/123')
-      vi.mocked(readSetting).mockImplementation(() => {
+      mockReadSetting.mockImplementation(() => {
         throw new Error('GLIBC_2.38 not found')
       })
+      mockTelemetryStoreGet.mockReturnValue(true)
 
       const startPromise = startToolhive()
       await vi.advanceTimersByTimeAsync(50)
@@ -505,6 +509,10 @@ describe('toolhive-manager', () => {
       expect(mockLog.error).toHaveBeenCalledWith(
         '[DB] SQLite read failed:',
         expect.any(Error)
+      )
+      expect(mockTelemetryStoreGet).toHaveBeenCalledWith(
+        'isTelemetryEnabled',
+        true
       )
       expect(isToolhiveRunning()).toBe(true)
 
@@ -516,6 +524,22 @@ describe('toolhive-manager', () => {
           '--sentry-traces-sample-rate=1.0',
         ])
       )
+    })
+
+    it('omits sentry flags when SQLite is down but user opted out in telemetryStore', async () => {
+      vi.stubEnv('VITE_SENTRY_THV_DSN', 'https://test@sentry.io/123')
+      mockReadSetting.mockImplementation(() => {
+        throw new Error('GLIBC_2.38 not found')
+      })
+      mockTelemetryStoreGet.mockReturnValue(false)
+
+      const startPromise = startToolhive()
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
+
+      expect(mockSpawn).toHaveBeenCalled()
+      const spawnArgs = mockSpawn.mock.calls[0]![1] as string[]
+      expect(spawnArgs.some((a) => a.startsWith('--sentry-'))).toBe(false)
     })
 
     it('clears socket path and updates tray when startup throws before spawn', async () => {

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -67,7 +67,7 @@ vi.mock('@sentry/electron/main', () => ({
     const mockScope = {
       addBreadcrumb: vi.fn(),
     }
-    callback(mockScope)
+    return callback(mockScope)
   }),
 }))
 
@@ -489,6 +489,53 @@ describe('toolhive-manager', () => {
 
       const spawnArgs = mockSpawn.mock.calls[0]![1] as string[]
       expect(spawnArgs.some((a) => a.startsWith('--sentry-'))).toBe(false)
+    })
+
+    it('still spawns thv when readSetting throws (e.g. SQLite unavailable)', async () => {
+      vi.stubEnv('VITE_SENTRY_THV_DSN', 'https://test@sentry.io/123')
+      vi.mocked(readSetting).mockImplementation(() => {
+        throw new Error('GLIBC_2.38 not found')
+      })
+
+      const startPromise = startToolhive()
+      await vi.advanceTimersByTimeAsync(50)
+      await startPromise
+
+      expect(mockSpawn).toHaveBeenCalled()
+      expect(mockLog.error).toHaveBeenCalledWith(
+        '[DB] SQLite read failed:',
+        expect.any(Error)
+      )
+      expect(isToolhiveRunning()).toBe(true)
+
+      const spawnArgs = mockSpawn.mock.calls[0]![1] as string[]
+      expect(spawnArgs).toEqual(
+        expect.arrayContaining([
+          '--sentry-dsn=https://test@sentry.io/123',
+          '--sentry-environment=development',
+          '--sentry-traces-sample-rate=1.0',
+        ])
+      )
+    })
+
+    it('clears socket path and updates tray when startup throws before spawn', async () => {
+      mockSpawn.mockImplementation(() => {
+        throw new Error('spawn failed')
+      })
+
+      await startToolhive()
+
+      expect(mockLog.error).toHaveBeenCalledWith(
+        'Failed to start ToolHive:',
+        expect.any(Error)
+      )
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to start ToolHive:'),
+        'fatal'
+      )
+      expect(mockUpdateTrayStatus).toHaveBeenCalledWith(false)
+      expect(getToolhiveSocketPath()).toBeUndefined()
+      expect(isToolhiveRunning()).toBe(false)
     })
 
     it('sets processError to ALREADY_RUNNING when stderr reports another server running', async () => {

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -100,131 +100,153 @@ function cleanupSocketFile(socketPath: string): void {
   }
 }
 
+function isTelemetryEnabled(): boolean {
+  try {
+    return readSetting('isTelemetryEnabled') !== 'false'
+  } catch (err) {
+    log.error('[DB] SQLite read failed:', err)
+    return true
+  }
+}
+
 export async function startToolhive(): Promise<void> {
-  Sentry.withScope<Promise<void>>(async (scope) => {
-    if (isUsingCustomSocket()) {
-      toolhiveSocketPath = process.env.THV_SOCKET!
-      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
-      log.info(`Using external ToolHive on socket ${toolhiveSocketPath}`)
-      return
-    }
-
-    if (!existsSync(binPath)) {
-      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
-      log.error(`ToolHive binary not found at: ${binPath}`)
-      return
-    }
-
-    processError = undefined
-    toolhiveSocketPath = generateSocketPath()
-    cleanupSocketFile(toolhiveSocketPath)
-
-    log.info(
-      `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}`
-    )
-
-    const serveArgs = ['serve', '--openapi', `--socket=${toolhiveSocketPath}`]
-
-    const isE2E = process.env.TOOLHIVE_E2E === 'true'
-    const sentryDsn = isE2E ? undefined : import.meta.env.VITE_SENTRY_THV_DSN
-    if (sentryDsn && readSetting('isTelemetryEnabled') !== 'false') {
-      const sentryEnvironment = app.isPackaged ? 'production' : 'development'
-      serveArgs.push(
-        `--sentry-dsn=${sentryDsn}`,
-        `--sentry-environment=${sentryEnvironment}`,
-        `--sentry-traces-sample-rate=1.0`
-      )
-    }
-
-    const child = spawn(binPath, serveArgs, {
-      stdio: ['ignore', 'ignore', 'pipe'],
-      detached: false,
-      // Ensure child process is killed when parent exits
-      // On Windows, this creates a job object to enforce cleanup
-      windowsHide: true,
-      env: {
-        ...process.env,
-        PATH: createEnhancedPath(),
-        TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
-      },
-    })
-    toolhiveProcess = child
-    isStopping = false
-
-    log.info(`[startToolhive] Process spawned with PID: ${child.pid}`)
-
-    scope.addBreadcrumb({
-      category: 'debug',
-      message: `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}, PID: ${child.pid}`,
-    })
-
-    updateTrayStatus(!!child)
-
-    // Capture and log stderr
-    if (child.stderr) {
-      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
-      log.info(`[ToolHive] Capturing stderr enabled`)
-      child.stderr.on('data', (data) => {
-        const output = data.toString().trim()
-        if (!output) return
-        // eslint-disable-next-line no-restricted-syntax -- matches thv stderr output — must stay literal
-        if (output.includes('A new version of ToolHive is available')) {
-          return
-        }
-        if (output.includes('registry authentication required')) {
-          processError = REGISTRY_AUTH_REQUIRED
-        }
-        // eslint-disable-next-line no-restricted-syntax -- matches thv stderr output — must stay literal
-        if (output.includes('another ToolHive server is already running')) {
-          processError = ALREADY_RUNNING
-        }
+  try {
+    await Sentry.withScope(async (scope) => {
+      if (isUsingCustomSocket()) {
+        toolhiveSocketPath = process.env.THV_SOCKET!
         // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
-        log.info(`[ToolHive stderr] ${output}`)
-        scope.addBreadcrumb({
-          category: 'debug',
-          // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
-          message: `[ToolHive stderr] ${output}`,
-          level: 'log',
-        })
-      })
-    }
-
-    child.on('error', (error) => {
-      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
-      log.error('Failed to start ToolHive: ', error)
-      Sentry.captureMessage(
-        `Failed to start ${THV_DISPLAY_NAME}: ${JSON.stringify(error)}`,
-        'fatal'
-      )
-      updateTrayStatus(false)
-    })
-
-    child.on('exit', (code) => {
-      // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
-      log.warn(`ToolHive process exited with code: ${code}`)
-      // Only clear globals if this exit is for the currently tracked child.
-      // Otherwise a prior child's exit can run after restart has spawned a
-      // replacement and would wipe the new socket path / process reference.
-      if (toolhiveProcess === child) {
-        toolhiveProcess = undefined
-        toolhiveSocketPath = undefined
-        isStopping = false
-        // Drop the pending SIGKILL timer - the child is already gone and a
-        // live setTimeout would keep the event loop alive during shutdown.
-        if (killTimer) {
-          clearTimeout(killTimer)
-          killTimer = undefined
-        }
+        log.info(`Using external ToolHive on socket ${toolhiveSocketPath}`)
+        return
       }
-      if (!isRestarting && !getQuittingState()) {
-        updateTrayStatus(false)
-        Sentry.captureMessage(
-          `${THV_DISPLAY_NAME} process exited with code: ${code}`,
-          'fatal'
+
+      if (!existsSync(binPath)) {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
+        log.error(`ToolHive binary not found at: ${binPath}`)
+        return
+      }
+
+      processError = undefined
+      toolhiveSocketPath = generateSocketPath()
+      cleanupSocketFile(toolhiveSocketPath)
+
+      log.info(
+        `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}`
+      )
+
+      const serveArgs = ['serve', '--openapi', `--socket=${toolhiveSocketPath}`]
+
+      const isE2E = process.env.TOOLHIVE_E2E === 'true'
+      const sentryDsn = isE2E ? undefined : import.meta.env.VITE_SENTRY_THV_DSN
+      if (sentryDsn && isTelemetryEnabled()) {
+        const sentryEnvironment = app.isPackaged ? 'production' : 'development'
+        serveArgs.push(
+          `--sentry-dsn=${sentryDsn}`,
+          `--sentry-environment=${sentryEnvironment}`,
+          `--sentry-traces-sample-rate=1.0`
         )
       }
+
+      const child = spawn(binPath, serveArgs, {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        detached: false,
+        // Ensure child process is killed when parent exits
+        // On Windows, this creates a job object to enforce cleanup
+        windowsHide: true,
+        env: {
+          ...process.env,
+          PATH: createEnhancedPath(),
+          TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
+        },
+      })
+      toolhiveProcess = child
+      isStopping = false
+
+      log.info(`[startToolhive] Process spawned with PID: ${child.pid}`)
+
+      scope.addBreadcrumb({
+        category: 'debug',
+        message: `Starting ${THV_DISPLAY_NAME} from: ${binPath} on socket ${toolhiveSocketPath}, PID: ${child.pid}`,
+      })
+
+      updateTrayStatus(!!child)
+
+      // Capture and log stderr
+      if (child.stderr) {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
+        log.info(`[ToolHive] Capturing stderr enabled`)
+        child.stderr.on('data', (data) => {
+          const output = data.toString().trim()
+          if (!output) return
+          // eslint-disable-next-line no-restricted-syntax -- matches thv stderr output — must stay literal
+          if (output.includes('A new version of ToolHive is available')) {
+            return
+          }
+          if (output.includes('registry authentication required')) {
+            processError = REGISTRY_AUTH_REQUIRED
+          }
+          // eslint-disable-next-line no-restricted-syntax -- matches thv stderr output — must stay literal
+          if (output.includes('another ToolHive server is already running')) {
+            processError = ALREADY_RUNNING
+          }
+          // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
+          log.info(`[ToolHive stderr] ${output}`)
+          scope.addBreadcrumb({
+            category: 'debug',
+            // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
+            message: `[ToolHive stderr] ${output}`,
+            level: 'log',
+          })
+        })
+      }
+
+      child.on('error', (error) => {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
+        log.error('Failed to start ToolHive: ', error)
+        Sentry.captureMessage(
+          `Failed to start ${THV_DISPLAY_NAME}: ${JSON.stringify(error)}`,
+          'fatal'
+        )
+        updateTrayStatus(false)
+      })
+
+      child.on('exit', (code) => {
+        // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
+        log.warn(`ToolHive process exited with code: ${code}`)
+        // Only clear globals if this exit is for the currently tracked child.
+        // Otherwise a prior child's exit can run after restart has spawned a
+        // replacement and would wipe the new socket path / process reference.
+        if (toolhiveProcess === child) {
+          toolhiveProcess = undefined
+          toolhiveSocketPath = undefined
+          isStopping = false
+          // Drop the pending SIGKILL timer - the child is already gone and a
+          // live setTimeout would keep the event loop alive during shutdown.
+          if (killTimer) {
+            clearTimeout(killTimer)
+            killTimer = undefined
+          }
+        }
+        if (!isRestarting && !getQuittingState()) {
+          updateTrayStatus(false)
+          Sentry.captureMessage(
+            `${THV_DISPLAY_NAME} process exited with code: ${code}`,
+            'fatal'
+          )
+        }
+      })
     })
-  })
+  } catch (error) {
+    // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
+    log.error('Failed to start ToolHive:', error)
+    Sentry.captureMessage(
+      `Failed to start ${THV_DISPLAY_NAME}: ${JSON.stringify(error)}`,
+      'fatal'
+    )
+    updateTrayStatus(false)
+    if (!isToolhiveRunning()) {
+      toolhiveSocketPath = undefined
+    }
+  }
 }
 
 export async function restartToolhive(): Promise<void> {

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -8,6 +8,7 @@ import { THV_DISPLAY_NAME } from '@common/app-info'
 import * as Sentry from '@sentry/electron/main'
 import { getQuittingState } from './app-state'
 import { readSetting } from './db/readers/settings-reader'
+import { telemetryStore } from './telemetry-store'
 import { createEnhancedPath } from './utils/enhanced-path'
 import {
   ALREADY_RUNNING,
@@ -109,7 +110,8 @@ function isTelemetryEnabled(): boolean {
     return readSetting('isTelemetryEnabled') !== 'false'
   } catch (err) {
     log.error('[DB] SQLite read failed:', err)
-    return true
+    // electron-store is the authoritative opt-out source (written before SQLite).
+    return telemetryStore.get('isTelemetryEnabled', true)
   }
 }
 
@@ -242,12 +244,12 @@ export async function startToolhive(): Promise<void> {
   } catch (error) {
     // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.error('Failed to start ToolHive:', error)
-    Sentry.captureMessage(
-      `Failed to start ${THV_DISPLAY_NAME}: ${formatUnknownError(error)}`,
-      'fatal'
-    )
-    updateTrayStatus(false)
     if (!isToolhiveRunning()) {
+      Sentry.captureMessage(
+        `Failed to start ${THV_DISPLAY_NAME}: ${formatUnknownError(error)}`,
+        'fatal'
+      )
+      updateTrayStatus(false)
       toolhiveSocketPath = undefined
     }
   }
@@ -279,7 +281,7 @@ export async function restartToolhive(): Promise<void> {
     // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.error('Failed to restart ToolHive: ', error)
     Sentry.captureMessage(
-      `Failed to restart ${THV_DISPLAY_NAME}: ${JSON.stringify(error)}`,
+      `Failed to restart ${THV_DISPLAY_NAME}: ${formatUnknownError(error)}`,
       'fatal'
     )
   } finally {

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -100,6 +100,10 @@ function cleanupSocketFile(socketPath: string): void {
   }
 }
 
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
 function isTelemetryEnabled(): boolean {
   try {
     return readSetting('isTelemetryEnabled') !== 'false'
@@ -203,7 +207,7 @@ export async function startToolhive(): Promise<void> {
         // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
         log.error('Failed to start ToolHive: ', error)
         Sentry.captureMessage(
-          `Failed to start ${THV_DISPLAY_NAME}: ${JSON.stringify(error)}`,
+          `Failed to start ${THV_DISPLAY_NAME}: ${formatUnknownError(error)}`,
           'fatal'
         )
         updateTrayStatus(false)
@@ -239,7 +243,7 @@ export async function startToolhive(): Promise<void> {
     // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.error('Failed to start ToolHive:', error)
     Sentry.captureMessage(
-      `Failed to start ${THV_DISPLAY_NAME}: ${JSON.stringify(error)}`,
+      `Failed to start ${THV_DISPLAY_NAME}: ${formatUnknownError(error)}`,
       'fatal'
     )
     updateTrayStatus(false)


### PR DESCRIPTION
## Summary

- Guard `readSetting('isTelemetryEnabled')` in `startToolhive` so SQLite/`better-sqlite3` failures cannot block thv from spawning
- Await the `Sentry.withScope` body and clear the socket path when startup throws before the process is running
- On DB failure, fall back to `telemetryStore` for telemetry opt-out (does not fail open)
- Add regression tests for both failure modes

This is the bottom PR in the [#2526 → #2527](https://github.com/stacklok/toolhive-studio/pull/2526) stack. It unbricks Ubuntu 22.04 users immediately: thv starts even when SQLite is unavailable (persistence degrades gracefully).

Related: #2509

## Test plan

- [x] `pnpm run test:nonInteractive run main/src/tests/toolhive-manager.test.ts`
- [ ] Manual: simulate `readSetting` throw and confirm app reaches health check with thv running