### PR TITLE
fix(playground): refine agent cards layout and overflow handling

### DIFF
--- a/renderer/src/features/agents/components/__tests__/agents-page.test.tsx
+++ b/renderer/src/features/agents/components/__tests__/agents-page.test.tsx
@@ -43,6 +43,21 @@ const customAgent: AgentConfig = {
   updatedAt: 0,
 }
 
+const longNameAgent: AgentConfig = {
+  id: 'custom.long-name-agent',
+  kind: 'custom',
+  name: 'PR Review Instructions (TypeScript + Next.js App Router + OpenAPI)',
+  description: 'Reviews pull requests with a very long checklist of rules.',
+  instructions: 'Review PRs.',
+  builtinToolsKey: null,
+  defaultModel: {
+    provider: 'openrouter',
+    model: 'moonshotai/kimi-k2.7-code-with-an-extremely-long-model-name',
+  },
+  createdAt: 0,
+  updatedAt: 0,
+}
+
 function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -66,7 +81,21 @@ describe('AgentsPage', () => {
       },
     } as unknown as typeof window.electronAPI
 
-    mockAgentsApi.list.mockResolvedValue([builtinAgent, customAgent])
+    mockAgentsApi.list.mockResolvedValue([
+      builtinAgent,
+      customAgent,
+      longNameAgent,
+    ])
+  })
+
+  it('renders the refreshed page subtitle', async () => {
+    renderPage()
+
+    expect(
+      await screen.findByText(
+        'Create and manage the agents available in Playground.'
+      )
+    ).toBeInTheDocument()
   })
 
   it('renders both built-in and custom agents in the All tab', async () => {
@@ -78,18 +107,85 @@ describe('AgentsPage', () => {
     expect(screen.getByText('Does cool things')).toBeInTheDocument()
   })
 
-  it('shows the default model for agents that have one', async () => {
+  it('shows built-in and custom badges with consistent labels', async () => {
+    renderPage()
+
+    await screen.findByText('ToolHive Assistant')
+    expect(
+      screen.getByTestId('agent-metadata-builtin.toolhive-assistant')
+    ).toHaveTextContent('Built-in')
+    expect(
+      screen.getByTestId('agent-metadata-custom.my-agent')
+    ).toHaveTextContent('Custom')
+  })
+
+  it('shows model metadata with a Model label for agents that have one', async () => {
     renderPage()
 
     await screen.findByText('My custom agent')
-    expect(screen.getByText(/openai · gpt-4o/i)).toBeInTheDocument()
+    const metadata = screen.getByTestId('agent-metadata-custom.my-agent')
+    expect(metadata).toHaveTextContent('Model')
+    expect(metadata).toHaveTextContent(/openai · gpt-4o/i)
+  })
+
+  it('renders long agent names and model values without a View details button', async () => {
+    renderPage()
+
+    const openTarget = await screen.findByTestId(
+      'open-agent-custom.long-name-agent'
+    )
+    expect(openTarget).toHaveAttribute(
+      'aria-label',
+      'Open PR Review Instructions (TypeScript + Next.js App Router + OpenAPI)'
+    )
+    expect(
+      screen.getByText(
+        'PR Review Instructions (TypeScript + Next.js App Router + OpenAPI)'
+      )
+    ).toHaveClass('line-clamp-2')
+    expect(
+      screen.getByText(
+        /moonshotai\/kimi-k2\.7-code-with-an-extremely-long-model-name/i
+      )
+    ).toHaveClass('truncate')
+    expect(
+      screen.queryByRole('button', { name: /view details/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('leaves the description area blank when an agent has no description', async () => {
+    const agentWithoutDescription: AgentConfig = {
+      ...customAgent,
+      id: 'custom.no-description',
+      name: 'No description agent',
+      description: '',
+    }
+    mockAgentsApi.list.mockResolvedValue([agentWithoutDescription])
+
+    renderPage()
+
+    await screen.findByText('No description agent')
+    expect(screen.queryByText('No description')).not.toBeInTheDocument()
   })
 
   it('navigates to the agent detail page when a card is clicked', async () => {
     renderPage()
 
     await screen.findByText('ToolHive Assistant')
-    await userEvent.click(screen.getByTestId('agent-card-custom.my-agent'))
+    await userEvent.click(screen.getByTestId('open-agent-custom.my-agent'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/playground/agents/$agentId',
+      params: { agentId: 'custom.my-agent' },
+    })
+  })
+
+  it('navigates to the agent detail page when Enter is pressed on the card', async () => {
+    renderPage()
+
+    const openTarget = await screen.findByTestId('open-agent-custom.my-agent')
+    openTarget.focus()
+    await userEvent.keyboard('{Enter}')
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: '/playground/agents/$agentId',

--- a/renderer/src/features/agents/components/__tests__/agents-page.test.tsx
+++ b/renderer/src/features/agents/components/__tests__/agents-page.test.tsx
@@ -193,6 +193,19 @@ describe('AgentsPage', () => {
     })
   })
 
+  it('navigates to the agent detail page when Space is released on the card', async () => {
+    renderPage()
+
+    const openTarget = await screen.findByTestId('open-agent-custom.my-agent')
+    openTarget.focus()
+    await userEvent.keyboard(' ')
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/playground/agents/$agentId',
+      params: { agentId: 'custom.my-agent' },
+    })
+  })
+
   it('navigates to /playground/agents/new when "New agent" is clicked', async () => {
     renderPage()
 

--- a/renderer/src/features/agents/components/agents-page.tsx
+++ b/renderer/src/features/agents/components/agents-page.tsx
@@ -29,8 +29,28 @@ import type { AgentConfig } from '@common/types/agents'
 
 type AgentsTab = 'all' | 'builtin' | 'custom'
 
-function activateOnKey(e: KeyboardEvent, onActivate: () => void) {
-  if (e.key === 'Enter' || e.key === ' ') {
+function isSpaceKey(e: KeyboardEvent) {
+  return e.code === 'Space' || e.key === ' ' || e.key === 'Spacebar'
+}
+
+function handleCardKeyDown(e: KeyboardEvent, onActivate: () => void) {
+  if (e.repeat) return
+
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    onActivate()
+    return
+  }
+
+  if (isSpaceKey(e)) {
+    e.preventDefault()
+  }
+}
+
+function handleCardKeyUp(e: KeyboardEvent, onActivate: () => void) {
+  if (e.repeat) return
+
+  if (isSpaceKey(e)) {
     e.preventDefault()
     onActivate()
   }
@@ -71,7 +91,8 @@ function AgentCard({
           flex-col rounded-t-md outline-none focus-visible:ring-2
           focus-visible:ring-offset-2"
         onClick={() => onOpen(agent)}
-        onKeyDown={(e) => activateOnKey(e, () => onOpen(agent))}
+        onKeyDown={(e) => handleCardKeyDown(e, () => onOpen(agent))}
+        onKeyUp={(e) => handleCardKeyUp(e, () => onOpen(agent))}
         data-testid={`open-agent-${agent.id}`}
       >
         <CardHeader className="pb-0">

--- a/renderer/src/features/agents/components/agents-page.tsx
+++ b/renderer/src/features/agents/components/agents-page.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type KeyboardEvent } from 'react'
 import { toast } from 'sonner'
 import { useNavigate } from '@tanstack/react-router'
-import { Bot, Copy, Plus, Sparkles } from 'lucide-react'
+import { Bot, Copy, Plus } from 'lucide-react'
 import { Button } from '@/common/components/ui/button'
 import { Badge } from '@/common/components/ui/badge'
 import {
@@ -18,11 +18,31 @@ import {
   TabsList,
   TabsTrigger,
 } from '@/common/components/ui/tabs'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
 import { trackEvent } from '@/common/lib/analytics'
 import { useAgents, useDuplicateAgent } from '../hooks/use-agents'
 import type { AgentConfig } from '@common/types/agents'
 
 type AgentsTab = 'all' | 'builtin' | 'custom'
+
+function activateOnKey(e: KeyboardEvent, onActivate: () => void) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    onActivate()
+  }
+}
+
+function getKindLabel(kind: AgentConfig['kind']) {
+  return kind === 'builtin' ? 'Built-in' : 'Custom'
+}
+
+function formatModelLabel(model: NonNullable<AgentConfig['defaultModel']>) {
+  return `${model.provider} · ${model.model}`
+}
 
 function AgentCard({
   agent,
@@ -33,58 +53,92 @@ function AgentCard({
   onOpen: (agent: AgentConfig) => void
   onDuplicate: (agent: AgentConfig) => void
 }) {
-  const Icon = agent.kind === 'custom' ? Sparkles : Bot
+  const modelLabel = agent.defaultModel
+    ? formatModelLabel(agent.defaultModel)
+    : null
 
   return (
     <Card
-      className="hover:border-accent-foreground/40 flex cursor-pointer flex-col
+      className="hover:border-accent-foreground/40 flex flex-col
         transition-colors"
-      onClick={() => onOpen(agent)}
       data-testid={`agent-card-${agent.id}`}
     >
-      <CardHeader>
-        <div className="flex items-start justify-between gap-3">
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={`Open ${agent.name}`}
+        className="focus-visible:ring-ring flex min-w-0 flex-1 cursor-pointer
+          flex-col rounded-t-md outline-none focus-visible:ring-2
+          focus-visible:ring-offset-2"
+        onClick={() => onOpen(agent)}
+        onKeyDown={(e) => activateOnKey(e, () => onOpen(agent))}
+        data-testid={`open-agent-${agent.id}`}
+      >
+        <CardHeader className="pb-0">
           <div className="flex min-w-0 items-start gap-2">
-            <Icon className="text-muted-foreground mt-0.5 h-5 w-5 shrink-0" />
-            <div className="min-w-0">
-              <CardTitle className="truncate" title={agent.name}>
-                {agent.name}
+            <Bot
+              className="text-muted-foreground mt-0.5 h-5 w-5 shrink-0"
+              aria-hidden
+            />
+            <div className="min-w-0 flex-1">
+              <CardTitle className="min-h-10 text-base leading-snug">
+                <Tooltip onlyWhenTruncated>
+                  <TooltipTrigger asChild>
+                    <span className="line-clamp-2 block text-left">
+                      {agent.name}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    {agent.name}
+                  </TooltipContent>
+                </Tooltip>
               </CardTitle>
-              <CardDescription className="mt-1 line-clamp-2">
-                {agent.description || 'No description'}
-              </CardDescription>
             </div>
           </div>
-          <Badge
-            variant={agent.kind === 'builtin' ? 'secondary' : 'outline'}
-            className="shrink-0 capitalize"
+        </CardHeader>
+
+        <CardContent className="flex flex-1 flex-col gap-3 pt-3">
+          <div className="min-h-10">
+            {agent.description ? (
+              <CardDescription className="line-clamp-2">
+                {agent.description}
+              </CardDescription>
+            ) : null}
+          </div>
+
+          <div
+            className="flex min-h-5 min-w-0 items-center justify-between gap-2"
+            data-testid={`agent-metadata-${agent.id}`}
           >
-            {agent.kind}
-          </Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="flex-1">
-        {agent.defaultModel && (
-          <p className="text-muted-foreground text-xs">
-            Default model:{' '}
-            <span className="font-mono">
-              {agent.defaultModel.provider} · {agent.defaultModel.model}
-            </span>
-          </p>
-        )}
-      </CardContent>
-      <CardFooter className="gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation()
-            onOpen(agent)
-          }}
-          data-testid={`open-agent-${agent.id}`}
-        >
-          View details
-        </Button>
+            <Badge
+              variant={agent.kind === 'builtin' ? 'secondary' : 'outline'}
+              className="shrink-0"
+            >
+              {getKindLabel(agent.kind)}
+            </Badge>
+            <div className="min-w-0 flex-1 text-right">
+              {modelLabel ? (
+                <p
+                  className="text-muted-foreground flex min-w-0 items-center
+                    justify-end gap-1.5 text-xs"
+                >
+                  <span className="shrink-0">Model</span>
+                  <Tooltip onlyWhenTruncated>
+                    <TooltipTrigger asChild>
+                      <span className="truncate font-mono">{modelLabel}</span>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs">
+                      {modelLabel}
+                    </TooltipContent>
+                  </Tooltip>
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </CardContent>
+      </div>
+
+      <CardFooter className="justify-end pt-0">
         <Button
           variant="ghost"
           size="sm"
@@ -152,8 +206,7 @@ export function AgentsPage() {
         <div>
           <h1 className="text-2xl font-semibold">Agents</h1>
           <p className="text-muted-foreground mt-1 text-sm">
-            Configure the personalities and instructions used by the Playground.
-            Built-in agents can be duplicated and customised.
+            Create and manage the agents available in Playground.
           </p>
         </div>
         <Button onClick={openCreate} data-testid="create-agent">


### PR DESCRIPTION
## Summary
- Refreshes Playground agent cards with fixed two-line title and description areas so long names no longer overflow the card header.
- Reorganizes card metadata into a consistent row with Built-in/Custom badges and truncated model info with tooltips.
- Removes the redundant View details button, makes cards keyboard-accessible, and right-aligns Duplicate as the secondary action.

<img width="1279" height="800" alt="Screenshot 2026-07-29 at 18 45 16" src="https://github.com/user-attachments/assets/215dd20d-c1a7-43be-b329-cc3086dac807" />


## Test plan
- [x] Run `pnpm run test:nonInteractive run renderer/src/features/agents/components/__tests__/agents-page.test.tsx`
- [x] Run `pnpm run type-check`
- [ ] Verify agent cards in Playground at narrow and three-column widths
- [ ] Confirm long agent names and model values truncate with tooltips
- [ ] Confirm Enter/Space opens agent details and Duplicate does not trigger navigation