### PR TITLE
chore(deps): prune redundant pnpm overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,22 +6,9 @@ settings:
 
 overrides:
   '@electron/rebuild': ^4.2.0
-  fast-xml-builder: '>=1.3.0'
   '@aws-sdk/xml-builder>fast-xml-parser': 5.10.1
   js-yaml: '>=5.2.2'
-  '@opentelemetry/core': '>=2.10.0'
   tmp: '>=0.2.7'
-  jsdom>undici: '>=7.28.0 <8'
-  node-gyp>undici: '>=6.27.0 <7'
-  body-parser: '>=2.3.0'
-  tar: '>=7.5.22'
-  brace-expansion@>=4.0.0 <5.0.8: 5.0.8
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@<1.1.16: 1.1.16
-  ajv>fast-uri: 3.1.4
-  '@modelcontextprotocol/sdk>hono': 4.12.32
-  '@modelcontextprotocol/sdk>@hono/node-server': 2.0.11
-  mermaid>dompurify: 3.4.12
   icon-gen>sharp: 0.35.3
 
 patchedDependencies:
@@ -387,7 +374,7 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       tar:
-        specifier: '>=7.5.22'
+        specifier: ^7.5.22
         version: 7.5.22
       tsx:
         specifier: ^4.23.1
@@ -2844,7 +2831,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/core': '>=2.10.0'
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
       '@opentelemetry/instrumentation': '>=0.57.1 <1'
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
@@ -2869,7 +2856,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/core': '>=2.10.0'
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
 
   '@sentry/replay-canvas@10.67.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,23 +34,11 @@ auditConfig:
     - GHSA-rmmr-r34h-pfm5
 
 overrides:
+  # Only overrides where parent ranges cannot reach a patched version.
   '@electron/rebuild': ^4.2.0
-  fast-xml-builder: '>=1.3.0'
   '@aws-sdk/xml-builder>fast-xml-parser': 5.10.1
   js-yaml: '>=5.2.2'
-  '@opentelemetry/core': '>=2.10.0'
   tmp: '>=0.2.7'
-  'jsdom>undici': '>=7.28.0 <8'
-  'node-gyp>undici': '>=6.27.0 <7'
-  body-parser: '>=2.3.0'
-  tar: '>=7.5.22'
-  brace-expansion@>=4.0.0 <5.0.8: 5.0.8
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@<1.1.16: 1.1.16
-  'ajv>fast-uri': 3.1.4
-  '@modelcontextprotocol/sdk>hono': 4.12.32
-  '@modelcontextprotocol/sdk>@hono/node-server': 2.0.11
-  'mermaid>dompurify': 3.4.12
   'icon-gen>sharp': 0.35.3
 
 patchedDependencies:


### PR DESCRIPTION
## Summary
- Remove pnpm overrides that are no longer needed because parent dependency ranges already resolve to patched versions.
- Keep only overrides where parents pin or range below the fixed version: `@electron/rebuild`, `fast-xml-parser` (AWS exact pin), `js-yaml`, `tmp`, and `sharp` (via `icon-gen`).

## Test plan
- [x] CI install/lockfile checks pass
- [x] Security/audit workflows stay green
- [x] Confirm no regressions from transitive resolution changes