### PR TITLE
fix(registry): stop matching reverse-DNS namespace in search

### DIFF
--- a/renderer/src/common/hooks/use-filter-sort.ts
+++ b/renderer/src/common/hooks/use-filter-sort.ts
@@ -2,7 +2,8 @@ import { useState, useMemo } from 'react'
 
 interface UseFilterSortOptions<T> {
   data: T[]
-  filterFields: (item: T) => string[]
+  /** Fields to match against. Receives the lowercased search term for query-aware matching. */
+  filterFields: (item: T, searchTerm: string) => string[]
   sortBy?: (item: T) => string
   sortOrder?: 'asc' | 'desc'
 }
@@ -26,7 +27,7 @@ export function useFilterSort<T>({
     return data
       .filter((item) => {
         if (!searchTerm) return true
-        const fields = filterFields(item)
+        const fields = filterFields(item, searchTerm)
         return fields.some((field) => field.toLowerCase().includes(searchTerm))
       })
       .sort((a, b) => {

--- a/renderer/src/routes/(registry)/-registry.route.tsx
+++ b/renderer/src/routes/(registry)/-registry.route.tsx
@@ -66,20 +66,27 @@ export default function RegistryRouteComponent() {
 
   const { filter, setFilter, filteredData } = useFilterSort({
     data: items,
-    filterFields: (item) => {
+    filterFields: (item, searchTerm) => {
       // Registry names are reverse-DNS namespaced (e.g. `io.github.stacklok/fetch`).
-      // Matching the full name makes common terms like "github" hit every entry's
-      // namespace prefix. Search the short name (segment after the last `/`) instead,
-      // plus title/description/tags — the fields users actually see and think in.
+      // Matching the full name for every query makes terms like "github" hit the
+      // namespace prefix on almost every entry. Prefer the short name (after the
+      // last `/`), plus title/description (what users see) and tags (common
+      // search terms). When the query itself contains `/`, also match the full
+      // name so pasting a CLI/docs reference still works.
       const name = item.name || ''
       const slash = name.lastIndexOf('/')
       const shortName = slash >= 0 ? name.slice(slash + 1) || name : name
       const title = ('title' in item && item.title) || ''
       const description = item.description || ''
-      const tags =
-        'tags' in item && Array.isArray(item.tags) ? item.tags.join(' ') : ''
+      const tags = 'tags' in item && Array.isArray(item.tags) ? item.tags : []
 
-      return [shortName, title, description, tags]
+      return [
+        shortName,
+        title,
+        description,
+        ...tags,
+        ...(searchTerm.includes('/') ? [name] : []),
+      ]
     },
     sortBy: (item) => item.name || '',
   })

--- a/renderer/src/routes/(registry)/-registry.route.tsx
+++ b/renderer/src/routes/(registry)/-registry.route.tsx
@@ -66,11 +66,22 @@ export default function RegistryRouteComponent() {
 
   const { filter, setFilter, filteredData } = useFilterSort({
     data: items,
-    filterFields: (item) => [
-      item.name || '',
-      ('title' in item && item.title) || '',
-      item.description || '',
-    ],
+    filterFields: (item) => {
+      // Registry names are reverse-DNS namespaced (e.g. `io.github.stacklok/fetch`).
+      // Matching the full name makes common terms like "github" hit every entry's
+      // namespace prefix. Search the short name (segment after the last `/`) instead,
+      // plus title/description/tags — the fields users actually see and think in.
+      const name = item.name || ''
+      const shortName = name.includes('/')
+        ? (name.split('/').pop() ?? name)
+        : name
+      const title = ('title' in item && item.title) || ''
+      const description = item.description || ''
+      const tags =
+        'tags' in item && Array.isArray(item.tags) ? item.tags.join(' ') : ''
+
+      return [shortName, title, description, tags]
+    },
     sortBy: (item) => item.name || '',
   })
 

--- a/renderer/src/routes/(registry)/-registry.route.tsx
+++ b/renderer/src/routes/(registry)/-registry.route.tsx
@@ -72,9 +72,8 @@ export default function RegistryRouteComponent() {
       // namespace prefix. Search the short name (segment after the last `/`) instead,
       // plus title/description/tags — the fields users actually see and think in.
       const name = item.name || ''
-      const shortName = name.includes('/')
-        ? (name.split('/').pop() ?? name)
-        : name
+      const slash = name.lastIndexOf('/')
+      const shortName = slash >= 0 ? name.slice(slash + 1) || name : name
       const title = ('title' in item && item.title) || ''
       const description = item.description || ''
       const tags =

--- a/renderer/src/routes/__tests__/registry.test.tsx
+++ b/renderer/src/routes/__tests__/registry.test.tsx
@@ -301,6 +301,8 @@ describe('Bug: search for "github" should match GitHub MCP servers', () => {
   })
 
   it('still matches the short name after the namespace prefix', async () => {
+    // Title/description deliberately omit the search term so a match can only
+    // come from the short name extracted after the namespace prefix.
     mockedGetApiV1BetaRegistryByName.override(
       (data) =>
         ({
@@ -315,15 +317,15 @@ describe('Bug: search for "github" should match GitHub MCP servers', () => {
       servers: [
         {
           name: 'io.github.stacklok/fetch',
-          title: 'Fetch',
+          title: 'Web Content Retriever',
           image: 'mcp/fetch:latest',
-          description: 'Fetch content from the web.',
+          description: 'Pulls pages over HTTP.',
         },
         {
           name: 'io.github.stacklok/time',
-          title: 'Time',
+          title: 'Clock',
           image: 'mcp/time:latest',
-          description: 'Time server.',
+          description: 'Reports the current time.',
         },
       ],
       remote_servers: [],
@@ -332,16 +334,16 @@ describe('Bug: search for "github" should match GitHub MCP servers', () => {
     renderRoute(router)
 
     await waitFor(() => {
-      expect(screen.queryByText('Fetch')).toBeVisible()
+      expect(screen.queryByText('Web Content Retriever')).toBeVisible()
     })
 
     const searchInput = screen.getByPlaceholderText('Search...')
     await userEvent.type(searchInput, 'fetch')
 
     await waitFor(() => {
-      expect(screen.queryByText('Fetch')).toBeVisible()
+      expect(screen.queryByText('Web Content Retriever')).toBeVisible()
     })
-    expect(screen.queryByText('Time')).not.toBeInTheDocument()
+    expect(screen.queryByText('Clock')).not.toBeInTheDocument()
   })
 
   it('matches servers by tag', async () => {

--- a/renderer/src/routes/__tests__/registry.test.tsx
+++ b/renderer/src/routes/__tests__/registry.test.tsx
@@ -233,4 +233,160 @@ describe('Bug: search for "github" should match GitHub MCP servers', () => {
     // The unrelated MCP should be filtered out.
     expect(screen.queryByText('time')).not.toBeInTheDocument()
   })
+
+  it('does not match every server just because the namespace contains "github"', async () => {
+    // Production registry names are reverse-DNS namespaced, e.g.
+    // `io.github.stacklok/fetch`. Matching the full name makes searching
+    // "github" return (almost) the entire catalog — search appears broken.
+    mockedGetApiV1BetaRegistryByName.override(
+      (data) =>
+        ({
+          ...data,
+          registry: {
+            ...(data as V1GetRegistryResponse).registry,
+            groups: [],
+          },
+        }) as unknown as V1GetRegistryResponse
+    )
+    mockedGetApiV1BetaRegistryByNameServers.override(() => ({
+      servers: [
+        {
+          name: 'io.github.stacklok/gh-mcp-server',
+          title: 'GitHub',
+          image: 'mcp/gh-server:latest',
+          description: 'Official MCP server for accessing repos and PRs.',
+        },
+        {
+          name: 'io.github.stacklok/time',
+          title: 'Time',
+          image: 'mcp/time:latest',
+          description: 'Time server.',
+        },
+        {
+          name: 'io.github.stacklok/fetch',
+          title: 'Fetch',
+          image: 'mcp/fetch:latest',
+          description: 'Fetch content from the web.',
+        },
+      ],
+      remote_servers: [],
+    }))
+
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.queryByText('GitHub')).toBeVisible()
+      expect(screen.queryByText('Time')).toBeVisible()
+      expect(screen.queryByText('Fetch')).toBeVisible()
+    })
+
+    const searchInput = screen.getByPlaceholderText('Search...')
+    await userEvent.type(searchInput, 'github')
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('GitHub'),
+        'GitHub MCP should remain visible when searching "github"'
+      ).toBeVisible()
+    })
+
+    expect(
+      screen.queryByText('Time'),
+      'Unrelated namespaced server must not match via io.github.* prefix'
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Fetch'),
+      'Unrelated namespaced server must not match via io.github.* prefix'
+    ).not.toBeInTheDocument()
+  })
+
+  it('still matches the short name after the namespace prefix', async () => {
+    mockedGetApiV1BetaRegistryByName.override(
+      (data) =>
+        ({
+          ...data,
+          registry: {
+            ...(data as V1GetRegistryResponse).registry,
+            groups: [],
+          },
+        }) as unknown as V1GetRegistryResponse
+    )
+    mockedGetApiV1BetaRegistryByNameServers.override(() => ({
+      servers: [
+        {
+          name: 'io.github.stacklok/fetch',
+          title: 'Fetch',
+          image: 'mcp/fetch:latest',
+          description: 'Fetch content from the web.',
+        },
+        {
+          name: 'io.github.stacklok/time',
+          title: 'Time',
+          image: 'mcp/time:latest',
+          description: 'Time server.',
+        },
+      ],
+      remote_servers: [],
+    }))
+
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Fetch')).toBeVisible()
+    })
+
+    const searchInput = screen.getByPlaceholderText('Search...')
+    await userEvent.type(searchInput, 'fetch')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Fetch')).toBeVisible()
+    })
+    expect(screen.queryByText('Time')).not.toBeInTheDocument()
+  })
+
+  it('matches servers by tag', async () => {
+    mockedGetApiV1BetaRegistryByName.override(
+      (data) =>
+        ({
+          ...data,
+          registry: {
+            ...(data as V1GetRegistryResponse).registry,
+            groups: [],
+          },
+        }) as unknown as V1GetRegistryResponse
+    )
+    mockedGetApiV1BetaRegistryByNameServers.override(() => ({
+      servers: [
+        {
+          name: 'io.github.stacklok/content-fetcher',
+          title: 'Content Fetcher',
+          image: 'mcp/content-fetcher:latest',
+          description: 'Retrieves web pages.',
+          tags: ['html', 'markdown', 'scrape'],
+        },
+        {
+          name: 'io.github.stacklok/time',
+          title: 'Time',
+          image: 'mcp/time:latest',
+          description: 'Time server.',
+          tags: ['clock'],
+        },
+      ],
+      remote_servers: [],
+    }))
+
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Content Fetcher')).toBeVisible()
+    })
+
+    const searchInput = screen.getByPlaceholderText('Search...')
+    await userEvent.type(searchInput, 'scrape')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Content Fetcher')).toBeVisible()
+    })
+    expect(screen.queryByText('Time')).not.toBeInTheDocument()
+  })
 })

--- a/renderer/src/routes/__tests__/registry.test.tsx
+++ b/renderer/src/routes/__tests__/registry.test.tsx
@@ -300,6 +300,50 @@ describe('Bug: search for "github" should match GitHub MCP servers', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('matches a fully qualified namespaced name when the query contains "/"', async () => {
+    mockedGetApiV1BetaRegistryByName.override(
+      (data) =>
+        ({
+          ...data,
+          registry: {
+            ...(data as V1GetRegistryResponse).registry,
+            groups: [],
+          },
+        }) as unknown as V1GetRegistryResponse
+    )
+    mockedGetApiV1BetaRegistryByNameServers.override(() => ({
+      servers: [
+        {
+          name: 'io.github.stacklok/fetch',
+          title: 'Web Content Retriever',
+          image: 'mcp/fetch:latest',
+          description: 'Pulls pages over HTTP.',
+        },
+        {
+          name: 'io.github.stacklok/time',
+          title: 'Clock',
+          image: 'mcp/time:latest',
+          description: 'Reports the current time.',
+        },
+      ],
+      remote_servers: [],
+    }))
+
+    renderRoute(router)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Web Content Retriever')).toBeVisible()
+    })
+
+    const searchInput = screen.getByPlaceholderText('Search...')
+    await userEvent.type(searchInput, 'io.github.stacklok/fetch')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Web Content Retriever')).toBeVisible()
+    })
+    expect(screen.queryByText('Clock')).not.toBeInTheDocument()
+  })
+
   it('still matches the short name after the namespace prefix', async () => {
     // Title/description deliberately omit the search term so a match can only
     // come from the short name extracted after the namespace prefix.


### PR DESCRIPTION
## Summary
- Registry search matched the full server name, including reverse-DNS namespaces like `io.github.stacklok/…`. Searching for common terms such as `github` therefore matched (almost) the entire catalog and looked broken.
- Filter on the short name (segment after the last `/`), plus title, description, and tags — the fields users actually see.
- Add regression tests for the namespace false-positive, short-name matching, and tag matching (existing title-search coverage kept).

## Test plan
- [x] Open Registry and type `github` — only GitHub-related servers remain (not the whole catalog)
- [x] Type `fetch` — finds `io.github.stacklok/fetch` via short name
- [x] Type a tag (e.g. a known catalog tag) — matching servers remain
- [x] `pnpm exec vitest run renderer/src/routes/__tests__/registry.test.tsx`