### PR TITLE
fix(security): bump mermaid to 11.16.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1673,8 +1673,8 @@ packages:
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
 
-  '@mermaid-js/parser@1.1.1':
-    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@modelcontextprotocol/client@2.0.0':
     resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
@@ -6076,8 +6076,8 @@ packages:
     resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
     engines: {node: '>=18.0.0'}
 
-  mermaid@11.15.0:
-    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -9803,7 +9803,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@mermaid-js/parser@1.1.1':
+  '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
 
@@ -11181,7 +11181,7 @@ snapshots:
 
   '@streamdown/mermaid@1.0.2(react@19.2.8)':
     dependencies:
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       react: 19.2.8
 
   '@szmarczak/http-timer@4.0.6':
@@ -14530,11 +14530,11 @@ snapshots:
 
   meriyah@6.1.4: {}
 
-  mermaid@11.15.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.3
-      '@mermaid-js/parser': 1.1.1
+      '@mermaid-js/parser': 1.2.0
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.3
@@ -15860,7 +15860,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       html-url-attributes: 3.0.1
       marked: 17.0.6
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       rehype-harden: 1.1.8


### PR DESCRIPTION
## Summary

Bump transitive `mermaid` from 11.15.0 to 11.16.1 (via `streamdown` / `@streamdown/mermaid`) to clear the moderate Mermaid advisories failing `pnpm audit` and Grype.

## Changes

| Advisory | Package | Severity | Production | Action | Verified |
| --- | --- | --- | --- | --- | --- |
| GHSA-6x64-9x62-f2gx | mermaid | moderate | Yes | Lockfile bump → 11.16.1 | Pass |
| GHSA-3rrr-jr9j-h3q3 | mermaid | moderate | Yes | Lockfile bump → 11.16.1 | Pass |
| GHSA-2v8p-3f2j-5mp7 | mermaid | moderate | Yes | Lockfile bump → 11.16.1 | Pass |
| GHSA-rhh3-jpg6-66xh | mermaid | moderate | Yes | Lockfile bump → 11.16.1 | Pass |
| GHSA-c4c3-pg64-4m4v | mermaid | low | Yes | Lockfile bump → 11.16.1 | Pass |

## Files Modified

- `pnpm-lock.yaml`: resolve `mermaid` 11.15.0 → 11.16.1 (and `@mermaid-js/parser` 1.1.1 → 1.2.0)

No override needed — parent ranges already allow `^11.12.2`.

## Verification

- `pnpm audit --prod --audit-level=moderate`: Pass
- `pnpm why mermaid`: 11.16.1 only

## Test plan

- [ ] CI security checks (`pnpm audit` + Grype) pass
- [ ] Spot-check mermaid rendering in the playground / streamdown UI if available