### PR TITLE
fix(security): override nanoid 3.x and dompurify (GHSA-2v37-7h3g-55p8, GHSA-55q2-fjhq-7xh7)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   fast-uri: '>=3.1.5 <4'
   ip-address: '>=10.4.0'
   hono: '>=4.12.34'
-  dompurify: '>=3.4.13'
+  dompurify: '>=3.4.13 <4'
   postcss>nanoid: '>=3.3.17 <4'
 
 patchedDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,8 @@ overrides:
   fast-uri: '>=3.1.5 <4'
   ip-address: '>=10.4.0'
   hono: '>=4.12.34'
+  dompurify: '>=3.4.13'
+  postcss>nanoid: '>=3.3.17 <4'
 
 patchedDependencies:
   electron-installer-redhat@3.4.0: 8fe238a56db4de235c10dd7f02c6a523c6ac3010edcc1d547dbc5c6416b89a37
@@ -4630,8 +4632,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
@@ -6291,8 +6293,8 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12768,7 +12770,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -14544,7 +14546,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -14873,7 +14875,7 @@ snapshots:
   nan@2.26.2:
     optional: true
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -15194,7 +15196,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,8 +46,8 @@ overrides:
   fast-uri: '>=3.1.5 <4'
   ip-address: '>=10.4.0'
   hono: '>=4.12.34'
-  # GHSA-55q2-fjhq-7xh7 — mermaid pins dompurify ^3.3.3; only one major in tree.
-  dompurify: '>=3.4.13'
+  # GHSA-55q2-fjhq-7xh7 — mermaid pins dompurify ^3.3.3; cap below v4.
+  dompurify: '>=3.4.13 <4'
   # GHSA-2v37-7h3g-55p8 — postcss pulls nanoid 3.x; keep direct nanoid 5.x untouched.
   'postcss>nanoid': '>=3.3.17 <4'
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,10 @@ overrides:
   fast-uri: '>=3.1.5 <4'
   ip-address: '>=10.4.0'
   hono: '>=4.12.34'
+  # GHSA-55q2-fjhq-7xh7 — mermaid pins dompurify ^3.3.3; only one major in tree.
+  dompurify: '>=3.4.13'
+  # GHSA-2v37-7h3g-55p8 — postcss pulls nanoid 3.x; keep direct nanoid 5.x untouched.
+  'postcss>nanoid': '>=3.3.17 <4'
 
 patchedDependencies:
   electron-installer-redhat@3.4.0: patches/electron-installer-redhat@3.4.0.patch


### PR DESCRIPTION
## Summary

Patches production audit/grype failures by overriding transitive `nanoid` 3.x (via `postcss`) and `dompurify` (via `mermaid`/`streamdown`) to fixed releases.

## Changes

| CVE | Package | Severity | Production | Action | Verified |
| --- | ------- | -------- | ---------- | ------ | -------- |
| GHSA-2v37-7h3g-55p8 | nanoid `<3.3.17` | High | Yes (`@sentry/vite-plugin` → webpack → postcss) | Override `postcss>nanoid` to `>=3.3.17 <4` (keeps direct nanoid 5.x) | Pass |
| GHSA-55q2-fjhq-7xh7 | dompurify `<=3.4.12` | Moderate | Yes (`streamdown` / `@streamdown/mermaid` → mermaid) | Override `dompurify` to `>=3.4.13` | Pass |

## Files Modified

- `pnpm-workspace.yaml`: added `dompurify` and `postcss>nanoid` overrides
- `pnpm-lock.yaml`: resolved `nanoid@3.3.18` and `dompurify@3.4.13`

## Verification

- `pnpm audit --prod --audit-level=moderate`: Pass
- `grype . --config .grype.yaml`: Pass