### PR TITLE
chore(ci): pin security fix agent to Opus 5 and Sonnet 5

### DIFF
--- a/.github/workflows/_security-fix-agent.yml
+++ b/.github/workflows/_security-fix-agent.yml
@@ -63,7 +63,7 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
           grype version
 
-      - name: 'Phase 1: Analyze and Plan (Opus)'
+      - name: 'Phase 1: Analyze and Plan (Opus 5)'
         id: phase1
         if: steps.existing.outputs.skip != 'true'
         continue-on-error: true
@@ -78,11 +78,11 @@ jobs:
             Write a detailed remediation-plan.md with your full analysis and proposed fixes.
             Do NOT modify any project files — only create remediation-plan.md.
           claude_args: >-
-            --model opus
+            --model claude-opus-5
             --max-turns 30
             --allowedTools "Read,Write,Bash(grype *),Bash(pnpm audit *),Bash(pnpm why *),Bash(pnpm view *),Bash(cat *),Bash(ls *)"
 
-      - name: 'Phase 2: Implement Fixes (Sonnet)'
+      - name: 'Phase 2: Implement Fixes (Sonnet 5)'
         id: phase2
         if: steps.existing.outputs.skip != 'true' && steps.phase1.outcome == 'success'
         continue-on-error: true
@@ -102,7 +102,7 @@ jobs:
             Write a conventional-commit-style PR title to remediation-title.txt (see skill for format).
             Do NOT run git, gh, or modify .env files.
           claude_args: >-
-            --model sonnet
+            --model claude-sonnet-5
             --max-turns 40
             --allowedTools "Read,Write,Edit,Bash(grype *),Bash(pnpm install *),Bash(pnpm audit *),Bash(pnpm why *),Bash(pnpm view *),Bash(cat *),Bash(ls *),Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check)"
 

--- a/.github/workflows/_security-fix-agent.yml
+++ b/.github/workflows/_security-fix-agent.yml
@@ -79,7 +79,7 @@ jobs:
             Do NOT modify any project files — only create remediation-plan.md.
           claude_args: >-
             --model claude-opus-5
-            --max-turns 30
+            --max-turns 50
             --allowedTools "Read,Write,Bash(grype *),Bash(pnpm audit *),Bash(pnpm why *),Bash(pnpm view *),Bash(cat *),Bash(ls *)"
 
       - name: 'Phase 2: Implement Fixes (Sonnet 5)'
@@ -103,7 +103,7 @@ jobs:
             Do NOT run git, gh, or modify .env files.
           claude_args: >-
             --model claude-sonnet-5
-            --max-turns 40
+            --max-turns 80
             --allowedTools "Read,Write,Edit,Bash(grype *),Bash(pnpm install *),Bash(pnpm audit *),Bash(pnpm why *),Bash(pnpm view *),Bash(cat *),Bash(ls *),Bash(pnpm run test:nonInteractive *),Bash(pnpm run lint),Bash(pnpm run type-check)"
 
       - name: Check for changes


### PR DESCRIPTION
## Summary
- Pin the security fix agent Phase 1 model to `claude-opus-5` (was `opus`)
- Pin the security fix agent Phase 2 model to `claude-sonnet-5` (was `sonnet`)
- Raise Phase 1 `--max-turns` from 30 → 50 (Phase 1 was exhausting the budget under Opus 5)
- Raise Phase 2 `--max-turns` from 40 → 80
- Update step names to reflect Opus 5 / Sonnet 5

## Test plan
- [ ] Confirm workflow YAML still validates in Actions
- [ ] Optionally trigger `security-fix-cron` (or a workflow that calls `_security-fix-agent`) and verify Phase 1 completes without hitting max-turns