### PR TITLE
feat(mcp): native Modern MCP client with SDK v2 auto-negotiation

### DIFF
--- a/e2e-tests/helpers/test-mcp-server.ts
+++ b/e2e-tests/helpers/test-mcp-server.ts
@@ -33,11 +33,24 @@ export interface TestMcpServer {
 async function readRequestBody(
   req: express.Request
 ): Promise<Uint8Array | undefined> {
-  if (req.method === 'GET' || req.method === 'HEAD') return undefined
-  if (req.body && Buffer.isBuffer(req.body)) return req.body
+  if (
+    req.method === 'GET' ||
+    req.method === 'HEAD' ||
+    req.method === 'DELETE'
+  ) {
+    return undefined
+  }
+
+  if (Buffer.isBuffer(req.body)) {
+    return req.body.length > 0 ? req.body : undefined
+  }
+
+  // express.raw() leaves `{}` for empty bodies — do not forward that as "{}".
   if (req.body && typeof req.body === 'object') {
+    if (Object.keys(req.body).length === 0) return undefined
     return Buffer.from(JSON.stringify(req.body))
   }
+
   return undefined
 }
 
@@ -45,6 +58,10 @@ function createTestMcpHandler(secretCode: string, serverName: string) {
   // ToolHive still probes remote streamable-HTTP endpoints with a Legacy
   // client during workload startup. SDK v2 handlers must accept Legacy there
   // while Studio negotiates Modern through the proxy.
+  //
+  // createMcpHandler invokes this factory once per HTTP request, so concurrent
+  // clients each get an isolated McpServer instance (same isolation intent as
+  // the old per-request McpServer + transport pattern / GHSA-345p-7cg4-v4c7).
   return createMcpHandler(() => {
     const server = new McpServer({
       name: serverName,
@@ -105,7 +122,7 @@ async function startStreamableHttpMcpServer(options: {
         new Request(url, {
           method: req.method,
           headers: req.headers as HeadersInit,
-          body: body ? Buffer.from(body) : undefined,
+          body: body && body.length > 0 ? Buffer.from(body) : undefined,
         })
       )
 

--- a/e2e-tests/helpers/test-mcp-server.ts
+++ b/e2e-tests/helpers/test-mcp-server.ts
@@ -1,6 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import {
+  createMcpHandler,
+  McpServer as ModernMcpServer,
+} from '@modelcontextprotocol/server'
 import express from 'express'
+import { z } from 'zod'
 import type { Server } from 'http'
 
 // Simple word+number format (e.g. "apple42") - hard to guess randomly but simple enough
@@ -28,6 +33,114 @@ export interface TestMcpServer {
   bearerToken: string
   url: string
   stop: () => Promise<void>
+}
+
+async function readRequestBody(
+  req: express.Request
+): Promise<Uint8Array | undefined> {
+  if (req.method === 'GET' || req.method === 'HEAD') return undefined
+  if (req.body && Buffer.isBuffer(req.body)) return req.body
+  if (req.body && typeof req.body === 'object') {
+    return Buffer.from(JSON.stringify(req.body))
+  }
+  return undefined
+}
+
+function createModernMcpHandler(secretCode: string) {
+  return createMcpHandler(
+    () => {
+      const server = new ModernMcpServer({
+        name: 'e2e-modern-test-server',
+        version: '1.0.0',
+      })
+
+      server.registerTool(
+        'get_secret_code',
+        {
+          description: 'Returns a secret code for testing',
+          inputSchema: z.object({}),
+        },
+        async () => ({
+          content: [{ type: 'text', text: secretCode }],
+        })
+      )
+
+      return server
+    },
+    { legacy: 'reject' }
+  )
+}
+
+export async function startModernTestMcpServer(): Promise<TestMcpServer> {
+  const secretCode = generateSimpleCode()
+  const bearerToken = `token-${generateSimpleCode()}`
+  const handler = createModernMcpHandler(secretCode)
+
+  const app = express()
+  app.use(express.raw({ type: '*/*' }))
+
+  app.get('/.well-known/oauth-protected-resource', (_req, res) => {
+    res.status(404).send('Not found')
+  })
+  app.get('/.well-known/oauth-protected-resource/mcp', (_req, res) => {
+    res.status(404).send('Not found')
+  })
+
+  app.get('/', (_req, res) => {
+    res.json({ status: 'ok', protocol: 'modern' })
+  })
+
+  app.all('/mcp', async (req, res) => {
+    if (req.method !== 'OPTIONS') {
+      const authHeader = req.headers.authorization
+      if (authHeader !== `Bearer ${bearerToken}`) {
+        res.status(401).send('Unauthorized')
+        return
+      }
+    }
+
+    try {
+      const host = req.headers.host ?? '127.0.0.1'
+      const url = new URL(req.url ?? '/mcp', `http://${host}`)
+      const body = await readRequestBody(req)
+      const response = await handler.fetch(
+        new Request(url, {
+          method: req.method,
+          headers: req.headers as HeadersInit,
+          body: body ? Buffer.from(body) : undefined,
+        })
+      )
+
+      res.statusCode = response.status
+      response.headers.forEach((value, key) => {
+        res.setHeader(key, value)
+      })
+      const responseBody = Buffer.from(await response.arrayBuffer())
+      res.end(responseBody)
+    } catch (error) {
+      res.statusCode = 500
+      res.end(String(error))
+    }
+  })
+
+  return new Promise((resolve) => {
+    const httpServer: Server = app.listen(0, () => {
+      const address = httpServer.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+
+      resolve({
+        port,
+        secretCode,
+        bearerToken,
+        url: `http://127.0.0.1:${port}/mcp`,
+        stop: async () => {
+          await new Promise<void>((res) => {
+            httpServer.close(() => res())
+          })
+        },
+      })
+    })
+  })
 }
 
 export async function startTestMcpServer(): Promise<TestMcpServer> {

--- a/e2e-tests/helpers/test-mcp-server.ts
+++ b/e2e-tests/helpers/test-mcp-server.ts
@@ -47,28 +47,28 @@ async function readRequestBody(
 }
 
 function createModernMcpHandler(secretCode: string) {
-  return createMcpHandler(
-    () => {
-      const server = new ModernMcpServer({
-        name: 'e2e-modern-test-server',
-        version: '1.0.0',
+  // ToolHive still probes remote streamable-HTTP endpoints with a Legacy
+  // client during workload startup. Rejecting Legacy here prevents the
+  // server card from reaching Running even though Studio negotiates Modern.
+  return createMcpHandler(() => {
+    const server = new ModernMcpServer({
+      name: 'e2e-modern-test-server',
+      version: '1.0.0',
+    })
+
+    server.registerTool(
+      'get_secret_code',
+      {
+        description: 'Returns a secret code for testing',
+        inputSchema: z.object({}),
+      },
+      async () => ({
+        content: [{ type: 'text', text: secretCode }],
       })
+    )
 
-      server.registerTool(
-        'get_secret_code',
-        {
-          description: 'Returns a secret code for testing',
-          inputSchema: z.object({}),
-        },
-        async () => ({
-          content: [{ type: 'text', text: secretCode }],
-        })
-      )
-
-      return server
-    },
-    { legacy: 'reject' }
-  )
+    return server
+  })
 }
 
 export async function startModernTestMcpServer(): Promise<TestMcpServer> {

--- a/e2e-tests/helpers/test-mcp-server.ts
+++ b/e2e-tests/helpers/test-mcp-server.ts
@@ -1,9 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import {
-  createMcpHandler,
-  McpServer as ModernMcpServer,
-} from '@modelcontextprotocol/server'
+import { createMcpHandler, McpServer } from '@modelcontextprotocol/server'
 import express from 'express'
 import { z } from 'zod'
 import type { Server } from 'http'
@@ -46,13 +41,13 @@ async function readRequestBody(
   return undefined
 }
 
-function createModernMcpHandler(secretCode: string) {
+function createTestMcpHandler(secretCode: string, serverName: string) {
   // ToolHive still probes remote streamable-HTTP endpoints with a Legacy
-  // client during workload startup. Rejecting Legacy here prevents the
-  // server card from reaching Running even though Studio negotiates Modern.
+  // client during workload startup. SDK v2 handlers must accept Legacy there
+  // while Studio negotiates Modern through the proxy.
   return createMcpHandler(() => {
-    const server = new ModernMcpServer({
-      name: 'e2e-modern-test-server',
+    const server = new McpServer({
+      name: serverName,
       version: '1.0.0',
     })
 
@@ -71,10 +66,13 @@ function createModernMcpHandler(secretCode: string) {
   })
 }
 
-export async function startModernTestMcpServer(): Promise<TestMcpServer> {
+async function startStreamableHttpMcpServer(options: {
+  serverName: string
+  healthPayload: Record<string, unknown>
+}): Promise<TestMcpServer> {
   const secretCode = generateSimpleCode()
   const bearerToken = `token-${generateSimpleCode()}`
-  const handler = createModernMcpHandler(secretCode)
+  const handler = createTestMcpHandler(secretCode, options.serverName)
 
   const app = express()
   app.use(express.raw({ type: '*/*' }))
@@ -87,7 +85,7 @@ export async function startModernTestMcpServer(): Promise<TestMcpServer> {
   })
 
   app.get('/', (_req, res) => {
-    res.json({ status: 'ok', protocol: 'modern' })
+    res.json(options.healthPayload)
   })
 
   app.all('/mcp', async (req, res) => {
@@ -143,74 +141,18 @@ export async function startModernTestMcpServer(): Promise<TestMcpServer> {
   })
 }
 
+/** Legacy-protocol E2E coverage via SDK v2 server (accepts Legacy probes + Modern negotiation). */
 export async function startTestMcpServer(): Promise<TestMcpServer> {
-  const secretCode = generateSimpleCode()
-  const bearerToken = `token-${generateSimpleCode()}`
-
-  const app = express()
-  app.use(express.json())
-
-  // Handle OAuth discovery - return 404 to indicate no auth required
-  app.get('/.well-known/oauth-protected-resource', (_req, res) => {
-    res.status(404).send('Not found')
+  return startStreamableHttpMcpServer({
+    serverName: 'e2e-test-server',
+    healthPayload: { status: 'ok' },
   })
-  app.get('/.well-known/oauth-protected-resource/mcp', (_req, res) => {
-    res.status(404).send('Not found')
-  })
+}
 
-  // Health check endpoint (app polls this)
-  app.get('/', (_req, res) => {
-    res.json({ status: 'ok' })
-  })
-
-  app.all('/mcp', async (req, res) => {
-    if (req.method !== 'OPTIONS') {
-      const authHeader = req.headers.authorization
-      if (authHeader !== `Bearer ${bearerToken}`) {
-        res.status(401).send('Unauthorized')
-        return
-      }
-    }
-
-    // Create fresh server + transport per request to avoid cross-client data leaks
-    // See: GHSA-345p-7cg4-v4c7
-    const mcpServer = new McpServer({
-      name: 'e2e-test-server',
-      version: '1.0.0',
-    })
-
-    mcpServer.tool(
-      'get_secret_code',
-      'Returns a secret code for testing',
-      {},
-      async () => ({
-        content: [{ type: 'text', text: secretCode }],
-      })
-    )
-
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
-    })
-    await mcpServer.connect(transport)
-    await transport.handleRequest(req, res, req.body)
-  })
-
-  return new Promise((resolve) => {
-    const httpServer: Server = app.listen(0, () => {
-      const address = httpServer.address()
-      const port = typeof address === 'object' && address ? address.port : 0
-
-      resolve({
-        port,
-        secretCode,
-        bearerToken,
-        url: `http://127.0.0.1:${port}/mcp`,
-        stop: async () => {
-          await new Promise<void>((res) => {
-            httpServer.close(() => res())
-          })
-        },
-      })
-    })
+/** Modern-protocol Playground path via SDK v2 server through ToolHive proxy. */
+export async function startModernTestMcpServer(): Promise<TestMcpServer> {
+  return startStreamableHttpMcpServer({
+    serverName: 'e2e-modern-test-server',
+    healthPayload: { status: 'ok', protocol: 'modern' },
   })
 }

--- a/e2e-tests/playground.spec.ts
+++ b/e2e-tests/playground.spec.ts
@@ -7,6 +7,7 @@ import {
 import type { Page } from '@playwright/test'
 import {
   startTestMcpServer,
+  startModernTestMcpServer,
   type TestMcpServer,
 } from './helpers/test-mcp-server'
 
@@ -113,6 +114,95 @@ async function clearPlaygroundState(window: Page): Promise<void> {
   await removeOllamaProvider(window)
 }
 
+async function installRemoteMcpServer(
+  window: Page,
+  serverName: string,
+  testServer: TestMcpServer
+): Promise<void> {
+  await window.getByRole('link', { name: 'MCP Servers' }).click()
+  await expect(window.getByRole('heading', { level: 1 })).toBeVisible()
+
+  await window.getByRole('button', { name: /add an mcp server/i }).click()
+  await window.getByRole('menuitem', { name: /remote mcp server/i }).click()
+  await window.getByRole('dialog').waitFor()
+
+  await window.getByPlaceholder('e.g. my-awesome-server').fill(serverName)
+
+  await window.getByRole('combobox', { name: /group/i }).click()
+  await window.getByRole('option', { name: TEST_GROUP_NAME }).click()
+
+  await window
+    .getByPlaceholder('e.g. https://example.com/mcp')
+    .fill(testServer.url)
+
+  await window.getByRole('combobox', { name: /transport/i }).click()
+  await window.getByRole('option', { name: /streamable http/i }).click()
+
+  await window.getByRole('combobox', { name: /authorization/i }).click()
+  await window.getByRole('option', { name: /bearer token/i }).click()
+  await window
+    .getByPlaceholder('e.g. token_123_ABC_789_XYZ')
+    .fill(testServer.bearerToken)
+
+  await window.getByRole('button', { name: /install server/i }).click()
+  await window.getByRole('dialog').waitFor({ state: 'hidden' })
+
+  await window.getByRole('link', { name: TEST_GROUP_NAME }).click()
+  await expect(window.getByText(new RegExp(serverName))).toBeVisible({
+    timeout: 30_000,
+  })
+  await expect(
+    window
+      .locator('[data-slot="card"]')
+      .filter({ hasText: serverName })
+      .getByText('Running')
+  ).toBeVisible({ timeout: 30_000 })
+}
+
+async function configureOllamaAndChat(
+  window: Page,
+  serverName: string,
+  testServer: TestMcpServer
+): Promise<void> {
+  await window.getByRole('link', { name: 'Playground' }).click()
+  await waitForPlaygroundReady(window)
+
+  await openProviderSettingsDialog(window)
+
+  await window.getByRole('button', { name: /ollama/i }).click()
+  await window.getByPlaceholder('http://localhost:11434').fill(OLLAMA_URL)
+
+  await window.getByTestId('refresh-models-button').click()
+
+  await expect(window.getByText(/connection successful/i)).toBeVisible({
+    timeout: 30_000,
+  })
+
+  await window.getByRole('button', { name: 'Save' }).click()
+  await window.getByRole('dialog').waitFor({ state: 'hidden' })
+
+  await selectOllamaModel(window)
+
+  await expect(window.getByPlaceholder(/type your message/i)).toBeVisible({
+    timeout: 10_000,
+  })
+
+  await enableMcpServer(window, serverName)
+
+  await window
+    .getByPlaceholder(/type your message/i)
+    .fill(
+      'Use the get_secret_code tool, then reply with ONLY the exact code the tool returned. No quotes, no extra words, no punctuation.'
+    )
+  await window.keyboard.press('Enter')
+
+  await expect(
+    window.getByText(new RegExp(testServer.secretCode, 'i'))
+  ).toBeVisible({
+    timeout: LONG_TIMEOUT,
+  })
+}
+
 test.describe('Playground chat with Ollama', () => {
   test.slow()
 
@@ -142,81 +232,41 @@ test.describe('Playground chat with Ollama', () => {
 
     const serverName = generateRandomServerName()
 
-    await window.getByRole('link', { name: 'MCP Servers' }).click()
-    await expect(window.getByRole('heading', { level: 1 })).toBeVisible()
+    await installRemoteMcpServer(window, serverName, testServer)
+    await configureOllamaAndChat(window, serverName, testServer)
+  })
+})
 
-    await window.getByRole('button', { name: /add an mcp server/i }).click()
-    await window.getByRole('menuitem', { name: /remote mcp server/i }).click()
-    await window.getByRole('dialog').waitFor()
+test.describe('Playground chat with Modern MCP server', () => {
+  test.slow()
 
-    await window.getByPlaceholder('e.g. my-awesome-server').fill(serverName)
+  let modernTestServer: TestMcpServer
 
-    await window.getByRole('combobox', { name: /group/i }).click()
-    await window.getByRole('option', { name: TEST_GROUP_NAME }).click()
+  test.beforeAll(async () => {
+    console.log('Warming up Ollama model for Modern MCP test...')
+    try {
+      await warmupOllamaModel()
+      console.log('Ollama warmup complete')
+    } catch (error) {
+      console.error('Ollama warmup failed:', error)
+      throw error
+    }
 
-    await window
-      .getByPlaceholder('e.g. https://example.com/mcp')
-      .fill(testServer.url)
+    modernTestServer = await startModernTestMcpServer()
+  })
 
-    await window.getByRole('combobox', { name: /transport/i }).click()
-    await window.getByRole('option', { name: /streamable http/i }).click()
+  test.afterAll(async () => {
+    await modernTestServer?.stop()
+  })
 
-    await window.getByRole('combobox', { name: /authorization/i }).click()
-    await window.getByRole('option', { name: /bearer token/i }).click()
-    await window
-      .getByPlaceholder('e.g. token_123_ABC_789_XYZ')
-      .fill(testServer.bearerToken)
+  test('calls tools through ToolHive proxy against a Modern MCP backend', async ({
+    window,
+  }) => {
+    await clearPlaygroundState(window)
 
-    await window.getByRole('button', { name: /install server/i }).click()
-    await window.getByRole('dialog').waitFor({ state: 'hidden' })
+    const serverName = generateRandomServerName()
 
-    await window.getByRole('link', { name: TEST_GROUP_NAME }).click()
-    await expect(window.getByText(new RegExp(serverName))).toBeVisible({
-      timeout: 30_000,
-    })
-    await expect(
-      window
-        .locator('[data-slot="card"]')
-        .filter({ hasText: serverName })
-        .getByText('Running')
-    ).toBeVisible({ timeout: 30_000 })
-
-    await window.getByRole('link', { name: 'Playground' }).click()
-    await waitForPlaygroundReady(window)
-
-    await openProviderSettingsDialog(window)
-
-    await window.getByRole('button', { name: /ollama/i }).click()
-    await window.getByPlaceholder('http://localhost:11434').fill(OLLAMA_URL)
-
-    await window.getByTestId('refresh-models-button').click()
-
-    await expect(window.getByText(/connection successful/i)).toBeVisible({
-      timeout: 30_000,
-    })
-
-    await window.getByRole('button', { name: 'Save' }).click()
-    await window.getByRole('dialog').waitFor({ state: 'hidden' })
-
-    await selectOllamaModel(window)
-
-    await expect(window.getByPlaceholder(/type your message/i)).toBeVisible({
-      timeout: 10_000,
-    })
-
-    await enableMcpServer(window, serverName)
-
-    await window
-      .getByPlaceholder(/type your message/i)
-      .fill(
-        'Use the get_secret_code tool, then reply with ONLY the exact code the tool returned. No quotes, no extra words, no punctuation.'
-      )
-    await window.keyboard.press('Enter')
-
-    await expect(
-      window.getByText(new RegExp(testServer.secretCode, 'i'))
-    ).toBeVisible({
-      timeout: LONG_TIMEOUT,
-    })
+    await installRemoteMcpServer(window, serverName, modernTestServer)
+    await configureOllamaAndChat(window, serverName, modernTestServer)
   })
 })

--- a/main/src/chat/__tests__/mcp-tools.test.ts
+++ b/main/src/chat/__tests__/mcp-tools.test.ts
@@ -17,30 +17,23 @@ const mockReadEnabledMcpTools = vi.hoisted(() => vi.fn().mockReturnValue({}))
 const mockReadThreadEnabledMcpTools = vi.hoisted(() =>
   vi.fn().mockReturnValue({})
 )
-const mockBuildRawTransport = vi.hoisted(() =>
-  vi.fn().mockReturnValue({ type: 'raw-mock-transport' })
+const mockConnectionClose = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined)
 )
-const mockCreateTransport = vi.hoisted(() =>
-  vi.fn().mockReturnValue({ name: 'test-server', transport: {} })
+const mockNativeClient = vi.hoisted(() => ({
+  listTools: vi.fn().mockResolvedValue({ tools: [] }),
+  readResource: vi.fn().mockResolvedValue({ contents: [] }),
+  callTool: vi.fn().mockResolvedValue({ content: [] }),
+  close: vi.fn().mockResolvedValue(undefined),
+}))
+const mockConnectWorkloadMcpClient = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    client: mockNativeClient,
+    close: mockConnectionClose,
+  })
 )
 const mockGetWorkloadAvailableTools = vi.hoisted(() =>
   vi.fn().mockResolvedValue(null)
-)
-
-// Raw SDK Client mock (used by fetchUiResource / proxyMcpToolCall)
-const mockSdkClient = vi.hoisted(() => ({
-  connect: vi.fn().mockResolvedValue(undefined),
-  request: vi.fn().mockResolvedValue({ contents: [] }),
-  close: vi.fn().mockResolvedValue(undefined),
-}))
-
-// AI SDK MCP client mock (used by createMcpTools)
-const mockAiMcpClient = vi.hoisted(() => ({
-  tools: vi.fn().mockResolvedValue({}),
-  close: vi.fn().mockResolvedValue(undefined),
-}))
-const mockCreateMCPClient = vi.hoisted(() =>
-  vi.fn().mockResolvedValue(mockAiMcpClient)
 )
 
 // MCP App UI metadata DB reader/writer mocks
@@ -82,31 +75,11 @@ vi.mock('../../utils/mcp-tools', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('../../utils/mcp-tools')>()
   return {
-    // Keep the real validator so fixtures need to be shaped correctly
-    isMcpToolDefinition: original.isMcpToolDefinition,
-    buildRawTransport: mockBuildRawTransport,
-    createTransport: mockCreateTransport,
+    ...original,
+    connectWorkloadMcpClient: mockConnectWorkloadMcpClient,
     getWorkloadAvailableTools: mockGetWorkloadAvailableTools,
   }
 })
-
-vi.mock('@ai-sdk/mcp', () => ({
-  createMCPClient: mockCreateMCPClient,
-}))
-
-vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
-  // Named function constructor so `new Client(...)` works
-  Client: function ClientMock() {
-    return mockSdkClient
-  },
-}))
-
-// The schemas are passed through to the mocked client.request(), so they
-// just need to be non-undefined objects.
-vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
-  ReadResourceResultSchema: {},
-  CallToolResultSchema: {},
-}))
 
 vi.mock('../../logger', () => ({
   default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
@@ -150,12 +123,30 @@ const makeWorkload = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 })
 
-/** Minimal object that passes isMcpToolDefinition validation. */
+/** Minimal native MCP tool returned by listTools(). */
+const makeNativeTool = (
+  name: string,
+  overrides: Record<string, unknown> = {}
+) => ({
+  name,
+  description: 'A test tool',
+  inputSchema: { type: 'object', properties: { foo: { type: 'string' } } },
+  ...overrides,
+})
+
 const makeToolDef = (overrides: Record<string, unknown> = {}) => ({
   description: 'A test tool',
   inputSchema: { type: 'object', properties: { foo: { type: 'string' } } },
   ...overrides,
 })
+
+function mockListedTools(toolsByName: Record<string, Record<string, unknown>>) {
+  mockNativeClient.listTools.mockResolvedValue({
+    tools: Object.entries(toolsByName).map(([name, def]) =>
+      makeNativeTool(name, def)
+    ),
+  })
+}
 
 // ---------------------------------------------------------------------------
 // Global per-test reset
@@ -173,19 +164,16 @@ beforeEach(() => {
   mockReadThreadEnabledMcpTools.mockReturnValue({})
 
   // Utils mocks
-  mockBuildRawTransport.mockReturnValue({ type: 'raw-mock-transport' })
-  mockCreateTransport.mockReturnValue({ name: 'test-server', transport: {} })
+  mockConnectWorkloadMcpClient.mockResolvedValue({
+    client: mockNativeClient,
+    close: mockConnectionClose,
+  })
   mockGetWorkloadAvailableTools.mockResolvedValue(null)
 
-  // Raw SDK client
-  mockSdkClient.connect.mockResolvedValue(undefined)
-  mockSdkClient.request.mockResolvedValue({ contents: [] })
-  mockSdkClient.close.mockResolvedValue(undefined)
-
-  // AI SDK client
-  mockAiMcpClient.tools.mockResolvedValue({})
-  mockAiMcpClient.close.mockResolvedValue(undefined)
-  mockCreateMCPClient.mockResolvedValue(mockAiMcpClient)
+  mockNativeClient.listTools.mockResolvedValue({ tools: [] })
+  mockNativeClient.readResource.mockResolvedValue({ contents: [] })
+  mockNativeClient.callTool.mockResolvedValue({ content: [] })
+  mockNativeClient.close.mockResolvedValue(undefined)
 
   // MCP App UI metadata DB reader/writer
   mockReadAllMcpAppUiMetadata.mockReturnValue({})
@@ -247,7 +235,7 @@ describe('getCachedUiMetadata', () => {
     mockReadEnabledMcpTools.mockReturnValue({
       'test-server': ['cached-tool'],
     })
-    mockAiMcpClient.tools.mockResolvedValue({ 'cached-tool': toolWithUi })
+    mockListedTools({ 'cached-tool': toolWithUi })
 
     await createMcpTools()
 
@@ -270,7 +258,7 @@ describe('fetchUiResource', () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [makeWorkload()] },
     })
-    mockSdkClient.request.mockResolvedValue({
+    mockNativeClient.readResource.mockResolvedValue({
       contents: [
         {
           text: '<html>hello</html>',
@@ -298,7 +286,7 @@ describe('fetchUiResource', () => {
       data: { workloads: [makeWorkload()] },
     })
     const html = '<html>blob</html>'
-    mockSdkClient.request.mockResolvedValue({
+    mockNativeClient.readResource.mockResolvedValue({
       contents: [{ blob: Buffer.from(html).toString('base64') }],
     })
 
@@ -311,7 +299,7 @@ describe('fetchUiResource', () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [makeWorkload()] },
     })
-    mockSdkClient.request.mockResolvedValue({ contents: [] })
+    mockNativeClient.readResource.mockResolvedValue({ contents: [] })
 
     await expect(fetchUiResource('test-server', 'res://empty')).rejects.toThrow(
       'Empty resource response'
@@ -322,7 +310,7 @@ describe('fetchUiResource', () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [makeWorkload()] },
     })
-    mockSdkClient.request.mockResolvedValue({ contents: [{}] })
+    mockNativeClient.readResource.mockResolvedValue({ contents: [{}] })
 
     await expect(fetchUiResource('test-server', 'res://bad')).rejects.toThrow(
       'Resource content has no text or blob'
@@ -333,23 +321,23 @@ describe('fetchUiResource', () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [makeWorkload()] },
     })
-    mockSdkClient.request.mockRejectedValue(new Error('network error'))
+    mockNativeClient.readResource.mockRejectedValue(new Error('network error'))
 
     await expect(fetchUiResource('test-server', 'res://fail')).rejects.toThrow()
-    expect(mockSdkClient.close).toHaveBeenCalledOnce()
+    expect(mockConnectionClose).toHaveBeenCalledOnce()
   })
 
   it('uses buildRawTransport for external servers', async () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [makeWorkload()] },
     })
-    mockSdkClient.request.mockResolvedValue({
+    mockNativeClient.readResource.mockResolvedValue({
       contents: [{ text: '<html>ext</html>' }],
     })
 
     await fetchUiResource('test-server', 'res://ext')
 
-    expect(mockBuildRawTransport).toHaveBeenCalledOnce()
+    expect(mockConnectWorkloadMcpClient).toHaveBeenCalledOnce()
   })
 
   it('throws when external server workload is not found', async () => {
@@ -374,32 +362,29 @@ describe('proxyMcpToolCall', () => {
       content: [{ type: 'text', text: 'done' }],
       isError: false,
     }
-    mockSdkClient.request.mockResolvedValue(toolResult)
+    mockNativeClient.callTool.mockResolvedValue(toolResult)
 
     const result = await proxyMcpToolCall('test-server', 'my-tool', {
       arg: 1,
     })
 
     expect(result).toEqual(toolResult)
-    expect(mockSdkClient.request).toHaveBeenCalledWith(
-      {
-        method: 'tools/call',
-        params: { name: 'my-tool', arguments: { arg: 1 } },
-      },
-      expect.anything()
-    )
+    expect(mockNativeClient.callTool).toHaveBeenCalledWith({
+      name: 'my-tool',
+      arguments: { arg: 1 },
+    })
   })
 
   it('always closes the client even when the request throws', async () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [makeWorkload()] },
     })
-    mockSdkClient.request.mockRejectedValue(new Error('call failed'))
+    mockNativeClient.callTool.mockRejectedValue(new Error('call failed'))
 
     await expect(
       proxyMcpToolCall('test-server', 'bad-tool', {})
     ).rejects.toThrow('call failed')
-    expect(mockSdkClient.close).toHaveBeenCalledOnce()
+    expect(mockConnectionClose).toHaveBeenCalledOnce()
   })
 })
 
@@ -480,13 +465,13 @@ describe('getMcpServerTools', () => {
 // ---------------------------------------------------------------------------
 
 describe('createMcpTools', () => {
-  it('returns empty tools and clients when no servers are enabled', async () => {
+  it('returns empty tools and close noop when no servers are enabled', async () => {
     mockReadEnabledMcpTools.mockReturnValue({})
 
-    const { tools, clients, enabledTools } = await createMcpTools()
+    const { tools, close, enabledTools } = await createMcpTools()
 
     expect(tools).toEqual({})
-    expect(clients).toHaveLength(0)
+    expect(typeof close).toBe('function')
     expect(enabledTools).toEqual({})
     expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
   })
@@ -507,7 +492,7 @@ describe('createMcpTools', () => {
     mockReadEnabledMcpTools.mockReturnValue({
       'test-server': ['schema-tool'],
     })
-    mockAiMcpClient.tools.mockResolvedValue({
+    mockListedTools({
       'schema-tool': toolWithDanglingRequired,
     })
 
@@ -540,7 +525,7 @@ describe('createMcpTools', () => {
     mockReadEnabledMcpTools.mockReturnValue({
       'test-server': ['enum-tool'],
     })
-    mockAiMcpClient.tools.mockResolvedValue({
+    mockListedTools({
       'enum-tool': toolWithBooleanEnum,
     })
 
@@ -550,7 +535,12 @@ describe('createMcpTools', () => {
     const registered = tools['enum-tool']
     expect(registered).toBeDefined()
 
-    expect(registered!.inputSchema).toEqual(toolWithBooleanEnum.inputSchema)
+    const schema = asSchema(registered!.inputSchema).jsonSchema as {
+      properties: {
+        delete: Record<string, unknown>
+      }
+    }
+    expect(schema.properties.delete).toEqual({ type: 'boolean', enum: [true] })
   })
 
   it('sanitizes schemas with JSON Schema if/then keywords when sanitizeSchemas is enabled', async () => {
@@ -572,7 +562,7 @@ describe('createMcpTools', () => {
     mockReadEnabledMcpTools.mockReturnValue({
       'test-server': ['conditional-tool'],
     })
-    mockAiMcpClient.tools.mockResolvedValue({
+    mockListedTools({
       'conditional-tool': toolWithConditionalSchema,
     })
 
@@ -618,7 +608,7 @@ describe('createMcpTools', () => {
     mockReadEnabledMcpTools.mockReturnValue({
       'test-server': ['enum-tool'],
     })
-    mockAiMcpClient.tools.mockResolvedValue({
+    mockListedTools({
       'enum-tool': toolWithBooleanEnum,
     })
 
@@ -657,7 +647,7 @@ describe('createMcpTools', () => {
       data: { workloads: [makeWorkload()] },
     })
     mockReadEnabledMcpTools.mockReturnValue({ 'test-server': ['cached'] })
-    mockAiMcpClient.tools.mockResolvedValue({ cached: toolWithUi })
+    mockListedTools({ cached: toolWithUi })
     await createMcpTools()
     expect(getCachedUiMetadata()).toHaveProperty('cached')
 
@@ -681,7 +671,7 @@ describe('createMcpTools', () => {
     mockReadEnabledMcpTools.mockReturnValue({
       'test-server': ['persist-tool'],
     })
-    mockAiMcpClient.tools.mockResolvedValue({ 'persist-tool': uiTool })
+    mockListedTools({ 'persist-tool': uiTool })
 
     await createMcpTools()
 
@@ -720,7 +710,7 @@ describe('createMcpTools', () => {
     mockReadEnabledMcpTools.mockReturnValueOnce({
       'test-server': ['survivor-tool'],
     })
-    mockAiMcpClient.tools.mockResolvedValueOnce({ 'survivor-tool': uiTool })
+    mockListedTools({ 'survivor-tool': uiTool })
 
     await createMcpTools()
     expect(getCachedUiMetadata()).toHaveProperty('survivor-tool')
@@ -761,23 +751,24 @@ describe('createMcpTools', () => {
 
     await createMcpTools()
 
-    expect(mockCreateMCPClient).not.toHaveBeenCalled()
+    expect(mockConnectWorkloadMcpClient).not.toHaveBeenCalled()
   })
 
-  it('registers per-server tools using createTransport', async () => {
+  it('registers per-server tools using connectWorkloadMcpClient', async () => {
     const workload = makeWorkload()
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [workload] },
     })
     mockReadEnabledMcpTools.mockReturnValue({ 'test-server': ['tool-a'] })
-    mockAiMcpClient.tools.mockResolvedValue({ 'tool-a': makeToolDef() })
+    mockListedTools({ 'tool-a': makeToolDef() })
 
-    const { tools, clients } = await createMcpTools()
+    const { tools } = await createMcpTools()
 
     expect(tools).toHaveProperty('tool-a')
-    expect(clients).toHaveLength(1)
-    expect(mockCreateTransport).toHaveBeenCalledWith(workload)
-    expect(mockCreateMCPClient).toHaveBeenCalledWith(
+    expect(mockConnectWorkloadMcpClient).toHaveBeenCalled()
+
+    expect(mockConnectWorkloadMcpClient).toHaveBeenCalledWith(
+      workload,
       expect.objectContaining({
         capabilities: expect.objectContaining({
           extensions: expect.objectContaining({
@@ -800,7 +791,7 @@ describe('createMcpTools', () => {
     mockReadEnabledMcpTools.mockReturnValue({
       'test-server': ['app-only-tool'],
     })
-    mockAiMcpClient.tools.mockResolvedValue({ 'app-only-tool': appOnlyTool })
+    mockListedTools({ 'app-only-tool': appOnlyTool })
 
     await expect(createMcpTools()).rejects.toThrow(
       'No MCP tools are available from the enabled servers.'
@@ -819,7 +810,7 @@ describe('createMcpTools', () => {
       data: { workloads: [workload] },
     })
     mockReadEnabledMcpTools.mockReturnValue({ 'test-server': ['hybrid-tool'] })
-    mockAiMcpClient.tools.mockResolvedValue({ 'hybrid-tool': hybridTool })
+    mockListedTools({ 'hybrid-tool': hybridTool })
 
     const { tools } = await createMcpTools()
 
@@ -836,7 +827,7 @@ describe('createMcpTools', () => {
       data: { workloads: [workload] },
     })
     mockReadEnabledMcpTools.mockReturnValue({ 'test-server': ['ui-tool'] })
-    mockAiMcpClient.tools.mockResolvedValue({ 'ui-tool': uiTool })
+    mockListedTools({ 'ui-tool': uiTool })
 
     await createMcpTools()
 
@@ -863,7 +854,7 @@ describe('createMcpTools', () => {
       data: { workloads: [workload] },
     })
     mockReadEnabledMcpTools.mockReturnValue({ 'test-server': ['no-uri-tool'] })
-    mockAiMcpClient.tools.mockResolvedValue({ 'no-uri-tool': noUriTool })
+    mockListedTools({ 'no-uri-tool': noUriTool })
 
     await createMcpTools()
 
@@ -883,13 +874,13 @@ describe('createMcpTools', () => {
     )
   })
 
-  it('logs and continues when createMCPClient throws for a server', async () => {
+  it('logs and continues when connectWorkloadMcpClient throws for a server', async () => {
     const workload = makeWorkload()
     mockGetApiV1BetaWorkloads.mockResolvedValue({
       data: { workloads: [workload] },
     })
     mockReadEnabledMcpTools.mockReturnValue({ 'test-server': ['tool-a'] })
-    mockCreateMCPClient.mockRejectedValue(new Error('conn refused'))
+    mockConnectWorkloadMcpClient.mockRejectedValue(new Error('conn refused'))
 
     await expect(createMcpTools()).rejects.toThrow(
       'No MCP tools are available from the enabled servers.'
@@ -910,16 +901,17 @@ describe('createMcpTools', () => {
       'server-a': ['tool-a'],
       'server-b': ['tool-b'],
     })
-    mockCreateMCPClient
-      .mockRejectedValueOnce(new Error('conn refused'))
-      .mockResolvedValueOnce(mockAiMcpClient)
-    mockAiMcpClient.tools.mockResolvedValue({ 'tool-b': makeToolDef() })
+    mockConnectWorkloadMcpClient.mockRejectedValueOnce(
+      new Error('conn refused')
+    )
 
-    const { tools, clients } = await createMcpTools()
+    mockListedTools({ 'tool-b': makeToolDef() })
+
+    const { tools } = await createMcpTools()
 
     expect(tools).toHaveProperty('tool-b')
     expect(tools).not.toHaveProperty('tool-a')
-    expect(clients).toHaveLength(1)
+    expect(mockConnectWorkloadMcpClient).toHaveBeenCalled()
     expect(log.error).toHaveBeenCalledWith(
       'Failed to create MCP client for server-a:',
       expect.any(Error)
@@ -935,7 +927,7 @@ describe('createMcpTools', () => {
       'test-server': ['missing-tool'],
     })
     // Server returns no tools
-    mockAiMcpClient.tools.mockResolvedValue({})
+    mockListedTools({})
 
     await expect(createMcpTools()).rejects.toThrow(
       'No MCP tools are available from the enabled servers.'

--- a/main/src/chat/__tests__/streaming.test.ts
+++ b/main/src/chat/__tests__/streaming.test.ts
@@ -15,7 +15,11 @@ const mockCreateModelFromRequest = vi.hoisted(() =>
   vi.fn(() => ({ id: 'model' }))
 )
 const mockCreateMcpTools = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({ tools: {}, clients: [], enabledTools: {} })
+  vi.fn().mockResolvedValue({
+    tools: {},
+    enabledTools: {},
+    close: vi.fn().mockResolvedValue(undefined),
+  })
 )
 const mockGetCachedUiMetadata = vi.hoisted(() => vi.fn(() => ({})))
 const mockCreateBuiltinAgentTools = vi.hoisted(() =>
@@ -165,8 +169,8 @@ beforeEach(() => {
   })
   mockCreateMcpTools.mockResolvedValue({
     tools: {},
-    clients: [],
     enabledTools: {},
+    close: vi.fn().mockResolvedValue(undefined),
   })
   mockCreateBuiltinAgentTools.mockReturnValue({
     tools: {},
@@ -458,6 +462,51 @@ describe('handleChatStreamRealtime — AI SDK v7 UI stream wiring', () => {
         allowSystemInMessages: true,
       })
     )
+  })
+
+  it('closes the MCP session after a successful stream', async () => {
+    const close = vi.fn().mockResolvedValue(undefined)
+    mockCreateMcpTools.mockResolvedValueOnce({
+      tools: {},
+      enabledTools: {},
+      close,
+    })
+    mockResolveAgentForThread.mockReturnValue(
+      fakeAgent('builtin.toolhive-assistant', 'DEFAULT INSTRUCTIONS')
+    )
+
+    await handleChatStreamRealtime(
+      makeRequest(),
+      'stream-close-success',
+      fakeSender
+    )
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the MCP session when builtin tool setup fails', async () => {
+    const close = vi.fn().mockResolvedValue(undefined)
+    mockCreateMcpTools.mockResolvedValueOnce({
+      tools: {},
+      enabledTools: {},
+      close,
+    })
+    mockResolveAgentForThread.mockReturnValue(
+      fakeAgent('builtin.skills', 'SKILLS INSTRUCTIONS', 'skills')
+    )
+    mockCreateBuiltinAgentTools.mockRejectedValueOnce(
+      new Error('builtin tools failed')
+    )
+
+    await expect(
+      handleChatStreamRealtime(
+        makeRequest(),
+        'stream-close-failure',
+        fakeSender
+      )
+    ).rejects.toThrow('builtin tools failed')
+
+    expect(close).toHaveBeenCalledTimes(1)
   })
 
   it('passes sanitizeSchemas to createMcpTools only for Gemini-compatible providers', async () => {

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -34,7 +34,7 @@ export async function createMcpTools(
 ) {
   return runChatPromiseOr(McpService.createMcpTools(threadId, options), {
     tools: {},
-    clients: [],
     enabledTools: {},
+    close: async () => undefined,
   })
 }

--- a/main/src/chat/mcp/__tests__/mcp-ai-tool.test.ts
+++ b/main/src/chat/mcp/__tests__/mcp-ai-tool.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { asSchema } from 'ai'
+import { createAiMcpTool } from '../mcp-ai-tool'
+import type {
+  Client,
+  Tool as NativeMcpTool,
+} from '@modelcontextprotocol/client'
+
+function makeClient(callToolImpl: Client['callTool'] = vi.fn()): Client {
+  return { callTool: callToolImpl } as unknown as Client
+}
+
+function makeTool(overrides: Partial<NativeMcpTool> = {}): NativeMcpTool {
+  return {
+    name: 'demo',
+    description: 'demo tool',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: true,
+    },
+    ...overrides,
+  } as NativeMcpTool
+}
+
+describe('createAiMcpTool', () => {
+  it('preserves additionalProperties: true from the server schema', () => {
+    const tool = createAiMcpTool({
+      client: makeClient(),
+      toolName: 'demo',
+      definition: makeTool(),
+    })
+
+    expect(asSchema(tool.inputSchema).jsonSchema).toMatchObject({
+      additionalProperties: true,
+    })
+  })
+
+  it('maps isError tool results to error-text for the model', async () => {
+    const tool = createAiMcpTool({
+      client: makeClient(),
+      toolName: 'demo',
+      definition: makeTool(),
+    })
+
+    const output = await tool.toModelOutput?.({
+      toolCallId: 'call-1',
+      input: {},
+      output: {
+        isError: true,
+        content: [{ type: 'text', text: 'tool blew up' }],
+      },
+    })
+
+    expect(output).toEqual({
+      type: 'error-text',
+      value: 'tool blew up',
+    })
+  })
+
+  it('maps successful content results to content blocks', async () => {
+    const tool = createAiMcpTool({
+      client: makeClient(),
+      toolName: 'demo',
+      definition: makeTool(),
+    })
+
+    const output = await tool.toModelOutput?.({
+      toolCallId: 'call-1',
+      input: {},
+      output: {
+        content: [{ type: 'text', text: 'ok' }],
+      },
+    })
+
+    expect(output).toEqual({
+      type: 'content',
+      value: [{ type: 'text', text: 'ok' }],
+    })
+  })
+})

--- a/main/src/chat/mcp/mcp-ai-tool.ts
+++ b/main/src/chat/mcp/mcp-ai-tool.ts
@@ -1,5 +1,4 @@
 import { dynamicTool, jsonSchema, type JSONSchema7, type JSONValue } from 'ai'
-import type { ToolResultOutput } from '@ai-sdk/provider-utils'
 import {
   isInputRequiredResult,
   type CallToolResult,
@@ -8,7 +7,7 @@ import {
 } from '@modelcontextprotocol/client'
 import { sanitizeJsonSchema } from '../../utils/sanitize-json-schema'
 
-export const INPUT_REQUIRED_UNSUPPORTED_MESSAGE =
+const INPUT_REQUIRED_UNSUPPORTED_MESSAGE =
   'This MCP server requested interactive input during tool execution, which the Playground does not support yet.'
 
 function normalizeInputSchema(schema: unknown, sanitize: boolean): JSONSchema7 {
@@ -28,17 +27,17 @@ function normalizeInputSchema(schema: unknown, sanitize: boolean): JSONSchema7 {
   return sanitize ? (sanitizeJsonSchema(normalized) as JSONSchema7) : normalized
 }
 
-export function mcpCallToolResultToModelOutput({
+function mcpCallToolResultToModelOutput({
   output,
 }: {
   toolCallId: string
   input: unknown
   output: unknown
-}): ToolResultOutput {
+}) {
   const result = output as CallToolResult
 
   if (!('content' in result) || !Array.isArray(result.content)) {
-    return { type: 'json', value: result as JSONValue }
+    return { type: 'json' as const, value: result as JSONValue }
   }
 
   const convertedContent = result.content.map(
@@ -57,7 +56,7 @@ export function mcpCallToolResultToModelOutput({
     }
   )
 
-  return { type: 'content', value: convertedContent }
+  return { type: 'content' as const, value: convertedContent }
 }
 
 export function createAiMcpTool(params: {

--- a/main/src/chat/mcp/mcp-ai-tool.ts
+++ b/main/src/chat/mcp/mcp-ai-tool.ts
@@ -1,0 +1,96 @@
+import { dynamicTool, jsonSchema, type JSONSchema7, type JSONValue } from 'ai'
+import type { ToolResultOutput } from '@ai-sdk/provider-utils'
+import {
+  isInputRequiredResult,
+  type CallToolResult,
+  type Client,
+  type Tool as NativeMcpTool,
+} from '@modelcontextprotocol/client'
+import { sanitizeJsonSchema } from '../../utils/sanitize-json-schema'
+
+export const INPUT_REQUIRED_UNSUPPORTED_MESSAGE =
+  'This MCP server requested interactive input during tool execution, which the Playground does not support yet.'
+
+function normalizeInputSchema(schema: unknown, sanitize: boolean): JSONSchema7 {
+  const raw = (
+    schema && typeof schema === 'object'
+      ? schema
+      : { type: 'object', properties: {} }
+  ) as JSONSchema7
+
+  const normalized: JSONSchema7 = {
+    ...raw,
+    type: raw.type ?? 'object',
+    properties: raw.properties ?? {},
+    additionalProperties: raw.additionalProperties ?? false,
+  }
+
+  return sanitize ? (sanitizeJsonSchema(normalized) as JSONSchema7) : normalized
+}
+
+export function mcpCallToolResultToModelOutput({
+  output,
+}: {
+  toolCallId: string
+  input: unknown
+  output: unknown
+}): ToolResultOutput {
+  const result = output as CallToolResult
+
+  if (!('content' in result) || !Array.isArray(result.content)) {
+    return { type: 'json', value: result as JSONValue }
+  }
+
+  const convertedContent = result.content.map(
+    (part: { type: string; [key: string]: unknown }) => {
+      if (part.type === 'text' && 'text' in part) {
+        return { type: 'text' as const, text: part.text as string }
+      }
+      if (part.type === 'image' && 'data' in part && 'mimeType' in part) {
+        return {
+          type: 'file' as const,
+          mediaType: part.mimeType as string,
+          data: { type: 'data' as const, data: part.data as string },
+        }
+      }
+      return { type: 'text' as const, text: JSON.stringify(part) }
+    }
+  )
+
+  return { type: 'content', value: convertedContent }
+}
+
+export function createAiMcpTool(params: {
+  client: Client
+  toolName: string
+  definition: NativeMcpTool
+  sanitizeSchema?: boolean
+}) {
+  const inputSchema = normalizeInputSchema(
+    params.definition.inputSchema,
+    params.sanitizeSchema ?? false
+  )
+
+  return dynamicTool({
+    description: params.definition.description ?? params.toolName,
+    inputSchema: jsonSchema(inputSchema),
+    execute: async (args, options) => {
+      options?.abortSignal?.throwIfAborted()
+
+      const result = await params.client.callTool(
+        {
+          name: params.toolName,
+          arguments: args as Record<string, unknown>,
+        },
+        { signal: options?.abortSignal }
+      )
+
+      if (isInputRequiredResult(result)) {
+        throw new Error(INPUT_REQUIRED_UNSUPPORTED_MESSAGE)
+      }
+
+      return result
+    },
+    toModelOutput: mcpCallToolResultToModelOutput,
+  })
+}

--- a/main/src/chat/mcp/mcp-ai-tool.ts
+++ b/main/src/chat/mcp/mcp-ai-tool.ts
@@ -1,4 +1,4 @@
-import { dynamicTool, jsonSchema, type JSONSchema7, type JSONValue } from 'ai'
+import { dynamicTool, jsonSchema, type JSONValue } from 'ai'
 import {
   isInputRequiredResult,
   type CallToolResult,
@@ -6,25 +6,24 @@ import {
   type Tool as NativeMcpTool,
 } from '@modelcontextprotocol/client'
 import { sanitizeJsonSchema } from '../../utils/sanitize-json-schema'
+import { normalizeMcpInputSchema } from '../../utils/normalize-mcp-input-schema'
 
 const INPUT_REQUIRED_UNSUPPORTED_MESSAGE =
   'This MCP server requested interactive input during tool execution, which the Playground does not support yet.'
 
-function normalizeInputSchema(schema: unknown, sanitize: boolean): JSONSchema7 {
-  const raw = (
-    schema && typeof schema === 'object'
-      ? schema
-      : { type: 'object', properties: {} }
-  ) as JSONSchema7
+function textFromCallToolContent(result: CallToolResult): string | undefined {
+  if (!('content' in result) || !Array.isArray(result.content)) return undefined
 
-  const normalized: JSONSchema7 = {
-    ...raw,
-    type: raw.type ?? 'object',
-    properties: raw.properties ?? {},
-    additionalProperties: raw.additionalProperties ?? false,
-  }
+  const text = result.content
+    .filter(
+      (part): part is { type: 'text'; text: string } =>
+        part.type === 'text' && 'text' in part && typeof part.text === 'string'
+    )
+    .map((part) => part.text)
+    .join('\n')
+    .trim()
 
-  return sanitize ? (sanitizeJsonSchema(normalized) as JSONSchema7) : normalized
+  return text.length > 0 ? text : undefined
 }
 
 function mcpCallToolResultToModelOutput({
@@ -35,6 +34,14 @@ function mcpCallToolResultToModelOutput({
   output: unknown
 }) {
   const result = output as CallToolResult
+
+  if (result && typeof result === 'object' && result.isError) {
+    const errorText = textFromCallToolContent(result)
+    if (errorText) {
+      return { type: 'error-text' as const, value: errorText }
+    }
+    return { type: 'error-json' as const, value: result as JSONValue }
+  }
 
   if (!('content' in result) || !Array.isArray(result.content)) {
     return { type: 'json' as const, value: result as JSONValue }
@@ -65,10 +72,10 @@ export function createAiMcpTool(params: {
   definition: NativeMcpTool
   sanitizeSchema?: boolean
 }) {
-  const inputSchema = normalizeInputSchema(
-    params.definition.inputSchema,
-    params.sanitizeSchema ?? false
-  )
+  const normalized = normalizeMcpInputSchema(params.definition.inputSchema)
+  const inputSchema = params.sanitizeSchema
+    ? (sanitizeJsonSchema(normalized) as typeof normalized)
+    : normalized
 
   return dynamicTool({
     description: params.definition.description ?? params.toolName,

--- a/main/src/chat/mcp/mcp-service-impl.ts
+++ b/main/src/chat/mcp/mcp-service-impl.ts
@@ -15,6 +15,7 @@ import {
   getWorkloadAvailableTools,
   MCP_UI_EXTENSION_CAPABILITY,
 } from '../../utils/mcp-tools'
+import { isUsableMcpTool } from '../../utils/normalize-mcp-input-schema'
 import type { CoreWorkload } from '@common/api/generated/types.gen'
 import { Effect } from 'effect'
 import { readAllMcpAppUiMetadata } from '../../db/readers/mcp-app-ui-metadata-reader'
@@ -74,11 +75,27 @@ function commitUiMetadata(next: Record<string, ToolUiMetadataEntry>): void {
   uiMetadataLoaded = true
 }
 
-/** Fetches all workloads from the ToolHive API. */
+let inFlightWorkloads: Promise<CoreWorkload[]> | null = null
+
+/**
+ * Fetches all workloads from the ToolHive API.
+ * Concurrent callers (e.g. tool discovery + MCP Apps in the same turn) share
+ * one in-flight request; sequential calls always refetch.
+ */
 async function fetchWorkloads(): Promise<CoreWorkload[]> {
-  const client = createMainProcessApiClient()
-  const { data } = await getApiV1BetaWorkloads({ client })
-  return data?.workloads ?? []
+  if (inFlightWorkloads) return inFlightWorkloads
+
+  inFlightWorkloads = (async () => {
+    try {
+      const client = createMainProcessApiClient()
+      const { data } = await getApiV1BetaWorkloads({ client })
+      return data?.workloads ?? []
+    } finally {
+      inFlightWorkloads = null
+    }
+  })()
+
+  return inFlightWorkloads
 }
 
 /** Extracts the `_meta.ui` block from a raw tool definition. */
@@ -244,6 +261,107 @@ export async function getMcpServerTools(
   return result
 }
 
+type ServerDiscoveryResult = {
+  serverName: string
+  tools: ToolSet
+  metadata: Record<string, ToolUiMetadataEntry>
+  close: () => Promise<void>
+  keepOpen: boolean
+}
+
+async function discoverToolsForServer(params: {
+  serverName: string
+  toolNames: string[]
+  workload: CoreWorkload
+  sanitizeSchemas?: boolean
+}): Promise<ServerDiscoveryResult | null> {
+  const { serverName, toolNames, workload } = params
+  log.debug(`Found MCP workload for ${serverName}:`, workload.package)
+
+  let connection: Awaited<ReturnType<typeof connectWorkloadMcpClient>> | null =
+    null
+
+  try {
+    connection = await connectWorkloadMcpClient(workload, {
+      clientName: 'toolhive-studio-playground',
+      capabilities: { extensions: MCP_UI_EXTENSION_CAPABILITY },
+    })
+
+    const { tools: listedTools } = await connection.client.listTools()
+    const toolsByName = new Map(listedTools.map((tool) => [tool.name, tool]))
+
+    const tools: ToolSet = {}
+    const metadata: Record<string, ToolUiMetadataEntry> = {}
+    let addedToolsCount = 0
+
+    for (const toolName of toolNames) {
+      const nativeTool = toolsByName.get(toolName)
+      if (nativeTool === undefined) {
+        log.warn(`Tool ${toolName} not found in server ${serverName}`)
+        continue
+      }
+
+      if (!isUsableMcpTool(nativeTool)) {
+        log.warn(
+          `Skipping malformed tool ${toolName} from server ${serverName}`
+        )
+        continue
+      }
+
+      const ui = extractToolUiMeta(nativeTool)
+      if (shouldSkipAppOnlyTool(ui)) {
+        log.debug(`Skipping app-only tool ${toolName} from ${serverName}`)
+        continue
+      }
+
+      tools[toolName] = createAiMcpTool({
+        client: connection.client,
+        toolName,
+        definition: nativeTool,
+        sanitizeSchema: params.sanitizeSchemas,
+      })
+
+      if (ui?.resourceUri) {
+        metadata[toolName] = {
+          resourceUri: ui.resourceUri,
+          serverName,
+        }
+      }
+      addedToolsCount++
+    }
+
+    log.debug(
+      `Added ${addedToolsCount}/${toolNames.length} tools from ${serverName}`
+    )
+
+    if (addedToolsCount === 0) {
+      await connection.close()
+      return null
+    }
+
+    return {
+      serverName,
+      tools,
+      metadata,
+      close: connection.close,
+      keepOpen: true,
+    }
+  } catch (error) {
+    if (connection) {
+      try {
+        await connection.close()
+      } catch (closeError) {
+        log.error(
+          `Failed to close MCP client for ${serverName} after error:`,
+          closeError
+        )
+      }
+    }
+    log.error(`Failed to create MCP client for ${serverName}:`, error)
+    return null
+  }
+}
+
 export async function createMcpTools(
   threadId?: string,
   options?: { sanitizeSchemas?: boolean },
@@ -255,7 +373,7 @@ export async function createMcpTools(
   }
 ): Promise<McpToolSession> {
   const mcpTools: ToolSet = {}
-  const closeCallbacks: Array<() => Promise<void>> = []
+  const closeByServer = new Map<string, () => Promise<void>>()
   let enabledTools: Record<string, string[]> = {}
   const nextCachedUiMetadata: Record<string, ToolUiMetadataEntry> = {}
   let discoverySucceeded = false
@@ -263,26 +381,10 @@ export async function createMcpTools(
   let closePromise: Promise<void> | null = null
   const close = async () => {
     if (closePromise) return closePromise
-    closePromise = Promise.allSettled(closeCallbacks.map((fn) => fn())).then(
-      () => undefined
-    )
+    closePromise = Promise.allSettled(
+      [...closeByServer.values()].map((fn) => fn())
+    ).then(() => undefined)
     return closePromise
-  }
-
-  const registerToolMetadata = (
-    toolName: string,
-    toolDef: unknown,
-    serverName: string
-  ): boolean => {
-    const ui = extractToolUiMeta(toolDef)
-    if (shouldSkipAppOnlyTool(ui)) return false
-    if (ui?.resourceUri) {
-      nextCachedUiMetadata[toolName] = {
-        resourceUri: ui.resourceUri,
-        serverName,
-      }
-    }
-    return true
   }
 
   try {
@@ -299,75 +401,36 @@ export async function createMcpTools(
     enabledTools = resolvedEnabledTools
     discoverySucceeded = true
 
-    for (const [serverName, toolNames] of Object.entries(enabledTools)) {
-      if (toolNames.length === 0) continue
+    const serverJobs = Object.entries(enabledTools)
+      .filter(([, toolNames]) => toolNames.length > 0)
+      .map(([serverName, toolNames]) => {
+        const workload = workloads.find((w) => w.name === serverName)
+        if (!workload) {
+          log.debug(`Skipping ${serverName}: workload not found`)
+          return Promise.resolve(null)
+        }
+        return discoverToolsForServer({
+          serverName,
+          toolNames,
+          workload,
+          sanitizeSchemas: options?.sanitizeSchemas,
+        })
+      })
 
-      const workload = workloads.find((w) => w.name === serverName)
-
-      if (!workload) {
-        log.debug(`Skipping ${serverName}: workload not found`)
+    const settled = await Promise.allSettled(serverJobs)
+    for (const outcome of settled) {
+      if (outcome.status === 'rejected') {
+        log.error('Failed to discover MCP tools for a server:', outcome.reason)
         continue
       }
 
-      log.debug(`Found MCP workload for ${serverName}:`, workload.package)
+      const result = outcome.value
+      if (!result) continue
 
-      let connection: Awaited<
-        ReturnType<typeof connectWorkloadMcpClient>
-      > | null = null
-
-      try {
-        connection = await connectWorkloadMcpClient(workload, {
-          clientName: 'toolhive-studio-playground',
-          capabilities: { extensions: MCP_UI_EXTENSION_CAPABILITY },
-        })
-        closeCallbacks.push(connection.close)
-
-        const { tools: listedTools } = await connection.client.listTools()
-        const toolsByName = new Map(
-          listedTools.map((tool) => [tool.name, tool])
-        )
-
-        let addedToolsCount = 0
-        for (const toolName of toolNames) {
-          const nativeTool = toolsByName.get(toolName)
-          if (nativeTool === undefined) {
-            log.warn(`Tool ${toolName} not found in server ${serverName}`)
-            continue
-          }
-
-          const ui = extractToolUiMeta(nativeTool)
-          if (shouldSkipAppOnlyTool(ui)) {
-            log.debug(`Skipping app-only tool ${toolName} from ${serverName}`)
-            continue
-          }
-
-          const aiTool = createAiMcpTool({
-            client: connection.client,
-            toolName,
-            definition: nativeTool,
-            sanitizeSchema: options?.sanitizeSchemas,
-          })
-
-          mcpTools[toolName] = aiTool
-          registerToolMetadata(toolName, nativeTool, serverName)
-          addedToolsCount++
-        }
-
-        log.debug(
-          `Added ${addedToolsCount}/${toolNames.length} tools from ${serverName}`
-        )
-
-        if (addedToolsCount === 0 && connection) {
-          await connection.close()
-          closeCallbacks.pop()
-        }
-      } catch (error) {
-        if (connection) {
-          await connection.close()
-          const idx = closeCallbacks.indexOf(connection.close)
-          if (idx >= 0) closeCallbacks.splice(idx, 1)
-        }
-        log.error(`Failed to create MCP client for ${serverName}:`, error)
+      Object.assign(mcpTools, result.tools)
+      Object.assign(nextCachedUiMetadata, result.metadata)
+      if (result.keepOpen) {
+        closeByServer.set(result.serverName, result.close)
       }
     }
   } catch (error) {

--- a/main/src/chat/mcp/mcp-service-impl.ts
+++ b/main/src/chat/mcp/mcp-service-impl.ts
@@ -1,11 +1,6 @@
 import * as Sentry from '@sentry/electron/main'
-import { createMCPClient } from '@ai-sdk/mcp'
-import { asSchema, jsonSchema, type JSONSchema7, type ToolSet } from 'ai'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import {
-  ReadResourceResultSchema,
-  CallToolResultSchema,
-} from '@modelcontextprotocol/sdk/types.js'
+import { createAiMcpTool } from './mcp-ai-tool'
+import type { ToolSet } from 'ai'
 import type {
   McpUiResourceCsp,
   McpUiResourcePermissions,
@@ -16,12 +11,10 @@ import log from '../../logger'
 import type { AvailableServer } from '../types'
 import {
   type McpToolDefinition,
-  buildRawTransport,
-  createTransport,
+  connectWorkloadMcpClient,
   getWorkloadAvailableTools,
-  isMcpToolDefinition,
+  MCP_UI_EXTENSION_CAPABILITY,
 } from '../../utils/mcp-tools'
-import { sanitizeJsonSchema } from '../../utils/sanitize-json-schema'
 import type { CoreWorkload } from '@common/api/generated/types.gen'
 import { Effect } from 'effect'
 import { readAllMcpAppUiMetadata } from '../../db/readers/mcp-app-ui-metadata-reader'
@@ -31,16 +24,17 @@ import type {
   ToolUiMetadataEntry,
 } from './mcp-ui-metadata-cache'
 
-// Advertised to MCP servers during initialize so they expose UI-enabled tools
-const MCP_UI_EXTENSION_CAPABILITY = {
-  'io.modelcontextprotocol/ui': { mimeTypes: ['text/html;profile=mcp-app'] },
-} as const
-
 interface UiResourceMetadata {
   html: string
   csp?: McpUiResourceCsp
   permissions?: McpUiResourcePermissions
   prefersBorder?: boolean
+}
+
+export interface McpToolSession {
+  tools: ToolSet
+  enabledTools: Record<string, string[]>
+  close: () => Promise<void>
 }
 
 // Module-level fallback cache for direct impl imports in unit tests.
@@ -80,10 +74,6 @@ function commitUiMetadata(next: Record<string, ToolUiMetadataEntry>): void {
   uiMetadataLoaded = true
 }
 
-// ---------------------------------------------------------------------------
-// Private helpers
-// ---------------------------------------------------------------------------
-
 /** Fetches all workloads from the ToolHive API. */
 async function fetchWorkloads(): Promise<CoreWorkload[]> {
   const client = createMainProcessApiClient()
@@ -106,20 +96,19 @@ function shouldSkipAppOnlyTool(
   return !!ui?.visibility && !ui.visibility.includes('model')
 }
 
-async function createRawMcpClientForServer(
-  serverName: string
-): Promise<{ client: Client; close: () => Promise<void> }> {
-  const clientInfo = { name: 'toolhive-studio-mcp-apps', version: '1.0.0' }
-  const clientOptions = {
-    capabilities: { extensions: MCP_UI_EXTENSION_CAPABILITY },
-  }
-
+async function createRawMcpClientForServer(serverName: string): Promise<{
+  client: Awaited<ReturnType<typeof connectWorkloadMcpClient>>['client']
+  close: () => Promise<void>
+}> {
   const workload = (await fetchWorkloads()).find((w) => w.name === serverName)
   if (!workload) throw new Error(`Workload not found: ${serverName}`)
 
-  const client = new Client(clientInfo, clientOptions)
-  await client.connect(buildRawTransport(workload))
-  return { client, close: () => client.close() }
+  const connection = await connectWorkloadMcpClient(workload, {
+    clientName: 'toolhive-studio-mcp-apps',
+    capabilities: { extensions: MCP_UI_EXTENSION_CAPABILITY },
+  })
+
+  return { client: connection.client, close: connection.close }
 }
 
 export async function fetchUiResource(
@@ -128,10 +117,7 @@ export async function fetchUiResource(
 ): Promise<UiResourceMetadata> {
   const { client, close } = await createRawMcpClientForServer(serverName)
   try {
-    const result = await client.request(
-      { method: 'resources/read', params: { uri: resourceUri } },
-      ReadResourceResultSchema
-    )
+    const result = await client.readResource({ uri: resourceUri })
     const content = result.contents[0]
     if (!content) throw new Error('Empty resource response')
 
@@ -144,7 +130,6 @@ export async function fetchUiResource(
       throw new Error('Resource content has no text or blob')
     }
 
-    // Extract per-resource CSP and permission metadata from the response
     const uiMeta = (content as { _meta?: { ui?: Record<string, unknown> } })
       ._meta?.ui
 
@@ -166,17 +151,12 @@ export async function proxyMcpToolCall(
 ): Promise<unknown> {
   const { client, close } = await createRawMcpClientForServer(serverName)
   try {
-    const result = await client.request(
-      { method: 'tools/call', params: { name: toolName, arguments: args } },
-      CallToolResultSchema
-    )
-    return result
+    return await client.callTool({ name: toolName, arguments: args })
   } finally {
     await close()
   }
 }
 
-// Helper to safely extract properties
 function getToolParameters(inputSchema: unknown): Record<string, unknown> {
   if (
     inputSchema &&
@@ -188,87 +168,28 @@ function getToolParameters(inputSchema: unknown): Record<string, unknown> {
   ) {
     return inputSchema['properties'] as Record<string, unknown>
   }
+
+  if (
+    inputSchema &&
+    typeof inputSchema === 'object' &&
+    'jsonSchema' in inputSchema
+  ) {
+    const wrapped = (inputSchema as { jsonSchema?: unknown }).jsonSchema
+    if (
+      wrapped &&
+      typeof wrapped === 'object' &&
+      'properties' in wrapped &&
+      wrapped.properties &&
+      typeof wrapped.properties === 'object' &&
+      !Array.isArray(wrapped.properties)
+    ) {
+      return wrapped.properties as Record<string, unknown>
+    }
+  }
+
   return {}
 }
 
-/**
- * Returns a copy of an MCP tool whose `inputSchema` has been sanitized so
- * strict function-calling validators (Google Gemini) accept it. MCP tools
- * wrap their JSON Schema in a `Schema` object (from `jsonSchema()`); we read
- * the raw schema (prune dangling `required`, drop non-string `enum`s, collapse
- * union `type` arrays), and re-wrap. Tools whose schema can't be resolved
- * synchronously are returned unchanged.
- */
-function isThenable(value: unknown): value is PromiseLike<unknown> {
-  return (
-    value != null &&
-    (typeof value === 'object' || typeof value === 'function') &&
-    typeof (value as { then?: unknown }).then === 'function'
-  )
-}
-
-function resolveRawJsonSchema(inputSchema: unknown): unknown | null {
-  if (
-    !inputSchema ||
-    typeof inputSchema !== 'object' ||
-    Array.isArray(inputSchema) ||
-    isThenable(inputSchema)
-  ) {
-    return null
-  }
-
-  const candidate = inputSchema as Record<string, unknown>
-  const wrapped = candidate.jsonSchema
-  if (
-    wrapped &&
-    typeof wrapped === 'object' &&
-    !Array.isArray(wrapped) &&
-    !isThenable(wrapped)
-  ) {
-    return wrapped
-  }
-
-  try {
-    const schema = asSchema(inputSchema as Parameters<typeof asSchema>[0])
-    const raw = schema.jsonSchema
-    if (
-      raw &&
-      typeof raw === 'object' &&
-      !Array.isArray(raw) &&
-      !isThenable(raw)
-    ) {
-      return raw
-    }
-  } catch {
-    // MCP fixtures and some clients expose bare JSON Schema objects.
-    return candidate
-  }
-
-  return null
-}
-
-function withSanitizedInputSchema(tool: McpToolDefinition): McpToolDefinition {
-  const { inputSchema } = tool
-  if (!inputSchema || typeof inputSchema !== 'object') return tool
-  try {
-    const raw = resolveRawJsonSchema(inputSchema)
-    if (raw) {
-      const sanitized = sanitizeJsonSchema(raw) as JSONSchema7
-      return {
-        ...tool,
-        inputSchema: jsonSchema(sanitized),
-      }
-    }
-    log.warn(
-      `[MCP SANITIZE] unresolved schema shape for tool: ${JSON.stringify(inputSchema).slice(0, 200)}`
-    )
-  } catch (error) {
-    log.warn('[MCP SANITIZE] error reading schema:', error)
-  }
-  return tool
-}
-
-// Get MCP server tools information
 export async function getMcpServerTools(
   serverName: string,
   _threadId?: string,
@@ -288,7 +209,6 @@ export async function getMcpServerTools(
     throw new Error('Server not in the workload list')
   }
 
-  // If workload.tools is empty, try to discover tools by connecting to the server
   let discoveredTools: string[] = workload.tools || []
   let serverMcpTools: Record<string, McpToolDefinition> = {}
 
@@ -324,7 +244,6 @@ export async function getMcpServerTools(
   return result
 }
 
-// Create MCP tools for AI SDK
 export async function createMcpTools(
   threadId?: string,
   options?: { sanitizeSchemas?: boolean },
@@ -334,34 +253,29 @@ export async function createMcpTools(
       threadId: string
     ) => Promise<Record<string, string[]>>
   }
-): Promise<{
-  tools: ToolSet
-  clients: Awaited<ReturnType<typeof createMCPClient>>[]
-  enabledTools: Record<string, string[]>
-}> {
+): Promise<McpToolSession> {
   const mcpTools: ToolSet = {}
-  const mcpClients: Awaited<ReturnType<typeof createMCPClient>>[] = []
+  const closeCallbacks: Array<() => Promise<void>> = []
   let enabledTools: Record<string, string[]> = {}
-  // Build the UI metadata map for this stream session into a local object
-  // and only swap it into the module-level cache (and persist it to SQLite)
-  // once discovery has completed successfully. A transient fetchWorkloads()
-  // or getEnabledMcpTools() failure must not wipe the previously persisted
-  // snapshot — historical MCP App iframes rely on it.
   const nextCachedUiMetadata: Record<string, ToolUiMetadataEntry> = {}
   let discoverySucceeded = false
 
-  /** Registers a validated tool and caches its UI metadata if present. */
-  const registerTool = (
+  let closePromise: Promise<void> | null = null
+  const close = async () => {
+    if (closePromise) return closePromise
+    closePromise = Promise.allSettled(closeCallbacks.map((fn) => fn())).then(
+      () => undefined
+    )
+    return closePromise
+  }
+
+  const registerToolMetadata = (
     toolName: string,
     toolDef: unknown,
     serverName: string
   ): boolean => {
-    if (!isMcpToolDefinition(toolDef)) return false
     const ui = extractToolUiMeta(toolDef)
     if (shouldSkipAppOnlyTool(ui)) return false
-    mcpTools[toolName] = options?.sanitizeSchemas
-      ? withSanitizedInputSchema(toolDef)
-      : toolDef
     if (ui?.resourceUri) {
       nextCachedUiMetadata[toolName] = {
         resourceUri: ui.resourceUri,
@@ -383,8 +297,6 @@ export async function createMcpTools(
       resolveEnabled(),
     ])
     enabledTools = resolvedEnabledTools
-    // Flag is set here, AFTER the two required calls resolved, so any
-    // rejection above propagates into the catch below without flipping it.
     discoverySucceeded = true
 
     for (const [serverName, toolNames] of Object.entries(enabledTools)) {
@@ -399,31 +311,62 @@ export async function createMcpTools(
 
       log.debug(`Found MCP workload for ${serverName}:`, workload.package)
 
+      let connection: Awaited<
+        ReturnType<typeof connectWorkloadMcpClient>
+      > | null = null
+
       try {
-        const mcpClient = await createMCPClient({
-          ...createTransport(workload),
+        connection = await connectWorkloadMcpClient(workload, {
+          clientName: 'toolhive-studio-playground',
           capabilities: { extensions: MCP_UI_EXTENSION_CAPABILITY },
         })
-        mcpClients.push(mcpClient)
+        closeCallbacks.push(connection.close)
 
-        const serverMcpTools = await mcpClient.tools()
+        const { tools: listedTools } = await connection.client.listTools()
+        const toolsByName = new Map(
+          listedTools.map((tool) => [tool.name, tool])
+        )
+
         let addedToolsCount = 0
         for (const toolName of toolNames) {
-          const tool = serverMcpTools[toolName]
-          if (tool === undefined) {
+          const nativeTool = toolsByName.get(toolName)
+          if (nativeTool === undefined) {
             log.warn(`Tool ${toolName} not found in server ${serverName}`)
-          } else if (registerTool(toolName, tool, serverName)) {
-            addedToolsCount++
-          } else if (shouldSkipAppOnlyTool(extractToolUiMeta(tool))) {
-            log.debug(`Skipping app-only tool ${toolName} from ${serverName}`)
-          } else {
-            log.warn(`Tool ${toolName} from ${serverName} failed validation`)
+            continue
           }
+
+          const ui = extractToolUiMeta(nativeTool)
+          if (shouldSkipAppOnlyTool(ui)) {
+            log.debug(`Skipping app-only tool ${toolName} from ${serverName}`)
+            continue
+          }
+
+          const aiTool = createAiMcpTool({
+            client: connection.client,
+            toolName,
+            definition: nativeTool,
+            sanitizeSchema: options?.sanitizeSchemas,
+          })
+
+          mcpTools[toolName] = aiTool
+          registerToolMetadata(toolName, nativeTool, serverName)
+          addedToolsCount++
         }
+
         log.debug(
           `Added ${addedToolsCount}/${toolNames.length} tools from ${serverName}`
         )
+
+        if (addedToolsCount === 0 && connection) {
+          await connection.close()
+          closeCallbacks.pop()
+        }
       } catch (error) {
+        if (connection) {
+          await connection.close()
+          const idx = closeCallbacks.indexOf(connection.close)
+          if (idx >= 0) closeCallbacks.splice(idx, 1)
+        }
         log.error(`Failed to create MCP client for ${serverName}:`, error)
       }
     }
@@ -432,10 +375,6 @@ export async function createMcpTools(
   }
 
   if (discoverySucceeded) {
-    // Swap the module-level cache in and persist it. Empty maps are
-    // persisted too — a server that lost all UI tools should have its
-    // stale entries removed. When discovery failed we skip both, keeping
-    // the previously hydrated cache and DB rows intact.
     commitUiMetadata(nextCachedUiMetadata)
 
     const uiToolCount = Object.keys(nextCachedUiMetadata).length
@@ -455,5 +394,5 @@ export async function createMcpTools(
     }
   }
 
-  return { tools: mcpTools, clients: mcpClients, enabledTools }
+  return { tools: mcpTools, enabledTools, close }
 }

--- a/main/src/chat/streaming/chat-stream-service-impl.ts
+++ b/main/src/chat/streaming/chat-stream-service-impl.ts
@@ -82,11 +82,7 @@ export async function handleChatStreamRealtime(
               deps.agents.resolveAgentForThread(request.chatId)
             )
 
-        const {
-          tools: mcpTools,
-          clients: mcpClients,
-          enabledTools,
-        } = await Effect.runPromise(
+        const mcpSession = await Effect.runPromise(
           deps.mcp.createMcpTools(request.chatId, {
             sanitizeSchemas: requiresGeminiSchemaCompat(
               request.provider,
@@ -95,29 +91,35 @@ export async function handleChatStreamRealtime(
           })
         )
 
-        // Agent-specific built-in tools (e.g. Skills Builder, Skill Tester).
-        // Pass the threadId so per-thread skill enablement is honoured.
-        const builtinToolsHandle = await createBuiltinAgentTools(
-          agentConfig.builtinToolsKey ?? null,
-          { threadId: request.chatId }
-        )
-        const builtinTools = builtinToolsHandle.tools
-
-        const combinedTools = {
-          ...mcpTools,
-          ...builtinTools,
-        }
-        const hasTools = Object.keys(combinedTools).length > 0
-
-        // Some bundles (e.g. the skills bundle) augment the agent's
-        // instructions with runtime data such as the list of installed skills,
-        // following the Vercel "Add Skills to Your Agent" progressive-
-        // disclosure pattern.
-        const instructions = builtinToolsHandle.instructionsSuffix
-          ? `${agentConfig.instructions}\n\n${builtinToolsHandle.instructionsSuffix}`
-          : agentConfig.instructions
+        let builtinToolsHandle: Awaited<
+          ReturnType<typeof createBuiltinAgentTools>
+        > | null = null
 
         try {
+          const { tools: mcpTools, enabledTools } = mcpSession
+
+          // Agent-specific built-in tools (e.g. Skills Builder, Skill Tester).
+          // Pass the threadId so per-thread skill enablement is honoured.
+          builtinToolsHandle = await createBuiltinAgentTools(
+            agentConfig.builtinToolsKey ?? null,
+            { threadId: request.chatId }
+          )
+          const builtinTools = builtinToolsHandle.tools
+
+          const combinedTools = {
+            ...mcpTools,
+            ...builtinTools,
+          }
+          const hasTools = Object.keys(combinedTools).length > 0
+
+          // Some bundles (e.g. the skills bundle) augment the agent's
+          // instructions with runtime data such as the list of installed skills,
+          // following the Vercel "Add Skills to Your Agent" progressive-
+          // disclosure pattern.
+          const instructions = builtinToolsHandle.instructionsSuffix
+            ? `${agentConfig.instructions}\n\n${builtinToolsHandle.instructionsSuffix}`
+            : agentConfig.instructions
+
           const agent = new ToolLoopAgent({
             model,
             instructions,
@@ -289,21 +291,6 @@ export async function handleChatStreamRealtime(
                 deps.mcp.getCachedUiMetadata()
               ),
               onComplete: async ({ status }) => {
-                for (const client of mcpClients) {
-                  try {
-                    await client.close()
-                  } catch (error) {
-                    log.error('[CHAT] Error closing MCP client:', error)
-                  }
-                }
-                try {
-                  await builtinToolsHandle.cleanup()
-                } catch (error) {
-                  log.error(
-                    '[CHAT] Error cleaning up builtin agent tools:',
-                    error
-                  )
-                }
                 // Only auto-title successful finishes — aborted/errored
                 // streams would waste tokens on a user-only transcript.
                 if (status !== 'finished') return
@@ -332,28 +319,23 @@ export async function handleChatStreamRealtime(
           )
           finish()
         } catch (error) {
-          // Clean up MCP clients on error as well
-
-          for (const client of mcpClients) {
+          throw new Error(toUserFacingProviderMessage(error), { cause: error })
+        } finally {
+          try {
+            await mcpSession.close()
+          } catch (cleanupError) {
+            log.error('[CHAT] Error closing MCP session:', cleanupError)
+          }
+          if (builtinToolsHandle) {
             try {
-              await client.close()
+              await builtinToolsHandle.cleanup()
             } catch (cleanupError) {
               log.error(
-                '[CHAT] Error closing MCP client during error cleanup:',
+                '[CHAT] Error cleaning up builtin agent tools during cleanup:',
                 cleanupError
               )
             }
           }
-          try {
-            await builtinToolsHandle.cleanup()
-          } catch (cleanupError) {
-            log.error(
-              '[CHAT] Error cleaning up builtin agent tools during error cleanup:',
-              cleanupError
-            )
-          }
-
-          throw new Error(toUserFacingProviderMessage(error), { cause: error })
         }
       } catch (error) {
         log.error('[CHAT] Chat stream error:', error)

--- a/main/src/utils/__tests__/mcp-client-modern.test.ts
+++ b/main/src/utils/__tests__/mcp-client-modern.test.ts
@@ -22,12 +22,19 @@ import type { CoreWorkload } from '@common/api/generated/types.gen'
 async function readRequestBody(
   req: import('node:http').IncomingMessage
 ): Promise<Uint8Array | undefined> {
-  if (req.method === 'GET' || req.method === 'HEAD') return undefined
+  if (
+    req.method === 'GET' ||
+    req.method === 'HEAD' ||
+    req.method === 'DELETE'
+  ) {
+    return undefined
+  }
   const chunks: Buffer[] = []
   for await (const chunk of req) {
     chunks.push(Buffer.from(chunk))
   }
-  return Buffer.concat(chunks)
+  const body = Buffer.concat(chunks)
+  return body.length > 0 ? body : undefined
 }
 
 async function startModernMcpHttpServer(): Promise<{
@@ -90,7 +97,7 @@ async function startModernMcpHttpServer(): Promise<{
           new Request(url, {
             method: req.method,
             headers: req.headers as HeadersInit,
-            body: body ? Buffer.from(body) : undefined,
+            body: body && body.length > 0 ? Buffer.from(body) : undefined,
           })
         )
 

--- a/main/src/utils/__tests__/mcp-client-modern.test.ts
+++ b/main/src/utils/__tests__/mcp-client-modern.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, afterAll, vi } from 'vitest'
+
+vi.mock('../../logger', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+import { createServer, type Server } from 'node:http'
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client'
+import { createMcpHandler, McpServer } from '@modelcontextprotocol/server'
+import { z } from 'zod'
+import { connectWorkloadMcpClient } from '../mcp-tools'
+import type { CoreWorkload } from '@common/api/generated/types.gen'
+
+async function readRequestBody(
+  req: import('node:http').IncomingMessage
+): Promise<Uint8Array | undefined> {
+  if (req.method === 'GET' || req.method === 'HEAD') return undefined
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+async function startModernMcpHttpServer(): Promise<{
+  port: number
+  secretCode: string
+  url: string
+  stop: () => Promise<void>
+}> {
+  const secretCode = 'modern42'
+  const handler = createMcpHandler(
+    () => {
+      const server = new McpServer({
+        name: 'modern-integration-server',
+        version: '1.0.0',
+      })
+
+      server.registerTool(
+        'get_secret_code',
+        {
+          description: 'Returns a secret code for testing',
+          inputSchema: z.object({}),
+        },
+        async () => ({
+          content: [{ type: 'text', text: secretCode }],
+        })
+      )
+
+      server.registerResource(
+        'app-html',
+        'ui://modern-app',
+        {
+          description: 'Modern MCP App HTML',
+          mimeType: 'text/html;profile=mcp-app',
+        },
+        async () => ({
+          contents: [
+            {
+              uri: 'ui://modern-app',
+              mimeType: 'text/html;profile=mcp-app',
+              text: '<html><body>modern app</body></html>',
+            },
+          ],
+        })
+      )
+
+      return server
+    },
+    { legacy: 'reject' }
+  )
+
+  let httpServer: Server | null = null
+
+  const port = await new Promise<number>((resolve) => {
+    httpServer = createServer(async (req, res) => {
+      try {
+        const host = req.headers.host ?? '127.0.0.1'
+        const url = new URL(req.url ?? '/mcp', `http://${host}`)
+        const body = await readRequestBody(req)
+        const response = await handler.fetch(
+          new Request(url, {
+            method: req.method,
+            headers: req.headers as HeadersInit,
+            body: body ? Buffer.from(body) : undefined,
+          })
+        )
+
+        res.statusCode = response.status
+        response.headers.forEach((value, key) => {
+          res.setHeader(key, value)
+        })
+        const responseBody = Buffer.from(await response.arrayBuffer())
+        res.end(responseBody)
+      } catch (error) {
+        res.statusCode = 500
+        res.end(String(error))
+      }
+    })
+
+    httpServer.listen(0, '127.0.0.1', () => {
+      const address = httpServer!.address()
+      resolve(typeof address === 'object' && address ? address.port : 0)
+    })
+  })
+
+  return {
+    port,
+    secretCode,
+    url: `http://127.0.0.1:${port}/mcp`,
+    stop: async () => {
+      await new Promise<void>((resolve, reject) => {
+        httpServer?.close((error) => (error ? reject(error) : resolve()))
+      })
+    },
+  }
+}
+
+describe('native Modern MCP client integration', () => {
+  let server: Awaited<ReturnType<typeof startModernMcpHttpServer>> | undefined
+
+  afterAll(async () => {
+    await server?.stop()
+  })
+
+  it('negotiates Modern, lists tools, executes them, and reads resources', async () => {
+    server = await startModernMcpHttpServer()
+
+    const workload: CoreWorkload = {
+      name: 'modern-integration',
+      port: server.port,
+      transport_type: 'streamable-http',
+      url: server.url,
+      status: 'running',
+    }
+
+    const { client, close } = await connectWorkloadMcpClient(workload, {
+      clientName: 'modern-integration-test',
+    })
+
+    try {
+      expect(client.getProtocolEra()).toBe('modern')
+
+      const { tools } = await client.listTools()
+      expect(tools.map((tool) => tool.name)).toContain('get_secret_code')
+
+      const result = await client.callTool({
+        name: 'get_secret_code',
+        arguments: {},
+      })
+      expect(result.content?.[0]).toMatchObject({
+        type: 'text',
+        text: server.secretCode,
+      })
+
+      const resource = await client.readResource({ uri: 'ui://modern-app' })
+      const firstContent = resource.contents[0]
+      expect(
+        firstContent && 'text' in firstContent ? firstContent.text : undefined
+      ).toContain('modern app')
+    } finally {
+      await close()
+    }
+  })
+
+  it('rejects legacy-only clients against a strict Modern server', async () => {
+    const legacyServer = await startModernMcpHttpServer()
+    if (server) {
+      await server.stop()
+    }
+    server = legacyServer
+
+    const legacyClient = new Client(
+      { name: 'legacy-probe', version: '1.0.0' },
+      { versionNegotiation: { mode: 'legacy' } }
+    )
+
+    await expect(
+      legacyClient.connect(
+        new StreamableHTTPClientTransport(new URL(legacyServer.url))
+      )
+    ).rejects.toThrow()
+
+    await legacyClient.close().catch(() => undefined)
+  })
+})

--- a/main/src/utils/__tests__/mcp-tools.test.ts
+++ b/main/src/utils/__tests__/mcp-tools.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createTransport } from '../mcp-tools'
+import {
+  SSEClientTransport,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client'
+import { buildMcpClientTransport } from '../mcp-tools'
 import type { CoreWorkload } from '@common/api/generated/types.gen'
-import { Experimental_StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
 
 vi.mock('../../logger', () => ({
   default: {
@@ -12,7 +15,7 @@ vi.mock('../../logger', () => ({
   },
 }))
 
-describe('createTransport', () => {
+describe('buildMcpClientTransport', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -28,51 +31,9 @@ describe('createTransport', () => {
         status: 'running',
       }
 
-      const config = createTransport(workload)
+      const transport = buildMcpClientTransport(workload)
 
-      expect(config.name).toBe('vercel')
-      expect(config.transport).toEqual({
-        type: 'http',
-        url: 'http://127.0.0.1:21454',
-      })
-    })
-
-    it('should use workload.url when provided for remote servers (GitHub)', () => {
-      const workload: CoreWorkload = {
-        name: 'github-remote',
-        port: 21153,
-        transport_type: 'streamable-http',
-        remote: true,
-        url: 'http://127.0.0.1:21153/mcp',
-        status: 'running',
-      }
-
-      const config = createTransport(workload)
-
-      expect(config.name).toBe('github-remote')
-      expect(config.transport).toEqual({
-        type: 'http',
-        url: 'http://127.0.0.1:21153/mcp',
-      })
-    })
-
-    it('should use workload.url when provided for remote servers (Notion)', () => {
-      const workload: CoreWorkload = {
-        name: 'notion-remote',
-        port: 48750,
-        transport_type: 'streamable-http',
-        remote: true,
-        url: 'http://127.0.0.1:48750/mcp',
-        status: 'running',
-      }
-
-      const config = createTransport(workload)
-
-      expect(config.name).toBe('notion-remote')
-      expect(config.transport).toEqual({
-        type: 'http',
-        url: 'http://127.0.0.1:48750/mcp',
-      })
+      expect(transport).toBeInstanceOf(StreamableHTTPClientTransport)
     })
 
     it('should fallback to /mcp path for local containers when url is missing', () => {
@@ -84,37 +45,14 @@ describe('createTransport', () => {
         status: 'running',
       }
 
-      const config = createTransport(workload)
+      const transport = buildMcpClientTransport(workload)
 
-      expect(config.name).toBe('local-server')
-      expect(config.transport).toEqual({
-        type: 'http',
-        url: 'http://localhost:36548/mcp',
-      })
-    })
-
-    it('should use correct path for local containers with url provided', () => {
-      const workload: CoreWorkload = {
-        name: 'github',
-        port: 36548,
-        transport_type: 'streamable-http',
-        remote: false,
-        url: 'http://127.0.0.1:36548/mcp',
-        status: 'running',
-      }
-
-      const config = createTransport(workload)
-
-      expect(config.name).toBe('github')
-      expect(config.transport).toEqual({
-        type: 'http',
-        url: 'http://127.0.0.1:36548/mcp',
-      })
+      expect(transport).toBeInstanceOf(StreamableHTTPClientTransport)
     })
   })
 
   describe('sse transport', () => {
-    it('should construct SSE URL with correct format', () => {
+    it('should construct an SSE transport', () => {
       const workload: CoreWorkload = {
         name: 'oci-registry',
         port: 57839,
@@ -122,15 +60,9 @@ describe('createTransport', () => {
         status: 'running',
       }
 
-      const config = createTransport(workload)
+      const transport = buildMcpClientTransport(workload)
 
-      expect(config.name).toBe('oci-registry')
-      expect(config.transport).toEqual(
-        expect.objectContaining({
-          url: 'http://localhost:57839/sse#oci-registry',
-          type: 'sse',
-        })
-      )
+      expect(transport).toBeInstanceOf(SSEClientTransport)
     })
   })
 
@@ -145,13 +77,9 @@ describe('createTransport', () => {
         status: 'running',
       }
 
-      const config = createTransport(workload)
+      const transport = buildMcpClientTransport(workload)
 
-      expect(config.name).toBe('stdio-server')
-      expect(config.transport).toEqual({
-        type: 'http',
-        url: 'http://127.0.0.1:40281/mcp',
-      })
+      expect(transport).toBeInstanceOf(StreamableHTTPClientTransport)
     })
 
     it('should use SSE when proxy_mode is sse', () => {
@@ -164,38 +92,12 @@ describe('createTransport', () => {
         status: 'running',
       }
 
-      const config = createTransport(workload)
+      const transport = buildMcpClientTransport(workload)
 
-      expect(config.name).toBe('stdio-server-sse')
-      expect(config.transport).toEqual(
-        expect.objectContaining({
-          url: 'http://localhost:18890/sse#stdio-server-sse',
-          type: 'sse',
-        })
-      )
+      expect(transport).toBeInstanceOf(SSEClientTransport)
     })
 
-    it('should use SSE when URL contains /sse even without proxy_mode', () => {
-      const workload: CoreWorkload = {
-        name: 'stdio-server-url-sse',
-        port: 18890,
-        transport_type: 'stdio',
-        url: 'http://127.0.0.1:18890/sse#stdio-server-url-sse',
-        status: 'running',
-      }
-
-      const config = createTransport(workload)
-
-      expect(config.name).toBe('stdio-server-url-sse')
-      expect(config.transport).toEqual(
-        expect.objectContaining({
-          url: 'http://localhost:18890/sse#stdio-server-url-sse',
-          type: 'sse',
-        })
-      )
-    })
-
-    it('should use stdio transport when no proxy_mode and no /sse in URL', () => {
+    it('should reject unresolved direct stdio workloads', () => {
       const workload: CoreWorkload = {
         name: 'pure-stdio',
         port: 40281,
@@ -203,10 +105,9 @@ describe('createTransport', () => {
         status: 'running',
       }
 
-      const config = createTransport(workload)
-
-      expect(config.name).toBe('pure-stdio')
-      expect(config.transport).toBeInstanceOf(Experimental_StdioMCPTransport)
+      expect(() => buildMcpClientTransport(workload)).toThrow(
+        /no HTTP proxy endpoint/i
+      )
     })
   })
 })

--- a/main/src/utils/__tests__/normalize-mcp-input-schema.test.ts
+++ b/main/src/utils/__tests__/normalize-mcp-input-schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isUsableMcpTool,
+  normalizeMcpInputSchema,
+} from '../normalize-mcp-input-schema'
+
+describe('normalizeMcpInputSchema', () => {
+  it('defaults missing fields and additionalProperties to false', () => {
+    expect(normalizeMcpInputSchema({})).toEqual({
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    })
+  })
+
+  it('preserves explicit additionalProperties: true', () => {
+    expect(
+      normalizeMcpInputSchema({
+        type: 'object',
+        properties: { q: { type: 'string' } },
+        additionalProperties: true,
+      })
+    ).toMatchObject({
+      additionalProperties: true,
+      properties: { q: { type: 'string' } },
+    })
+  })
+})
+
+describe('isUsableMcpTool', () => {
+  it('accepts a well-formed tool', () => {
+    expect(
+      isUsableMcpTool({
+        name: 'ok',
+        description: 'fine',
+        inputSchema: { type: 'object', properties: {} },
+      })
+    ).toBe(true)
+  })
+
+  it('rejects non-string descriptions and non-object schemas', () => {
+    expect(
+      isUsableMcpTool({
+        name: 'bad',
+        description: 42 as unknown as string,
+      })
+    ).toBe(false)
+    expect(
+      isUsableMcpTool({
+        name: 'bad',
+        inputSchema: 'nope',
+      })
+    ).toBe(false)
+    expect(isUsableMcpTool({ name: '' })).toBe(false)
+  })
+})

--- a/main/src/utils/mcp-tools.ts
+++ b/main/src/utils/mcp-tools.ts
@@ -1,178 +1,185 @@
-import { createMCPClient, type MCPClientConfig } from '@ai-sdk/mcp'
-import { type Tool } from 'ai'
-import { Experimental_StdioMCPTransport as StdioMCPTransport } from '@ai-sdk/mcp/mcp-stdio'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import {
+  Client,
+  SSEClientTransport,
+  StreamableHTTPClientTransport,
+  type ClientOptions,
+  type Transport,
+} from '@modelcontextprotocol/client'
+import { jsonSchema, type Tool } from 'ai'
 import type { CoreWorkload } from '@common/api/generated/types.gen'
 import log from '../logger'
 
 export interface McpToolDefinition {
   description?: string
   inputSchema: Tool['inputSchema']
+  _meta?: Record<string, unknown>
+}
+
+export const MCP_UI_EXTENSION_CAPABILITY = {
+  'io.modelcontextprotocol/ui': {
+    mimeTypes: ['text/html;profile=mcp-app'],
+  },
+}
+
+export interface ConnectWorkloadMcpClientOptions {
+  clientName?: string
+  capabilities?: ClientOptions['capabilities']
+}
+
+export interface ConnectedMcpClient {
+  client: Client
+  close: () => Promise<void>
 }
 
 export function isMcpToolDefinition(obj: unknown): obj is McpToolDefinition {
   if (!obj || typeof obj !== 'object' || obj === null) return false
 
-  const tool = obj
+  const tool = obj as Record<string, unknown>
 
-  // Description should be string if present
   if (
     'description' in tool &&
     tool.description !== undefined &&
     typeof tool.description !== 'string'
-  )
+  ) {
     return false
+  }
 
-  // InputSchema should be object if present
   if ('inputSchema' in tool && tool.inputSchema !== undefined) {
-    if (typeof tool.inputSchema !== 'object' || tool.inputSchema === null)
+    if (typeof tool.inputSchema !== 'object' || tool.inputSchema === null) {
       return false
+    }
 
     const inputSchema = tool.inputSchema as Record<string, unknown>
-    if ('properties' in inputSchema && inputSchema.properties !== undefined) {
-      if (
-        typeof inputSchema.properties !== 'object' ||
-        inputSchema.properties === null ||
-        Array.isArray(inputSchema.properties)
-      ) {
-        return false
-      }
+    const schemaBody =
+      'jsonSchema' in inputSchema && inputSchema.jsonSchema
+        ? (inputSchema.jsonSchema as Record<string, unknown>)
+        : inputSchema
+
+    if (
+      'properties' in schemaBody &&
+      schemaBody.properties !== undefined &&
+      (typeof schemaBody.properties !== 'object' ||
+        schemaBody.properties === null ||
+        Array.isArray(schemaBody.properties))
+    ) {
+      return false
     }
   }
 
   return true
 }
 
-export function createTransport(workload: CoreWorkload): MCPClientConfig {
-  const transportConfigs = {
-    stdio: () => ({
-      name: workload.name,
-      transport: new StdioMCPTransport({
-        command: 'node',
-        args: [],
-      }),
-    }),
-    'streamable-http': () => {
-      // ToolHive provides the correct URL with path in workload.url
-      // Fallback to /mcp for local containers if url is missing
-      const urlString = workload.url || `http://localhost:${workload.port}/mcp`
-      // Use the AI SDK's transport config form (not a transport instance).
-      // `@ai-sdk/mcp` >=1.0.42 assigns to `transport.protocolVersion` after
-      // `initialize`, but `StreamableHTTPClientTransport` from
-      // `@modelcontextprotocol/sdk` exposes `protocolVersion` as a
-      // getter-only property and throws TypeError on assignment in strict
-      // mode, breaking tool discovery for every streamable-http server.
-      return {
-        name: workload.name,
-        transport: {
-          type: 'http' as const,
-          url: urlString,
-          // AI SDK v7 defaults redirect to 'error' (SSRF protection). ToolHive
-          // proxies are localhost and do not redirect; keep the secure default.
-        },
-      }
-    },
-    sse: () => ({
-      name: workload.name,
-      transport: {
-        type: 'sse' as const,
-        url: `http://localhost:${workload.port}/sse#${workload.name}`,
-      },
-    }),
-    default: () => ({
-      name: workload.name,
-      transport: {
-        type: 'sse' as const,
-        url: `http://localhost:${workload.port}/sse#${workload.name}`,
-      },
-    }),
-  }
+type ResolvedTransportType = 'streamable-http' | 'sse' | 'unsupported'
 
-  // For stdio transport, ToolHive exposes the server via a proxy (SSE or streamable-http)
-  // Check proxy_mode or URL pattern to determine the actual transport to use
-  let transportType = workload.transport_type as keyof typeof transportConfigs
+function resolveTransportType(workload: CoreWorkload): ResolvedTransportType {
+  const transportType = workload.transport_type
 
   if (transportType === 'stdio') {
-    // Use proxy_mode if available, otherwise check URL pattern
     if (workload.proxy_mode === 'streamable-http') {
-      transportType = 'streamable-http'
-    } else if (
-      workload.proxy_mode === 'sse' ||
-      workload.url?.includes('/sse')
-    ) {
-      transportType = 'sse'
+      return 'streamable-http'
     }
+    if (workload.proxy_mode === 'sse' || workload.url?.includes('/sse')) {
+      return 'sse'
+    }
+    return 'unsupported'
   }
 
-  const configBuilder =
-    transportConfigs[transportType] || transportConfigs.default
-  return configBuilder()
+  if (transportType === 'streamable-http') return 'streamable-http'
+  if (transportType === 'sse') return 'sse'
+  return 'sse'
 }
 
-/**
- * Builds a raw SDK `Transport` for a workload. Unlike `createTransport`, this
- * returns a concrete transport instance suitable for `Client.connect()` from
- * `@modelcontextprotocol/sdk` rather than the AI SDK client config shape.
- */
-export function buildRawTransport(workload: CoreWorkload): Transport {
-  const config = createTransport(workload)
-  const { transport } = config
-  // `createTransport` returns AI SDK config shapes (`{ type: 'http' | 'sse',
-  // url }`) for HTTP-based transports. Materialize them into the raw SDK
-  // transport instances expected by `Client.connect()`.
-  const cfgTransport = transport as {
-    type?: string
-    url?: string | URL
+export function buildMcpClientTransport(workload: CoreWorkload): Transport {
+  const transportType = resolveTransportType(workload)
+
+  if (transportType === 'unsupported') {
+    throw new Error(
+      `Workload ${workload.name ?? 'unknown'} has no HTTP proxy endpoint; use streamable-http or sse proxy_mode`
+    )
   }
-  if (cfgTransport.type === 'http' && cfgTransport.url) {
-    const url =
-      cfgTransport.url instanceof URL
-        ? cfgTransport.url
-        : new URL(cfgTransport.url)
-    return new StreamableHTTPClientTransport(url)
+
+  if (transportType === 'streamable-http') {
+    const urlString = workload.url || `http://localhost:${workload.port}/mcp`
+    return new StreamableHTTPClientTransport(new URL(urlString))
   }
-  if (cfgTransport.type === 'sse' && cfgTransport.url) {
-    const url =
-      cfgTransport.url instanceof URL
-        ? cfgTransport.url
-        : new URL(cfgTransport.url)
-    return new SSEClientTransport(url)
-  }
-  throw new Error(
-    `Unsupported raw transport for workload ${workload.name ?? 'unknown'}`
+
+  const sseUrl = workload.url?.includes('/sse')
+    ? workload.url
+    : `http://localhost:${workload.port}/sse#${workload.name}`
+  return new SSEClientTransport(new URL(sseUrl))
+}
+
+export async function connectWorkloadMcpClient(
+  workload: CoreWorkload,
+  options: ConnectWorkloadMcpClientOptions = {}
+): Promise<ConnectedMcpClient> {
+  const client = new Client(
+    {
+      name: options.clientName ?? 'toolhive-studio',
+      version: '1.0.0',
+    },
+    {
+      capabilities: options.capabilities,
+      versionNegotiation: { mode: 'auto' },
+      inputRequired: { autoFulfill: false },
+    }
   )
+
+  await client.connect(buildMcpClientTransport(workload))
+
+  let closed = false
+  const close = async () => {
+    if (closed) return
+    closed = true
+    await client.close()
+  }
+
+  return { client, close }
 }
 
-// Get available tools from a workload
 export async function getWorkloadAvailableTools(
   workload: CoreWorkload
 ): Promise<Record<string, McpToolDefinition> | null> {
   if (!workload.name) return null
 
-  try {
-    // Try to create an MCP client and discover tools
-    const config = createTransport(workload)
-    if (config) {
-      const mcpClient = await createMCPClient(config)
-      const rawTools = await mcpClient.tools<'automatic'>()
+  let connection: ConnectedMcpClient | null = null
 
-      // Filter and validate tools using type guard
-      const serverMcpTools: Record<string, McpToolDefinition> = {}
-      for (const [name, defTool] of Object.entries(rawTools)) {
-        if (!name || !isMcpToolDefinition(defTool)) continue
-        serverMcpTools[name] = {
-          description: defTool.description,
-          inputSchema: defTool.inputSchema as Tool['inputSchema'],
-        }
+  try {
+    connection = await connectWorkloadMcpClient(workload, {
+      clientName: 'toolhive-studio-discovery',
+    })
+    const { tools } = await connection.client.listTools()
+
+    const serverMcpTools: Record<string, McpToolDefinition> = {}
+    for (const tool of tools) {
+      if (!tool.name) continue
+      const schema =
+        tool.inputSchema && typeof tool.inputSchema === 'object'
+          ? tool.inputSchema
+          : { type: 'object', properties: {} }
+
+      serverMcpTools[tool.name] = {
+        description: tool.description,
+        inputSchema: jsonSchema({
+          ...(schema as Record<string, unknown>),
+          type: 'object',
+          properties:
+            'properties' in schema && schema.properties
+              ? schema.properties
+              : {},
+          additionalProperties: false,
+        }),
+        _meta: tool._meta,
       }
-      await mcpClient.close()
-      return serverMcpTools
     }
-    return null
+
+    return serverMcpTools
   } catch (error) {
     log.error(`Failed to discover tools for ${workload.name}:`, error)
     throw error
+  } finally {
+    if (connection) {
+      await connection.close()
+    }
   }
 }

--- a/main/src/utils/mcp-tools.ts
+++ b/main/src/utils/mcp-tools.ts
@@ -8,6 +8,7 @@ import {
 import { jsonSchema, type Tool } from 'ai'
 import type { CoreWorkload } from '@common/api/generated/types.gen'
 import log from '../logger'
+import { normalizeMcpInputSchema } from './normalize-mcp-input-schema'
 
 export interface McpToolDefinition {
   description?: string
@@ -54,6 +55,9 @@ function resolveTransportType(workload: CoreWorkload): ResolvedTransportType {
 export function buildMcpClientTransport(workload: CoreWorkload): Transport {
   const transportType = resolveTransportType(workload)
 
+  // Intentional: Studio only talks to ToolHive's HTTP/SSE proxy. Direct stdio
+  // without a resolved proxy_mode is a configuration race/error, not a silent
+  // fallback case — fail loudly so discovery surfaces the real problem.
   if (transportType === 'unsupported') {
     throw new Error(
       `Workload ${workload.name ?? 'unknown'} has no HTTP proxy endpoint; use streamable-http or sse proxy_mode`
@@ -115,22 +119,10 @@ export async function getWorkloadAvailableTools(
     const serverMcpTools: Record<string, McpToolDefinition> = {}
     for (const tool of tools) {
       if (!tool.name) continue
-      const schema =
-        tool.inputSchema && typeof tool.inputSchema === 'object'
-          ? tool.inputSchema
-          : { type: 'object', properties: {} }
 
       serverMcpTools[tool.name] = {
         description: tool.description,
-        inputSchema: jsonSchema({
-          ...(schema as Record<string, unknown>),
-          type: 'object',
-          properties:
-            'properties' in schema && schema.properties
-              ? schema.properties
-              : {},
-          additionalProperties: false,
-        }),
+        inputSchema: jsonSchema(normalizeMcpInputSchema(tool.inputSchema)),
         _meta: tool._meta,
       }
     }

--- a/main/src/utils/mcp-tools.ts
+++ b/main/src/utils/mcp-tools.ts
@@ -31,44 +31,6 @@ export interface ConnectedMcpClient {
   close: () => Promise<void>
 }
 
-export function isMcpToolDefinition(obj: unknown): obj is McpToolDefinition {
-  if (!obj || typeof obj !== 'object' || obj === null) return false
-
-  const tool = obj as Record<string, unknown>
-
-  if (
-    'description' in tool &&
-    tool.description !== undefined &&
-    typeof tool.description !== 'string'
-  ) {
-    return false
-  }
-
-  if ('inputSchema' in tool && tool.inputSchema !== undefined) {
-    if (typeof tool.inputSchema !== 'object' || tool.inputSchema === null) {
-      return false
-    }
-
-    const inputSchema = tool.inputSchema as Record<string, unknown>
-    const schemaBody =
-      'jsonSchema' in inputSchema && inputSchema.jsonSchema
-        ? (inputSchema.jsonSchema as Record<string, unknown>)
-        : inputSchema
-
-    if (
-      'properties' in schemaBody &&
-      schemaBody.properties !== undefined &&
-      (typeof schemaBody.properties !== 'object' ||
-        schemaBody.properties === null ||
-        Array.isArray(schemaBody.properties))
-    ) {
-      return false
-    }
-  }
-
-  return true
-}
-
 type ResolvedTransportType = 'streamable-http' | 'sse' | 'unsupported'
 
 function resolveTransportType(workload: CoreWorkload): ResolvedTransportType {

--- a/main/src/utils/normalize-mcp-input-schema.ts
+++ b/main/src/utils/normalize-mcp-input-schema.ts
@@ -1,0 +1,41 @@
+import type { JSONSchema7 } from 'ai'
+
+/**
+ * Normalize MCP tool input schemas for both discovery UI and AI SDK tools.
+ * Preserves an explicit `additionalProperties` when the server sets one.
+ */
+export function normalizeMcpInputSchema(schema: unknown): JSONSchema7 {
+  const raw = (
+    schema && typeof schema === 'object'
+      ? schema
+      : { type: 'object', properties: {} }
+  ) as JSONSchema7
+
+  return {
+    ...raw,
+    type: raw.type ?? 'object',
+    properties: raw.properties ?? {},
+    additionalProperties: raw.additionalProperties ?? false,
+  }
+}
+
+/** Lightweight guard against malformed listTools() entries before AI adaptation. */
+export function isUsableMcpTool(tool: {
+  name?: string
+  description?: unknown
+  inputSchema?: unknown
+}): boolean {
+  if (!tool.name || typeof tool.name !== 'string') return false
+
+  if (tool.description !== undefined && typeof tool.description !== 'string') {
+    return false
+  }
+
+  if (tool.inputSchema !== undefined) {
+    if (typeof tool.inputSchema !== 'object' || tool.inputSchema === null) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@electron/fuses": "^2.1.3",
     "@eslint/js": "^10.0.1",
     "@hey-api/openapi-ts": "0.99.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@playwright/test": "^1.62.1",
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/router-plugin": "^1.168.23",
@@ -103,7 +104,6 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.25",
     "@ai-sdk/google": "^4.0.29",
-    "@ai-sdk/mcp": "^2.0.20",
     "@ai-sdk/openai": "^4.0.25",
     "@ai-sdk/openai-compatible": "^3.0.18",
     "@ai-sdk/react": "^4.0.47",
@@ -112,6 +112,7 @@
     "@fontsource-variable/merriweather": "^5.3.0",
     "@fontsource/atkinson-hyperlegible": "^5.3.0",
     "@fontsource/space-mono": "^5.3.0",
+    "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/ext-apps": "^1.7.5",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "@fontsource/space-mono": "^5.3.0",
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/ext-apps": "^1.7.5",
-    "@modelcontextprotocol/sdk": "^1.30.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "@radix-ui/react-checkbox": "^1.3.11",
     "@radix-ui/react-collapsible": "^1.1.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,9 +67,6 @@ importers:
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.5
         version: 1.7.5(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.30.0
-        version: 1.30.0(supports-color@8.1.1)(zod@4.4.3)
       '@openrouter/ai-sdk-provider':
         specifier: ^3.0.0
         version: 3.0.0(ai@7.0.48(zod@4.4.3))(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,6 @@ importers:
       '@ai-sdk/google':
         specifier: ^4.0.29
         version: 4.0.31(zod@4.4.3)
-      '@ai-sdk/mcp':
-        specifier: ^2.0.20
-        version: 2.0.22(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^4.0.25
         version: 4.0.27(zod@4.4.3)
@@ -64,6 +61,9 @@ importers:
       '@fontsource/space-mono':
         specifier: ^5.3.0
         version: 5.3.0
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.5
         version: 1.7.5(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
@@ -275,6 +275,9 @@ importers:
       '@hey-api/openapi-ts':
         specifier: 0.99.0
         version: 0.99.0(@typescript/typescript6@6.0.2)(magicast@0.5.2)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
@@ -1680,6 +1683,14 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/ext-apps@1.7.5':
     resolution: {integrity: sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==}
     engines: {node: '>=20'}
@@ -1703,6 +1714,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@mswjs/interceptors@0.41.8':
     resolution: {integrity: sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==}
@@ -9712,6 +9727,20 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      jose: 6.2.3
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
   '@modelcontextprotocol/ext-apps@1.7.5(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.30.0(supports-color@8.1.1)(zod@4.4.3)
@@ -9742,6 +9771,11 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@mswjs/interceptors@0.41.8':
     dependencies:

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -11,6 +11,7 @@ import {
 } from './renderer/src/common/mocks/matchMedia'
 import { resetElectronAPI } from './renderer/src/common/mocks/electronAPI'
 import { server } from './renderer/src/common/mocks/node'
+import { http, passthrough } from 'msw'
 import type { ElectronAPI } from './preload/src/preload'
 
 expect.extend(testingLibraryMatchers)
@@ -47,6 +48,15 @@ beforeEach(() => {
   resetAllAutoAPIMocks()
   resetMatchMediaState()
   resetElectronAPI()
+  server.use(
+    http.all(
+      ({ request }) => {
+        const { hostname } = new URL(request.url)
+        return hostname === '127.0.0.1' || hostname === 'localhost'
+      },
+      () => passthrough()
+    )
+  )
 })
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Adds native MCP **2026-07-28 / 2025-11-25** support in the Playground by replacing `@ai-sdk/mcp` with the official TypeScript SDK v2 client. Studio now auto-negotiates Modern with ToolHive v0.41 while still talking to Legacy backends.

### Client & transport
- Centralize MCP connectivity in `connectWorkloadMcpClient()` with `versionNegotiation: { mode: 'auto' }` and streamable-HTTP/SSE transports via the ToolHive proxy
- Remove `@ai-sdk/mcp`; add `@modelcontextprotocol/client` (runtime) and `@modelcontextprotocol/server` (E2E fixtures)
- Drop the direct `@modelcontextprotocol/sdk` dependency — v1 remains only as a **transitive** dep of `@modelcontextprotocol/ext-apps` (MCP Apps app-bridge)

### Playground integration
- New `mcp-ai-tool.ts` adapter maps native MCP tools to AI SDK `dynamicTool` (schema sanitization, metadata, `isError`, abort signals)
- MCP Apps use the same native client for `readResource` / `callTool`
- Session-scoped `{ tools, enabledTools, close }` replaces leaking client arrays; streaming closes MCP + builtin tools in `finally`

### Deferred by design
- **Interactive `input_required`**: `autoFulfill: false` with a clear unsupported error — no pause/resume UX yet

### Tests
- Unit/integration: auto-negotiation config, tool adaptation, cleanup, strict Modern-only fixture (`legacy: 'reject'`)
- E2E: Legacy + Modern Playground paths through ToolHive proxy (SDK v2 test servers accept Legacy startup probes from thv)

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run knip`
- [x] `pnpm run test:nonInteractive`
- [x] `pnpm run package`
- [x] CI Playground E2E (Legacy + Modern; Docker + Ollama)