### PR TITLE
feat(playground): add optional Stacklok Gateway provider

### DIFF
--- a/main/src/app-events/block-quit.ts
+++ b/main/src/app-events/block-quit.ts
@@ -9,6 +9,7 @@ import {
   sendToMainWindowRenderer,
 } from '../main-window'
 import { stopToolhive, binPath } from '../toolhive-manager'
+import { stopOwnedProxy } from '../chat/providers/thv-llm'
 import { stopAllServers } from '../graceful-exit'
 import { createMainProcessFetch } from '../unix-socket-fetch'
 import { safeTrayDestroy } from '../system-tray'
@@ -46,6 +47,7 @@ export async function blockQuit(source: string, event?: Electron.Event) {
     log.error('Teardown failed: ', err)
   } finally {
     await shutdownChatRuntime()
+    stopOwnedProxy()
     // Stop the embedded ToolHive server
     stopToolhive()
 

--- a/main/src/app-events/process-exit.ts
+++ b/main/src/app-events/process-exit.ts
@@ -1,10 +1,12 @@
 import { stopToolhive } from '../toolhive-manager'
+import { stopOwnedProxy } from '../chat/providers/thv-llm'
 import log from '../logger'
 
 export function register() {
   process.on('exit', (code) => {
     // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
     log.info(`[process exit] code=${code}, ensuring ToolHive is stopped...`)
+    stopOwnedProxy()
     // Note: Only synchronous operations work here, so we force immediate SIGKILL
     stopToolhive({ force: true })
   })

--- a/main/src/app-events/process-signals.ts
+++ b/main/src/app-events/process-signals.ts
@@ -4,6 +4,7 @@ import {
   setQuittingState,
 } from '../app-state'
 import { stopToolhive, binPath } from '../toolhive-manager'
+import { stopOwnedProxy } from '../chat/providers/thv-llm'
 import { stopAllServers } from '../graceful-exit'
 import { createMainProcessFetch } from '../unix-socket-fetch'
 import { safeTrayDestroy } from '../system-tray'
@@ -20,6 +21,7 @@ export function register() {
       try {
         await stopAllServers(binPath, { createFetch: createMainProcessFetch })
       } finally {
+        stopOwnedProxy()
         stopToolhive()
         safeTrayDestroy()
         process.exit(0)

--- a/main/src/app-events/quit.ts
+++ b/main/src/app-events/quit.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron'
 import { getTearingDownState } from '../app-state'
 import { stopToolhive } from '../toolhive-manager'
+import { stopOwnedProxy } from '../chat/providers/thv-llm'
 import { safeTrayDestroy } from '../system-tray'
 import { closeDb } from '../db/database'
 import log from '../logger'
@@ -11,6 +12,7 @@ export function register() {
     log.info('[quit event] Ensuring ToolHive cleanup...')
     // Only cleanup if not already tearing down to avoid double cleanup
     if (!getTearingDownState()) {
+      stopOwnedProxy()
       stopToolhive()
       safeTrayDestroy()
     }

--- a/main/src/app-events/when-ready.ts
+++ b/main/src/app-events/when-ready.ts
@@ -13,6 +13,10 @@ import {
   isToolhiveRunning,
   stopToolhive,
 } from '../toolhive-manager'
+import {
+  startConfiguredLlmProxyIfNeeded,
+  stopOwnedProxy,
+} from '../chat/providers/thv-llm'
 import { registerApiFetchHandlers } from '../unix-socket-fetch'
 import { getMainWindow, createMainWindow, hideMainWindow } from '../main-window'
 import { extractDeepLinkFromArgs, handleDeepLink } from '../deep-links'
@@ -71,6 +75,8 @@ export function register() {
     // Start ToolHive with tray reference
     await startToolhive()
 
+    void startConfiguredLlmProxyIfNeeded()
+
     // Register IPC handlers for renderer -> main -> thv API bridge
     registerApiFetchHandlers()
 
@@ -110,6 +116,7 @@ export function register() {
             log.info(
               `[session-end] Windows session ending (reasons: ${event.reasons.join(', ')}), forcing cleanup...`
             )
+            stopOwnedProxy()
             stopToolhive()
             safeTrayDestroy()
           })

--- a/main/src/auto-update.ts
+++ b/main/src/auto-update.ts
@@ -3,6 +3,7 @@ import { updateElectronApp, UpdateSourceType } from 'update-electron-app'
 import * as Sentry from '@sentry/electron/main'
 import { stopAllServers } from './graceful-exit'
 import { stopToolhive, binPath, isToolhiveRunning } from './toolhive-manager'
+import { stopOwnedProxy } from './chat/providers/thv-llm'
 import { createMainProcessFetch } from './unix-socket-fetch'
 import { safeTrayDestroy } from './system-tray'
 import { getAppVersion, pollWindowReady } from './util'
@@ -449,6 +450,7 @@ async function performUpdateInstallation({
         }
 
         try {
+          stopOwnedProxy()
           stopToolhive()
           // eslint-disable-next-line no-restricted-syntax -- TODO: decide on branding in logs
           log.info('[update] ToolHive stopped')

--- a/main/src/chat/__tests__/enrich-gateway-request.test.ts
+++ b/main/src/chat/__tests__/enrich-gateway-request.test.ts
@@ -114,6 +114,26 @@ describe('enrichGatewayChatRequest', () => {
     ).resolves.toMatchObject({ endpointURL: LOOPBACK })
   })
 
+  it('throws when the loopback base URL cannot be resolved', async () => {
+    resolveGatewayBaseURLMock.mockResolvedValue(null)
+
+    await expect(
+      enrichGatewayChatRequest(gatewayRequest('enabled'))
+    ).rejects.toThrow('Stacklok Gateway is not configured')
+  })
+
+  it('uses a default warmup message when none is provided', async () => {
+    warmupGatewayAuthMock.mockResolvedValue({
+      ready: false,
+      authState: 'error',
+      modelCount: 0,
+    })
+
+    await expect(
+      enrichGatewayChatRequest(gatewayRequest('enabled'))
+    ).rejects.toThrow('Stacklok Gateway is not ready')
+  })
+
   it('propagates warmup failures', async () => {
     warmupGatewayAuthMock.mockResolvedValue({
       ready: false,

--- a/main/src/chat/__tests__/enrich-gateway-request.test.ts
+++ b/main/src/chat/__tests__/enrich-gateway-request.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { ChatRequest } from '../types'
+
+const {
+  ensureProxyStartedMock,
+  resolveGatewayBaseURLMock,
+  warmupGatewayAuthMock,
+} = vi.hoisted(() => ({
+  ensureProxyStartedMock: vi.fn(),
+  resolveGatewayBaseURLMock: vi.fn(),
+  warmupGatewayAuthMock: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => '/tmp'),
+  },
+}))
+
+vi.mock('../providers/thv-llm', () => ({
+  ensureProxyStarted: (...args: unknown[]) => ensureProxyStartedMock(...args),
+  resolveGatewayBaseURL: (...args: unknown[]) =>
+    resolveGatewayBaseURLMock(...args),
+  warmupGatewayAuth: (...args: unknown[]) => warmupGatewayAuthMock(...args),
+}))
+
+import { enrichGatewayChatRequest } from '../enrich-gateway-request'
+
+const LOOPBACK = 'http://127.0.0.1:14000/v1'
+
+function gatewayRequest(
+  endpointURL: string
+): Extract<ChatRequest, { provider: 'thv-llm' }> {
+  return {
+    chatId: 'chat-1',
+    messages: [],
+    model: 'gpt-4.1',
+    provider: 'thv-llm',
+    endpointURL,
+  }
+}
+
+describe('enrichGatewayChatRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ensureProxyStartedMock.mockResolvedValue({
+      started: true,
+      alreadyRunning: false,
+      studioOwnsProxy: true,
+    })
+    resolveGatewayBaseURLMock.mockResolvedValue(LOOPBACK)
+    warmupGatewayAuthMock.mockResolvedValue({
+      ready: true,
+      authState: 'ready',
+      modelCount: 1,
+    })
+  })
+
+  it('passes non-gateway requests through unchanged', async () => {
+    const request: ChatRequest = {
+      chatId: 'chat-1',
+      messages: [],
+      model: 'gpt-4o',
+      provider: 'openai',
+      apiKey: 'sk-test',
+    }
+
+    await expect(enrichGatewayChatRequest(request)).resolves.toBe(request)
+    expect(ensureProxyStartedMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves the Playground marker to the loopback proxy URL', async () => {
+    const enriched = await enrichGatewayChatRequest(gatewayRequest('enabled'))
+
+    expect(resolveGatewayBaseURLMock).toHaveBeenCalled()
+    expect(enriched).toMatchObject({
+      provider: 'thv-llm',
+      endpointURL: LOOPBACK,
+    })
+  })
+
+  it('keeps an explicit http endpoint URL', async () => {
+    const stored = 'http://127.0.0.1:15000/v1'
+    const enriched = await enrichGatewayChatRequest(gatewayRequest(stored))
+
+    expect(resolveGatewayBaseURLMock).not.toHaveBeenCalled()
+    expect(enriched).toMatchObject({ endpointURL: stored })
+  })
+
+  it('throws when the proxy fails to start', async () => {
+    ensureProxyStartedMock.mockResolvedValue({
+      started: false,
+      alreadyRunning: false,
+      studioOwnsProxy: false,
+      error: 'Stacklok Gateway is not configured',
+    })
+
+    await expect(
+      enrichGatewayChatRequest(gatewayRequest('enabled'))
+    ).rejects.toThrow('Stacklok Gateway is not configured')
+  })
+
+  it('does not throw on start error when the proxy is already running', async () => {
+    ensureProxyStartedMock.mockResolvedValue({
+      started: false,
+      alreadyRunning: true,
+      studioOwnsProxy: false,
+      error: 'LLM proxy did not become reachable in time',
+    })
+
+    await expect(
+      enrichGatewayChatRequest(gatewayRequest('enabled'))
+    ).resolves.toMatchObject({ endpointURL: LOOPBACK })
+  })
+
+  it('propagates warmup failures', async () => {
+    warmupGatewayAuthMock.mockResolvedValue({
+      ready: false,
+      authState: 'authenticating',
+      modelCount: 0,
+      error: 'Complete sign-in in your browser',
+    })
+
+    await expect(
+      enrichGatewayChatRequest(gatewayRequest('enabled'))
+    ).rejects.toThrow('Complete sign-in in your browser')
+  })
+})

--- a/main/src/chat/__tests__/generate-thread-title.test.ts
+++ b/main/src/chat/__tests__/generate-thread-title.test.ts
@@ -15,6 +15,7 @@ const mockReadThreadSelectedModel = vi.hoisted(() =>
   vi.fn<() => { provider: string; model: string } | null>(() => null)
 )
 const mockCreateModelFromRequest = vi.hoisted(() => vi.fn())
+const mockResolveGatewayBaseURL = vi.hoisted(() => vi.fn())
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -58,6 +59,10 @@ vi.mock('../../db/readers/chat-settings-reader', () => ({
 
 vi.mock('../utils', () => ({
   createModelFromRequest: mockCreateModelFromRequest,
+}))
+
+vi.mock('../providers/thv-llm/proxy-manager', () => ({
+  resolveGatewayBaseURL: mockResolveGatewayBaseURL,
 }))
 
 vi.mock('../constants', async (importOriginal) => importOriginal())
@@ -112,6 +117,7 @@ describe('generateThreadTitle', () => {
     })
     mockReadChatProvider.mockReturnValue({ apiKey: 'sk-test' })
     mockCreateModelFromRequest.mockReturnValue(fakeModel)
+    mockResolveGatewayBaseURL.mockResolvedValue('http://127.0.0.1:14000/v1')
     mockConvertToModelMessages.mockResolvedValue(fakeConvertedMessages)
     mockGenerateText.mockResolvedValue({ text: 'Great Title' })
   })
@@ -554,6 +560,44 @@ describe('generateThreadTitle', () => {
       expect(mockCreateModelFromRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ endpointURL: '' })
+      )
+    })
+  })
+
+  describe('gateway provider', () => {
+    it('fails before createModel when the loopback URL is missing', async () => {
+      mockReadSelectedModel.mockReturnValue({
+        provider: 'thv-llm',
+        model: 'gpt-4.1',
+      })
+      mockReadChatProvider.mockReturnValue({ endpointURL: 'enabled' })
+      mockResolveGatewayBaseURL.mockResolvedValue(null)
+
+      const result = await generateThreadTitle('thread-1')
+
+      expect(result).toMatchObject({
+        success: false,
+        error:
+          'Stacklok Gateway is not configured. Open Provider Settings and save your gateway connection.',
+      })
+      expect(mockCreateModelFromRequest).not.toHaveBeenCalled()
+      expect(mockGenerateText).not.toHaveBeenCalled()
+    })
+
+    it('passes the resolved loopback URL to createModel', async () => {
+      mockReadSelectedModel.mockReturnValue({
+        provider: 'thv-llm',
+        model: 'gpt-4.1',
+      })
+      mockReadChatProvider.mockReturnValue({ endpointURL: 'enabled' })
+
+      await generateThreadTitle('thread-1')
+
+      expect(mockCreateModelFromRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'thv-llm' }),
+        expect.objectContaining({
+          endpointURL: 'http://127.0.0.1:14000/v1',
+        })
       )
     })
   })

--- a/main/src/chat/__tests__/mcp-tools.test.ts
+++ b/main/src/chat/__tests__/mcp-tools.test.ts
@@ -862,13 +862,13 @@ describe('createMcpTools', () => {
     expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
   })
 
-  it('logs and skips servers whose workload is not found', async () => {
+  it('skips missing workloads and still allows chat with no MCP tools', async () => {
     mockGetApiV1BetaWorkloads.mockResolvedValue({ data: { workloads: [] } })
     mockReadEnabledMcpTools.mockReturnValue({ 'ghost-server': ['tool-x'] })
 
-    await expect(createMcpTools()).rejects.toThrow(
-      'No MCP tools are available from the enabled servers.'
-    )
+    const { tools } = await createMcpTools()
+
+    expect(tools).toEqual({})
     expect(log.debug).toHaveBeenCalledWith(
       'Skipping ghost-server: workload not found'
     )

--- a/main/src/chat/constants.ts
+++ b/main/src/chat/constants.ts
@@ -1,10 +1,27 @@
+import {
+  THV_LLM_PROVIDER_ID,
+  THV_LLM_PROVIDER_NAME,
+} from './providers/thv-llm/types'
+
 // Default endpoint URLs for local server providers
 export const DEFAULT_OLLAMA_URL = 'http://localhost:11434'
 export const DEFAULT_LMSTUDIO_URL = 'http://localhost:1234'
 
-// Local server provider IDs
+// Local server provider IDs (user-configured endpoint URL)
 export const LOCAL_PROVIDER_IDS = ['ollama', 'lmstudio'] as const
 export type LocalProviderId = (typeof LOCAL_PROVIDER_IDS)[number]
+
+// Optional gateway provider (loopback proxy; enabled from Provider Settings)
+export const GATEWAY_PROVIDER_IDS = [THV_LLM_PROVIDER_ID] as const
+export type GatewayProviderId = (typeof GATEWAY_PROVIDER_IDS)[number]
+
+export const ENDPOINT_PROVIDER_IDS = [
+  ...LOCAL_PROVIDER_IDS,
+  ...GATEWAY_PROVIDER_IDS,
+] as const
+export type EndpointProviderId = (typeof ENDPOINT_PROVIDER_IDS)[number]
+
+export { THV_LLM_PROVIDER_ID, THV_LLM_PROVIDER_NAME }
 
 // Provider configuration for IPC (serializable)
 export interface ChatProviderInfo {
@@ -184,6 +201,11 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
     id: 'lmstudio',
     name: 'LM Studio',
     models: [], // Models will be dynamically fetched from LM Studio API
+  },
+  {
+    id: THV_LLM_PROVIDER_ID,
+    name: THV_LLM_PROVIDER_NAME,
+    models: [],
   },
   {
     id: 'openrouter',

--- a/main/src/chat/enrich-gateway-request.ts
+++ b/main/src/chat/enrich-gateway-request.ts
@@ -1,0 +1,49 @@
+import type { ChatRequest } from './types'
+import { THV_LLM_PROVIDER_ID } from './constants'
+import {
+  ensureProxyStarted,
+  resolveGatewayBaseURL,
+  warmupGatewayAuth,
+} from './providers/thv-llm'
+
+export async function enrichGatewayChatRequest(
+  request: ChatRequest
+): Promise<ChatRequest> {
+  if (request.provider !== THV_LLM_PROVIDER_ID) {
+    return request
+  }
+
+  const gatewayRequest = request as Extract<
+    ChatRequest,
+    { provider: typeof THV_LLM_PROVIDER_ID }
+  >
+
+  const ensure = await ensureProxyStarted()
+  if (ensure.error && !ensure.alreadyRunning && !ensure.started) {
+    throw new Error(ensure.error)
+  }
+
+  const storedEndpoint = gatewayRequest.endpointURL?.trim()
+  const baseURL =
+    storedEndpoint && /^https?:\/\//i.test(storedEndpoint)
+      ? storedEndpoint
+      : await resolveGatewayBaseURL()
+  if (!baseURL) {
+    throw new Error(
+      'Stacklok Gateway is not configured. Open Provider Settings and save your gateway connection.'
+    )
+  }
+
+  const warmup = await warmupGatewayAuth()
+  if (!warmup.ready) {
+    throw new Error(
+      warmup.error ??
+        'Stacklok Gateway is not ready. Complete sign-in in your browser.'
+    )
+  }
+
+  return {
+    ...gatewayRequest,
+    endpointURL: baseURL,
+  }
+}

--- a/main/src/chat/mcp-tools.ts
+++ b/main/src/chat/mcp-tools.ts
@@ -35,6 +35,7 @@ export async function createMcpTools(
   return runChatPromiseOr(McpService.createMcpTools(threadId, options), {
     tools: {},
     enabledTools: {},
+    enabledServersWithWorkload: 0,
     close: async () => undefined,
   })
 }

--- a/main/src/chat/mcp/mcp-service-impl.ts
+++ b/main/src/chat/mcp/mcp-service-impl.ts
@@ -35,6 +35,9 @@ interface UiResourceMetadata {
 export interface McpToolSession {
   tools: ToolSet
   enabledTools: Record<string, string[]>
+  /** Enabled servers whose workloads were actually found. Missing/stopped
+   * servers do not count — chat should still work without MCP. */
+  enabledServersWithWorkload: number
   close: () => Promise<void>
 }
 
@@ -375,6 +378,7 @@ export async function createMcpTools(
   const mcpTools: ToolSet = {}
   const closeByServer = new Map<string, () => Promise<void>>()
   let enabledTools: Record<string, string[]> = {}
+  let enabledServersWithWorkload = 0
   const nextCachedUiMetadata: Record<string, ToolUiMetadataEntry> = {}
   let discoverySucceeded = false
 
@@ -409,6 +413,7 @@ export async function createMcpTools(
           log.debug(`Skipping ${serverName}: workload not found`)
           return Promise.resolve(null)
         }
+        enabledServersWithWorkload += 1
         return discoverToolsForServer({
           serverName,
           toolNames,
@@ -457,5 +462,5 @@ export async function createMcpTools(
     }
   }
 
-  return { tools: mcpTools, enabledTools, close }
+  return { tools: mcpTools, enabledTools, enabledServersWithWorkload, close }
 }

--- a/main/src/chat/mcp/mcp-service.ts
+++ b/main/src/chat/mcp/mcp-service.ts
@@ -103,12 +103,8 @@ export class McpService extends Effect.Service<McpService>()(
                 }),
             })
 
-            const hasEnabledServers = Object.values(result.enabledTools).some(
-              (tools) => tools.length > 0
-            )
-
             if (
-              hasEnabledServers &&
+              result.enabledServersWithWorkload > 0 &&
               Object.keys(result.tools as ToolSet).length === 0
             ) {
               return yield* Effect.fail(

--- a/main/src/chat/providers/__tests__/providers-catalog.test.ts
+++ b/main/src/chat/providers/__tests__/providers-catalog.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { responsesMock, chatMock, anthropicMock, googleMock } = vi.hoisted(
+  () => ({
+    responsesMock: vi.fn((modelId: string) => ({ modelId, mode: 'responses' })),
+    chatMock: vi.fn((modelId: string) => ({ modelId, mode: 'chat' })),
+    anthropicMock: vi.fn((modelId: string) => ({ modelId, mode: 'anthropic' })),
+    googleMock: vi.fn((modelId: string) => ({ modelId, mode: 'google' })),
+  })
+)
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => '/tmp'),
+  },
+}))
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => ({
+    responses: responsesMock,
+    chat: chatMock,
+  })),
+}))
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: vi.fn(() => anthropicMock),
+}))
+
+vi.mock('@ai-sdk/google', () => ({
+  createGoogle: vi.fn(() => googleMock),
+}))
+
+vi.mock('../thv-llm', () => ({
+  THV_LLM_PROVIDER_ID: 'thv-llm',
+  THV_LLM_PROXY_API_KEY: 'thv-proxy',
+  assertLoopbackBaseURL: vi.fn(),
+  gatewayFetch: vi.fn(),
+  isClaudeGatewayModel: (modelId: string) => {
+    const id = modelId.trim().toLowerCase()
+    return id.includes('claude') || id.startsWith('anthropic.')
+  },
+  isGeminiGatewayModel: (modelId: string) => {
+    const id = modelId.trim().toLowerCase()
+    return id.includes('gemini') || id.startsWith('google.')
+  },
+  anthropicBaseURLFromGatewayEndpoint: (endpointURL: string) => {
+    const parsed = new URL(endpointURL)
+    return `${parsed.protocol}//${parsed.host}/anthropic/v1`
+  },
+  googleBaseURLFromGatewayEndpoint: (endpointURL: string) => {
+    const parsed = new URL(endpointURL)
+    return `${parsed.protocol}//${parsed.host}/v1beta`
+  },
+}))
+
+describe('ToolHive LLM gateway provider catalog', () => {
+  it('uses OpenAI Chat Completions for GPT models', async () => {
+    const { CHAT_PROVIDERS } = await import('../providers-catalog')
+    const gateway = CHAT_PROVIDERS.find((provider) => provider.id === 'thv-llm')
+    expect(gateway).toBeDefined()
+
+    chatMock.mockClear()
+    anthropicMock.mockClear()
+    googleMock.mockClear()
+
+    const model = gateway!.createModel('gpt-4.1', 'http://127.0.0.1:14000/v1')
+
+    expect(chatMock).toHaveBeenCalledWith('gpt-4.1')
+    expect(anthropicMock).not.toHaveBeenCalled()
+    expect(googleMock).not.toHaveBeenCalled()
+    expect(model).toEqual({ modelId: 'gpt-4.1', mode: 'chat' })
+  })
+
+  it('uses Anthropic Messages for Claude models', async () => {
+    const { CHAT_PROVIDERS } = await import('../providers-catalog')
+    const gateway = CHAT_PROVIDERS.find((provider) => provider.id === 'thv-llm')
+    expect(gateway).toBeDefined()
+
+    chatMock.mockClear()
+    anthropicMock.mockClear()
+    googleMock.mockClear()
+
+    const model = gateway!.createModel(
+      'claude-sonnet-5',
+      'http://127.0.0.1:14000/v1'
+    )
+
+    expect(anthropicMock).toHaveBeenCalledWith('claude-sonnet-5')
+    expect(chatMock).not.toHaveBeenCalled()
+    expect(googleMock).not.toHaveBeenCalled()
+    expect(model).toEqual({ modelId: 'claude-sonnet-5', mode: 'anthropic' })
+  })
+
+  it('uses Google generateContent for Gemini models', async () => {
+    const { CHAT_PROVIDERS } = await import('../providers-catalog')
+    const gateway = CHAT_PROVIDERS.find((provider) => provider.id === 'thv-llm')
+    expect(gateway).toBeDefined()
+
+    chatMock.mockClear()
+    anthropicMock.mockClear()
+    googleMock.mockClear()
+
+    const model = gateway!.createModel(
+      'gemini-2.5-flash',
+      'http://127.0.0.1:14000/v1'
+    )
+
+    expect(googleMock).toHaveBeenCalledWith('gemini-2.5-flash')
+    expect(chatMock).not.toHaveBeenCalled()
+    expect(anthropicMock).not.toHaveBeenCalled()
+    expect(model).toEqual({ modelId: 'gemini-2.5-flash', mode: 'google' })
+  })
+})

--- a/main/src/chat/providers/__tests__/providers-catalog.test.ts
+++ b/main/src/chat/providers/__tests__/providers-catalog.test.ts
@@ -36,6 +36,7 @@ vi.mock('../thv-llm', () => ({
   THV_LLM_PROXY_API_KEY: 'thv-proxy',
   assertLoopbackBaseURL: vi.fn(),
   gatewayFetch: vi.fn(),
+  gatewayFetchFromInput: vi.fn(),
   isClaudeGatewayModel: (modelId: string) => {
     const id = modelId.trim().toLowerCase()
     return id.includes('claude') || id.startsWith('anthropic.')

--- a/main/src/chat/providers/__tests__/providers-service.test.ts
+++ b/main/src/chat/providers/__tests__/providers-service.test.ts
@@ -92,19 +92,20 @@ const configuredLlm = {
 
 function settingsLayer(playgroundEnabled: boolean) {
   return Layer.mock(SettingsService, {
-    getChatSettings: (providerId: string) => {
+    _tag: 'chat/SettingsService',
+    getChatSettings: (providerId) => {
       if (providerId === 'thv-llm') {
         return Effect.succeed({
-          providerId: 'thv-llm' as const,
+          providerId: 'thv-llm',
           endpointURL: playgroundEnabled ? 'enabled' : '',
-          enabledTools: [],
+          enabledTools: [] as string[],
         })
       }
       if (providerId === 'ollama' || providerId === 'lmstudio') {
         return Effect.succeed({
           providerId,
           endpointURL: '',
-          enabledTools: [],
+          enabledTools: [] as string[],
         })
       }
       return Effect.succeed({

--- a/main/src/chat/providers/__tests__/providers-service.test.ts
+++ b/main/src/chat/providers/__tests__/providers-service.test.ts
@@ -1,0 +1,234 @@
+import { Effect, Layer } from 'effect'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const {
+  fetchGatewayModelsMock,
+  invalidateLlmConfigCacheMock,
+  readLlmConfigMock,
+  resolveGatewayBaseURLMock,
+} = vi.hoisted(() => ({
+  fetchGatewayModelsMock: vi.fn(),
+  invalidateLlmConfigCacheMock: vi.fn(),
+  readLlmConfigMock: vi.fn(),
+  resolveGatewayBaseURLMock: vi.fn(),
+}))
+
+let lastKnownModels: string[] = []
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => '/tmp'),
+    getName: vi.fn(() => 'ToolHive Studio'),
+    on: vi.fn(),
+    once: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+    on: vi.fn(),
+  },
+  webContents: {
+    getAllWebContents: vi.fn(() => []),
+  },
+}))
+
+vi.mock('@sentry/electron/main', () => ({
+  startSpanManual: vi.fn(),
+  startSpan: vi.fn(),
+  addBreadcrumb: vi.fn(),
+  withScope: vi.fn(),
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}))
+
+vi.mock('../../../logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../../../toolhive-manager', () => ({
+  isToolhiveRunning: vi.fn(() => false),
+  binPath: '/tmp/thv',
+}))
+
+vi.mock('../../../unix-socket-fetch', () => ({
+  createMainProcessApiClient: vi.fn(),
+  createMainProcessFetch: vi.fn(),
+}))
+
+vi.mock('../thv-llm', () => ({
+  fetchGatewayModels: (...args: unknown[]) => fetchGatewayModelsMock(...args),
+  getLastKnownGatewayModels: () => lastKnownModels,
+  invalidateLlmConfigCache: (...args: unknown[]) =>
+    invalidateLlmConfigCacheMock(...args),
+  isLlmConfigured: (
+    config: {
+      gateway_url?: string
+      oidc?: { issuer?: string; client_id?: string }
+    } | null
+  ) =>
+    Boolean(
+      config?.gateway_url?.trim() &&
+      config?.oidc?.issuer?.trim() &&
+      config?.oidc?.client_id?.trim()
+    ),
+  readLlmConfig: (...args: unknown[]) => readLlmConfigMock(...args),
+  resolveGatewayBaseURL: (...args: unknown[]) =>
+    resolveGatewayBaseURLMock(...args),
+}))
+
+import { SettingsService } from '../../settings/settings-service'
+import { ProvidersService } from '../providers-service'
+
+const configuredLlm = {
+  gateway_url: 'https://gateway.example.com',
+  oidc: { issuer: 'https://issuer.example.com', client_id: 'client' },
+  proxy: { listen_port: 14000 },
+}
+
+function settingsLayer(playgroundEnabled: boolean) {
+  return Layer.mock(SettingsService, {
+    getChatSettings: (providerId: string) => {
+      if (providerId === 'thv-llm') {
+        return Effect.succeed({
+          providerId: 'thv-llm' as const,
+          endpointURL: playgroundEnabled ? 'enabled' : '',
+          enabledTools: [],
+        })
+      }
+      if (providerId === 'ollama' || providerId === 'lmstudio') {
+        return Effect.succeed({
+          providerId,
+          endpointURL: '',
+          enabledTools: [],
+        })
+      }
+      return Effect.succeed({
+        providerId,
+        apiKey: '',
+        enabledTools: [],
+      })
+    },
+  })
+}
+
+function runWithSettings<A, E>(
+  effect: Effect.Effect<A, E, ProvidersService>,
+  playgroundEnabled = true
+) {
+  const layer = ProvidersService.DefaultWithoutDependencies.pipe(
+    Layer.provide(settingsLayer(playgroundEnabled))
+  )
+  return Effect.runPromise(effect.pipe(Effect.provide(layer)))
+}
+
+describe('ProvidersService gateway models', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    lastKnownModels = []
+    readLlmConfigMock.mockResolvedValue(configuredLlm)
+    resolveGatewayBaseURLMock.mockResolvedValue('http://127.0.0.1:14000/v1')
+    fetchGatewayModelsMock.mockResolvedValue({
+      models: ['gpt-4.1'],
+      authRequired: false,
+    })
+  })
+
+  it('lists Stacklok Gateway models from the loopback URL', async () => {
+    const result = await runWithSettings(
+      ProvidersService.fetchProviderModels('thv-llm')
+    )
+
+    expect(invalidateLlmConfigCacheMock).toHaveBeenCalled()
+    expect(resolveGatewayBaseURLMock).toHaveBeenCalled()
+    expect(fetchGatewayModelsMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:14000/v1'
+    )
+    expect(result).toEqual({
+      id: 'thv-llm',
+      name: 'Stacklok Gateway',
+      models: ['gpt-4.1'],
+    })
+  })
+
+  it('prefers an explicit credential URL over resolved loopback', async () => {
+    const result = await runWithSettings(
+      ProvidersService.fetchProviderModels(
+        'thv-llm',
+        'http://127.0.0.1:15000/v1'
+      )
+    )
+
+    expect(resolveGatewayBaseURLMock).not.toHaveBeenCalled()
+    expect(fetchGatewayModelsMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:15000/v1'
+    )
+    expect(result?.models).toEqual(['gpt-4.1'])
+  })
+
+  it('falls back to cached models when listing requires sign-in', async () => {
+    lastKnownModels = ['cached-model']
+    fetchGatewayModelsMock.mockResolvedValue({
+      models: [],
+      authRequired: true,
+    })
+
+    const result = await runWithSettings(
+      ProvidersService.fetchProviderModels('thv-llm')
+    )
+
+    expect(result?.models).toEqual(['cached-model'])
+  })
+
+  it('falls back to cached models when listing fails', async () => {
+    lastKnownModels = ['cached-model']
+    fetchGatewayModelsMock.mockResolvedValue({
+      models: [],
+      authRequired: false,
+      error: 'Gateway model list failed: 503',
+    })
+
+    const result = await runWithSettings(
+      ProvidersService.fetchProviderModels('thv-llm')
+    )
+
+    expect(result?.models).toEqual(['cached-model'])
+  })
+
+  it('uses cached models when no gateway base URL is available', async () => {
+    lastKnownModels = ['cached-model']
+    resolveGatewayBaseURLMock.mockResolvedValue(null)
+
+    const result = await runWithSettings(
+      ProvidersService.fetchProviderModels('thv-llm')
+    )
+
+    expect(fetchGatewayModelsMock).not.toHaveBeenCalled()
+    expect(result?.models).toEqual(['cached-model'])
+  })
+
+  it('includes live gateway models in getAllProviders when Playground is enabled', async () => {
+    const providers = await runWithSettings(ProvidersService.getAllProviders())
+    const gateway = providers.find((provider) => provider.id === 'thv-llm')
+
+    expect(fetchGatewayModelsMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:14000/v1'
+    )
+    expect(gateway?.models).toEqual(['gpt-4.1'])
+  })
+
+  it('does not fetch gateway models when Playground has not opted in', async () => {
+    const providers = await runWithSettings(
+      ProvidersService.getAllProviders(),
+      false
+    )
+    const gateway = providers.find((provider) => provider.id === 'thv-llm')
+
+    expect(fetchGatewayModelsMock).not.toHaveBeenCalled()
+    expect(gateway?.models).toEqual([])
+  })
+})

--- a/main/src/chat/providers/providers-catalog.ts
+++ b/main/src/chat/providers/providers-catalog.ts
@@ -10,8 +10,24 @@ import {
   CHAT_PROVIDER_INFO,
   DEFAULT_OLLAMA_URL,
   DEFAULT_LMSTUDIO_URL,
+  THV_LLM_PROVIDER_ID,
+  THV_LLM_PROVIDER_NAME,
 } from '../constants'
 import type { ChatProvider } from '../types'
+import {
+  THV_LLM_PROXY_API_KEY,
+  assertLoopbackBaseURL,
+  anthropicBaseURLFromGatewayEndpoint,
+  googleBaseURLFromGatewayEndpoint,
+  gatewayFetch,
+  isClaudeGatewayModel,
+  isGeminiGatewayModel,
+} from './thv-llm'
+
+function createGatewayFetch(): typeof fetch {
+  return (input, init) =>
+    gatewayFetch(typeof input === 'string' ? input : input.toString(), init)
+}
 
 export const CHAT_PROVIDERS: ChatProvider[] = [
   {
@@ -120,6 +136,65 @@ export const CHAT_PROVIDERS: ChatProvider[] = [
 
       const openrouter = createOpenRouter({ apiKey })
       return openrouter(modelId)
+    },
+  },
+  {
+    id: THV_LLM_PROVIDER_ID,
+    name: THV_LLM_PROVIDER_NAME,
+    models:
+      CHAT_PROVIDER_INFO.find((p) => p.id === THV_LLM_PROVIDER_ID)?.models ||
+      [],
+    createModel: (modelId: string, endpointURL: string) => {
+      assertLoopbackBaseURL(endpointURL)
+
+      // The proxy is transparent: it injects a JWT and forwards path+body.
+      // Match official clients — Claude Code uses Anthropic Messages
+      // (`/anthropic/v1/messages`); Gemini CLI uses Google generateContent
+      // (`/v1beta/models/{id}:generateContent`). GPT stays on OpenAI
+      // Chat Completions (`/v1/chat/completions`).
+      if (isClaudeGatewayModel(modelId)) {
+        const anthropicBaseURL =
+          anthropicBaseURLFromGatewayEndpoint(endpointURL)
+        assertLoopbackBaseURL(anthropicBaseURL)
+
+        log.info(
+          `[CHAT] Creating Stacklok Gateway Anthropic model: ${modelId} with baseURL: ${anthropicBaseURL}`
+        )
+
+        const anthropic = createAnthropic({
+          baseURL: anthropicBaseURL,
+          apiKey: THV_LLM_PROXY_API_KEY,
+          fetch: createGatewayFetch(),
+        })
+        return anthropic(modelId)
+      }
+
+      if (isGeminiGatewayModel(modelId)) {
+        const googleBaseURL = googleBaseURLFromGatewayEndpoint(endpointURL)
+        assertLoopbackBaseURL(googleBaseURL)
+
+        log.info(
+          `[CHAT] Creating Stacklok Gateway Google model: ${modelId} with baseURL: ${googleBaseURL}`
+        )
+
+        const google = createGoogle({
+          baseURL: googleBaseURL,
+          apiKey: THV_LLM_PROXY_API_KEY,
+          fetch: createGatewayFetch(),
+        })
+        return google(modelId)
+      }
+
+      log.info(
+        `[CHAT] Creating Stacklok Gateway model: ${modelId} with baseURL: ${endpointURL}`
+      )
+
+      const openai = createOpenAI({
+        baseURL: endpointURL,
+        apiKey: THV_LLM_PROXY_API_KEY,
+        fetch: createGatewayFetch(),
+      })
+      return openai.chat(modelId)
     },
   },
 ]

--- a/main/src/chat/providers/providers-catalog.ts
+++ b/main/src/chat/providers/providers-catalog.ts
@@ -19,14 +19,13 @@ import {
   assertLoopbackBaseURL,
   anthropicBaseURLFromGatewayEndpoint,
   googleBaseURLFromGatewayEndpoint,
-  gatewayFetch,
+  gatewayFetchFromInput,
   isClaudeGatewayModel,
   isGeminiGatewayModel,
 } from './thv-llm'
 
 function createGatewayFetch(): typeof fetch {
-  return (input, init) =>
-    gatewayFetch(typeof input === 'string' ? input : input.toString(), init)
+  return (input, init) => gatewayFetchFromInput(input, init)
 }
 
 export const CHAT_PROVIDERS: ChatProvider[] = [

--- a/main/src/chat/providers/providers-facade.ts
+++ b/main/src/chat/providers/providers-facade.ts
@@ -1,4 +1,5 @@
 import { runChatPromiseOr } from '../runtime'
+import log from '../../logger'
 import { ProvidersService } from './providers-service'
 import { CHAT_PROVIDER_INFO } from '../constants'
 
@@ -31,7 +32,21 @@ export async function fetchProviderModelsHandler(
 export async function getAllProvidersHandler(): Promise<
   Array<{ id: string; name: string; models: string[] }>
 > {
-  // Empty fallback when unavailable — do not return the static catalog, which
-  // would look like live providers during an outage.
-  return runChatPromiseOr(ProvidersService.getAllProviders(), [])
+  try {
+    const providers = await runChatPromiseOr(
+      ProvidersService.getAllProviders(),
+      []
+    )
+    return providers
+  } catch (error) {
+    log.error(
+      '[chat] getAllProviders failed, returning static provider catalog:',
+      error
+    )
+    return CHAT_PROVIDER_INFO.map((provider) => ({
+      id: provider.id,
+      name: provider.name,
+      models: [...provider.models],
+    }))
+  }
 }

--- a/main/src/chat/providers/providers-facade.ts
+++ b/main/src/chat/providers/providers-facade.ts
@@ -1,5 +1,4 @@
 import { runChatPromiseOr } from '../runtime'
-import log from '../../logger'
 import { ProvidersService } from './providers-service'
 import { CHAT_PROVIDER_INFO } from '../constants'
 
@@ -32,21 +31,7 @@ export async function fetchProviderModelsHandler(
 export async function getAllProvidersHandler(): Promise<
   Array<{ id: string; name: string; models: string[] }>
 > {
-  try {
-    const providers = await runChatPromiseOr(
-      ProvidersService.getAllProviders(),
-      []
-    )
-    return providers
-  } catch (error) {
-    log.error(
-      '[chat] getAllProviders failed, returning static provider catalog:',
-      error
-    )
-    return CHAT_PROVIDER_INFO.map((provider) => ({
-      id: provider.id,
-      name: provider.name,
-      models: [...provider.models],
-    }))
-  }
+  // Empty fallback when unavailable — do not return the static catalog, which
+  // would look like live providers during an outage.
+  return runChatPromiseOr(ProvidersService.getAllProviders(), [])
 }

--- a/main/src/chat/providers/providers-service.ts
+++ b/main/src/chat/providers/providers-service.ts
@@ -4,9 +4,18 @@ import {
   CHAT_PROVIDER_INFO,
   DEFAULT_LMSTUDIO_URL,
   DEFAULT_OLLAMA_URL,
+  THV_LLM_PROVIDER_ID,
+  THV_LLM_PROVIDER_NAME,
 } from '../constants'
 import { ProviderError } from '../runtime/errors'
 import { SettingsService } from '../settings/settings-service'
+import {
+  fetchGatewayModels,
+  getLastKnownGatewayModels,
+  isLlmConfigured,
+  readLlmConfig,
+  resolveGatewayBaseURL,
+} from './thv-llm'
 
 async function fetchOllamaModels(baseURL?: string): Promise<string[]> {
   if (!baseURL || !baseURL.trim()) return []
@@ -34,6 +43,30 @@ async function fetchLMStudioModels(baseURL?: string): Promise<string[]> {
   return data.models
     .filter((model) => model.type === 'llm' || model.type === 'vlm')
     .map((model) => model.key)
+}
+
+async function fetchThvLlmModels(baseURL?: string): Promise<string[]> {
+  if (!baseURL?.trim()) {
+    return [...getLastKnownGatewayModels()]
+  }
+
+  const result = await fetchGatewayModels(baseURL)
+  if (result.models.length > 0) {
+    return result.models
+  }
+
+  if (result.authRequired) {
+    log.debug(
+      '[thv-llm] model list requires authentication; using cached models if any'
+    )
+    return [...getLastKnownGatewayModels()]
+  }
+
+  if (result.error) {
+    log.debug('[thv-llm] model list failed:', result.error)
+  }
+
+  return [...getLastKnownGatewayModels()]
 }
 
 async function fetchOpenRouterModels(): Promise<string[]> {
@@ -95,6 +128,18 @@ export class ProvidersService extends Effect.Service<ProvidersService>()(
                     : DEFAULT_LMSTUDIO_URL
                 const models = await fetchLMStudioModels(baseURL)
                 return { id: 'lmstudio', name: 'LM Studio', models }
+              }
+              if (providerId === THV_LLM_PROVIDER_ID) {
+                const baseURL =
+                  tempCredential?.trim() ||
+                  (await resolveGatewayBaseURL()) ||
+                  ''
+                const models = await fetchThvLlmModels(baseURL)
+                return {
+                  id: THV_LLM_PROVIDER_ID,
+                  name: THV_LLM_PROVIDER_NAME,
+                  models,
+                }
               }
               return null
             },
@@ -203,6 +248,56 @@ export class ProvidersService extends Effect.Service<ProvidersService>()(
                     'Failed to fetch OpenRouter models, using fallback:',
                     error
                   )
+                }
+              }
+            }
+
+            const llmConfig = yield* Effect.tryPromise({
+              try: () => readLlmConfig(),
+              catch: (cause) => cause,
+            }).pipe(Effect.catchAll(() => Effect.succeed(null)))
+
+            const gatewaySettings =
+              yield* settings.getChatSettings(THV_LLM_PROVIDER_ID)
+            const playgroundEnabled = Boolean(
+              'endpointURL' in gatewaySettings &&
+              gatewaySettings.endpointURL.trim()
+            )
+
+            const thvLlmIndex = providers.findIndex(
+              (p) => p.id === THV_LLM_PROVIDER_ID
+            )
+            if (
+              thvLlmIndex !== -1 &&
+              playgroundEnabled &&
+              isLlmConfigured(llmConfig)
+            ) {
+              const baseURL = yield* Effect.tryPromise({
+                try: () => resolveGatewayBaseURL(),
+                catch: (cause) => cause,
+              }).pipe(Effect.catchAll(() => Effect.succeed('')))
+
+              const gatewayModels = baseURL
+                ? yield* Effect.tryPromise({
+                    try: () => fetchThvLlmModels(baseURL),
+                    catch: (cause) => cause,
+                  }).pipe(
+                    Effect.catchAll((error) => {
+                      log.error(
+                        'Failed to fetch Stacklok Gateway models:',
+                        error
+                      )
+                      return Effect.succeed([...getLastKnownGatewayModels()])
+                    })
+                  )
+                : [...getLastKnownGatewayModels()]
+
+              const original = providers[thvLlmIndex]
+              if (original) {
+                providers[thvLlmIndex] = {
+                  id: original.id,
+                  name: original.name,
+                  models: gatewayModels,
                 }
               }
             }

--- a/main/src/chat/providers/providers-service.ts
+++ b/main/src/chat/providers/providers-service.ts
@@ -12,10 +12,12 @@ import { SettingsService } from '../settings/settings-service'
 import {
   fetchGatewayModels,
   getLastKnownGatewayModels,
+  invalidateLlmConfigCache,
   isLlmConfigured,
   readLlmConfig,
   resolveGatewayBaseURL,
 } from './thv-llm'
+import { buildLoopbackBaseURL, effectiveListenPort } from './thv-llm/url'
 
 async function fetchOllamaModels(baseURL?: string): Promise<string[]> {
   if (!baseURL || !baseURL.trim()) return []
@@ -130,6 +132,7 @@ export class ProvidersService extends Effect.Service<ProvidersService>()(
                 return { id: 'lmstudio', name: 'LM Studio', models }
               }
               if (providerId === THV_LLM_PROVIDER_ID) {
+                invalidateLlmConfigCache()
                 const baseURL =
                   tempCredential?.trim() ||
                   (await resolveGatewayBaseURL()) ||
@@ -272,10 +275,9 @@ export class ProvidersService extends Effect.Service<ProvidersService>()(
               playgroundEnabled &&
               isLlmConfigured(llmConfig)
             ) {
-              const baseURL = yield* Effect.tryPromise({
-                try: () => resolveGatewayBaseURL(),
-                catch: (cause) => cause,
-              }).pipe(Effect.catchAll(() => Effect.succeed('')))
+              const baseURL = buildLoopbackBaseURL(
+                effectiveListenPort(llmConfig)
+              )
 
               const gatewayModels = baseURL
                 ? yield* Effect.tryPromise({

--- a/main/src/chat/providers/thv-llm/__tests__/fetch.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/fetch.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { isAuthenticationRequiredResponse } from '../fetch'
+import {
+  isAuthenticationRequiredResponse,
+  resolveGatewayFetchInput,
+} from '../fetch'
 
 describe('isAuthenticationRequiredResponse', () => {
   it('returns false for non-401 responses', () => {
@@ -24,5 +27,47 @@ describe('isAuthenticationRequiredResponse', () => {
         'Authentication required'
       )
     ).toBe(true)
+  })
+})
+
+describe('resolveGatewayFetchInput', () => {
+  it('passes string URLs through', () => {
+    expect(
+      resolveGatewayFetchInput('http://127.0.0.1:14000/v1/chat/completions')
+    ).toEqual({
+      url: 'http://127.0.0.1:14000/v1/chat/completions',
+      init: undefined,
+    })
+  })
+
+  it('uses href for URL objects', () => {
+    expect(
+      resolveGatewayFetchInput(new URL('http://127.0.0.1:14000/v1/models'))
+    ).toEqual({
+      url: 'http://127.0.0.1:14000/v1/models',
+      init: undefined,
+    })
+  })
+
+  it('reads url and request fields from a Request object', () => {
+    const request = new Request('http://127.0.0.1:14000/v1/messages', {
+      method: 'POST',
+      headers: { 'x-test': '1' },
+      body: '{"ok":true}',
+    })
+    const resolved = resolveGatewayFetchInput(request)
+
+    expect(resolved.url).toBe('http://127.0.0.1:14000/v1/messages')
+    expect(resolved.init?.method).toBe('POST')
+    expect(resolved.url).not.toBe('[object Request]')
+  })
+
+  it('lets init override Request fields', () => {
+    const request = new Request('http://127.0.0.1:14000/v1/messages', {
+      method: 'POST',
+    })
+    const resolved = resolveGatewayFetchInput(request, { method: 'GET' })
+
+    expect(resolved.init?.method).toBe('GET')
   })
 })

--- a/main/src/chat/providers/thv-llm/__tests__/fetch.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/fetch.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isAuthenticationRequiredResponse } from '../fetch'
+
+describe('isAuthenticationRequiredResponse', () => {
+  it('returns false for non-401 responses', () => {
+    expect(
+      isAuthenticationRequiredResponse(new Response('', { status: 200 }), '{}')
+    ).toBe(false)
+  })
+
+  it('returns true for 401 with authentication_required error', () => {
+    expect(
+      isAuthenticationRequiredResponse(
+        new Response('', { status: 401 }),
+        JSON.stringify({ error: 'authentication_required' })
+      )
+    ).toBe(true)
+  })
+
+  it('returns true for 401 with authentication text in body', () => {
+    expect(
+      isAuthenticationRequiredResponse(
+        new Response('', { status: 401 }),
+        'Authentication required'
+      )
+    ).toBe(true)
+  })
+})

--- a/main/src/chat/providers/thv-llm/__tests__/fetch.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/fetch.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, afterEach } from 'vitest'
 import {
+  gatewayFetch,
+  gatewayFetchFromInput,
   isAuthenticationRequiredResponse,
   resolveGatewayFetchInput,
 } from '../fetch'
@@ -27,6 +29,75 @@ describe('isAuthenticationRequiredResponse', () => {
         'Authentication required'
       )
     ).toBe(true)
+  })
+
+  it('treats a 401 with no body as authentication required', () => {
+    expect(
+      isAuthenticationRequiredResponse(new Response('', { status: 401 }))
+    ).toBe(true)
+  })
+
+  it('returns false for 401 JSON that is not an auth challenge', () => {
+    expect(
+      isAuthenticationRequiredResponse(
+        new Response('', { status: 401 }),
+        JSON.stringify({ error: 'quota_exceeded' })
+      )
+    ).toBe(false)
+  })
+
+  it('falls back to a text match when the 401 body is not JSON', () => {
+    expect(
+      isAuthenticationRequiredResponse(
+        new Response('', { status: 401 }),
+        'not-json'
+      )
+    ).toBe(false)
+  })
+})
+
+describe('gatewayFetch', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('refuses redirects on loopback requests', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await gatewayFetch('http://127.0.0.1:14000/v1/models', {
+      headers: { Authorization: 'Bearer thv-proxy' },
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:14000/v1/models',
+      expect.objectContaining({
+        redirect: 'manual',
+        headers: { Authorization: 'Bearer thv-proxy' },
+      })
+    )
+  })
+
+  it('unwraps Request input before calling fetch', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await gatewayFetchFromInput(
+      new Request('http://127.0.0.1:14000/v1/messages', { method: 'POST' })
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:14000/v1/messages',
+      expect.objectContaining({
+        method: 'POST',
+        redirect: 'manual',
+      })
+    )
   })
 })
 

--- a/main/src/chat/providers/thv-llm/__tests__/playground.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/playground.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const {
+  getChatSettingsMock,
+  getSelectedModelMock,
+  handleSaveSettingsMock,
+  clearChatSettingsMock,
+  saveSelectedModelMock,
+} = vi.hoisted(() => ({
+  getChatSettingsMock: vi.fn(),
+  getSelectedModelMock: vi.fn(),
+  handleSaveSettingsMock: vi.fn(),
+  clearChatSettingsMock: vi.fn(),
+  saveSelectedModelMock: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => '/tmp'),
+  },
+}))
+
+vi.mock('../../../settings-storage', () => ({
+  getChatSettings: (...args: unknown[]) => getChatSettingsMock(...args),
+  getSelectedModel: (...args: unknown[]) => getSelectedModelMock(...args),
+  handleSaveSettings: (...args: unknown[]) => handleSaveSettingsMock(...args),
+  clearChatSettings: (...args: unknown[]) => clearChatSettingsMock(...args),
+  saveSelectedModel: (...args: unknown[]) => saveSelectedModelMock(...args),
+}))
+
+import {
+  clearPlaygroundGatewaySettings,
+  enablePlaygroundGateway,
+  isPlaygroundGatewayEnabled,
+  migratePlaygroundGatewayEnablement,
+} from '../playground'
+
+describe('playground gateway enablement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getChatSettingsMock.mockReturnValue({
+      providerId: 'thv-llm',
+      endpointURL: '',
+      enabledTools: [],
+    })
+    getSelectedModelMock.mockReturnValue({ provider: '', model: '' })
+  })
+
+  it('is disabled when Playground has no stored endpoint', () => {
+    expect(isPlaygroundGatewayEnabled()).toBe(false)
+  })
+
+  it('is enabled when Playground stored the opt-in marker', () => {
+    getChatSettingsMock.mockReturnValue({
+      providerId: 'thv-llm',
+      endpointURL: 'enabled',
+      enabledTools: [],
+    })
+    expect(isPlaygroundGatewayEnabled()).toBe(true)
+  })
+
+  it('migrates opt-in when the selected model is already the gateway', () => {
+    getSelectedModelMock.mockReturnValue({
+      provider: 'thv-llm',
+      model: 'gpt-4.1',
+    })
+
+    migratePlaygroundGatewayEnablement()
+
+    expect(handleSaveSettingsMock).toHaveBeenCalledWith('thv-llm', {
+      endpointURL: 'enabled',
+      enabledTools: [],
+    })
+  })
+
+  it('does not migrate when another provider is selected', () => {
+    getSelectedModelMock.mockReturnValue({
+      provider: 'openai',
+      model: 'gpt-4.1',
+    })
+
+    migratePlaygroundGatewayEnablement()
+
+    expect(handleSaveSettingsMock).not.toHaveBeenCalled()
+  })
+
+  it('clears Playground settings and selected model on disable', () => {
+    getSelectedModelMock.mockReturnValue({
+      provider: 'thv-llm',
+      model: 'gpt-4.1',
+    })
+
+    clearPlaygroundGatewaySettings()
+
+    expect(clearChatSettingsMock).toHaveBeenCalledWith('thv-llm')
+    expect(saveSelectedModelMock).toHaveBeenCalledWith('', '')
+  })
+
+  it('enablePlaygroundGateway writes the opt-in marker', () => {
+    enablePlaygroundGateway()
+    expect(handleSaveSettingsMock).toHaveBeenCalledWith('thv-llm', {
+      endpointURL: 'enabled',
+      enabledTools: [],
+    })
+  })
+})

--- a/main/src/chat/providers/thv-llm/__tests__/playground.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/playground.test.ts
@@ -85,6 +85,22 @@ describe('playground gateway enablement', () => {
     expect(handleSaveSettingsMock).not.toHaveBeenCalled()
   })
 
+  it('does not migrate when Playground is already opted in', () => {
+    getChatSettingsMock.mockReturnValue({
+      providerId: 'thv-llm',
+      endpointURL: 'enabled',
+      enabledTools: [],
+    })
+    getSelectedModelMock.mockReturnValue({
+      provider: 'thv-llm',
+      model: 'gpt-4.1',
+    })
+
+    migratePlaygroundGatewayEnablement()
+
+    expect(handleSaveSettingsMock).not.toHaveBeenCalled()
+  })
+
   it('clears Playground settings and selected model on disable', () => {
     getSelectedModelMock.mockReturnValue({
       provider: 'thv-llm',
@@ -95,6 +111,18 @@ describe('playground gateway enablement', () => {
 
     expect(clearChatSettingsMock).toHaveBeenCalledWith('thv-llm')
     expect(saveSelectedModelMock).toHaveBeenCalledWith('', '')
+  })
+
+  it('clears Playground settings without resetting a different selected provider', () => {
+    getSelectedModelMock.mockReturnValue({
+      provider: 'openai',
+      model: 'gpt-4.1',
+    })
+
+    clearPlaygroundGatewaySettings()
+
+    expect(clearChatSettingsMock).toHaveBeenCalledWith('thv-llm')
+    expect(saveSelectedModelMock).not.toHaveBeenCalled()
   })
 
   it('enablePlaygroundGateway writes the opt-in marker', () => {

--- a/main/src/chat/providers/thv-llm/__tests__/proxy-manager.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/proxy-manager.test.ts
@@ -58,9 +58,12 @@ import {
   ensureProxyStarted,
   fetchGatewayModels,
   getGatewayStatus,
+  getLastKnownGatewayModels,
   resetThvLlmGatewayStateForTests,
+  resolveGatewayBaseURL,
   startConfiguredLlmProxyIfNeeded,
   stopOwnedProxy,
+  warmupGatewayAuth,
 } from '../proxy-manager'
 
 const configuredConfig = {
@@ -266,5 +269,159 @@ describe('thv-llm proxy manager', () => {
     expect(spawnThvMock).toHaveBeenCalledTimes(1)
     expect(a).toEqual(b)
     expect(a.started).toBe(true)
+  })
+
+  it('resolves the loopback base URL from llm config', async () => {
+    await expect(resolveGatewayBaseURL(deps)).resolves.toBe(
+      'http://127.0.0.1:14000/v1'
+    )
+  })
+
+  it('returns null when resolving a base URL without llm config', async () => {
+    readLlmConfigMock.mockResolvedValue(null)
+    await expect(resolveGatewayBaseURL(deps)).resolves.toBeNull()
+  })
+
+  it('lists gateway models and remembers them for later failures', async () => {
+    mockReachableProxy(['gpt-4.1', 'claude-sonnet-5'])
+
+    await expect(
+      fetchGatewayModels('http://127.0.0.1:14000/v1')
+    ).resolves.toEqual({
+      models: ['gpt-4.1', 'claude-sonnet-5'],
+      authRequired: false,
+    })
+    expect(getLastKnownGatewayModels()).toEqual(['gpt-4.1', 'claude-sonnet-5'])
+
+    gatewayFetchMock.mockResolvedValue(
+      new Response('unavailable', { status: 503 })
+    )
+
+    await expect(
+      fetchGatewayModels('http://127.0.0.1:14000/v1')
+    ).resolves.toMatchObject({
+      models: ['gpt-4.1', 'claude-sonnet-5'],
+      authRequired: false,
+      error: expect.stringContaining('503'),
+    })
+  })
+
+  it('returns a listing error when the models request throws', async () => {
+    gatewayFetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    await expect(
+      fetchGatewayModels('http://127.0.0.1:14000/v1')
+    ).resolves.toEqual({
+      models: [],
+      authRequired: false,
+      error: 'ECONNREFUSED',
+    })
+  })
+
+  it('reports ready status when the proxy lists models', async () => {
+    mockReachableProxy(['gpt-4.1'])
+
+    const status = await getGatewayStatus(deps)
+
+    expect(status).toMatchObject({
+      configured: true,
+      proxyRunning: true,
+      authState: 'ready',
+      listenPort: 14000,
+      baseURL: 'http://127.0.0.1:14000/v1',
+      gatewayURL: 'https://gateway.example.com',
+      modelCount: 1,
+      error: null,
+    })
+  })
+
+  it('reports proxy_stopped when the loopback proxy is unreachable', async () => {
+    gatewayFetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const status = await getGatewayStatus(deps)
+
+    expect(status.proxyRunning).toBe(false)
+    expect(status.authState).toBe('proxy_stopped')
+    expect(status.configured).toBe(true)
+  })
+
+  it('reports an error when the gateway returns no models', async () => {
+    gatewayFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 })
+    )
+
+    const status = await getGatewayStatus(deps)
+
+    expect(status.authState).toBe('error')
+    expect(status.error).toBe('Gateway returned no models')
+  })
+
+  it('warms up as not_configured when llm config is missing', async () => {
+    readLlmConfigMock.mockResolvedValue(null)
+
+    await expect(warmupGatewayAuth(deps)).resolves.toEqual({
+      ready: false,
+      authState: 'not_configured',
+      modelCount: 0,
+      error: 'Stacklok Gateway is not configured',
+    })
+  })
+
+  it('warms up as authenticating when model listing needs sign-in', async () => {
+    mockAuthRequiredProxy()
+
+    await expect(warmupGatewayAuth(deps)).resolves.toMatchObject({
+      ready: false,
+      authState: 'authenticating',
+      modelCount: 0,
+    })
+  })
+
+  it('warms up as ready when models are listed', async () => {
+    mockReachableProxy(['gpt-4.1'])
+
+    await expect(warmupGatewayAuth(deps)).resolves.toMatchObject({
+      ready: true,
+      authState: 'ready',
+      modelCount: 1,
+    })
+  })
+
+  it('warms up as error when proxy spawn fails', async () => {
+    gatewayFetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+    spawnThvMock.mockImplementation(() => {
+      throw new Error('spawn failed')
+    })
+
+    await expect(warmupGatewayAuth(deps)).resolves.toEqual({
+      ready: false,
+      authState: 'error',
+      modelCount: 0,
+      error: 'spawn failed',
+    })
+  })
+
+  it('warms up as proxy_stopped when the spawned proxy never becomes reachable', async () => {
+    vi.useFakeTimers()
+    const child = {
+      pid: 4242,
+      exitCode: null,
+      signalCode: null,
+      unref: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as ChildProcess
+    spawnThvMock.mockReturnValue(child)
+    gatewayFetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const resultPromise = warmupGatewayAuth(deps)
+    await vi.runAllTimersAsync()
+    const result = await resultPromise
+    vi.useRealTimers()
+
+    expect(result).toMatchObject({
+      ready: false,
+      authState: 'proxy_stopped',
+      modelCount: 0,
+    })
   })
 })

--- a/main/src/chat/providers/thv-llm/__tests__/proxy-manager.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/proxy-manager.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type { ChildProcess } from 'node:child_process'
+
+const { gatewayFetchMock, readLlmConfigMock, spawnThvMock } = vi.hoisted(
+  () => ({
+    gatewayFetchMock: vi.fn(),
+    readLlmConfigMock: vi.fn(),
+    spawnThvMock: vi.fn(),
+  })
+)
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => '/tmp'),
+  },
+}))
+
+vi.mock('../../../../logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../fetch', () => ({
+  gatewayFetch: (...args: unknown[]) => gatewayFetchMock(...args),
+  isAuthenticationRequiredResponse: (response: Response, bodyText?: string) => {
+    if (response.status !== 401) return false
+    if (!bodyText) return true
+    try {
+      const parsed = JSON.parse(bodyText) as { error?: string }
+      return (
+        parsed.error === 'authentication_required' ||
+        /authentication/i.test(bodyText)
+      )
+    } catch {
+      return /authentication/i.test(bodyText)
+    }
+  },
+}))
+
+vi.mock('../playground', () => ({
+  isPlaygroundGatewayEnabled: vi.fn(() => true),
+  migratePlaygroundGatewayEnablement: vi.fn(),
+}))
+
+vi.mock('../thv-cli', () => ({
+  isLlmConfigured: (config: { gateway_url?: string } | null) =>
+    Boolean(config?.gateway_url?.trim()),
+  readLlmConfig: (...args: unknown[]) => readLlmConfigMock(...args),
+  spawnThvProcess: (...args: unknown[]) => spawnThvMock(...args),
+  runThvCommand: vi.fn(),
+}))
+
+import {
+  ensureProxyStarted,
+  fetchGatewayModels,
+  getGatewayStatus,
+  resetThvLlmGatewayStateForTests,
+  startConfiguredLlmProxyIfNeeded,
+  stopOwnedProxy,
+} from '../proxy-manager'
+
+const configuredConfig = {
+  gateway_url: 'https://gateway.example.com',
+  oidc: { issuer: 'https://issuer.example.com', client_id: 'client' },
+  proxy: { listen_port: 14000 },
+}
+
+const deps = {
+  binPath: '/tmp/thv',
+  spawnThv: spawnThvMock,
+}
+
+function mockReachableProxy(models = ['gpt-4.1']) {
+  gatewayFetchMock.mockImplementation(async (url: string) => {
+    if (url.endsWith('/models')) {
+      return new Response(
+        JSON.stringify({ data: models.map((id) => ({ id })) }),
+        {
+          status: 200,
+        }
+      )
+    }
+    return new Response('', { status: 404 })
+  })
+}
+
+function mockAuthRequiredProxy() {
+  gatewayFetchMock.mockResolvedValue(
+    new Response(JSON.stringify({ error: 'authentication_required' }), {
+      status: 401,
+    })
+  )
+}
+
+describe('thv-llm proxy manager', () => {
+  beforeEach(() => {
+    resetThvLlmGatewayStateForTests()
+    vi.clearAllMocks()
+    readLlmConfigMock.mockResolvedValue(configuredConfig)
+  })
+
+  afterEach(() => {
+    stopOwnedProxy()
+    resetThvLlmGatewayStateForTests()
+  })
+
+  it('omits gateway from status when llm config is absent', async () => {
+    readLlmConfigMock.mockResolvedValue(null)
+
+    const status = await getGatewayStatus(deps)
+
+    expect(status.configured).toBe(false)
+    expect(status.authState).toBe('not_configured')
+    expect(spawnThvMock).not.toHaveBeenCalled()
+  })
+
+  it('does not spawn when proxy is already reachable', async () => {
+    mockReachableProxy()
+
+    const result = await ensureProxyStarted(deps)
+
+    expect(result.alreadyRunning).toBe(true)
+    expect(result.started).toBe(false)
+    expect(spawnThvMock).not.toHaveBeenCalled()
+  })
+
+  it('spawns proxy once when it is down', async () => {
+    vi.useFakeTimers()
+
+    const child = {
+      pid: 1234,
+      exitCode: null,
+      signalCode: null,
+      unref: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as ChildProcess
+
+    spawnThvMock.mockReturnValue(child)
+    gatewayFetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const resultPromise = ensureProxyStarted(deps)
+    await vi.runAllTimersAsync()
+    const result = await resultPromise
+
+    vi.useRealTimers()
+
+    expect(spawnThvMock).toHaveBeenCalledTimes(1)
+    expect(spawnThvMock).toHaveBeenCalledWith(['llm', 'proxy', 'start'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    expect(result.started).toBe(true)
+    expect(result.studioOwnsProxy).toBe(true)
+    expect(result.error).toContain('did not become reachable')
+  })
+
+  it('stopOwnedProxy only stops processes started by Studio', async () => {
+    vi.useFakeTimers()
+
+    const child = {
+      pid: 1234,
+      exitCode: null,
+      signalCode: null,
+      unref: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as ChildProcess
+    spawnThvMock.mockReturnValue(child)
+    gatewayFetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const startPromise = ensureProxyStarted(deps)
+    await vi.runAllTimersAsync()
+    await startPromise
+
+    vi.useRealTimers()
+
+    stopOwnedProxy()
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+
+    stopOwnedProxy()
+    expect(child.kill).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports auth required for 401 model listing', async () => {
+    mockAuthRequiredProxy()
+
+    const result = await fetchGatewayModels('http://127.0.0.1:14000/v1')
+
+    expect(result.authRequired).toBe(true)
+    expect(result.models).toEqual([])
+  })
+
+  it('reports authenticating status when proxy needs sign-in', async () => {
+    mockAuthRequiredProxy()
+
+    const status = await getGatewayStatus(deps)
+
+    expect(status.configured).toBe(true)
+    expect(status.proxyRunning).toBe(true)
+    expect(status.authState).toBe('authenticating')
+  })
+
+  it('starts the proxy immediately when llm config is present', async () => {
+    vi.useFakeTimers()
+    const child = {
+      pid: 5555,
+      exitCode: null,
+      signalCode: null,
+      unref: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as ChildProcess
+    spawnThvMock.mockReturnValue(child)
+    gatewayFetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const resultPromise = startConfiguredLlmProxyIfNeeded(deps)
+    await vi.runAllTimersAsync()
+    const result = await resultPromise
+    vi.useRealTimers()
+
+    expect(result).not.toBeNull()
+    expect(spawnThvMock).toHaveBeenCalled()
+  })
+
+  it('does not start the proxy when Playground has not enabled the gateway', async () => {
+    const { isPlaygroundGatewayEnabled } = await import('../playground')
+    vi.mocked(isPlaygroundGatewayEnabled).mockReturnValue(false)
+
+    const result = await startConfiguredLlmProxyIfNeeded(deps)
+
+    expect(result).toBeNull()
+    expect(spawnThvMock).not.toHaveBeenCalled()
+  })
+
+  it('does not start the proxy when llm config is absent', async () => {
+    readLlmConfigMock.mockResolvedValue(null)
+
+    const result = await startConfiguredLlmProxyIfNeeded(deps)
+
+    expect(result).toBeNull()
+    expect(spawnThvMock).not.toHaveBeenCalled()
+  })
+})

--- a/main/src/chat/providers/thv-llm/__tests__/proxy-manager.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/proxy-manager.test.ts
@@ -52,7 +52,6 @@ vi.mock('../thv-cli', () => ({
     Boolean(config?.gateway_url?.trim()),
   readLlmConfig: (...args: unknown[]) => readLlmConfigMock(...args),
   spawnThvProcess: (...args: unknown[]) => spawnThvMock(...args),
-  runThvCommand: vi.fn(),
 }))
 
 import {
@@ -243,5 +242,29 @@ describe('thv-llm proxy manager', () => {
 
     expect(result).toBeNull()
     expect(spawnThvMock).not.toHaveBeenCalled()
+  })
+
+  it('coalesces concurrent ensureProxyStarted calls into a single spawn', async () => {
+    vi.useFakeTimers()
+
+    const child = {
+      pid: 7777,
+      exitCode: null,
+      signalCode: null,
+      unref: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as ChildProcess
+    spawnThvMock.mockReturnValue(child)
+    gatewayFetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const first = ensureProxyStarted(deps)
+    const second = ensureProxyStarted(deps)
+    await vi.runAllTimersAsync()
+    const [a, b] = await Promise.all([first, second])
+    vi.useRealTimers()
+
+    expect(spawnThvMock).toHaveBeenCalledTimes(1)
+    expect(a).toEqual(b)
+    expect(a.started).toBe(true)
   })
 })

--- a/main/src/chat/providers/thv-llm/__tests__/thv-cli.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/thv-cli.test.ts
@@ -1,0 +1,308 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn(() => '/tmp'),
+  },
+}))
+
+vi.mock('../../../../logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../../../../toolhive-manager', () => ({
+  binPath: '/tmp/thv',
+}))
+
+vi.mock('../../../../utils/enhanced-path', () => ({
+  createEnhancedPath: () => '/tmp/bin',
+}))
+
+import {
+  isLlmConfigured,
+  readLlmConfig,
+  saveLlmConfig,
+  toLlmGatewayConfigForm,
+  type ThvCliDeps,
+} from '../thv-cli'
+
+function fakeChild(
+  options: {
+    stdout?: string
+    stderr?: string
+    exitCode?: number
+    error?: Error
+  } = {}
+) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+
+  queueMicrotask(() => {
+    if (options.error) {
+      child.emit('error', options.error)
+      return
+    }
+    if (options.stdout) {
+      child.stdout.emit('data', Buffer.from(options.stdout))
+    }
+    if (options.stderr) {
+      child.stderr.emit('data', Buffer.from(options.stderr))
+    }
+    child.emit('close', options.exitCode ?? 0)
+  })
+
+  return child
+}
+
+describe('thv-cli llm config', () => {
+  let spawnThv: ReturnType<typeof vi.fn>
+  let deps: ThvCliDeps
+
+  beforeEach(() => {
+    spawnThv = vi.fn()
+    deps = { binPath: '/tmp/thv', spawnThv }
+  })
+
+  describe('isLlmConfigured', () => {
+    it('requires gateway URL, issuer, and client ID', () => {
+      expect(isLlmConfigured(null)).toBe(false)
+      expect(isLlmConfigured({})).toBe(false)
+      expect(
+        isLlmConfigured({
+          gateway_url: 'https://gw.example',
+          oidc: { issuer: 'https://issuer', client_id: 'client' },
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe('toLlmGatewayConfigForm', () => {
+    it('maps JSON config onto the settings form', () => {
+      expect(
+        toLlmGatewayConfigForm({
+          gateway_url: ' https://gw.example ',
+          oidc: {
+            issuer: ' https://issuer ',
+            client_id: ' client ',
+            audience: ' api://gw ',
+            callback_port: 9090,
+          },
+          proxy: { listen_port: 15000 },
+        })
+      ).toEqual({
+        gatewayUrl: 'https://gw.example',
+        issuer: 'https://issuer',
+        clientId: 'client',
+        audience: 'api://gw',
+        callbackPort: 9090,
+        proxyPort: 15000,
+        configured: true,
+      })
+    })
+
+    it('uses empty defaults when config is missing', () => {
+      expect(toLlmGatewayConfigForm(null)).toMatchObject({
+        gatewayUrl: '',
+        issuer: '',
+        clientId: '',
+        proxyPort: 14000,
+        configured: false,
+      })
+    })
+  })
+
+  describe('readLlmConfig', () => {
+    it('parses JSON from thv llm config show', async () => {
+      spawnThv.mockReturnValue(
+        fakeChild({
+          stdout: JSON.stringify({
+            gateway_url: 'https://gw.example',
+            oidc: { issuer: 'https://issuer', client_id: 'client' },
+          }),
+        })
+      )
+
+      await expect(readLlmConfig(deps)).resolves.toEqual({
+        gateway_url: 'https://gw.example',
+        oidc: { issuer: 'https://issuer', client_id: 'client' },
+      })
+      expect(spawnThv).toHaveBeenCalledWith(
+        ['llm', 'config', 'show', '--format', 'json'],
+        { stdio: 'pipe' }
+      )
+    })
+
+    it('returns null when the command fails', async () => {
+      spawnThv.mockReturnValue(fakeChild({ exitCode: 1, stderr: 'boom' }))
+      await expect(readLlmConfig(deps)).resolves.toBeNull()
+    })
+
+    it('returns null when stdout is empty', async () => {
+      spawnThv.mockReturnValue(fakeChild({ stdout: '  ' }))
+      await expect(readLlmConfig(deps)).resolves.toBeNull()
+    })
+
+    it('returns null when JSON is invalid', async () => {
+      spawnThv.mockReturnValue(fakeChild({ stdout: '{not-json' }))
+      await expect(readLlmConfig(deps)).resolves.toBeNull()
+    })
+
+    it('returns null when the process fails to start', async () => {
+      spawnThv.mockReturnValue(fakeChild({ error: new Error('ENOENT') }))
+      await expect(readLlmConfig(deps)).resolves.toBeNull()
+    })
+  })
+
+  describe('saveLlmConfig', () => {
+    it('rejects missing required fields', async () => {
+      await expect(
+        saveLlmConfig(
+          { gatewayUrl: '', issuer: 'https://issuer', clientId: 'client' },
+          deps
+        )
+      ).resolves.toEqual({
+        ok: false,
+        error: 'Gateway URL, issuer, and client ID are required.',
+      })
+      expect(spawnThv).not.toHaveBeenCalled()
+    })
+
+    it('passes optional flags to thv llm config set', async () => {
+      spawnThv.mockReturnValue(fakeChild({ exitCode: 0 }))
+
+      await expect(
+        saveLlmConfig(
+          {
+            gatewayUrl: 'https://gw.example',
+            issuer: 'https://issuer',
+            clientId: 'client',
+            audience: 'api://gw',
+            callbackPort: 8080,
+            proxyPort: 14000,
+          },
+          deps
+        )
+      ).resolves.toEqual({ ok: true })
+
+      expect(spawnThv).toHaveBeenCalledWith(
+        [
+          'llm',
+          'config',
+          'set',
+          '--gateway-url',
+          'https://gw.example',
+          '--issuer',
+          'https://issuer',
+          '--client-id',
+          'client',
+          '--audience',
+          'api://gw',
+          '--callback-port',
+          '8080',
+          '--proxy-port',
+          '14000',
+        ],
+        { stdio: 'pipe' }
+      )
+    })
+
+    it('omits optional flags when they are empty', async () => {
+      spawnThv.mockReturnValue(fakeChild({ exitCode: 0 }))
+
+      await expect(
+        saveLlmConfig(
+          {
+            gatewayUrl: 'https://gw.example',
+            issuer: 'https://issuer',
+            clientId: 'client',
+          },
+          deps
+        )
+      ).resolves.toEqual({ ok: true })
+
+      expect(spawnThv).toHaveBeenCalledWith(
+        [
+          'llm',
+          'config',
+          'set',
+          '--gateway-url',
+          'https://gw.example',
+          '--issuer',
+          'https://issuer',
+          '--client-id',
+          'client',
+        ],
+        { stdio: 'pipe' }
+      )
+    })
+
+    it('returns stderr when thv exits non-zero', async () => {
+      spawnThv.mockReturnValue(
+        fakeChild({ exitCode: 2, stderr: ' invalid issuer \n' })
+      )
+
+      await expect(
+        saveLlmConfig(
+          {
+            gatewayUrl: 'https://gw.example',
+            issuer: 'https://issuer',
+            clientId: 'client',
+          },
+          deps
+        )
+      ).resolves.toEqual({
+        ok: false,
+        error: 'invalid issuer',
+      })
+    })
+
+    it('returns a fallback error when stderr is empty', async () => {
+      spawnThv.mockReturnValue(fakeChild({ exitCode: 1 }))
+
+      await expect(
+        saveLlmConfig(
+          {
+            gatewayUrl: 'https://gw.example',
+            issuer: 'https://issuer',
+            clientId: 'client',
+          },
+          deps
+        )
+      ).resolves.toEqual({
+        ok: false,
+        error: 'thv llm config set failed',
+      })
+    })
+
+    it('returns the spawn error message when the process fails to start', async () => {
+      spawnThv.mockReturnValue(fakeChild({ error: new Error('ENOENT') }))
+
+      await expect(
+        saveLlmConfig(
+          {
+            gatewayUrl: 'https://gw.example',
+            issuer: 'https://issuer',
+            clientId: 'client',
+          },
+          deps
+        )
+      ).resolves.toEqual({
+        ok: false,
+        error: 'ENOENT',
+      })
+    })
+  })
+})

--- a/main/src/chat/providers/thv-llm/__tests__/thv-cli.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/thv-cli.test.ts
@@ -73,7 +73,10 @@ describe('thv-cli llm config', () => {
 
   beforeEach(() => {
     spawnThv = vi.fn()
-    deps = { binPath: '/tmp/thv', spawnThv }
+    deps = {
+      binPath: '/tmp/thv',
+      spawnThv: spawnThv as ThvCliDeps['spawnThv'],
+    }
   })
 
   describe('isLlmConfigured', () => {

--- a/main/src/chat/providers/thv-llm/__tests__/url.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/url.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertLoopbackBaseURL,
+  anthropicBaseURLFromGatewayEndpoint,
+  googleBaseURLFromGatewayEndpoint,
+  buildLoopbackBaseURL,
+  effectiveListenPort,
+  isClaudeGatewayModel,
+  isGeminiGatewayModel,
+  isLoopbackHost,
+} from '../url'
+
+describe('thv-llm url helpers', () => {
+  it('uses default port when proxy listen_port is missing', () => {
+    expect(effectiveListenPort({})).toBe(14000)
+    expect(effectiveListenPort({ proxy: {} })).toBe(14000)
+  })
+
+  it('builds loopback base URL from listen port', () => {
+    expect(buildLoopbackBaseURL(14000)).toBe('http://127.0.0.1:14000/v1')
+  })
+
+  it('builds Anthropic Messages base URL from the OpenAI gateway endpoint', () => {
+    expect(
+      anthropicBaseURLFromGatewayEndpoint('http://127.0.0.1:14000/v1')
+    ).toBe('http://127.0.0.1:14000/anthropic/v1')
+  })
+
+  it('builds Google generateContent base URL from the OpenAI gateway endpoint', () => {
+    expect(googleBaseURLFromGatewayEndpoint('http://127.0.0.1:14000/v1')).toBe(
+      'http://127.0.0.1:14000/v1beta'
+    )
+  })
+
+  it('detects Claude models for the Anthropic gateway path', () => {
+    expect(isClaudeGatewayModel('claude-sonnet-5')).toBe(true)
+    expect(isClaudeGatewayModel('anthropic.claude-sonnet-4')).toBe(true)
+    expect(isClaudeGatewayModel('gpt-4.1')).toBe(false)
+  })
+
+  it('detects Gemini models for the Google gateway path', () => {
+    expect(isGeminiGatewayModel('gemini-2.5-flash')).toBe(true)
+    expect(isGeminiGatewayModel('google/gemini-2.5-flash')).toBe(true)
+    expect(isGeminiGatewayModel('google.gemini-2.5-pro')).toBe(true)
+    expect(isGeminiGatewayModel('gpt-4.1')).toBe(false)
+    expect(isGeminiGatewayModel('claude-sonnet-5')).toBe(false)
+  })
+
+  it('accepts localhost and 127.0.0.1 as loopback hosts', () => {
+    expect(isLoopbackHost('localhost')).toBe(true)
+    expect(isLoopbackHost('127.0.0.1')).toBe(true)
+    expect(isLoopbackHost('10.0.0.1')).toBe(false)
+    expect(isLoopbackHost('example.com')).toBe(false)
+  })
+
+  it('assertLoopbackBaseURL rejects non-loopback hosts', () => {
+    expect(() => assertLoopbackBaseURL('http://10.0.0.1/v1')).toThrow(
+      /loopback-only/
+    )
+  })
+
+  it('assertLoopbackBaseURL accepts loopback http URLs', () => {
+    expect(() =>
+      assertLoopbackBaseURL('http://127.0.0.1:14000/v1')
+    ).not.toThrow()
+  })
+})

--- a/main/src/chat/providers/thv-llm/__tests__/url.test.ts
+++ b/main/src/chat/providers/thv-llm/__tests__/url.test.ts
@@ -14,6 +14,8 @@ describe('thv-llm url helpers', () => {
   it('uses default port when proxy listen_port is missing', () => {
     expect(effectiveListenPort({})).toBe(14000)
     expect(effectiveListenPort({ proxy: {} })).toBe(14000)
+    expect(effectiveListenPort({ proxy: { listen_port: 0 } })).toBe(14000)
+    expect(effectiveListenPort({ proxy: { listen_port: 15000 } })).toBe(15000)
   })
 
   it('builds loopback base URL from listen port', () => {
@@ -49,13 +51,20 @@ describe('thv-llm url helpers', () => {
   it('accepts localhost and 127.0.0.1 as loopback hosts', () => {
     expect(isLoopbackHost('localhost')).toBe(true)
     expect(isLoopbackHost('127.0.0.1')).toBe(true)
+    expect(isLoopbackHost('127.0.0.2')).toBe(true)
     expect(isLoopbackHost('10.0.0.1')).toBe(false)
     expect(isLoopbackHost('example.com')).toBe(false)
+    expect(isLoopbackHost('127.0.0')).toBe(false)
+    expect(isLoopbackHost('127.256.0.1')).toBe(false)
   })
 
   it('assertLoopbackBaseURL rejects non-loopback hosts', () => {
     expect(() => assertLoopbackBaseURL('http://10.0.0.1/v1')).toThrow(
       /loopback-only/
+    )
+    expect(() => assertLoopbackBaseURL('not-a-url')).toThrow(/Invalid gateway/)
+    expect(() => assertLoopbackBaseURL('https://127.0.0.1/v1')).toThrow(
+      /must use http/
     )
   })
 

--- a/main/src/chat/providers/thv-llm/fetch.ts
+++ b/main/src/chat/providers/thv-llm/fetch.ts
@@ -1,9 +1,42 @@
-import http from 'node:http'
+type GatewayFetchInit = RequestInit & { timeoutMs?: number }
+
+/** Normalize fetch() input so Request objects are not stringified to `[object Request]`. */
+export function resolveGatewayFetchInput(
+  input: RequestInfo | URL,
+  init?: GatewayFetchInit
+): { url: string; init?: GatewayFetchInit } {
+  if (typeof input === 'string') {
+    return { url: input, init }
+  }
+  if (input instanceof URL) {
+    return { url: input.href, init }
+  }
+  if (typeof Request !== 'undefined' && input instanceof Request) {
+    return {
+      url: input.url,
+      init: {
+        method: input.method,
+        headers: input.headers,
+        body: input.body,
+        ...init,
+      },
+    }
+  }
+  return { url: String(input), init }
+}
+
+export async function gatewayFetchFromInput(
+  input: RequestInfo | URL,
+  init?: GatewayFetchInit
+): Promise<Response> {
+  const resolved = resolveGatewayFetchInput(input, init)
+  return gatewayFetch(resolved.url, resolved.init)
+}
 
 /** Refuse redirects so a hostile loopback listener cannot bounce requests off-host. */
 export async function gatewayFetch(
   url: string,
-  init: RequestInit & { timeoutMs?: number } = {}
+  init: GatewayFetchInit = {}
 ): Promise<Response> {
   const { timeoutMs = 15_000, ...requestInit } = init
   const controller = new AbortController()
@@ -39,9 +72,4 @@ export function isAuthenticationRequiredResponse(
   } catch {
     return /authentication/i.test(bodyText)
   }
-}
-
-/** Node http agent placeholder for tests documenting redirect refusal policy. */
-export function createRedirectRefusingHttpClient(): http.Agent {
-  return new http.Agent({ keepAlive: true })
 }

--- a/main/src/chat/providers/thv-llm/fetch.ts
+++ b/main/src/chat/providers/thv-llm/fetch.ts
@@ -1,0 +1,47 @@
+import http from 'node:http'
+
+/** Refuse redirects so a hostile loopback listener cannot bounce requests off-host. */
+export async function gatewayFetch(
+  url: string,
+  init: RequestInit & { timeoutMs?: number } = {}
+): Promise<Response> {
+  const { timeoutMs = 15_000, ...requestInit } = init
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    return await fetch(url, {
+      ...requestInit,
+      signal: controller.signal,
+      redirect: 'manual',
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export function isAuthenticationRequiredResponse(
+  response: Response,
+  bodyText?: string
+): boolean {
+  if (response.status !== 401) {
+    return false
+  }
+  if (!bodyText) {
+    return true
+  }
+  try {
+    const parsed = JSON.parse(bodyText) as { error?: string }
+    return (
+      parsed.error === 'authentication_required' ||
+      /authentication/i.test(bodyText)
+    )
+  } catch {
+    return /authentication/i.test(bodyText)
+  }
+}
+
+/** Node http agent placeholder for tests documenting redirect refusal policy. */
+export function createRedirectRefusingHttpClient(): http.Agent {
+  return new http.Agent({ keepAlive: true })
+}

--- a/main/src/chat/providers/thv-llm/index.ts
+++ b/main/src/chat/providers/thv-llm/index.ts
@@ -1,0 +1,55 @@
+export {
+  THV_LLM_PROVIDER_ID,
+  THV_LLM_PROVIDER_NAME,
+  THV_LLM_PLAYGROUND_ENABLED_MARKER,
+  THV_LLM_PROXY_API_KEY,
+  DEFAULT_THV_LLM_PROXY_PORT,
+} from './types'
+export type {
+  LlmGatewayStatus,
+  EnsureStartedResult,
+  WarmupAuthResult,
+  ThvLlmConfigJson,
+  LlmGatewaySetupInput,
+  LlmGatewayConfigForm,
+} from './types'
+export {
+  buildLoopbackBaseURL,
+  buildLoopbackAnthropicBaseURL,
+  anthropicBaseURLFromGatewayEndpoint,
+  googleBaseURLFromGatewayEndpoint,
+  effectiveListenPort,
+  isLoopbackHost,
+  isClaudeGatewayModel,
+  isGeminiGatewayModel,
+  assertLoopbackBaseURL,
+} from './url'
+export {
+  ensureProxyStarted,
+  fetchGatewayModels,
+  getGatewayStatus,
+  getLastKnownGatewayModels,
+  invalidateLlmConfigCache,
+  isProxyReachable,
+  resolveGatewayBaseURL,
+  resetThvLlmGatewayStateForTests,
+  runThvLlmTokenForWarmup,
+  setLastKnownGatewayModelsForTests,
+  stopOwnedProxy,
+  warmupGatewayAuth,
+  startConfiguredLlmProxyIfNeeded,
+} from './proxy-manager'
+export {
+  isPlaygroundGatewayEnabled,
+  migratePlaygroundGatewayEnablement,
+  enablePlaygroundGateway,
+  clearPlaygroundGatewaySettings,
+} from './playground'
+export {
+  isLlmConfigured,
+  readLlmConfig,
+  saveLlmConfig,
+  toLlmGatewayConfigForm,
+} from './thv-cli'
+export { gatewayFetch, isAuthenticationRequiredResponse } from './fetch'
+export type { ThvCliDeps } from './thv-cli'

--- a/main/src/chat/providers/thv-llm/index.ts
+++ b/main/src/chat/providers/thv-llm/index.ts
@@ -1,55 +1,26 @@
+export { THV_LLM_PROXY_API_KEY, type LlmGatewaySetupInput } from './types'
 export {
-  THV_LLM_PROVIDER_ID,
-  THV_LLM_PROVIDER_NAME,
-  THV_LLM_PLAYGROUND_ENABLED_MARKER,
-  THV_LLM_PROXY_API_KEY,
-  DEFAULT_THV_LLM_PROXY_PORT,
-} from './types'
-export type {
-  LlmGatewayStatus,
-  EnsureStartedResult,
-  WarmupAuthResult,
-  ThvLlmConfigJson,
-  LlmGatewaySetupInput,
-  LlmGatewayConfigForm,
-} from './types'
-export {
-  buildLoopbackBaseURL,
-  buildLoopbackAnthropicBaseURL,
+  assertLoopbackBaseURL,
   anthropicBaseURLFromGatewayEndpoint,
   googleBaseURLFromGatewayEndpoint,
-  effectiveListenPort,
-  isLoopbackHost,
   isClaudeGatewayModel,
   isGeminiGatewayModel,
-  assertLoopbackBaseURL,
 } from './url'
+export { gatewayFetchFromInput } from './fetch'
 export {
   ensureProxyStarted,
   fetchGatewayModels,
   getGatewayStatus,
   getLastKnownGatewayModels,
   invalidateLlmConfigCache,
-  isProxyReachable,
   resolveGatewayBaseURL,
-  resetThvLlmGatewayStateForTests,
-  runThvLlmTokenForWarmup,
-  setLastKnownGatewayModelsForTests,
   stopOwnedProxy,
   warmupGatewayAuth,
   startConfiguredLlmProxyIfNeeded,
 } from './proxy-manager'
-export {
-  isPlaygroundGatewayEnabled,
-  migratePlaygroundGatewayEnablement,
-  enablePlaygroundGateway,
-  clearPlaygroundGatewaySettings,
-} from './playground'
 export {
   isLlmConfigured,
   readLlmConfig,
   saveLlmConfig,
   toLlmGatewayConfigForm,
 } from './thv-cli'
-export { gatewayFetch, isAuthenticationRequiredResponse } from './fetch'
-export type { ThvCliDeps } from './thv-cli'

--- a/main/src/chat/providers/thv-llm/playground.ts
+++ b/main/src/chat/providers/thv-llm/playground.ts
@@ -1,0 +1,40 @@
+import {
+  clearChatSettings,
+  getChatSettings,
+  getSelectedModel,
+  handleSaveSettings,
+  saveSelectedModel,
+} from '../../settings-storage'
+import { THV_LLM_PLAYGROUND_ENABLED_MARKER, THV_LLM_PROVIDER_ID } from './types'
+
+export function isPlaygroundGatewayEnabled(): boolean {
+  const settings = getChatSettings(THV_LLM_PROVIDER_ID)
+  return Boolean('endpointURL' in settings && settings.endpointURL.trim())
+}
+
+/** If the user already selected this provider, persist Playground opt-in. */
+export function migratePlaygroundGatewayEnablement(): void {
+  const selected = getSelectedModel()
+  if (selected.provider !== THV_LLM_PROVIDER_ID) {
+    return
+  }
+  if (isPlaygroundGatewayEnabled()) {
+    return
+  }
+  enablePlaygroundGateway()
+}
+
+export function enablePlaygroundGateway(): void {
+  handleSaveSettings(THV_LLM_PROVIDER_ID, {
+    endpointURL: THV_LLM_PLAYGROUND_ENABLED_MARKER,
+    enabledTools: [],
+  })
+}
+
+export function clearPlaygroundGatewaySettings(): void {
+  clearChatSettings(THV_LLM_PROVIDER_ID)
+  const selected = getSelectedModel()
+  if (selected.provider === THV_LLM_PROVIDER_ID) {
+    saveSelectedModel('', '')
+  }
+}

--- a/main/src/chat/providers/thv-llm/proxy-manager.ts
+++ b/main/src/chat/providers/thv-llm/proxy-manager.ts
@@ -3,6 +3,8 @@ import log from '../../../logger'
 import {
   THV_LLM_PROXY_API_KEY,
   type EnsureStartedResult,
+  type LlmGatewayAuthState,
+  type LlmGatewayStatus,
   type ThvLlmConfigJson,
 } from './types'
 import { buildLoopbackBaseURL, effectiveListenPort } from './url'
@@ -10,33 +12,31 @@ import { gatewayFetch, isAuthenticationRequiredResponse } from './fetch'
 import {
   isLlmConfigured,
   readLlmConfig,
-  runThvCommand,
   spawnThvProcess,
   type ThvCliDeps,
 } from './thv-cli'
-import {
-  isPlaygroundGatewayEnabled,
-  migratePlaygroundGatewayEnablement,
-} from './playground'
 
 let ownedProxyProcess: ChildProcess | undefined
 let studioOwnsProxy = false
+/** Last `thv llm config show` result. Cleared by invalidateLlmConfigCache
+ * (save-config, disable, get-config, warmup-auth, and boot proxy start). */
 let cachedConfig: ThvLlmConfigJson | null | undefined
 let lastKnownModels: string[] = []
+let inFlightEnsure: Promise<EnsureStartedResult> | undefined
+
+const MODELS_LIST_TIMEOUT_MS = 15_000
+const MODELS_AUTH_TIMEOUT_MS = 90_000
 
 export function resetThvLlmGatewayStateForTests(): void {
   ownedProxyProcess = undefined
   studioOwnsProxy = false
   cachedConfig = undefined
   lastKnownModels = []
+  inFlightEnsure = undefined
 }
 
 export function getLastKnownGatewayModels(): readonly string[] {
   return lastKnownModels
-}
-
-export function setLastKnownGatewayModelsForTests(models: string[]): void {
-  lastKnownModels = models
 }
 
 async function getConfiguredLlmConfig(
@@ -65,7 +65,7 @@ export async function resolveGatewayBaseURL(
   return baseURL
 }
 
-export async function isProxyReachable(baseURL: string): Promise<boolean> {
+async function isProxyReachable(baseURL: string): Promise<boolean> {
   try {
     const response = await gatewayFetch(`${baseURL}/models`, {
       headers: {
@@ -90,9 +90,18 @@ async function waitForProxy(baseURL: string, attempts = 20): Promise<boolean> {
   return false
 }
 
-export async function ensureProxyStarted(
+export function ensureProxyStarted(
   deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
 ): Promise<EnsureStartedResult> {
+  if (!inFlightEnsure) {
+    inFlightEnsure = startOwnedProxy(deps).finally(() => {
+      inFlightEnsure = undefined
+    })
+  }
+  return inFlightEnsure
+}
+
+async function startOwnedProxy(deps: ThvCliDeps): Promise<EnsureStartedResult> {
   const config = await getConfiguredLlmConfig(deps)
   if (!isLlmConfigured(config)) {
     return {
@@ -167,6 +176,8 @@ export async function ensureProxyStarted(
 export async function startConfiguredLlmProxyIfNeeded(
   deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
 ): Promise<EnsureStartedResult | null> {
+  const { migratePlaygroundGatewayEnablement, isPlaygroundGatewayEnabled } =
+    await import('./playground')
   migratePlaygroundGatewayEnablement()
   if (!isPlaygroundGatewayEnabled()) {
     log.debug(
@@ -194,7 +205,8 @@ export async function startConfiguredLlmProxyIfNeeded(
 }
 
 export async function fetchGatewayModels(
-  baseURL: string
+  baseURL: string,
+  options?: { timeoutMs?: number }
 ): Promise<{ models: string[]; authRequired: boolean; error?: string }> {
   try {
     const response = await gatewayFetch(`${baseURL}/models`, {
@@ -202,7 +214,7 @@ export async function fetchGatewayModels(
         Authorization: `Bearer ${THV_LLM_PROXY_API_KEY}`,
         'Content-Type': 'application/json',
       },
-      timeoutMs: 90_000,
+      timeoutMs: options?.timeoutMs ?? MODELS_LIST_TIMEOUT_MS,
     })
 
     const bodyText = await response.text()
@@ -281,7 +293,9 @@ export async function warmupGatewayAuth(
     }
   }
 
-  const listing = await fetchGatewayModels(baseURL)
+  const listing = await fetchGatewayModels(baseURL, {
+    timeoutMs: MODELS_AUTH_TIMEOUT_MS,
+  })
   if (listing.authRequired) {
     return {
       ready: false,
@@ -314,7 +328,7 @@ export async function warmupGatewayAuth(
 
 export async function getGatewayStatus(
   deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
-): Promise<import('./types').LlmGatewayStatus> {
+): Promise<LlmGatewayStatus> {
   const config = await getConfiguredLlmConfig(deps)
   if (!isLlmConfigured(config)) {
     return {
@@ -334,7 +348,7 @@ export async function getGatewayStatus(
   const baseURL = buildLoopbackBaseURL(listenPort)
   const proxyRunning = await isProxyReachable(baseURL)
 
-  let authState: import('./types').LlmGatewayAuthState = 'proxy_stopped'
+  let authState: LlmGatewayAuthState = 'proxy_stopped'
   let modelCount = lastKnownModels.length
   let error: string | null = null
 
@@ -386,29 +400,5 @@ export function stopOwnedProxy(): void {
   } finally {
     ownedProxyProcess = undefined
     studioOwnsProxy = false
-  }
-}
-
-export async function runThvLlmTokenForWarmup(
-  deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
-): Promise<{ ok: boolean; error?: string }> {
-  try {
-    const { exitCode, stderr } = await runThvCommand(
-      ['llm', 'token'],
-      deps,
-      120_000
-    )
-    if (exitCode !== 0) {
-      return {
-        ok: false,
-        error: stderr.trim() || 'thv llm token failed',
-      }
-    }
-    return { ok: true }
-  } catch (error) {
-    return {
-      ok: false,
-      error: error instanceof Error ? error.message : String(error),
-    }
   }
 }

--- a/main/src/chat/providers/thv-llm/proxy-manager.ts
+++ b/main/src/chat/providers/thv-llm/proxy-manager.ts
@@ -1,0 +1,414 @@
+import type { ChildProcess } from 'node:child_process'
+import log from '../../../logger'
+import {
+  THV_LLM_PROXY_API_KEY,
+  type EnsureStartedResult,
+  type ThvLlmConfigJson,
+} from './types'
+import { buildLoopbackBaseURL, effectiveListenPort } from './url'
+import { gatewayFetch, isAuthenticationRequiredResponse } from './fetch'
+import {
+  isLlmConfigured,
+  readLlmConfig,
+  runThvCommand,
+  spawnThvProcess,
+  type ThvCliDeps,
+} from './thv-cli'
+import {
+  isPlaygroundGatewayEnabled,
+  migratePlaygroundGatewayEnablement,
+} from './playground'
+
+let ownedProxyProcess: ChildProcess | undefined
+let studioOwnsProxy = false
+let cachedConfig: ThvLlmConfigJson | null | undefined
+let lastKnownModels: string[] = []
+
+export function resetThvLlmGatewayStateForTests(): void {
+  ownedProxyProcess = undefined
+  studioOwnsProxy = false
+  cachedConfig = undefined
+  lastKnownModels = []
+}
+
+export function getLastKnownGatewayModels(): readonly string[] {
+  return lastKnownModels
+}
+
+export function setLastKnownGatewayModelsForTests(models: string[]): void {
+  lastKnownModels = models
+}
+
+async function getConfiguredLlmConfig(
+  deps: ThvCliDeps
+): Promise<ThvLlmConfigJson | null> {
+  if (cachedConfig !== undefined) {
+    return cachedConfig
+  }
+  cachedConfig = await readLlmConfig(deps)
+  return cachedConfig
+}
+
+export function invalidateLlmConfigCache(): void {
+  cachedConfig = undefined
+}
+
+export async function resolveGatewayBaseURL(
+  deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
+): Promise<string | null> {
+  const config = await getConfiguredLlmConfig(deps)
+  if (!isLlmConfigured(config)) {
+    return null
+  }
+  const port = effectiveListenPort(config)
+  const baseURL = buildLoopbackBaseURL(port)
+  return baseURL
+}
+
+export async function isProxyReachable(baseURL: string): Promise<boolean> {
+  try {
+    const response = await gatewayFetch(`${baseURL}/models`, {
+      headers: {
+        Authorization: `Bearer ${THV_LLM_PROXY_API_KEY}`,
+      },
+      timeoutMs: 2_000,
+    })
+    // Any response from the proxy (including 401) means something is listening.
+    return response.status > 0
+  } catch {
+    return false
+  }
+}
+
+async function waitForProxy(baseURL: string, attempts = 20): Promise<boolean> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (await isProxyReachable(baseURL)) {
+      return true
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  return false
+}
+
+export async function ensureProxyStarted(
+  deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
+): Promise<EnsureStartedResult> {
+  const config = await getConfiguredLlmConfig(deps)
+  if (!isLlmConfigured(config)) {
+    return {
+      started: false,
+      alreadyRunning: false,
+      studioOwnsProxy: false,
+      error: 'Stacklok Gateway is not configured',
+    }
+  }
+
+  const baseURL = buildLoopbackBaseURL(effectiveListenPort(config))
+
+  if (await isProxyReachable(baseURL)) {
+    return {
+      started: false,
+      alreadyRunning: true,
+      studioOwnsProxy,
+    }
+  }
+
+  if (
+    ownedProxyProcess &&
+    ownedProxyProcess.exitCode === null &&
+    ownedProxyProcess.signalCode === null
+  ) {
+    const ready = await waitForProxy(baseURL)
+    if (ready) {
+      return {
+        started: false,
+        alreadyRunning: true,
+        studioOwnsProxy: true,
+      }
+    }
+  }
+
+  try {
+    const child = deps.spawnThv(['llm', 'proxy', 'start'], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    child.unref()
+    ownedProxyProcess = child
+    studioOwnsProxy = true
+    log.info('[thv-llm] started llm proxy', { pid: child.pid })
+
+    const ready = await waitForProxy(baseURL)
+    if (!ready) {
+      return {
+        started: true,
+        alreadyRunning: false,
+        studioOwnsProxy: true,
+        error: 'LLM proxy did not become reachable in time',
+      }
+    }
+
+    return {
+      started: true,
+      alreadyRunning: false,
+      studioOwnsProxy: true,
+    }
+  } catch (error) {
+    return {
+      started: false,
+      alreadyRunning: false,
+      studioOwnsProxy: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+/** Start the local proxy when Playground has opted in and llm config exists. */
+export async function startConfiguredLlmProxyIfNeeded(
+  deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
+): Promise<EnsureStartedResult | null> {
+  migratePlaygroundGatewayEnablement()
+  if (!isPlaygroundGatewayEnabled()) {
+    log.debug(
+      '[thv-llm] playground has not enabled the gateway; skipping proxy start'
+    )
+    return null
+  }
+
+  invalidateLlmConfigCache()
+  const config = await getConfiguredLlmConfig(deps)
+  if (!isLlmConfigured(config)) {
+    log.debug('[thv-llm] no llm config; skipping proxy start')
+    return null
+  }
+
+  const result = await ensureProxyStarted(deps)
+  if (result.error) {
+    log.warn('[thv-llm] proxy start on config failed', result.error)
+  } else if (result.started) {
+    log.info('[thv-llm] proxy started because playground gateway is enabled')
+  } else if (result.alreadyRunning) {
+    log.debug('[thv-llm] proxy already running')
+  }
+  return result
+}
+
+export async function fetchGatewayModels(
+  baseURL: string
+): Promise<{ models: string[]; authRequired: boolean; error?: string }> {
+  try {
+    const response = await gatewayFetch(`${baseURL}/models`, {
+      headers: {
+        Authorization: `Bearer ${THV_LLM_PROXY_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      timeoutMs: 90_000,
+    })
+
+    const bodyText = await response.text()
+
+    if (isAuthenticationRequiredResponse(response, bodyText)) {
+      return { models: [], authRequired: true }
+    }
+
+    if (!response.ok) {
+      return {
+        models: lastKnownModels,
+        authRequired: false,
+        error: `Gateway model list failed: ${response.status} ${bodyText.slice(0, 200)}`,
+      }
+    }
+
+    const data = JSON.parse(bodyText) as {
+      data?: Array<{ id?: string }>
+    }
+    const models = (data.data ?? [])
+      .map((entry) => entry.id)
+      .filter((id): id is string => Boolean(id))
+
+    if (models.length > 0) {
+      lastKnownModels = models
+    } else {
+      lastKnownModels = []
+    }
+
+    return { models, authRequired: false }
+  } catch (error) {
+    return {
+      models: lastKnownModels,
+      authRequired: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export async function warmupGatewayAuth(
+  deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
+): Promise<{
+  ready: boolean
+  authState:
+    'ready' | 'authenticating' | 'error' | 'not_configured' | 'proxy_stopped'
+  modelCount: number
+  error?: string
+}> {
+  const config = await getConfiguredLlmConfig(deps)
+  if (!isLlmConfigured(config)) {
+    return {
+      ready: false,
+      authState: 'not_configured',
+      modelCount: 0,
+      error: 'Stacklok Gateway is not configured',
+    }
+  }
+
+  const ensure = await ensureProxyStarted(deps)
+  if (ensure.error && !ensure.alreadyRunning && !ensure.started) {
+    return {
+      ready: false,
+      authState: 'error',
+      modelCount: 0,
+      error: ensure.error,
+    }
+  }
+
+  const baseURL = buildLoopbackBaseURL(effectiveListenPort(config))
+  if (!(await isProxyReachable(baseURL))) {
+    return {
+      ready: false,
+      authState: 'proxy_stopped',
+      modelCount: 0,
+      error: ensure.error ?? 'LLM proxy is not running',
+    }
+  }
+
+  const listing = await fetchGatewayModels(baseURL)
+  if (listing.authRequired) {
+    return {
+      ready: false,
+      authState: 'authenticating',
+      modelCount: 0,
+      error:
+        'Complete sign-in in your browser, then try again. The LLM proxy opened an OIDC login flow.',
+    }
+  }
+
+  if (listing.error && listing.models.length === 0) {
+    return {
+      ready: false,
+      authState: 'error',
+      modelCount: 0,
+      error: listing.error,
+    }
+  }
+
+  return {
+    ready: listing.models.length > 0,
+    authState: listing.models.length > 0 ? 'ready' : 'error',
+    modelCount: listing.models.length,
+    error:
+      listing.models.length === 0
+        ? 'Gateway returned no models'
+        : listing.error,
+  }
+}
+
+export async function getGatewayStatus(
+  deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
+): Promise<import('./types').LlmGatewayStatus> {
+  const config = await getConfiguredLlmConfig(deps)
+  if (!isLlmConfigured(config)) {
+    return {
+      configured: false,
+      proxyRunning: false,
+      authState: 'not_configured',
+      listenPort: null,
+      baseURL: null,
+      gatewayURL: null,
+      modelCount: 0,
+      error: null,
+      studioOwnsProxy: false,
+    }
+  }
+
+  const listenPort = effectiveListenPort(config)
+  const baseURL = buildLoopbackBaseURL(listenPort)
+  const proxyRunning = await isProxyReachable(baseURL)
+
+  let authState: import('./types').LlmGatewayAuthState = 'proxy_stopped'
+  let modelCount = lastKnownModels.length
+  let error: string | null = null
+
+  if (proxyRunning) {
+    const listing = await fetchGatewayModels(baseURL)
+    if (listing.authRequired) {
+      authState = 'authenticating'
+      error =
+        'Sign in required. Start the proxy and complete OIDC login in your browser.'
+    } else if (listing.error && listing.models.length === 0) {
+      authState = 'error'
+      error = listing.error
+    } else if (listing.models.length > 0) {
+      authState = 'ready'
+      modelCount = listing.models.length
+    } else {
+      authState = 'error'
+      error = listing.error ?? 'Gateway returned no models'
+    }
+  }
+
+  return {
+    configured: true,
+    proxyRunning,
+    authState,
+    listenPort,
+    baseURL,
+    gatewayURL: config.gateway_url ?? null,
+    modelCount,
+    error,
+    studioOwnsProxy,
+  }
+}
+
+export function stopOwnedProxy(): void {
+  if (!studioOwnsProxy || !ownedProxyProcess) {
+    return
+  }
+  try {
+    if (
+      ownedProxyProcess.exitCode === null &&
+      ownedProxyProcess.signalCode === null
+    ) {
+      ownedProxyProcess.kill('SIGTERM')
+      log.info('[thv-llm] stopped owned llm proxy')
+    }
+  } catch (error) {
+    log.warn('[thv-llm] failed to stop owned llm proxy', error)
+  } finally {
+    ownedProxyProcess = undefined
+    studioOwnsProxy = false
+  }
+}
+
+export async function runThvLlmTokenForWarmup(
+  deps: ThvCliDeps = { binPath: '', spawnThv: spawnThvProcess }
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const { exitCode, stderr } = await runThvCommand(
+      ['llm', 'token'],
+      deps,
+      120_000
+    )
+    if (exitCode !== 0) {
+      return {
+        ok: false,
+        error: stderr.trim() || 'thv llm token failed',
+      }
+    }
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/main/src/chat/providers/thv-llm/thv-cli.ts
+++ b/main/src/chat/providers/thv-llm/thv-cli.ts
@@ -38,7 +38,7 @@ export function spawnThvProcess(
   })
 }
 
-export async function runThvCommand(
+async function runThvCommand(
   args: string[],
   deps: ThvCliDeps = defaultDeps,
   timeoutMs = 30_000

--- a/main/src/chat/providers/thv-llm/thv-cli.ts
+++ b/main/src/chat/providers/thv-llm/thv-cli.ts
@@ -1,0 +1,180 @@
+import { spawn } from 'node:child_process'
+import { binPath } from '../../../toolhive-manager'
+import { createEnhancedPath } from '../../../utils/enhanced-path'
+import log from '../../../logger'
+import {
+  DEFAULT_THV_LLM_PROXY_PORT,
+  type LlmGatewayConfigForm,
+  type LlmGatewaySetupInput,
+  type ThvLlmConfigJson,
+} from './types'
+
+export interface ThvCliDeps {
+  binPath: string
+  spawnThv: typeof spawnThvProcess
+}
+
+const defaultDeps: ThvCliDeps = {
+  binPath,
+  spawnThv: spawnThvProcess,
+}
+
+export function spawnThvProcess(
+  args: string[],
+  options: {
+    detached?: boolean
+    stdio?: 'pipe' | 'ignore' | 'inherit'
+  } = {}
+): ReturnType<typeof spawn> {
+  return spawn(binPath, args, {
+    stdio: options.stdio ?? 'pipe',
+    detached: options.detached ?? false,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      PATH: createEnhancedPath(),
+      TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
+    },
+  })
+}
+
+export async function runThvCommand(
+  args: string[],
+  deps: ThvCliDeps = defaultDeps,
+  timeoutMs = 30_000
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = deps.spawnThv(args, { stdio: 'pipe' })
+    let stdout = ''
+    let stderr = ''
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`thv ${args.join(' ')} timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+
+    child.on('close', (exitCode) => {
+      clearTimeout(timer)
+      resolve({ stdout, stderr, exitCode })
+    })
+  })
+}
+
+export async function readLlmConfig(
+  deps: ThvCliDeps = defaultDeps
+): Promise<ThvLlmConfigJson | null> {
+  try {
+    const { stdout, exitCode } = await runThvCommand(
+      ['llm', 'config', 'show', '--format', 'json'],
+      deps,
+      5_000
+    )
+    if (exitCode !== 0) {
+      log.debug('[thv-llm] llm config show failed', { exitCode })
+      return null
+    }
+    const trimmed = stdout.trim()
+    if (!trimmed) {
+      return null
+    }
+    const parsed = JSON.parse(trimmed) as ThvLlmConfigJson
+    return parsed
+  } catch (error) {
+    log.debug('[thv-llm] failed to read llm config', error)
+    return null
+  }
+}
+
+export function isLlmConfigured(
+  config: ThvLlmConfigJson | null
+): config is ThvLlmConfigJson {
+  if (!config) return false
+  return Boolean(
+    config.gateway_url?.trim() &&
+    config.oidc?.issuer?.trim() &&
+    config.oidc?.client_id?.trim()
+  )
+}
+
+export function toLlmGatewayConfigForm(
+  config: ThvLlmConfigJson | null
+): LlmGatewayConfigForm {
+  return {
+    gatewayUrl: config?.gateway_url?.trim() ?? '',
+    issuer: config?.oidc?.issuer?.trim() ?? '',
+    clientId: config?.oidc?.client_id?.trim() ?? '',
+    audience: config?.oidc?.audience?.trim() ?? '',
+    callbackPort: config?.oidc?.callback_port,
+    proxyPort: config?.proxy?.listen_port ?? DEFAULT_THV_LLM_PROXY_PORT,
+    configured: isLlmConfigured(config),
+  }
+}
+
+export async function saveLlmConfig(
+  input: LlmGatewaySetupInput,
+  deps: ThvCliDeps = defaultDeps
+): Promise<{ ok: boolean; error?: string }> {
+  const gatewayUrl = input.gatewayUrl.trim()
+  const issuer = input.issuer.trim()
+  const clientId = input.clientId.trim()
+
+  if (!gatewayUrl || !issuer || !clientId) {
+    return {
+      ok: false,
+      error: 'Gateway URL, issuer, and client ID are required.',
+    }
+  }
+
+  const args = [
+    'llm',
+    'config',
+    'set',
+    '--gateway-url',
+    gatewayUrl,
+    '--issuer',
+    issuer,
+    '--client-id',
+    clientId,
+  ]
+
+  const audience = input.audience?.trim()
+  if (audience) {
+    args.push('--audience', audience)
+  }
+
+  if (input.callbackPort != null && input.callbackPort > 0) {
+    args.push('--callback-port', String(input.callbackPort))
+  }
+
+  if (input.proxyPort != null && input.proxyPort > 0) {
+    args.push('--proxy-port', String(input.proxyPort))
+  }
+
+  try {
+    const { exitCode, stderr } = await runThvCommand(args, deps, 30_000)
+    if (exitCode !== 0) {
+      return {
+        ok: false,
+        error: stderr.trim() || 'thv llm config set failed',
+      }
+    }
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/main/src/chat/providers/thv-llm/types.ts
+++ b/main/src/chat/providers/thv-llm/types.ts
@@ -1,0 +1,67 @@
+export const THV_LLM_PROVIDER_ID = 'thv-llm' as const
+
+export const THV_LLM_PROVIDER_NAME = 'Stacklok Gateway'
+
+/** SQLite endpointURL marker: Playground has opted in to this provider. */
+export const THV_LLM_PLAYGROUND_ENABLED_MARKER = 'enabled'
+
+export const THV_LLM_PROXY_API_KEY = 'thv-proxy'
+
+export const DEFAULT_THV_LLM_PROXY_PORT = 14000
+
+/** Shape of `thv llm config show --format json`. */
+export interface ThvLlmConfigJson {
+  gateway_url?: string
+  oidc?: {
+    issuer?: string
+    client_id?: string
+    audience?: string
+    callback_port?: number
+  }
+  proxy?: {
+    listen_port?: number
+  }
+}
+
+/** Connection settings persisted via `thv llm config set` (same flags as setup). */
+export interface LlmGatewaySetupInput {
+  gatewayUrl: string
+  issuer: string
+  clientId: string
+  audience?: string
+  callbackPort?: number
+  proxyPort?: number
+}
+
+export interface LlmGatewayConfigForm extends LlmGatewaySetupInput {
+  configured: boolean
+}
+
+export type LlmGatewayAuthState =
+  'not_configured' | 'proxy_stopped' | 'authenticating' | 'ready' | 'error'
+
+export interface LlmGatewayStatus {
+  configured: boolean
+  proxyRunning: boolean
+  authState: LlmGatewayAuthState
+  listenPort: number | null
+  baseURL: string | null
+  gatewayURL: string | null
+  modelCount: number
+  error: string | null
+  studioOwnsProxy: boolean
+}
+
+export interface EnsureStartedResult {
+  started: boolean
+  alreadyRunning: boolean
+  studioOwnsProxy: boolean
+  error?: string
+}
+
+export interface WarmupAuthResult {
+  ready: boolean
+  authState: LlmGatewayAuthState
+  modelCount: number
+  error?: string
+}

--- a/main/src/chat/providers/thv-llm/types.ts
+++ b/main/src/chat/providers/thv-llm/types.ts
@@ -58,10 +58,3 @@ export interface EnsureStartedResult {
   studioOwnsProxy: boolean
   error?: string
 }
-
-export interface WarmupAuthResult {
-  ready: boolean
-  authState: LlmGatewayAuthState
-  modelCount: number
-  error?: string
-}

--- a/main/src/chat/providers/thv-llm/url.ts
+++ b/main/src/chat/providers/thv-llm/url.ts
@@ -14,10 +14,6 @@ export function buildLoopbackBaseURL(listenPort: number): string {
   return `http://127.0.0.1:${listenPort}/v1`
 }
 
-export function buildLoopbackAnthropicBaseURL(listenPort: number): string {
-  return `http://127.0.0.1:${listenPort}/anthropic/v1`
-}
-
 export function anthropicBaseURLFromGatewayEndpoint(
   endpointURL: string
 ): string {

--- a/main/src/chat/providers/thv-llm/url.ts
+++ b/main/src/chat/providers/thv-llm/url.ts
@@ -1,0 +1,75 @@
+import { DEFAULT_THV_LLM_PROXY_PORT } from './types'
+
+export function effectiveListenPort(config: {
+  proxy?: { listen_port?: number }
+}): number {
+  const port = config.proxy?.listen_port
+  if (typeof port === 'number' && port > 0) {
+    return port
+  }
+  return DEFAULT_THV_LLM_PROXY_PORT
+}
+
+export function buildLoopbackBaseURL(listenPort: number): string {
+  return `http://127.0.0.1:${listenPort}/v1`
+}
+
+export function buildLoopbackAnthropicBaseURL(listenPort: number): string {
+  return `http://127.0.0.1:${listenPort}/anthropic/v1`
+}
+
+export function anthropicBaseURLFromGatewayEndpoint(
+  endpointURL: string
+): string {
+  const parsed = new URL(endpointURL)
+  return `${parsed.protocol}//${parsed.host}/anthropic/v1`
+}
+
+export function googleBaseURLFromGatewayEndpoint(endpointURL: string): string {
+  const parsed = new URL(endpointURL)
+  return `${parsed.protocol}//${parsed.host}/v1beta`
+}
+
+export function isClaudeGatewayModel(modelId: string): boolean {
+  const id = modelId.trim().toLowerCase()
+  return id.includes('claude') || id.startsWith('anthropic.')
+}
+
+export function isGeminiGatewayModel(modelId: string): boolean {
+  const id = modelId.trim().toLowerCase()
+  return id.includes('gemini') || id.startsWith('google.')
+}
+
+export function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase()
+  if (normalized === 'localhost') {
+    return true
+  }
+  // IPv4 loopback only — no DNS resolution.
+  const parts = normalized.split('.')
+  if (parts.length !== 4) {
+    return false
+  }
+  if (parts[0] !== '127') {
+    return false
+  }
+  return parts.every((part) => {
+    const n = Number(part)
+    return Number.isInteger(n) && n >= 0 && n <= 255
+  })
+}
+
+export function assertLoopbackBaseURL(baseURL: string): void {
+  let parsed: URL
+  try {
+    parsed = new URL(baseURL)
+  } catch {
+    throw new Error(`Invalid gateway base URL: ${baseURL}`)
+  }
+  if (parsed.protocol !== 'http:') {
+    throw new Error('Stacklok Gateway must use http on loopback')
+  }
+  if (!isLoopbackHost(parsed.hostname)) {
+    throw new Error('Stacklok Gateway base URL must be loopback-only')
+  }
+}

--- a/main/src/chat/settings-storage.ts
+++ b/main/src/chat/settings-storage.ts
@@ -1,5 +1,9 @@
 import { Effect } from 'effect'
-import { runChatSyncOr, runChatPromiseOr, runChatToResultSync } from './runtime'
+import {
+  runChatSyncOr,
+  runChatPromiseOr,
+  runChatToResultSync,
+} from './runtime/adapters'
 import { SettingsService } from './settings/settings-service'
 import type {
   ChatSettingsProvider,

--- a/main/src/chat/settings-storage.ts
+++ b/main/src/chat/settings-storage.ts
@@ -8,7 +8,9 @@ import type {
 import {
   CHAT_PROVIDER_INFO,
   LOCAL_PROVIDER_IDS,
+  GATEWAY_PROVIDER_IDS,
   type LocalProviderId,
+  type GatewayProviderId,
 } from './constants'
 
 type ProviderId = (typeof CHAT_PROVIDER_INFO)[number]['id']
@@ -19,12 +21,24 @@ function isLocalProvider(
   return LOCAL_PROVIDER_IDS.includes(providerId as LocalProviderId)
 }
 
+function isGatewayProvider(
+  providerId: ProviderId
+): providerId is GatewayProviderId {
+  return GATEWAY_PROVIDER_IDS.includes(providerId as GatewayProviderId)
+}
+
 function defaultChatSettings(providerId: ProviderId): ChatSettingsProvider {
   if (isLocalProvider(providerId)) {
     return { providerId, endpointURL: '', enabledTools: [] }
   }
+  if (isGatewayProvider(providerId)) {
+    return { providerId, endpointURL: '', enabledTools: [] }
+  }
   return {
-    providerId,
+    providerId: providerId as Exclude<
+      ProviderId,
+      LocalProviderId | GatewayProviderId
+    >,
     apiKey: '',
     enabledTools: [],
   }

--- a/main/src/chat/settings/settings-service.ts
+++ b/main/src/chat/settings/settings-service.ts
@@ -24,7 +24,9 @@ import {
 import {
   CHAT_PROVIDER_INFO,
   LOCAL_PROVIDER_IDS,
+  GATEWAY_PROVIDER_IDS,
   type LocalProviderId,
+  type GatewayProviderId,
 } from '../constants'
 import { StorageError, ValidationError } from '../runtime/errors'
 import { chatLogInfo, chatLogWarning } from '../runtime/logging'
@@ -39,7 +41,12 @@ export type ChatSettingsProvider =
       enabledTools: string[]
     }
   | {
-      providerId: Exclude<ProviderId, 'ollama' | 'lmstudio'>
+      providerId: GatewayProviderId
+      endpointURL: string
+      enabledTools: string[]
+    }
+  | {
+      providerId: Exclude<ProviderId, LocalProviderId | GatewayProviderId>
       apiKey: string
       /** Legacy field kept for IPC shape; MCP tool enablement is stored separately. */
       enabledTools: string[]
@@ -52,6 +59,11 @@ export interface ChatSettingsSelectedModel {
 
 const isLocalProvider = (providerId: string): providerId is LocalProviderId =>
   LOCAL_PROVIDER_IDS.includes(providerId as LocalProviderId)
+
+const isGatewayProvider = (
+  providerId: string
+): providerId is GatewayProviderId =>
+  GATEWAY_PROVIDER_IDS.includes(providerId as GatewayProviderId)
 
 function wrapSync<A>(
   operation: string,
@@ -168,17 +180,22 @@ export class SettingsService extends Effect.Service<SettingsService>()(
 
       const defaultProviderSettings = (
         providerId: ProviderId
-      ): ChatSettingsProvider =>
-        isLocalProvider(providerId)
-          ? { providerId, endpointURL: '', enabledTools: [] }
-          : {
-              providerId: providerId as Exclude<
-                ProviderId,
-                'ollama' | 'lmstudio'
-              >,
-              apiKey: '',
-              enabledTools: [],
-            }
+      ): ChatSettingsProvider => {
+        if (isLocalProvider(providerId)) {
+          return { providerId, endpointURL: '', enabledTools: [] }
+        }
+        if (isGatewayProvider(providerId)) {
+          return { providerId, endpointURL: '', enabledTools: [] }
+        }
+        return {
+          providerId: providerId as Exclude<
+            ProviderId,
+            LocalProviderId | GatewayProviderId
+          >,
+          apiKey: '',
+          enabledTools: [],
+        }
+      }
 
       return {
         getChatSettings: (providerId: ProviderId) =>
@@ -192,10 +209,17 @@ export class SettingsService extends Effect.Service<SettingsService>()(
                 enabledTools: [],
               }
             }
+            if (isGatewayProvider(providerId)) {
+              return {
+                providerId,
+                endpointURL: dbProvider.endpointURL ?? '',
+                enabledTools: [],
+              }
+            }
             return {
               providerId: providerId as Exclude<
                 ProviderId,
-                'ollama' | 'lmstudio'
+                LocalProviderId | GatewayProviderId
               >,
               apiKey: dbProvider.apiKey ?? '',
               enabledTools: [],
@@ -329,7 +353,8 @@ export class SettingsService extends Effect.Service<SettingsService>()(
 
             const providerIdTyped = providerId as ProviderId
             const credentialValue =
-              providerIdTyped === 'ollama' || providerIdTyped === 'lmstudio'
+              isLocalProvider(providerIdTyped) ||
+              isGatewayProvider(providerIdTyped)
                 ? 'endpointURL' in settings
                   ? settings.endpointURL
                   : ''
@@ -342,7 +367,10 @@ export class SettingsService extends Effect.Service<SettingsService>()(
               return
             }
 
-            if (isLocalProvider(providerIdTyped)) {
+            if (
+              isLocalProvider(providerIdTyped) ||
+              isGatewayProvider(providerIdTyped)
+            ) {
               yield* repo.writeProvider(providerIdTyped, {
                 endpointURL: credentialValue,
               })

--- a/main/src/chat/streaming/chat-stream-service-impl.ts
+++ b/main/src/chat/streaming/chat-stream-service-impl.ts
@@ -22,6 +22,7 @@ import { createBuiltinAgentTools } from '../agents/builtin-agent-tools'
 import { sanitizeMessagesForModel } from './sanitize-messages-for-model'
 import { generateThreadTitle } from '../generate-thread-title'
 import { broadcastThreadUpdated } from './stream-registry-broadcast'
+import { enrichGatewayChatRequest } from '../enrich-gateway-request'
 
 /** Gemini's function-declaration validator rejects schema constructs other
  * providers accept. True for Google directly or a `google/*` OpenRouter model. */
@@ -58,18 +59,22 @@ export async function handleChatStreamRealtime(
     },
     async (span, finish) => {
       const abortController = new AbortController()
+      let activeRequest = request
 
       try {
+        activeRequest = await enrichGatewayChatRequest(activeRequest)
+
         // Validate provider
         const provider = CHAT_PROVIDERS.find(
-          (p: (typeof CHAT_PROVIDERS)[number]) => p.id === request.provider
+          (p: (typeof CHAT_PROVIDERS)[number]) =>
+            p.id === activeRequest.provider
         )
         if (!provider) {
-          throw new Error(`Unknown provider: ${request.provider}`)
+          throw new Error(`Unknown provider: ${activeRequest.provider}`)
         }
 
         // Create AI model using type guards for discriminated union
-        const model = createModelFromRequest(provider, request)
+        const model = createModelFromRequest(provider, activeRequest)
 
         // Resolve the agent for this request. Prefer the id on the request
         // (selected in the UI), then the thread's stored agent, then default.

--- a/main/src/chat/streaming/title-service.ts
+++ b/main/src/chat/streaming/title-service.ts
@@ -5,7 +5,12 @@ import {
   fallbackTitleFromParts,
 } from '@common/chat/thread-title'
 import log from '../../logger'
-import { LOCAL_PROVIDER_IDS } from '../constants'
+import {
+  ENDPOINT_PROVIDER_IDS,
+  THV_LLM_PROVIDER_ID,
+  type EndpointProviderId,
+} from '../constants'
+import { resolveGatewayBaseURL } from '../providers/thv-llm'
 import { CHAT_PROVIDERS } from '../providers/providers-catalog'
 import { createModelFromRequest } from '../utils'
 import type { ChatRequest, ChatUIMessage } from '../types'
@@ -34,10 +39,8 @@ const OPENROUTER_TITLE_PROVIDER_OPTIONS = {
   },
 }
 
-function isLocalProvider(providerId: string): boolean {
-  return LOCAL_PROVIDER_IDS.includes(
-    providerId as (typeof LOCAL_PROVIDER_IDS)[number]
-  )
+function isEndpointProvider(providerId: string): boolean {
+  return ENDPOINT_PROVIDER_IDS.includes(providerId as EndpointProviderId)
 }
 
 function extractMessageText(message: ChatUIMessage): string {
@@ -161,7 +164,10 @@ export class TitleService extends Effect.Service<TitleService>()(
                 typeof settingsRepo.readProvider
               >[0]
             )
-            if (!providerSettings) {
+            if (
+              !providerSettings &&
+              selected.provider !== THV_LLM_PROVIDER_ID
+            ) {
               return yield* Effect.fail(
                 new ProviderError({
                   providerId: selected.provider,
@@ -170,21 +176,29 @@ export class TitleService extends Effect.Service<TitleService>()(
               )
             }
 
+            const endpointURL =
+              selected.provider === THV_LLM_PROVIDER_ID
+                ? ((yield* Effect.tryPromise({
+                    try: () => resolveGatewayBaseURL(),
+                    catch: (cause) => cause,
+                  }).pipe(Effect.catchAll(() => Effect.succeed(null)))) ?? '')
+                : (providerSettings?.endpointURL ?? '')
+
             const request = (
-              isLocalProvider(selected.provider)
+              isEndpointProvider(selected.provider)
                 ? {
                     chatId: threadId,
                     messages: contextMessages,
                     provider: selected.provider,
                     model: selected.model,
-                    endpointURL: providerSettings.endpointURL ?? '',
+                    endpointURL,
                   }
                 : {
                     chatId: threadId,
                     messages: contextMessages,
                     provider: selected.provider,
                     model: selected.model,
-                    apiKey: providerSettings.apiKey ?? '',
+                    apiKey: providerSettings?.apiKey ?? '',
                   }
             ) as ChatRequest
 

--- a/main/src/chat/streaming/title-service.ts
+++ b/main/src/chat/streaming/title-service.ts
@@ -184,6 +184,16 @@ export class TitleService extends Effect.Service<TitleService>()(
                   }).pipe(Effect.catchAll(() => Effect.succeed(null)))) ?? '')
                 : (providerSettings?.endpointURL ?? '')
 
+            if (selected.provider === THV_LLM_PROVIDER_ID && !endpointURL) {
+              return yield* Effect.fail(
+                new ProviderError({
+                  providerId: THV_LLM_PROVIDER_ID,
+                  userMessage:
+                    'Stacklok Gateway is not configured. Open Provider Settings and save your gateway connection.',
+                })
+              )
+            }
+
             const request = (
               isEndpointProvider(selected.provider)
                 ? {

--- a/main/src/chat/streaming/title-service.ts
+++ b/main/src/chat/streaming/title-service.ts
@@ -10,7 +10,7 @@ import {
   THV_LLM_PROVIDER_ID,
   type EndpointProviderId,
 } from '../constants'
-import { resolveGatewayBaseURL } from '../providers/thv-llm'
+import { resolveGatewayBaseURL } from '../providers/thv-llm/proxy-manager'
 import { CHAT_PROVIDERS } from '../providers/providers-catalog'
 import { createModelFromRequest } from '../utils'
 import type { ChatRequest, ChatUIMessage } from '../types'

--- a/main/src/chat/types.ts
+++ b/main/src/chat/types.ts
@@ -1,5 +1,9 @@
 import type { LanguageModelUsage, UIMessage, LanguageModel } from 'ai'
-import type { LocalProviderId, ChatProviderInfo } from './constants'
+import type {
+  LocalProviderId,
+  GatewayProviderId,
+  ChatProviderInfo,
+} from './constants'
 
 // Define message metadata schema for type safety
 interface MessageMetadata {
@@ -34,19 +38,26 @@ export type ChatRequest =
       endpointURL: string
     })
   | (BaseChatRequest & {
-      provider: Exclude<string, LocalProviderId>
+      provider: GatewayProviderId
+      endpointURL: string
+    })
+  | (BaseChatRequest & {
+      provider: Exclude<string, LocalProviderId | GatewayProviderId>
       apiKey: string
     })
 
 // Chat provider configuration with functions
-// Discriminated union: Ollama and LM Studio use endpointURL, others use apiKey
 export type ChatProvider =
   | (ChatProviderInfo & {
       id: 'ollama' | 'lmstudio'
       createModel: (modelId: string, endpointURL: string) => LanguageModel
     })
   | (ChatProviderInfo & {
-      id: Exclude<string, 'ollama' | 'lmstudio'>
+      id: GatewayProviderId
+      createModel: (modelId: string, endpointURL: string) => LanguageModel
+    })
+  | (ChatProviderInfo & {
+      id: Exclude<string, LocalProviderId | GatewayProviderId>
       createModel: (modelId: string, apiKey: string) => LanguageModel
     })
 

--- a/main/src/chat/utils.ts
+++ b/main/src/chat/utils.ts
@@ -1,12 +1,12 @@
 import type { LanguageModel } from 'ai'
 import type { ChatRequest, ChatProvider } from './types'
-import { LOCAL_PROVIDER_IDS, type LocalProviderId } from './constants'
+import { ENDPOINT_PROVIDER_IDS, type EndpointProviderId } from './constants'
 
-function isLocalServerRequest(
+function isEndpointProviderRequest(
   request: ChatRequest
-): request is Extract<ChatRequest, { provider: LocalProviderId }> {
+): request is Extract<ChatRequest, { endpointURL: string }> {
   return (
-    LOCAL_PROVIDER_IDS.includes(request.provider as LocalProviderId) &&
+    ENDPOINT_PROVIDER_IDS.includes(request.provider as EndpointProviderId) &&
     'endpointURL' in request
   )
 }
@@ -21,7 +21,7 @@ export function createModelFromRequest(
   provider: ChatProvider,
   request: ChatRequest
 ): LanguageModel {
-  if (isLocalServerRequest(request)) {
+  if (isEndpointProviderRequest(request)) {
     return provider.createModel(request.model, request.endpointURL)
   }
   if (hasApiKey(request)) {

--- a/main/src/ipc-handlers/chat/__tests__/index.test.ts
+++ b/main/src/ipc-handlers/chat/__tests__/index.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   registerThreads: vi.fn(),
   registerAgents: vi.fn(),
   registerThreadSettings: vi.fn(),
+  registerLlmGateway: vi.fn(),
 }))
 
 vi.mock('../mcp-tools', () => ({ register: mocks.registerMcpTools }))
@@ -25,6 +26,7 @@ vi.mock('../agents', () => ({ register: mocks.registerAgents }))
 vi.mock('../thread-settings', () => ({
   register: mocks.registerThreadSettings,
 }))
+vi.mock('../llm-gateway', () => ({ register: mocks.registerLlmGateway }))
 
 import { register } from '../index'
 
@@ -46,5 +48,6 @@ describe('chat register', () => {
     expect(mocks.registerSkills).toHaveBeenCalledOnce()
     expect(mocks.registerPricing).toHaveBeenCalledOnce()
     expect(mocks.registerThreadSettings).toHaveBeenCalledOnce()
+    expect(mocks.registerLlmGateway).toHaveBeenCalledOnce()
   })
 })

--- a/main/src/ipc-handlers/chat/__tests__/llm-gateway.test.ts
+++ b/main/src/ipc-handlers/chat/__tests__/llm-gateway.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const ctx = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  getGatewayStatus: vi.fn(),
+  ensureProxyStarted: vi.fn(),
+  warmupGatewayAuth: vi.fn(),
+  invalidateLlmConfigCache: vi.fn(),
+  readLlmConfig: vi.fn(),
+  saveLlmConfig: vi.fn(),
+  startConfiguredLlmProxyIfNeeded: vi.fn(),
+  stopOwnedProxy: vi.fn(),
+  toLlmGatewayConfigForm: vi.fn(),
+  enablePlaygroundGateway: vi.fn(),
+  clearPlaygroundGatewaySettings: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+      ctx.handlers.set(channel, handler)
+    },
+  },
+}))
+
+vi.mock('../../../chat/providers/thv-llm', () => ({
+  getGatewayStatus: (...args: unknown[]) => ctx.getGatewayStatus(...args),
+  ensureProxyStarted: (...args: unknown[]) => ctx.ensureProxyStarted(...args),
+  warmupGatewayAuth: (...args: unknown[]) => ctx.warmupGatewayAuth(...args),
+  invalidateLlmConfigCache: (...args: unknown[]) =>
+    ctx.invalidateLlmConfigCache(...args),
+  readLlmConfig: (...args: unknown[]) => ctx.readLlmConfig(...args),
+  saveLlmConfig: (...args: unknown[]) => ctx.saveLlmConfig(...args),
+  startConfiguredLlmProxyIfNeeded: (...args: unknown[]) =>
+    ctx.startConfiguredLlmProxyIfNeeded(...args),
+  stopOwnedProxy: (...args: unknown[]) => ctx.stopOwnedProxy(...args),
+  toLlmGatewayConfigForm: (...args: unknown[]) =>
+    ctx.toLlmGatewayConfigForm(...args),
+}))
+
+vi.mock('../../../chat/providers/thv-llm/playground', () => ({
+  enablePlaygroundGateway: (...args: unknown[]) =>
+    ctx.enablePlaygroundGateway(...args),
+  clearPlaygroundGatewaySettings: (...args: unknown[]) =>
+    ctx.clearPlaygroundGatewaySettings(...args),
+}))
+
+import { register } from '../llm-gateway'
+
+describe('chat/llm-gateway IPC handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ctx.handlers.clear()
+    register()
+  })
+
+  it('returns gateway status', async () => {
+    ctx.getGatewayStatus.mockResolvedValue({ configured: true })
+    const result = await ctx.handlers.get('chat:llm-gateway:status')!(null)
+    expect(result).toEqual({ configured: true })
+  })
+
+  it('starts the proxy', async () => {
+    ctx.ensureProxyStarted.mockResolvedValue({ started: true })
+    const result = await ctx.handlers.get('chat:llm-gateway:ensure-started')!(
+      null
+    )
+    expect(result).toEqual({ started: true })
+  })
+
+  it('invalidates cache before warmup', async () => {
+    ctx.warmupGatewayAuth.mockResolvedValue({ ready: true })
+    const result = await ctx.handlers.get('chat:llm-gateway:warmup-auth')!(null)
+    expect(ctx.invalidateLlmConfigCache).toHaveBeenCalled()
+    expect(result).toEqual({ ready: true })
+  })
+
+  it('invalidates the cached llm config', async () => {
+    await ctx.handlers.get('chat:llm-gateway:invalidate-config')!(null)
+    expect(ctx.invalidateLlmConfigCache).toHaveBeenCalled()
+  })
+
+  it('maps stored config onto the settings form', async () => {
+    ctx.readLlmConfig.mockResolvedValue({ gateway_url: 'https://gw' })
+    ctx.toLlmGatewayConfigForm.mockReturnValue({
+      gatewayUrl: 'https://gw',
+      configured: true,
+    })
+
+    const result = await ctx.handlers.get('chat:llm-gateway:get-config')!(null)
+
+    expect(ctx.invalidateLlmConfigCache).toHaveBeenCalled()
+    expect(result).toEqual({ gatewayUrl: 'https://gw', configured: true })
+  })
+
+  it('enables Playground and starts the proxy after a successful save', async () => {
+    ctx.saveLlmConfig.mockResolvedValue({ ok: true })
+    const input = {
+      gatewayUrl: 'https://gw',
+      issuer: 'https://issuer',
+      clientId: 'client',
+    }
+
+    const result = await ctx.handlers.get('chat:llm-gateway:save-config')!(
+      null,
+      input
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(ctx.invalidateLlmConfigCache).toHaveBeenCalled()
+    expect(ctx.enablePlaygroundGateway).toHaveBeenCalled()
+    expect(ctx.startConfiguredLlmProxyIfNeeded).toHaveBeenCalled()
+  })
+
+  it('does not enable Playground when save fails', async () => {
+    ctx.saveLlmConfig.mockResolvedValue({ ok: false, error: 'nope' })
+
+    const result = await ctx.handlers.get('chat:llm-gateway:save-config')!(
+      null,
+      { gatewayUrl: '', issuer: '', clientId: '' }
+    )
+
+    expect(result).toEqual({ ok: false, error: 'nope' })
+    expect(ctx.enablePlaygroundGateway).not.toHaveBeenCalled()
+    expect(ctx.startConfiguredLlmProxyIfNeeded).not.toHaveBeenCalled()
+  })
+
+  it('clears Playground enablement and stops the owned proxy', async () => {
+    const result = await ctx.handlers.get('chat:llm-gateway:disable')!(null)
+    expect(result).toEqual({ ok: true })
+    expect(ctx.clearPlaygroundGatewaySettings).toHaveBeenCalled()
+    expect(ctx.stopOwnedProxy).toHaveBeenCalled()
+    expect(ctx.invalidateLlmConfigCache).toHaveBeenCalled()
+  })
+})

--- a/main/src/ipc-handlers/chat/index.ts
+++ b/main/src/ipc-handlers/chat/index.ts
@@ -8,6 +8,7 @@ import { register as registerSkills } from './skills'
 import { register as registerStreaming } from './streaming'
 import { register as registerThreads } from './threads'
 import { register as registerThreadSettings } from './thread-settings'
+import { register as registerLlmGateway } from './llm-gateway'
 
 export function register() {
   registerProviders()
@@ -20,4 +21,5 @@ export function register() {
   registerSkills()
   registerPricing()
   registerThreadSettings()
+  registerLlmGateway()
 }

--- a/main/src/ipc-handlers/chat/llm-gateway.ts
+++ b/main/src/ipc-handlers/chat/llm-gateway.ts
@@ -1,0 +1,58 @@
+import { ipcMain } from 'electron'
+import type { LlmGatewaySetupInput } from '../../chat/providers/thv-llm'
+import {
+  clearPlaygroundGatewaySettings,
+  enablePlaygroundGateway,
+  ensureProxyStarted,
+  getGatewayStatus,
+  invalidateLlmConfigCache,
+  readLlmConfig,
+  saveLlmConfig,
+  startConfiguredLlmProxyIfNeeded,
+  stopOwnedProxy,
+  toLlmGatewayConfigForm,
+  warmupGatewayAuth,
+} from '../../chat/providers/thv-llm'
+
+export function register() {
+  ipcMain.handle('chat:llm-gateway:status', async () => getGatewayStatus())
+
+  ipcMain.handle('chat:llm-gateway:ensure-started', async () =>
+    ensureProxyStarted()
+  )
+
+  ipcMain.handle('chat:llm-gateway:warmup-auth', async () => {
+    invalidateLlmConfigCache()
+    return warmupGatewayAuth()
+  })
+
+  ipcMain.handle('chat:llm-gateway:invalidate-config', () => {
+    invalidateLlmConfigCache()
+  })
+
+  ipcMain.handle('chat:llm-gateway:get-config', async () => {
+    invalidateLlmConfigCache()
+    const config = await readLlmConfig()
+    return toLlmGatewayConfigForm(config)
+  })
+
+  ipcMain.handle(
+    'chat:llm-gateway:save-config',
+    async (_event, input: LlmGatewaySetupInput) => {
+      const result = await saveLlmConfig(input)
+      if (result.ok) {
+        invalidateLlmConfigCache()
+        enablePlaygroundGateway()
+        void startConfiguredLlmProxyIfNeeded()
+      }
+      return result
+    }
+  )
+
+  ipcMain.handle('chat:llm-gateway:disable', async () => {
+    clearPlaygroundGatewaySettings()
+    stopOwnedProxy()
+    invalidateLlmConfigCache()
+    return { ok: true }
+  })
+}

--- a/main/src/ipc-handlers/chat/llm-gateway.ts
+++ b/main/src/ipc-handlers/chat/llm-gateway.ts
@@ -1,8 +1,6 @@
 import { ipcMain } from 'electron'
 import type { LlmGatewaySetupInput } from '../../chat/providers/thv-llm'
 import {
-  clearPlaygroundGatewaySettings,
-  enablePlaygroundGateway,
   ensureProxyStarted,
   getGatewayStatus,
   invalidateLlmConfigCache,
@@ -13,6 +11,10 @@ import {
   toLlmGatewayConfigForm,
   warmupGatewayAuth,
 } from '../../chat/providers/thv-llm'
+import {
+  clearPlaygroundGatewaySettings,
+  enablePlaygroundGateway,
+} from '../../chat/providers/thv-llm/playground'
 
 export function register() {
   ipcMain.handle('chat:llm-gateway:status', async () => getGatewayStatus())

--- a/main/src/tests/auto-update.test.ts
+++ b/main/src/tests/auto-update.test.ts
@@ -123,6 +123,10 @@ vi.mock('../toolhive-manager', () => ({
   binPath: '/mock/bin/path',
 }))
 
+vi.mock('../chat/providers/thv-llm', () => ({
+  stopOwnedProxy: vi.fn(),
+}))
+
 vi.mock('../unix-socket-fetch', () => ({
   createMainProcessFetch: vi.fn(() => vi.fn()),
 }))

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -189,7 +189,6 @@ describe('toolhive-manager', () => {
           windowsHide: true,
           env: expect.objectContaining({
             TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
-            TOOLHIVE_SKILLS_LOCK_ENABLED: 'true',
           }),
         }
       )
@@ -423,7 +422,6 @@ describe('toolhive-manager', () => {
           windowsHide: true,
           env: expect.objectContaining({
             TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
-            TOOLHIVE_SKILLS_LOCK_ENABLED: 'true',
           }),
         }
       )
@@ -482,7 +480,6 @@ describe('toolhive-manager', () => {
       expect(entries).toContain('/bin')
 
       expect(spawnOptions.env.TOOLHIVE_SKIP_DESKTOP_CHECK).toBe('true')
-      expect(spawnOptions.env.TOOLHIVE_SKILLS_LOCK_ENABLED).toBe('true')
     })
 
     it('omits sentry flags when telemetry is disabled', async () => {

--- a/main/src/tests/toolhive-manager.test.ts
+++ b/main/src/tests/toolhive-manager.test.ts
@@ -189,6 +189,7 @@ describe('toolhive-manager', () => {
           windowsHide: true,
           env: expect.objectContaining({
             TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
+            TOOLHIVE_SKILLS_LOCK_ENABLED: 'true',
           }),
         }
       )
@@ -422,6 +423,7 @@ describe('toolhive-manager', () => {
           windowsHide: true,
           env: expect.objectContaining({
             TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
+            TOOLHIVE_SKILLS_LOCK_ENABLED: 'true',
           }),
         }
       )
@@ -480,6 +482,7 @@ describe('toolhive-manager', () => {
       expect(entries).toContain('/bin')
 
       expect(spawnOptions.env.TOOLHIVE_SKIP_DESKTOP_CHECK).toBe('true')
+      expect(spawnOptions.env.TOOLHIVE_SKILLS_LOCK_ENABLED).toBe('true')
     })
 
     it('omits sentry flags when telemetry is disabled', async () => {

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -162,6 +162,9 @@ export async function startToolhive(): Promise<void> {
           ...process.env,
           PATH: createEnhancedPath(),
           TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
+          // Feature-gate for project-level skills lock file (toolhive.lock.yaml).
+          // Remove once the lockfile feature is GA in thv.
+          TOOLHIVE_SKILLS_LOCK_ENABLED: 'true',
         },
       })
       toolhiveProcess = child

--- a/main/src/toolhive-manager.ts
+++ b/main/src/toolhive-manager.ts
@@ -162,9 +162,6 @@ export async function startToolhive(): Promise<void> {
           ...process.env,
           PATH: createEnhancedPath(),
           TOOLHIVE_SKIP_DESKTOP_CHECK: 'true',
-          // Feature-gate for project-level skills lock file (toolhive.lock.yaml).
-          // Remove once the lockfile feature is GA in thv.
-          TOOLHIVE_SKILLS_LOCK_ENABLED: 'true',
         },
       })
       toolhiveProcess = child

--- a/preload/src/api/chat.ts
+++ b/preload/src/api/chat.ts
@@ -212,6 +212,24 @@ export const chatApi = {
           enabled
         ),
     },
+    llmGateway: {
+      getStatus: () => ipcRenderer.invoke('chat:llm-gateway:status'),
+      ensureStarted: () =>
+        ipcRenderer.invoke('chat:llm-gateway:ensure-started'),
+      warmupAuth: () => ipcRenderer.invoke('chat:llm-gateway:warmup-auth'),
+      invalidateConfig: () =>
+        ipcRenderer.invoke('chat:llm-gateway:invalidate-config'),
+      getConfig: () => ipcRenderer.invoke('chat:llm-gateway:get-config'),
+      saveConfig: (input: {
+        gatewayUrl: string
+        issuer: string
+        clientId: string
+        audience?: string
+        callbackPort?: number
+        proxyPort?: number
+      }) => ipcRenderer.invoke('chat:llm-gateway:save-config', input),
+      disable: () => ipcRenderer.invoke('chat:llm-gateway:disable'),
+    },
   },
 }
 
@@ -230,6 +248,15 @@ export interface ChatAPI {
             chatId: string
             messages: ChatUIMessage[]
             provider: 'ollama' | 'lmstudio'
+            model: string
+            endpointURL: string
+            enabledTools?: string[]
+            agentId?: string
+          }
+        | {
+            chatId: string
+            messages: ChatUIMessage[]
+            provider: 'thv-llm'
             model: string
             endpointURL: string
             enabledTools?: string[]
@@ -257,6 +284,11 @@ export interface ChatAPI {
     getSettings: (providerId: string) => Promise<
       | {
           providerId: 'ollama' | 'lmstudio'
+          endpointURL: string
+          enabledTools: string[]
+        }
+      | {
+          providerId: 'thv-llm'
           endpointURL: string
           enabledTools: string[]
         }
@@ -501,6 +533,61 @@ export interface ChatAPI {
         name: string,
         enabled: boolean
       ) => Promise<{ success: boolean; error?: string }>
+    }
+
+    llmGateway: {
+      getStatus: () => Promise<{
+        configured: boolean
+        proxyRunning: boolean
+        authState:
+          | 'not_configured'
+          | 'proxy_stopped'
+          | 'authenticating'
+          | 'ready'
+          | 'error'
+        listenPort: number | null
+        baseURL: string | null
+        gatewayURL: string | null
+        modelCount: number
+        error: string | null
+        studioOwnsProxy: boolean
+      }>
+      ensureStarted: () => Promise<{
+        started: boolean
+        alreadyRunning: boolean
+        studioOwnsProxy: boolean
+        error?: string
+      }>
+      warmupAuth: () => Promise<{
+        ready: boolean
+        authState:
+          | 'ready'
+          | 'authenticating'
+          | 'error'
+          | 'not_configured'
+          | 'proxy_stopped'
+        modelCount: number
+        error?: string
+      }>
+      invalidateConfig: () => Promise<void>
+      getConfig: () => Promise<{
+        gatewayUrl: string
+        issuer: string
+        clientId: string
+        audience?: string
+        callbackPort?: number
+        proxyPort?: number
+        configured: boolean
+      }>
+      saveConfig: (input: {
+        gatewayUrl: string
+        issuer: string
+        clientId: string
+        audience?: string
+        callbackPort?: number
+        proxyPort?: number
+      }) => Promise<{ ok: boolean; error?: string }>
+      disable: () => Promise<{ ok: boolean }>
     }
   }
 }

--- a/renderer/src/features/chat/components/__tests__/chat-interface.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/chat-interface.test.tsx
@@ -132,6 +132,9 @@ vi.mock('../../hooks/use-mcp-app-metadata', () => ({
 vi.mock('../../lib/utils', () => ({
   hasCredentials: (settings: Record<string, unknown>) =>
     !!settings.apiKey || !!settings.endpointURL,
+  isGatewayProvider: (provider: string) => provider === 'thv-llm',
+  isLocalServerProvider: (provider: string) =>
+    provider === 'ollama' || provider === 'lmstudio',
 }))
 
 const now = Date.now()

--- a/renderer/src/features/chat/components/__tests__/dialog-provider-settings.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/dialog-provider-settings.test.tsx
@@ -17,6 +17,33 @@ const mockChatAPI = {
   saveSettings: vi.fn(),
   clearSettings: vi.fn(),
   fetchProviderModels: vi.fn(),
+  llmGateway: {
+    getStatus: vi.fn().mockResolvedValue({
+      configured: false,
+      proxyRunning: false,
+      authState: 'not_configured',
+      listenPort: null,
+      baseURL: null,
+      gatewayURL: null,
+      modelCount: 0,
+      error: null,
+      studioOwnsProxy: false,
+    }),
+    getConfig: vi.fn().mockResolvedValue({
+      gatewayUrl: '',
+      issuer: '',
+      clientId: '',
+      audience: '',
+      callbackPort: 8080,
+      proxyPort: 14000,
+      configured: false,
+    }),
+    saveConfig: vi.fn().mockResolvedValue({ ok: true }),
+    disable: vi.fn().mockResolvedValue({ ok: true }),
+    ensureStarted: vi.fn(),
+    warmupAuth: vi.fn(),
+    invalidateConfig: vi.fn(),
+  },
 }
 
 const createWrapper = () => {
@@ -134,6 +161,64 @@ describe('DialogProviderSettings', () => {
 
       await waitFor(() => {
         expect(screen.getByText(/Found 3 model/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Stacklok Gateway', () => {
+    it('lists the gateway and removes it from Playground on save', async () => {
+      const user = userEvent.setup()
+
+      mockChatAPI.getProviders.mockResolvedValue([
+        {
+          id: 'thv-llm',
+          name: 'Stacklok Gateway',
+          models: ['gpt-4.1'],
+        },
+      ])
+      mockChatAPI.getSettings.mockResolvedValue({
+        endpointURL: 'enabled',
+        enabledTools: [],
+      })
+      mockChatAPI.llmGateway.getConfig.mockResolvedValue({
+        gatewayUrl: 'https://llm-gateway.stacklok.dev',
+        issuer: 'https://issuer.example.com',
+        clientId: 'client',
+        audience: '',
+        callbackPort: 8080,
+        proxyPort: 14000,
+        configured: true,
+      })
+      mockChatAPI.llmGateway.getStatus.mockResolvedValue({
+        configured: true,
+        proxyRunning: true,
+        authState: 'ready',
+        listenPort: 14000,
+        baseURL: 'http://127.0.0.1:14000/v1',
+        gatewayURL: 'https://llm-gateway.stacklok.dev',
+        modelCount: 1,
+        error: null,
+        studioOwnsProxy: true,
+      })
+
+      render(<DialogProviderSettings isOpen={true} onOpenChange={vi.fn()} />, {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /stacklok gateway/i })
+        ).toBeInTheDocument()
+      })
+
+      await user.click(
+        screen.getByRole('button', { name: /stacklok gateway/i })
+      )
+      await user.click(screen.getByTestId('remove-credentials-button'))
+      await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+      await waitFor(() => {
+        expect(mockChatAPI.llmGateway.disable).toHaveBeenCalled()
       })
     })
   })

--- a/renderer/src/features/chat/components/__tests__/dialog-provider-settings.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/dialog-provider-settings.test.tsx
@@ -214,7 +214,9 @@ describe('DialogProviderSettings', () => {
       await user.click(
         screen.getByRole('button', { name: /stacklok gateway/i })
       )
-      await user.click(screen.getByTestId('remove-credentials-button'))
+      await user.click(
+        screen.getByRole('button', { name: /remove gateway connection/i })
+      )
       await user.click(screen.getByRole('button', { name: /^save$/i }))
 
       await waitFor(() => {

--- a/renderer/src/features/chat/components/__tests__/llm-gateway-login-modal.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/llm-gateway-login-modal.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { LlmGatewayLoginModal } from '../llm-gateway-login-modal'
+
+describe('LlmGatewayLoginModal', () => {
+  it('shows the sign-in prompt and optional message', () => {
+    render(
+      <LlmGatewayLoginModal
+        open
+        onOpenChange={vi.fn()}
+        onRetry={vi.fn()}
+        message="Complete sign-in in your browser"
+      />
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /sign in to stacklok gateway/i })
+    ).toBeVisible()
+    expect(screen.getByText('Complete sign-in in your browser')).toBeVisible()
+  })
+
+  it('calls onRetry when the user completed sign-in', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+
+    render(
+      <LlmGatewayLoginModal open onOpenChange={vi.fn()} onRetry={onRetry} />
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: /i completed sign-in/i })
+    )
+    expect(onRetry).toHaveBeenCalled()
+  })
+
+  it('disables retry while checking', () => {
+    render(
+      <LlmGatewayLoginModal
+        open
+        onOpenChange={vi.fn()}
+        onRetry={vi.fn()}
+        isRetrying
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /checking/i })).toBeDisabled()
+  })
+
+  it('closes on cancel', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <LlmGatewayLoginModal
+        open
+        onOpenChange={onOpenChange}
+        onRetry={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/renderer/src/features/chat/components/__tests__/llm-gateway-settings-panel.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/llm-gateway-settings-panel.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { LlmGatewaySettingsPanel } from '../llm-gateway-settings-panel'
+
+const mockLlmGateway = {
+  getStatus: vi.fn(),
+  getConfig: vi.fn(),
+  saveConfig: vi.fn(),
+  ensureStarted: vi.fn(),
+  warmupAuth: vi.fn(),
+  disable: vi.fn(),
+  invalidateConfig: vi.fn(),
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+describe('LlmGatewaySettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.electronAPI.chat = {
+      ...window.electronAPI.chat,
+      llmGateway: mockLlmGateway,
+    } as unknown as typeof window.electronAPI.chat
+
+    mockLlmGateway.getConfig.mockResolvedValue({
+      gatewayUrl: 'https://gw.example',
+      issuer: 'https://issuer.example',
+      clientId: 'client',
+      audience: 'api://gw',
+      callbackPort: 8080,
+      proxyPort: 14000,
+      configured: true,
+    })
+    mockLlmGateway.getStatus.mockResolvedValue({
+      configured: true,
+      proxyRunning: false,
+      authState: 'proxy_stopped',
+      listenPort: 14000,
+      baseURL: 'http://127.0.0.1:14000/v1',
+      gatewayURL: 'https://gw.example',
+      modelCount: 0,
+      error: null,
+      studioOwnsProxy: false,
+    })
+    mockLlmGateway.saveConfig.mockResolvedValue({ ok: true })
+    mockLlmGateway.ensureStarted.mockResolvedValue({ started: true })
+    mockLlmGateway.warmupAuth.mockResolvedValue({ ready: true })
+  })
+
+  it('hydrates saved connection settings into the form', async () => {
+    render(<LlmGatewaySettingsPanel />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Gateway URL')).toHaveValue(
+        'https://gw.example'
+      )
+    })
+    expect(screen.getByLabelText('Issuer')).toHaveValue(
+      'https://issuer.example'
+    )
+    expect(screen.getByLabelText('Client ID')).toHaveValue('client')
+  })
+
+  it('saves the connection settings', async () => {
+    const user = userEvent.setup()
+    render(<LlmGatewaySettingsPanel />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Gateway URL')).toHaveValue(
+        'https://gw.example'
+      )
+    })
+
+    await user.click(
+      screen.getByRole('button', { name: /save connection settings/i })
+    )
+
+    await waitFor(() => {
+      expect(mockLlmGateway.saveConfig).toHaveBeenCalledWith({
+        gatewayUrl: 'https://gw.example',
+        issuer: 'https://issuer.example',
+        clientId: 'client',
+        audience: 'api://gw',
+        callbackPort: 8080,
+        proxyPort: 14000,
+      })
+    })
+  })
+
+  it('shows a save error from the main process', async () => {
+    const user = userEvent.setup()
+    mockLlmGateway.saveConfig.mockResolvedValue({
+      ok: false,
+      error: 'Gateway URL, issuer, and client ID are required.',
+    })
+
+    render(<LlmGatewaySettingsPanel />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Gateway URL')).toBeVisible()
+    })
+
+    await user.click(
+      screen.getByRole('button', { name: /save connection settings/i })
+    )
+
+    expect(
+      await screen.findByText(
+        'Gateway URL, issuer, and client ID are required.'
+      )
+    ).toBeVisible()
+  })
+
+  it('starts the proxy when it is stopped', async () => {
+    const user = userEvent.setup()
+    render(<LlmGatewaySettingsPanel />, { wrapper: createWrapper() })
+
+    await user.click(
+      await screen.findByRole('button', { name: /start proxy/i })
+    )
+
+    await waitFor(() => {
+      expect(mockLlmGateway.ensureStarted).toHaveBeenCalled()
+    })
+  })
+
+  it('shows a save error when starting the proxy fails', async () => {
+    const user = userEvent.setup()
+    mockLlmGateway.ensureStarted.mockRejectedValue(new Error('proxy timeout'))
+
+    render(<LlmGatewaySettingsPanel />, { wrapper: createWrapper() })
+
+    await user.click(
+      await screen.findByRole('button', { name: /start proxy/i })
+    )
+
+    expect(await screen.findByText('proxy timeout')).toBeVisible()
+  })
+
+  it('signs in through the gateway warmup flow', async () => {
+    const user = userEvent.setup()
+    mockLlmGateway.getStatus.mockResolvedValue({
+      configured: true,
+      proxyRunning: true,
+      authState: 'authenticating',
+      listenPort: 14000,
+      baseURL: 'http://127.0.0.1:14000/v1',
+      gatewayURL: 'https://gw.example',
+      modelCount: 0,
+      error: null,
+      studioOwnsProxy: true,
+    })
+    mockLlmGateway.warmupAuth.mockResolvedValue({ ready: true, modelCount: 1 })
+
+    render(<LlmGatewaySettingsPanel />, { wrapper: createWrapper() })
+
+    await user.click(await screen.findByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(mockLlmGateway.ensureStarted).toHaveBeenCalled()
+      expect(mockLlmGateway.warmupAuth).toHaveBeenCalled()
+    })
+  })
+})

--- a/renderer/src/features/chat/components/__tests__/model-picker.test.tsx
+++ b/renderer/src/features/chat/components/__tests__/model-picker.test.tsx
@@ -29,6 +29,31 @@ vi.mock('../provider-icons', () => ({
 const mockChatAPI = {
   getProviders: vi.fn(),
   getSettings: vi.fn(),
+  llmGateway: {
+    getStatus: vi.fn().mockResolvedValue({
+      configured: false,
+      proxyRunning: false,
+      authState: 'not_configured',
+      listenPort: null,
+      baseURL: null,
+      gatewayURL: null,
+      modelCount: 0,
+      error: null,
+      studioOwnsProxy: false,
+    }),
+    getConfig: vi.fn().mockResolvedValue({
+      gatewayUrl: '',
+      issuer: '',
+      clientId: '',
+      audience: '',
+      configured: false,
+    }),
+    saveConfig: vi.fn().mockResolvedValue({ ok: true }),
+    disable: vi.fn().mockResolvedValue({ ok: true }),
+    ensureStarted: vi.fn(),
+    warmupAuth: vi.fn(),
+    invalidateConfig: vi.fn(),
+  },
 }
 
 function renderPicker(

--- a/renderer/src/features/chat/components/chat-interface.tsx
+++ b/renderer/src/features/chat/components/chat-interface.tsx
@@ -21,6 +21,7 @@ import { hasCredentials } from '../lib/utils'
 import { getEmptyStateCopy } from '../lib/empty-state-copy'
 import { useAgents, useThreadAgentId } from '../../agents/hooks/use-agents'
 import { DEFAULT_AGENT_ID } from '@common/types/agents'
+import { isGatewayProvider } from '../lib/utils'
 
 interface ChatInterfaceProps {
   threadId?: string | null
@@ -139,7 +140,9 @@ export function ChatInterface({
   const { data: threadAgentId } = useThreadAgentId(threadId ?? undefined)
   const selectedAgentId = threadAgentId || DEFAULT_AGENT_ID
   const selectedAgent = agents.find((a) => a.id === selectedAgentId)
-  const emptyStateCopy = getEmptyStateCopy(selectedAgent)
+  const emptyStateCopy = getEmptyStateCopy(selectedAgent, {
+    usesGatewayProvider: isGatewayProvider(settings.provider),
+  })
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/renderer/src/features/chat/components/dialog-provider-settings.tsx
+++ b/renderer/src/features/chat/components/dialog-provider-settings.tsx
@@ -418,6 +418,7 @@ export function DialogProviderSettings({
                               className="hover:bg-destructive
                                 hover:text-destructive-foreground
                                 cursor-pointer"
+                              aria-label="Remove gateway connection"
                               data-testid="remove-credentials-button"
                             >
                               <Trash2 className="h-4 w-4" />
@@ -542,6 +543,7 @@ export function DialogProviderSettings({
                                         handleRemoveApiKey(pk.provider.id)
                                       }
                                       className="hover:bg-destructive hover:text-destructive-foreground cursor-pointer"
+                                      aria-label="Remove credentials"
                                       data-testid="remove-credentials-button"
                                     >
                                       <Trash2 className="h-4 w-4" />

--- a/renderer/src/features/chat/components/dialog-provider-settings.tsx
+++ b/renderer/src/features/chat/components/dialog-provider-settings.tsx
@@ -34,7 +34,9 @@ import {
 import { ScrollArea } from '@/common/components/ui/scroll-area'
 import { trackEvent } from '@/common/lib/analytics'
 import type { ChatSettings } from '../types'
-import { hasCredentials } from '../lib/utils'
+import { hasCredentials, isGatewayProvider } from '../lib/utils'
+import { LlmGatewaySettingsPanel } from './llm-gateway-settings-panel'
+import { THV_LLM_PROVIDER_ID } from '../lib/gateway-provider'
 
 // Provider-specific configuration for credential input
 function getProviderCredentialConfig(providerId: string, providerName: string) {
@@ -55,6 +57,15 @@ function getProviderCredentialConfig(providerId: string, providerName: string) {
       isSecret: false,
       helpText:
         'Enter the URL of your LM Studio server (default: http://localhost:1234)',
+    }
+  }
+
+  if (providerId === THV_LLM_PROVIDER_ID) {
+    return {
+      label: 'Gateway',
+      placeholder: '',
+      isSecret: false,
+      helpText: undefined,
     }
   }
 
@@ -165,7 +176,7 @@ export function DialogProviderSettings({
       prev.map((pk) => {
         if (pk.provider.id !== providerId) return pk
 
-        if (isLocalServerProvider(pk)) {
+        if (isLocalServerProvider(pk) || isGatewayProvider(pk.provider.id)) {
           return { ...pk, endpointURL: '', hasKey: false }
         } else {
           return { ...pk, apiKey: '', hasKey: false }
@@ -239,6 +250,13 @@ export function DialogProviderSettings({
       trackEvent(`Playground: save provider settings`)
       await Promise.all(
         providerKeys.map(async (pk) => {
+          if (isGatewayProvider(pk.provider.id)) {
+            if (!pk.hasKey) {
+              await window.electronAPI.chat.llmGateway.disable()
+            }
+            return
+          }
+
           const originalProvider = allProvidersWithSettings.find(
             (p) => p.provider.id === pk.provider.id
           )
@@ -260,6 +278,17 @@ export function DialogProviderSettings({
         })
       )
 
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['chat', 'allProvidersWithSettings'],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['chat', 'availableModels'],
+        }),
+        queryClient.invalidateQueries({ queryKey: ['chat', 'selectedModel'] }),
+        queryClient.invalidateQueries({ queryKey: ['chat', 'llmGateway'] }),
+      ])
+
       const updatedProvidersWithKeys = providerKeys.filter(
         (pk) => pk.hasKey && getProviderCredential(pk).trim()
       )
@@ -277,21 +306,31 @@ export function DialogProviderSettings({
         (!hasCredentials(settings) || !currentProviderHasCredentials)
       ) {
         const credential = getProviderCredential(firstProviderWithCredentials)
-        const newSettings: ChatSettings = isLocalServerProvider(
-          firstProviderWithCredentials
-        )
-          ? {
-              provider: firstProviderWithCredentials.provider.id,
-              model: firstProviderWithCredentials.provider.models[0] || '',
-              endpointURL: credential,
-              enabledTools: settings.enabledTools,
-            }
-          : {
-              provider: firstProviderWithCredentials.provider.id,
-              model: firstProviderWithCredentials.provider.models[0] || '',
-              apiKey: credential,
-              enabledTools: settings.enabledTools,
-            }
+        let newSettings: ChatSettings
+        if (isLocalServerProvider(firstProviderWithCredentials)) {
+          newSettings = {
+            provider: firstProviderWithCredentials.provider.id,
+            model: firstProviderWithCredentials.provider.models[0] || '',
+            endpointURL: credential,
+            enabledTools: settings.enabledTools,
+          }
+        } else if (
+          isGatewayProvider(firstProviderWithCredentials.provider.id)
+        ) {
+          newSettings = {
+            provider: THV_LLM_PROVIDER_ID,
+            model: firstProviderWithCredentials.provider.models[0] || '',
+            endpointURL: credential,
+            enabledTools: settings.enabledTools,
+          }
+        } else {
+          newSettings = {
+            provider: firstProviderWithCredentials.provider.id,
+            model: firstProviderWithCredentials.provider.models[0] || '',
+            apiKey: credential,
+            enabledTools: settings.enabledTools,
+          }
+        }
 
         updateSettings(newSettings)
       }
@@ -302,6 +341,7 @@ export function DialogProviderSettings({
       log.error('Failed to save provider settings:', error)
     }
   }, [
+    queryClient,
     providerKeys,
     allProvidersWithSettings,
     settings,
@@ -363,159 +403,193 @@ export function DialogProviderSettings({
                   </CollapsibleTrigger>
 
                   <CollapsibleContent>
-                    {(() => {
-                      const credentialConfig = getProviderCredentialConfig(
-                        pk.provider.id,
-                        pk.provider.name
-                      )
-                      return (
-                        <div className="border-border/30 bg-muted/10 space-y-3 border-t px-4 pb-4">
-                          <div className="space-y-2 pt-2">
-                            <div className="space-y-2">
-                              <div>
-                                <Label
-                                  htmlFor={`apikey-${pk.provider.id}`}
-                                  className="text-sm font-medium"
-                                >
-                                  {credentialConfig.label}
-                                </Label>
-                                {credentialConfig.helpText && (
-                                  <p className="text-muted-foreground mt-1 text-xs">
-                                    {credentialConfig.helpText}
-                                  </p>
-                                )}
-                              </div>
-                              <div className="flex gap-2">
-                                <div className="relative flex-1">
-                                  <Input
-                                    id={`apikey-${pk.provider.id}`}
-                                    type={
-                                      credentialConfig.isSecret &&
-                                      !showApiKeys[pk.provider.id]
-                                        ? 'password'
-                                        : 'text'
-                                    }
-                                    value={getProviderCredential(pk)}
-                                    onChange={(e) =>
-                                      handleApiKeyChange(
-                                        pk.provider.id,
-                                        e.target.value
-                                      )
-                                    }
-                                    placeholder={credentialConfig.placeholder}
-                                    className="pr-10"
-                                  />
-                                  {credentialConfig.isSecret && (
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="sm"
-                                      className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
-                                      onClick={() =>
-                                        toggleShowApiKey(pk.provider.id)
-                                      }
-                                    >
-                                      {showApiKeys[pk.provider.id] ? (
-                                        <EyeOff className="text-muted-foreground h-4 w-4" />
-                                      ) : (
-                                        <Eye className="text-muted-foreground h-4 w-4" />
-                                      )}
-                                    </Button>
+                    {pk.provider.id === THV_LLM_PROVIDER_ID ? (
+                      <div
+                        className="border-border/30 bg-muted/10 border-t px-4
+                          pb-4"
+                      >
+                        {pk.hasKey ? (
+                          <div className="flex justify-end pt-2">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="icon"
+                              onClick={() => handleRemoveApiKey(pk.provider.id)}
+                              className="hover:bg-destructive
+                                hover:text-destructive-foreground
+                                cursor-pointer"
+                              data-testid="remove-credentials-button"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        ) : null}
+                        <LlmGatewaySettingsPanel
+                          onStatusChange={() => {
+                            void queryClient.invalidateQueries({
+                              queryKey: ['chat', 'availableModels'],
+                            })
+                            void queryClient.invalidateQueries({
+                              queryKey: ['chat', 'allProvidersWithSettings'],
+                            })
+                          }}
+                        />
+                      </div>
+                    ) : (
+                      (() => {
+                        const credentialConfig = getProviderCredentialConfig(
+                          pk.provider.id,
+                          pk.provider.name
+                        )
+                        return (
+                          <div className="border-border/30 bg-muted/10 space-y-3 border-t px-4 pb-4">
+                            <div className="space-y-2 pt-2">
+                              <div className="space-y-2">
+                                <div>
+                                  <Label
+                                    htmlFor={`apikey-${pk.provider.id}`}
+                                    className="text-sm font-medium"
+                                  >
+                                    {credentialConfig.label}
+                                  </Label>
+                                  {credentialConfig.helpText && (
+                                    <p className="text-muted-foreground mt-1 text-xs">
+                                      {credentialConfig.helpText}
+                                    </p>
                                   )}
                                 </div>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
+                                <div className="flex gap-2">
+                                  <div className="relative flex-1">
+                                    <Input
+                                      id={`apikey-${pk.provider.id}`}
+                                      type={
+                                        credentialConfig.isSecret &&
+                                        !showApiKeys[pk.provider.id]
+                                          ? 'password'
+                                          : 'text'
+                                      }
+                                      value={getProviderCredential(pk)}
+                                      onChange={(e) =>
+                                        handleApiKeyChange(
+                                          pk.provider.id,
+                                          e.target.value
+                                        )
+                                      }
+                                      placeholder={credentialConfig.placeholder}
+                                      className="pr-10"
+                                    />
+                                    {credentialConfig.isSecret && (
+                                      <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
+                                        onClick={() =>
+                                          toggleShowApiKey(pk.provider.id)
+                                        }
+                                      >
+                                        {showApiKeys[pk.provider.id] ? (
+                                          <EyeOff className="text-muted-foreground h-4 w-4" />
+                                        ) : (
+                                          <Eye className="text-muted-foreground h-4 w-4" />
+                                        )}
+                                      </Button>
+                                    )}
+                                  </div>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => handleRefreshModels(pk)}
+                                        disabled={
+                                          isRefreshing ||
+                                          (pk.provider.id === 'ollama' ||
+                                          pk.provider.id === 'lmstudio'
+                                            ? !getProviderCredential(pk).trim()
+                                            : !pk.hasKey ||
+                                              !getProviderCredential(pk).trim())
+                                        }
+                                        className="px-3"
+                                        data-testid="refresh-models-button"
+                                      >
+                                        <RefreshCw
+                                          className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`}
+                                        />
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>
+                                        {!getProviderCredential(pk).trim()
+                                          ? pk.provider.id === 'ollama' ||
+                                            pk.provider.id === 'lmstudio'
+                                            ? 'Enter a server URL to fetch available models'
+                                            : 'Enter an API key to fetch available models'
+                                          : pk.provider.id === 'ollama' ||
+                                              pk.provider.id === 'lmstudio'
+                                            ? `Fetch available models from the ${pk.provider.name} server URL (will use the current input)`
+                                            : 'Fetch available models using the configured API key'}
+                                      </p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                  {pk.hasKey && (
                                     <Button
                                       type="button"
                                       variant="outline"
-                                      size="sm"
-                                      onClick={() => handleRefreshModels(pk)}
-                                      disabled={
-                                        isRefreshing ||
-                                        (pk.provider.id === 'ollama' ||
-                                        pk.provider.id === 'lmstudio'
-                                          ? !getProviderCredential(pk).trim()
-                                          : !pk.hasKey ||
-                                            !getProviderCredential(pk).trim())
+                                      size="icon"
+                                      onClick={() =>
+                                        handleRemoveApiKey(pk.provider.id)
                                       }
-                                      className="px-3"
-                                      data-testid="refresh-models-button"
+                                      className="hover:bg-destructive hover:text-destructive-foreground cursor-pointer"
+                                      data-testid="remove-credentials-button"
                                     >
-                                      <RefreshCw
-                                        className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`}
-                                      />
+                                      <Trash2 className="h-4 w-4" />
                                     </Button>
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    <p>
-                                      {!getProviderCredential(pk).trim()
-                                        ? pk.provider.id === 'ollama' ||
-                                          pk.provider.id === 'lmstudio'
-                                          ? 'Enter a server URL to fetch available models'
-                                          : 'Enter an API key to fetch available models'
-                                        : pk.provider.id === 'ollama' ||
-                                            pk.provider.id === 'lmstudio'
-                                          ? `Fetch available models from the ${pk.provider.name} server URL (will use the current input)`
-                                          : 'Fetch available models using the configured API key'}
-                                    </p>
-                                  </TooltipContent>
-                                </Tooltip>
-                                {pk.hasKey && (
-                                  <Button
-                                    type="button"
-                                    variant="outline"
-                                    size="icon"
-                                    onClick={() =>
-                                      handleRemoveApiKey(pk.provider.id)
-                                    }
-                                    className="hover:bg-destructive hover:text-destructive-foreground cursor-pointer"
-                                    data-testid="remove-credentials-button"
-                                  >
-                                    <Trash2 className="h-4 w-4" />
-                                  </Button>
-                                )}
+                                  )}
+                                </div>
                               </div>
-                            </div>
-                            {validationStatus[pk.provider.id] && (
-                              <div
-                                className={`rounded-md border p-3 ${
-                                  validationStatus[pk.provider.id]?.valid
-                                    ? 'border-success/20 bg-success/10'
-                                    : 'border-destructive/20 bg-destructive/10'
-                                }`}
-                              >
-                                <p
-                                  className={`text-sm ${
+                              {validationStatus[pk.provider.id] && (
+                                <div
+                                  className={`rounded-md border p-3 ${
                                     validationStatus[pk.provider.id]?.valid
-                                      ? 'text-success'
-                                      : 'text-destructive'
+                                      ? 'border-success/20 bg-success/10'
+                                      : 'border-destructive/20 bg-destructive/10'
                                   }`}
                                 >
-                                  {validationStatus[pk.provider.id]?.valid
-                                    ? `✓ Connection successful! Found ${validationStatus[pk.provider.id]?.modelCount} model${validationStatus[pk.provider.id]?.modelCount === 1 ? '' : 's'}.`
-                                    : `✗ Connection failed. Please check the URL and ensure ${pk.provider.name} is running.`}
-                                </p>
-                              </div>
-                            )}
-                            {pk.hasKey &&
-                              pk.provider.models.length === 0 &&
-                              !validationStatus[pk.provider.id] &&
-                              (isLocalServerProvider(pk)
-                                ? pk.endpointURL.trim() !== ''
-                                : true) && (
-                                <div className="border-warning/20 bg-warning/10 rounded-md border p-3">
-                                  <p className="text-warning text-sm">
-                                    {pk.provider.id === 'ollama' ||
-                                    pk.provider.id === 'lmstudio'
-                                      ? `${pk.provider.name} server is not running or no models are installed. Please start ${pk.provider.name} and ensure you have models available, then click the refresh button above.`
-                                      : 'This provider appears to be offline or has no models available. Click the refresh button above to check again.'}
+                                  <p
+                                    className={`text-sm ${
+                                      validationStatus[pk.provider.id]?.valid
+                                        ? 'text-success'
+                                        : 'text-destructive'
+                                    }`}
+                                  >
+                                    {validationStatus[pk.provider.id]?.valid
+                                      ? `✓ Connection successful! Found ${validationStatus[pk.provider.id]?.modelCount} model${validationStatus[pk.provider.id]?.modelCount === 1 ? '' : 's'}.`
+                                      : `✗ Connection failed. Please check the URL and ensure ${pk.provider.name} is running.`}
                                   </p>
                                 </div>
                               )}
+                              {pk.hasKey &&
+                                pk.provider.models.length === 0 &&
+                                !validationStatus[pk.provider.id] &&
+                                (isLocalServerProvider(pk)
+                                  ? pk.endpointURL.trim() !== ''
+                                  : true) && (
+                                  <div className="border-warning/20 bg-warning/10 rounded-md border p-3">
+                                    <p className="text-warning text-sm">
+                                      {pk.provider.id === 'ollama' ||
+                                      pk.provider.id === 'lmstudio'
+                                        ? `${pk.provider.name} server is not running or no models are installed. Please start ${pk.provider.name} and ensure you have models available, then click the refresh button above.`
+                                        : 'This provider appears to be offline or has no models available. Click the refresh button above to check again.'}
+                                    </p>
+                                  </div>
+                                )}
+                            </div>
                           </div>
-                        </div>
-                      )
-                    })()}
+                        )
+                      })()
+                    )}
                   </CollapsibleContent>
                 </Collapsible>
               ))

--- a/renderer/src/features/chat/components/llm-gateway-login-modal.tsx
+++ b/renderer/src/features/chat/components/llm-gateway-login-modal.tsx
@@ -1,0 +1,58 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/common/components/ui/dialog'
+import { Button } from '@/common/components/ui/button'
+import { Loader2 } from 'lucide-react'
+
+interface LlmGatewayLoginModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onRetry: () => void
+  isRetrying?: boolean
+  message?: string | null
+}
+
+export function LlmGatewayLoginModal({
+  open,
+  onOpenChange,
+  onRetry,
+  isRetrying = false,
+  message,
+}: LlmGatewayLoginModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Sign in to Stacklok Gateway</DialogTitle>
+          <DialogDescription>
+            Complete sign-in in your browser. The LLM proxy may have opened an
+            OIDC login page — finish that flow, then return here and continue.
+          </DialogDescription>
+        </DialogHeader>
+        {message ? (
+          <p className="text-muted-foreground text-sm">{message}</p>
+        ) : null}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={onRetry} disabled={isRetrying}>
+            {isRetrying ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Checking…
+              </>
+            ) : (
+              'I completed sign-in'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/renderer/src/features/chat/components/llm-gateway-settings-panel.tsx
+++ b/renderer/src/features/chat/components/llm-gateway-settings-panel.tsx
@@ -1,0 +1,295 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Button } from '@/common/components/ui/button'
+import { Badge } from '@/common/components/ui/badge'
+import { Input } from '@/common/components/ui/input'
+import { Label } from '@/common/components/ui/label'
+import { Loader2 } from 'lucide-react'
+import {
+  ensureGatewayReady,
+  useLlmGatewayStatus,
+} from '../hooks/use-llm-gateway'
+
+interface LlmGatewaySettingsPanelProps {
+  onStatusChange?: () => void
+}
+
+const DEFAULT_PROXY_PORT = 14000
+const DEFAULT_CALLBACK_PORT = 8080
+
+function authStateLabel(
+  authState: Awaited<
+    ReturnType<typeof window.electronAPI.chat.llmGateway.getStatus>
+  >['authState']
+): string {
+  switch (authState) {
+    case 'ready':
+      return 'Signed in'
+    case 'authenticating':
+      return 'Sign-in required'
+    case 'proxy_stopped':
+      return 'Proxy stopped'
+    case 'error':
+      return 'Error'
+    case 'not_configured':
+      return 'Not configured'
+    default:
+      return authState
+  }
+}
+
+export function LlmGatewaySettingsPanel({
+  onStatusChange,
+}: LlmGatewaySettingsPanelProps) {
+  const queryClient = useQueryClient()
+  const {
+    data: status,
+    isLoading: isStatusLoading,
+    refetch,
+    isFetching,
+  } = useLlmGatewayStatus()
+
+  const { data: savedConfig, isLoading: isConfigLoading } = useQuery({
+    queryKey: ['chat', 'llmGateway', 'config'],
+    queryFn: () => window.electronAPI.chat.llmGateway.getConfig(),
+  })
+
+  const [gatewayUrl, setGatewayUrl] = useState('')
+  const [issuer, setIssuer] = useState('')
+  const [audience, setAudience] = useState('')
+  const [clientId, setClientId] = useState('')
+  const [callbackPort, setCallbackPort] = useState(
+    String(DEFAULT_CALLBACK_PORT)
+  )
+  const [proxyPort, setProxyPort] = useState(String(DEFAULT_PROXY_PORT))
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const configFingerprint = savedConfig
+    ? [
+        savedConfig.gatewayUrl,
+        savedConfig.issuer,
+        savedConfig.audience ?? '',
+        savedConfig.clientId,
+        savedConfig.callbackPort ?? '',
+        savedConfig.proxyPort ?? '',
+      ].join('|')
+    : ''
+  const [prevConfigFingerprint, setPrevConfigFingerprint] = useState('')
+  if (savedConfig && configFingerprint !== prevConfigFingerprint) {
+    setPrevConfigFingerprint(configFingerprint)
+    setGatewayUrl(savedConfig.gatewayUrl)
+    setIssuer(savedConfig.issuer)
+    setAudience(savedConfig.audience ?? '')
+    setClientId(savedConfig.clientId)
+    setCallbackPort(
+      savedConfig.callbackPort != null
+        ? String(savedConfig.callbackPort)
+        : String(DEFAULT_CALLBACK_PORT)
+    )
+    setProxyPort(
+      savedConfig.proxyPort != null
+        ? String(savedConfig.proxyPort)
+        : String(DEFAULT_PROXY_PORT)
+    )
+  }
+
+  const saveConfigMutation = useMutation({
+    mutationFn: () =>
+      window.electronAPI.chat.llmGateway.saveConfig({
+        gatewayUrl: gatewayUrl.trim(),
+        issuer: issuer.trim(),
+        clientId: clientId.trim(),
+        audience: audience.trim() || undefined,
+        callbackPort: Number.parseInt(callbackPort, 10) || undefined,
+        proxyPort: Number.parseInt(proxyPort, 10) || undefined,
+      }),
+    onSuccess: async (result) => {
+      if (!result.ok) {
+        setSaveError(result.error ?? 'Failed to save gateway configuration')
+        return
+      }
+      setSaveError(null)
+      await queryClient.invalidateQueries({ queryKey: ['chat', 'llmGateway'] })
+      await queryClient.invalidateQueries({
+        queryKey: ['chat', 'availableModels'],
+      })
+      await queryClient.invalidateQueries({
+        queryKey: ['chat', 'allProvidersWithSettings'],
+      })
+      onStatusChange?.()
+    },
+  })
+
+  const handleStart = async () => {
+    await window.electronAPI.chat.llmGateway.ensureStarted()
+    await refetch()
+    onStatusChange?.()
+  }
+
+  const handleSignIn = async () => {
+    await ensureGatewayReady()
+    await refetch()
+    onStatusChange?.()
+  }
+
+  const isLoading = isStatusLoading || isConfigLoading
+
+  if (isLoading) {
+    return (
+      <p className="text-muted-foreground text-sm">Loading gateway settings…</p>
+    )
+  }
+
+  return (
+    <div className="space-y-4 pt-2">
+      <p className="text-muted-foreground text-xs">
+        Same connection settings as{' '}
+        <code className="text-[10px]">thv llm setup</code>. Save to enable this
+        provider in Playground — no API key required.
+      </p>
+
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <Label htmlFor="llm-gateway-url">Gateway URL</Label>
+          <Input
+            id="llm-gateway-url"
+            value={gatewayUrl}
+            onChange={(e) => setGatewayUrl(e.target.value)}
+            placeholder="https://llm-gateway.stacklok.dev"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="llm-issuer">Issuer</Label>
+          <Input
+            id="llm-issuer"
+            value={issuer}
+            onChange={(e) => setIssuer(e.target.value)}
+            placeholder="https://your-idp.example.com/oauth2/default"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="llm-audience">Audience (optional)</Label>
+          <Input
+            id="llm-audience"
+            value={audience}
+            onChange={(e) => setAudience(e.target.value)}
+            placeholder="api://llm-gateway"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="llm-client-id">Client ID</Label>
+          <Input
+            id="llm-client-id"
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            placeholder="0oa..."
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <Label htmlFor="llm-callback-port">Callback port</Label>
+            <Input
+              id="llm-callback-port"
+              type="number"
+              min={1}
+              max={65535}
+              value={callbackPort}
+              onChange={(e) => setCallbackPort(e.target.value)}
+              placeholder={String(DEFAULT_CALLBACK_PORT)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="llm-proxy-port">Local proxy port</Label>
+            <Input
+              id="llm-proxy-port"
+              type="number"
+              min={1}
+              max={65535}
+              value={proxyPort}
+              onChange={(e) => setProxyPort(e.target.value)}
+              placeholder={String(DEFAULT_PROXY_PORT)}
+            />
+          </div>
+        </div>
+
+        {saveError ? (
+          <p className="text-destructive text-sm">{saveError}</p>
+        ) : null}
+
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => saveConfigMutation.mutate()}
+          disabled={saveConfigMutation.isPending}
+        >
+          {saveConfigMutation.isPending ? (
+            <Loader2 className="mr-2 size-4 animate-spin" />
+          ) : null}
+          Save connection settings
+        </Button>
+      </div>
+
+      {status?.configured ? (
+        <div className="space-y-3 border-t pt-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant={status.authState === 'ready' ? 'secondary' : 'outline'}
+            >
+              {authStateLabel(status.authState)}
+            </Badge>
+            {status.proxyRunning ? (
+              <Badge variant="secondary">Proxy running</Badge>
+            ) : (
+              <Badge variant="outline">Proxy stopped</Badge>
+            )}
+            {status.modelCount > 0 ? (
+              <span className="text-muted-foreground text-xs">
+                {status.modelCount} model{status.modelCount === 1 ? '' : 's'}
+              </span>
+            ) : null}
+          </div>
+          {status.baseURL ? (
+            <p className="text-muted-foreground text-xs break-all">
+              Playground endpoint: {status.baseURL}
+            </p>
+          ) : null}
+          {status.error ? (
+            <p className="text-destructive text-sm">{status.error}</p>
+          ) : null}
+          <div className="flex flex-wrap gap-2">
+            {!status.proxyRunning ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={handleStart}
+                disabled={isFetching}
+              >
+                {isFetching ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : null}
+                Start proxy
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={handleSignIn}
+              disabled={isFetching}
+            >
+              {isFetching ? (
+                <Loader2 className="mr-2 size-4 animate-spin" />
+              ) : null}
+              Sign in
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/renderer/src/features/chat/components/llm-gateway-settings-panel.tsx
+++ b/renderer/src/features/chat/components/llm-gateway-settings-panel.tsx
@@ -118,18 +118,41 @@ export function LlmGatewaySettingsPanel({
       })
       onStatusChange?.()
     },
+    onError: (error) => {
+      setSaveError(
+        error instanceof Error
+          ? error.message
+          : 'Failed to save gateway configuration'
+      )
+    },
   })
 
   const handleStart = async () => {
-    await window.electronAPI.chat.llmGateway.ensureStarted()
-    await refetch()
-    onStatusChange?.()
+    try {
+      await window.electronAPI.chat.llmGateway.ensureStarted()
+      setSaveError(null)
+      await refetch()
+      onStatusChange?.()
+    } catch (error) {
+      setSaveError(
+        error instanceof Error ? error.message : 'Failed to start the LLM proxy'
+      )
+    }
   }
 
   const handleSignIn = async () => {
-    await ensureGatewayReady()
-    await refetch()
-    onStatusChange?.()
+    try {
+      const ready = await ensureGatewayReady()
+      if (!ready.ready) {
+        setSaveError(ready.error ?? 'Sign-in did not complete')
+      } else {
+        setSaveError(null)
+      }
+      await refetch()
+      onStatusChange?.()
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'Failed to sign in')
+    }
   }
 
   const isLoading = isStatusLoading || isConfigLoading

--- a/renderer/src/features/chat/components/model-picker.tsx
+++ b/renderer/src/features/chat/components/model-picker.tsx
@@ -21,6 +21,7 @@ import {
 import { cn } from '@/common/lib/utils'
 import { useAvailableModels } from '../hooks/use-available-models'
 import { getProviderIcon } from './provider-icons'
+import { THV_LLM_PROVIDER_ID } from '../lib/gateway-provider'
 
 export interface ModelSelection {
   provider: string
@@ -207,7 +208,9 @@ export function ModelPicker({
                       {provider.models.length === 0
                         ? provider.id === 'ollama'
                           ? 'Ollama is not running or no models available'
-                          : 'No models available'
+                          : provider.id === THV_LLM_PROVIDER_ID
+                            ? 'Start the LLM proxy and sign in to list models'
+                            : 'No models available'
                         : `No models found matching "${searchQueries[provider.id]}"`}
                     </div>
                   )}

--- a/renderer/src/features/chat/components/model-selector.tsx
+++ b/renderer/src/features/chat/components/model-selector.tsx
@@ -1,7 +1,12 @@
 import log from 'electron-log/renderer'
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { ModelPicker, type ModelSelection } from './model-picker'
 import type { ChatSettings } from '../types'
 import { trackEvent } from '@/common/lib/analytics'
+import { isGatewayProvider, THV_LLM_PROVIDER_ID } from '../lib/gateway-provider'
+import { ensureGatewayReady } from '../hooks/use-llm-gateway'
+import { LlmGatewayLoginModal } from './llm-gateway-login-modal'
 
 interface ModelSelectorProps {
   settings: ChatSettings
@@ -15,7 +20,47 @@ export function ModelSelector({
   onSettingsChange,
   onOpenSettings,
 }: ModelSelectorProps) {
-  const handleModelSelect = async ({ provider, model }: ModelSelection) => {
+  const queryClient = useQueryClient()
+  const [loginModalOpen, setLoginModalOpen] = useState(false)
+  const [loginMessage, setLoginMessage] = useState<string | null>(null)
+  const [isRetryingLogin, setIsRetryingLogin] = useState(false)
+  const [pendingSelection, setPendingSelection] =
+    useState<ModelSelection | null>(null)
+
+  const applySelection = async ({ provider, model }: ModelSelection) => {
+    const providerSettings = await window.electronAPI.chat.getSettings(provider)
+
+    let newSettings: ChatSettings
+    if (provider === 'ollama' || provider === 'lmstudio') {
+      newSettings = {
+        provider,
+        model,
+        endpointURL:
+          'endpointURL' in providerSettings ? providerSettings.endpointURL : '',
+        enabledTools: settings.enabledTools,
+      }
+    } else if (provider === THV_LLM_PROVIDER_ID) {
+      newSettings = {
+        provider: THV_LLM_PROVIDER_ID,
+        model,
+        endpointURL:
+          'endpointURL' in providerSettings ? providerSettings.endpointURL : '',
+        enabledTools: settings.enabledTools,
+      }
+    } else {
+      newSettings = {
+        provider,
+        model,
+        apiKey: 'apiKey' in providerSettings ? providerSettings.apiKey : '',
+        enabledTools: settings.enabledTools,
+      }
+    }
+
+    onSettingsChange(newSettings)
+  }
+
+  const handleModelSelect = async (selection: ModelSelection) => {
+    const { provider, model } = selection
     trackEvent(`Playground: select model ${model}`, { provider })
 
     if (provider === settings.provider) {
@@ -23,32 +68,47 @@ export function ModelSelector({
       return
     }
 
+    if (isGatewayProvider(provider)) {
+      setPendingSelection(selection)
+      const ready = await ensureGatewayReady()
+      if (!ready.ready) {
+        setLoginMessage(ready.error ?? null)
+        setLoginModalOpen(true)
+        return
+      }
+      setPendingSelection(null)
+    }
+
     try {
-      const providerSettings =
-        await window.electronAPI.chat.getSettings(provider)
-
-      const newSettings: ChatSettings =
-        provider === 'ollama' || provider === 'lmstudio'
-          ? {
-              provider,
-              model,
-              endpointURL:
-                'endpointURL' in providerSettings
-                  ? providerSettings.endpointURL
-                  : '',
-              enabledTools: settings.enabledTools,
-            }
-          : {
-              provider,
-              model,
-              apiKey:
-                'apiKey' in providerSettings ? providerSettings.apiKey : '',
-              enabledTools: settings.enabledTools,
-            }
-
-      onSettingsChange(newSettings)
+      await applySelection(selection)
+      void queryClient.invalidateQueries({
+        queryKey: ['chat', 'availableModels'],
+      })
     } catch (error) {
       log.error('Failed to load provider settings:', error)
+    }
+  }
+
+  const handleRetryLogin = async () => {
+    if (!pendingSelection) {
+      setLoginModalOpen(false)
+      return
+    }
+    setIsRetryingLogin(true)
+    try {
+      const ready = await ensureGatewayReady()
+      if (!ready.ready) {
+        setLoginMessage(ready.error ?? null)
+        return
+      }
+      setLoginModalOpen(false)
+      setPendingSelection(null)
+      await applySelection(pendingSelection)
+      void queryClient.invalidateQueries({
+        queryKey: ['chat', 'availableModels'],
+      })
+    } finally {
+      setIsRetryingLogin(false)
     }
   }
 
@@ -58,10 +118,19 @@ export function ModelSelector({
       : null
 
   return (
-    <ModelPicker
-      value={value}
-      onChange={handleModelSelect}
-      onOpenSettings={onOpenSettings}
-    />
+    <>
+      <ModelPicker
+        value={value}
+        onChange={handleModelSelect}
+        onOpenSettings={onOpenSettings}
+      />
+      <LlmGatewayLoginModal
+        open={loginModalOpen}
+        onOpenChange={setLoginModalOpen}
+        onRetry={handleRetryLogin}
+        isRetrying={isRetryingLogin}
+        message={loginMessage}
+      />
+    </>
   )
 }

--- a/renderer/src/features/chat/components/model-selector.tsx
+++ b/renderer/src/features/chat/components/model-selector.tsx
@@ -107,6 +107,10 @@ export function ModelSelector({
       void queryClient.invalidateQueries({
         queryKey: ['chat', 'availableModels'],
       })
+    } catch (error) {
+      setLoginMessage(
+        error instanceof Error ? error.message : 'Failed to apply model'
+      )
     } finally {
       setIsRetryingLogin(false)
     }

--- a/renderer/src/features/chat/components/provider-icons.tsx
+++ b/renderer/src/features/chat/components/provider-icons.tsx
@@ -109,6 +109,23 @@ const PROVIDER_ICONS: Record<string, React.ReactElement> = {
       </g>
     </svg>
   ),
+
+  'thv-llm': (
+    <svg
+      className="size-4"
+      viewBox="-1 12 26 24"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      stroke="currentColor"
+    >
+      <title>Stacklok</title>
+      <path
+        d="M0.79 34L12.34 20.2L23.89 34M0.79 34L12.34 24.85L23.89 34M0.79 34L12.34 29.24L23.89 34M0.79 34L12.34 14L23.89 34"
+        strokeWidth="1.6"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
 }
 
 // Provider names for tooltips
@@ -120,6 +137,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   ollama: 'Ollama',
   lmstudio: 'LM Studio',
   openrouter: 'OpenRouter',
+  'thv-llm': 'Stacklok Gateway',
 }
 // Get provider icon wrapped with tooltip
 function getProviderIconWithTooltip(

--- a/renderer/src/features/chat/hooks/__tests__/use-chat-settings.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-chat-settings.test.ts
@@ -13,6 +13,31 @@ const mockChatAPI = {
   saveSelectedModel: vi.fn(),
   saveSettings: vi.fn(),
   clearSettings: vi.fn(),
+  llmGateway: {
+    getStatus: vi.fn().mockResolvedValue({
+      configured: false,
+      proxyRunning: false,
+      authState: 'not_configured',
+      listenPort: null,
+      baseURL: null,
+      gatewayURL: null,
+      modelCount: 0,
+      error: null,
+      studioOwnsProxy: false,
+    }),
+    getConfig: vi.fn().mockResolvedValue({
+      gatewayUrl: '',
+      issuer: '',
+      clientId: '',
+      audience: '',
+      configured: false,
+    }),
+    saveConfig: vi.fn().mockResolvedValue({ ok: true }),
+    disable: vi.fn().mockResolvedValue({ ok: true }),
+    ensureStarted: vi.fn(),
+    warmupAuth: vi.fn(),
+    invalidateConfig: vi.fn(),
+  },
 }
 
 // Test wrapper with QueryClient
@@ -172,6 +197,59 @@ describe('useChatSettings', () => {
         hasKey: false,
         enabledTools: [],
       })
+    })
+
+    it('does not inject Stacklok Gateway when it is absent from getProviders', async () => {
+      const { Wrapper } = createTestUtils()
+      const { result } = renderHook(() => useChatSettings(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(
+        result.current.allProvidersWithSettings.some(
+          (entry) => entry.provider.id === 'thv-llm'
+        )
+      ).toBe(false)
+    })
+
+    it('marks Stacklok Gateway configured only when Playground has enabled it', async () => {
+      mockChatAPI.getProviders.mockResolvedValue([
+        {
+          id: 'thv-llm',
+          name: 'Stacklok Gateway',
+          models: ['gpt-4.1'],
+        },
+      ])
+      mockChatAPI.getSettings.mockResolvedValue({
+        endpointURL: 'enabled',
+        enabledTools: [],
+      })
+
+      const { Wrapper } = createTestUtils()
+      const { result } = renderHook(() => useChatSettings(), {
+        wrapper: Wrapper,
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.allProvidersWithSettings).toEqual([
+        {
+          provider: {
+            id: 'thv-llm',
+            name: 'Stacklok Gateway',
+            models: ['gpt-4.1'],
+          },
+          endpointURL: 'enabled',
+          hasKey: true,
+          enabledTools: [],
+        },
+      ])
     })
   })
 

--- a/renderer/src/features/chat/hooks/__tests__/use-llm-gateway.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-llm-gateway.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { ensureGatewayReady } from '../use-llm-gateway'
+
+const mockLlmGateway = {
+  ensureStarted: vi.fn(),
+  warmupAuth: vi.fn(),
+}
+
+describe('ensureGatewayReady', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.electronAPI.chat = {
+      ...window.electronAPI.chat,
+      llmGateway: mockLlmGateway,
+    } as typeof window.electronAPI.chat
+  })
+
+  it('returns ready when warmup succeeds', async () => {
+    mockLlmGateway.ensureStarted.mockResolvedValue({ started: true })
+    mockLlmGateway.warmupAuth.mockResolvedValue({ ready: true, modelCount: 1 })
+
+    await expect(ensureGatewayReady()).resolves.toEqual({ ready: true })
+  })
+
+  it('returns warmup error without throwing', async () => {
+    mockLlmGateway.ensureStarted.mockResolvedValue({ started: true })
+    mockLlmGateway.warmupAuth.mockResolvedValue({
+      ready: false,
+      error: 'Complete sign-in in your browser',
+    })
+
+    await expect(ensureGatewayReady()).resolves.toEqual({
+      ready: false,
+      error: 'Complete sign-in in your browser',
+    })
+  })
+
+  it('surfaces IPC rejections as a not-ready error', async () => {
+    mockLlmGateway.ensureStarted.mockRejectedValue(new Error('proxy timeout'))
+
+    await expect(ensureGatewayReady()).resolves.toEqual({
+      ready: false,
+      error: 'proxy timeout',
+    })
+  })
+})

--- a/renderer/src/features/chat/hooks/__tests__/use-llm-gateway.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-llm-gateway.test.ts
@@ -12,7 +12,7 @@ describe('ensureGatewayReady', () => {
     window.electronAPI.chat = {
       ...window.electronAPI.chat,
       llmGateway: mockLlmGateway,
-    } as typeof window.electronAPI.chat
+    } as unknown as typeof window.electronAPI.chat
   })
 
   it('returns ready when warmup succeeds', async () => {

--- a/renderer/src/features/chat/hooks/__tests__/use-llm-gateway.test.ts
+++ b/renderer/src/features/chat/hooks/__tests__/use-llm-gateway.test.ts
@@ -43,4 +43,23 @@ describe('ensureGatewayReady', () => {
       error: 'proxy timeout',
     })
   })
+
+  it('uses a default message when warmup fails without one', async () => {
+    mockLlmGateway.ensureStarted.mockResolvedValue({ started: true })
+    mockLlmGateway.warmupAuth.mockResolvedValue({ ready: false })
+
+    await expect(ensureGatewayReady()).resolves.toEqual({
+      ready: false,
+      error: 'Complete sign-in in your browser to use Stacklok Gateway.',
+    })
+  })
+
+  it('uses a default message when IPC throws a non-Error', async () => {
+    mockLlmGateway.ensureStarted.mockRejectedValue('unavailable')
+
+    await expect(ensureGatewayReady()).resolves.toEqual({
+      ready: false,
+      error: 'Failed to connect to Stacklok Gateway.',
+    })
+  })
 })

--- a/renderer/src/features/chat/hooks/use-available-models.ts
+++ b/renderer/src/features/chat/hooks/use-available-models.ts
@@ -38,7 +38,7 @@ export function useAvailableModels() {
 
       return providersWithCredentials
     },
-    staleTime: 2 * 60 * 1000, // 2 minutes
+    staleTime: 2 * 60 * 1000,
     refetchOnWindowFocus: true,
   })
 

--- a/renderer/src/features/chat/hooks/use-chat-settings.ts
+++ b/renderer/src/features/chat/hooks/use-chat-settings.ts
@@ -5,10 +5,17 @@ import {
   isLocalServerSettings,
   providerHasApiKey as hasApiKey,
 } from '../lib/utils'
+import { THV_LLM_PROVIDER_ID } from '../lib/gateway-provider'
 
 export type ProviderWithSettings =
   | {
       provider: ChatProvider & { id: 'ollama' | 'lmstudio' }
+      endpointURL: string
+      hasKey: boolean
+      enabledTools: string[]
+    }
+  | {
+      provider: ChatProvider & { id: 'thv-llm' }
       endpointURL: string
       hasKey: boolean
       enabledTools: string[]
@@ -22,7 +29,10 @@ export type ProviderWithSettings =
 
 export function isLocalServerProvider(
   provider: ProviderWithSettings
-): provider is Extract<ProviderWithSettings, { endpointURL: string }> {
+): provider is Extract<
+  ProviderWithSettings,
+  { provider: ChatProvider & { id: 'ollama' | 'lmstudio' } }
+> {
   return (
     (provider.provider.id === 'ollama' ||
       provider.provider.id === 'lmstudio') &&
@@ -31,15 +41,22 @@ export function isLocalServerProvider(
 }
 
 export function getProviderCredential(provider: ProviderWithSettings): string {
-  return isLocalServerProvider(provider)
-    ? provider.endpointURL
-    : provider.apiKey
+  if ('endpointURL' in provider) {
+    return provider.endpointURL
+  }
+  return provider.apiKey
 }
 
 function isChatProviderLocalServer(
   provider: ChatProvider
 ): provider is ChatProvider & { id: 'ollama' | 'lmstudio' } {
   return provider.id === 'ollama' || provider.id === 'lmstudio'
+}
+
+function isChatProviderGateway(
+  provider: ChatProvider
+): provider is ChatProvider & { id: 'thv-llm' } {
+  return provider.id === THV_LLM_PROVIDER_ID
 }
 
 // Query keys
@@ -116,6 +133,17 @@ function useAllProvidersWithSettings() {
               provider.id
             )
 
+            if (isChatProviderGateway(provider)) {
+              const endpointURL =
+                'endpointURL' in settings ? settings.endpointURL || '' : ''
+              return {
+                provider,
+                endpointURL,
+                hasKey: Boolean(endpointURL.trim()),
+                enabledTools: settings.enabledTools || [],
+              }
+            }
+
             if (isChatProviderLocalServer(provider)) {
               const endpointURL =
                 'endpointURL' in settings ? settings.endpointURL || '' : ''
@@ -135,6 +163,14 @@ function useAllProvidersWithSettings() {
               }
             }
           } catch {
+            if (isChatProviderGateway(provider)) {
+              return {
+                provider,
+                endpointURL: '',
+                hasKey: false,
+                enabledTools: [],
+              }
+            }
             if (isChatProviderLocalServer(provider)) {
               return {
                 provider,
@@ -236,7 +272,23 @@ export function useChatSettings(threadId?: string | null) {
         endpointURL,
         enabledTools: allEnabledTools,
       }
-    } else {
+    }
+
+    if (selectedModel?.provider === THV_LLM_PROVIDER_ID) {
+      const endpointURL =
+        providerSettings && 'endpointURL' in providerSettings
+          ? providerSettings.endpointURL || ''
+          : ''
+
+      return {
+        provider: THV_LLM_PROVIDER_ID,
+        model: selectedModel.model || '',
+        endpointURL,
+        enabledTools: allEnabledTools,
+      }
+    }
+
+    {
       const apiKey =
         providerSettings && hasApiKey(providerSettings)
           ? providerSettings.apiKey || ''
@@ -311,7 +363,9 @@ export function useChatSettings(threadId?: string | null) {
         | { endpointURL: string; enabledTools: string[] }
     }) => {
       const settingsToSave =
-        provider === 'ollama' || provider === 'lmstudio'
+        provider === 'ollama' ||
+        provider === 'lmstudio' ||
+        provider === THV_LLM_PROVIDER_ID
           ? 'endpointURL' in newSettings
             ? {
                 endpointURL: newSettings.endpointURL,
@@ -372,17 +426,22 @@ export function useChatSettings(threadId?: string | null) {
 
         await updateProviderSettingsMutation.mutateAsync({
           provider: selectedModel.provider,
-          settings: isLocalServerSettings(currentProviderSettings)
-            ? {
-                endpointURL: currentProviderSettings.endpointURL || '',
-                enabledTools: tools,
-              }
-            : {
-                apiKey: hasApiKey(currentProviderSettings)
-                  ? currentProviderSettings.apiKey || ''
-                  : '',
-                enabledTools: tools,
-              },
+          settings:
+            isLocalServerSettings(currentProviderSettings) ||
+            selectedModel.provider === THV_LLM_PROVIDER_ID
+              ? {
+                  endpointURL:
+                    'endpointURL' in currentProviderSettings
+                      ? currentProviderSettings.endpointURL || ''
+                      : '',
+                  enabledTools: tools,
+                }
+              : {
+                  apiKey: hasApiKey(currentProviderSettings)
+                    ? currentProviderSettings.apiKey || ''
+                    : '',
+                  enabledTools: tools,
+                },
         })
       } catch (error) {
         console.error('Failed to update enabled tools:', error)

--- a/renderer/src/features/chat/hooks/use-chat-settings.ts
+++ b/renderer/src/features/chat/hooks/use-chat-settings.ts
@@ -288,18 +288,16 @@ export function useChatSettings(threadId?: string | null) {
       }
     }
 
-    {
-      const apiKey =
-        providerSettings && hasApiKey(providerSettings)
-          ? providerSettings.apiKey || ''
-          : ''
+    const apiKey =
+      providerSettings && hasApiKey(providerSettings)
+        ? providerSettings.apiKey || ''
+        : ''
 
-      return {
-        provider: selectedModel?.provider || '',
-        model: selectedModel?.model || '',
-        apiKey,
-        enabledTools: allEnabledTools,
-      }
+    return {
+      provider: selectedModel?.provider || '',
+      model: selectedModel?.model || '',
+      apiKey,
+      enabledTools: allEnabledTools,
     }
   }, [selectedModel, providerSettings, enabledMcpTools, enabledMcpServers])
 

--- a/renderer/src/features/chat/hooks/use-llm-gateway.ts
+++ b/renderer/src/features/chat/hooks/use-llm-gateway.ts
@@ -13,15 +13,25 @@ export async function ensureGatewayReady(): Promise<{
   ready: boolean
   error?: string
 }> {
-  await window.electronAPI.chat.llmGateway.ensureStarted()
-  const warmup = await window.electronAPI.chat.llmGateway.warmupAuth()
-  if (!warmup.ready) {
+  try {
+    await window.electronAPI.chat.llmGateway.ensureStarted()
+    const warmup = await window.electronAPI.chat.llmGateway.warmupAuth()
+    if (!warmup.ready) {
+      return {
+        ready: false,
+        error:
+          warmup.error ??
+          'Complete sign-in in your browser to use Stacklok Gateway.',
+      }
+    }
+    return { ready: true }
+  } catch (error) {
     return {
       ready: false,
       error:
-        warmup.error ??
-        'Complete sign-in in your browser to use Stacklok Gateway.',
+        error instanceof Error
+          ? error.message
+          : 'Failed to connect to Stacklok Gateway.',
     }
   }
-  return { ready: true }
 }

--- a/renderer/src/features/chat/hooks/use-llm-gateway.ts
+++ b/renderer/src/features/chat/hooks/use-llm-gateway.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+
+export function useLlmGatewayStatus() {
+  return useQuery({
+    queryKey: ['chat', 'llmGateway', 'status'],
+    queryFn: () => window.electronAPI.chat.llmGateway.getStatus(),
+    refetchOnWindowFocus: true,
+    staleTime: 30_000,
+  })
+}
+
+export async function ensureGatewayReady(): Promise<{
+  ready: boolean
+  error?: string
+}> {
+  await window.electronAPI.chat.llmGateway.ensureStarted()
+  const warmup = await window.electronAPI.chat.llmGateway.warmupAuth()
+  if (!warmup.ready) {
+    return {
+      ready: false,
+      error:
+        warmup.error ??
+        'Complete sign-in in your browser to use Stacklok Gateway.',
+    }
+  }
+  return { ready: true }
+}

--- a/renderer/src/features/chat/lib/__tests__/empty-state-copy.test.ts
+++ b/renderer/src/features/chat/lib/__tests__/empty-state-copy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { getEmptyStateCopy } from '../empty-state-copy'
+import { BUILTIN_AGENT_IDS } from '@common/types/agents'
+
+describe('getEmptyStateCopy', () => {
+  it('uses gateway-specific copy when Stacklok Gateway is active', () => {
+    const copy = getEmptyStateCopy(undefined, { usesGatewayProvider: true })
+    expect(copy.subtext).toContain('Stacklok Gateway')
+    expect(copy.subtext).not.toContain('Configure an AI service provider')
+  })
+
+  it('keeps default provider prompt when no gateway is selected', () => {
+    const copy = getEmptyStateCopy(undefined, { usesGatewayProvider: false })
+    expect(copy.subtext).toContain('Configure an AI service provider')
+  })
+
+  it('uses gateway copy for skills agent', () => {
+    const copy = getEmptyStateCopy(
+      {
+        id: BUILTIN_AGENT_IDS.skills,
+        kind: 'builtin',
+        name: 'Skills',
+        description: '',
+        instructions: '',
+        builtinToolsKey: 'skills',
+        createdAt: 0,
+        updatedAt: 0,
+      },
+      { usesGatewayProvider: true }
+    )
+    expect(copy.subtext).toContain('Stacklok Gateway')
+  })
+})

--- a/renderer/src/features/chat/lib/__tests__/gateway-provider.test.ts
+++ b/renderer/src/features/chat/lib/__tests__/gateway-provider.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { hasCredentials } from '../utils'
+import { isGatewayProvider, THV_LLM_PROVIDER_ID } from '../gateway-provider'
+
+describe('gateway provider credentials', () => {
+  it('treats thv-llm as configured only when Playground has enabled it', () => {
+    expect(
+      hasCredentials({
+        providerId: THV_LLM_PROVIDER_ID,
+        endpointURL: '',
+        enabledTools: [],
+      })
+    ).toBe(false)
+    expect(
+      hasCredentials({
+        providerId: THV_LLM_PROVIDER_ID,
+        endpointURL: 'enabled',
+        enabledTools: [],
+      })
+    ).toBe(true)
+    expect(
+      hasCredentials({
+        provider: THV_LLM_PROVIDER_ID,
+        model: 'gpt-4.1',
+        endpointURL: '',
+      })
+    ).toBe(false)
+  })
+
+  it('identifies gateway provider id', () => {
+    expect(isGatewayProvider('thv-llm')).toBe(true)
+    expect(isGatewayProvider('openai')).toBe(false)
+  })
+})

--- a/renderer/src/features/chat/lib/empty-state-copy.ts
+++ b/renderer/src/features/chat/lib/empty-state-copy.ts
@@ -19,15 +19,32 @@ const SKILLS_COPY: EmptyStateCopy = {
 }
 
 export function getEmptyStateCopy(
-  agent: AgentConfig | undefined
+  agent: AgentConfig | undefined,
+  options?: { usesGatewayProvider?: boolean }
 ): EmptyStateCopy {
   if (agent?.id === BUILTIN_AGENT_IDS.skills) {
-    return SKILLS_COPY
+    return options?.usesGatewayProvider
+      ? {
+          heading: SKILLS_COPY.heading,
+          subtext: 'Use Stacklok Gateway to design, build, and audit Skills',
+        }
+      : SKILLS_COPY
   }
   if (agent?.kind === 'custom') {
+    return options?.usesGatewayProvider
+      ? {
+          heading: `Chat with ${agent.name}`,
+          subtext: 'Use Stacklok Gateway to chat with your agent',
+        }
+      : {
+          heading: `Chat with ${agent.name}`,
+          subtext: 'Configure an AI service provider to chat with your agent',
+        }
+  }
+  if (options?.usesGatewayProvider) {
     return {
-      heading: `Chat with ${agent.name}`,
-      subtext: 'Configure an AI service provider to chat with your agent',
+      heading: TOOLHIVE_ASSISTANT_COPY.heading,
+      subtext: 'Use Stacklok Gateway to test responses from your MCP servers',
     }
   }
   return TOOLHIVE_ASSISTANT_COPY

--- a/renderer/src/features/chat/lib/gateway-provider.ts
+++ b/renderer/src/features/chat/lib/gateway-provider.ts
@@ -1,0 +1,9 @@
+export const THV_LLM_PROVIDER_ID = 'thv-llm' as const
+
+export type GatewayProviderId = typeof THV_LLM_PROVIDER_ID
+
+export function isGatewayProvider(
+  providerId: string
+): providerId is GatewayProviderId {
+  return providerId === THV_LLM_PROVIDER_ID
+}

--- a/renderer/src/features/chat/lib/utils.ts
+++ b/renderer/src/features/chat/lib/utils.ts
@@ -6,6 +6,11 @@ type ProviderSettings =
       endpointURL: string
       enabledTools: string[]
     }
+  | {
+      providerId: 'thv-llm'
+      endpointURL: string
+      enabledTools: string[]
+    }
   | { providerId: string; apiKey: string; enabledTools: string[] }
 
 type CredentialSettings = ChatSettings | ProviderSettings
@@ -45,6 +50,12 @@ export function isLocalServerSettings(settings: ProviderSettings): settings is {
   )
 }
 
+export function isEndpointProviderSettings(
+  settings: ProviderSettings
+): settings is Extract<ProviderSettings, { endpointURL: string }> {
+  return 'endpointURL' in settings
+}
+
 export function providerHasApiKey(
   settings: ProviderSettings
 ): settings is { providerId: string; apiKey: string; enabledTools: string[] } {
@@ -56,3 +67,5 @@ export function isLocalServerProvider(
 ): provider is 'ollama' | 'lmstudio' {
   return provider === 'ollama' || provider === 'lmstudio'
 }
+
+export { isGatewayProvider } from './gateway-provider'

--- a/renderer/src/features/chat/lib/utils.ts
+++ b/renderer/src/features/chat/lib/utils.ts
@@ -50,12 +50,6 @@ export function isLocalServerSettings(settings: ProviderSettings): settings is {
   )
 }
 
-export function isEndpointProviderSettings(
-  settings: ProviderSettings
-): settings is Extract<ProviderSettings, { endpointURL: string }> {
-  return 'endpointURL' in settings
-}
-
 export function providerHasApiKey(
   settings: ProviderSettings
 ): settings is { providerId: string; apiKey: string; enabledTools: string[] } {

--- a/renderer/src/features/chat/transport/__tests__/electron-ipc-chat-transport.test.ts
+++ b/renderer/src/features/chat/transport/__tests__/electron-ipc-chat-transport.test.ts
@@ -215,6 +215,33 @@ describe('Electron IPC Chat Transport', () => {
       )
     })
 
+    it('streams through the ToolHive LLM gateway without an API key', async () => {
+      queryClient.setQueryData(['chat', 'selectedModel'], {
+        provider: 'thv-llm',
+        model: 'moonshotai/kimi-k2',
+      })
+      queryClient.setQueryData(['chat', 'settings', 'thv-llm'], {
+        providerId: 'thv-llm',
+        endpointURL: '',
+        enabledTools: [],
+      })
+      ;(window.electronAPI.chat.stream as Mock).mockResolvedValue({
+        streamId: 'stream-123',
+      })
+
+      const stream = await transport.sendMessages(defaultOptions)
+
+      expect(window.electronAPI.chat.stream as Mock).toHaveBeenCalledWith({
+        chatId: 'test-chat',
+        messages: defaultOptions.messages,
+        provider: 'thv-llm',
+        model: 'moonshotai/kimi-k2',
+        endpointURL: '',
+        enabledTools: [],
+      })
+      expect(stream).toBeInstanceOf(ReadableStream)
+    })
+
     it('calls electron API with correct parameters', async () => {
       ;(window.electronAPI.chat.stream as Mock).mockResolvedValue({
         streamId: 'stream-123',

--- a/renderer/src/features/chat/transport/electron-ipc-chat-transport.ts
+++ b/renderer/src/features/chat/transport/electron-ipc-chat-transport.ts
@@ -1,7 +1,8 @@
 import type { ChatTransport, UIMessageChunk, ChatRequestOptions } from 'ai'
 import type { QueryClient } from '@tanstack/react-query'
 import type { ChatUIMessage } from '../types'
-import { isLocalServerProvider } from '../lib/utils'
+import { isLocalServerProvider, isGatewayProvider } from '../lib/utils'
+import { THV_LLM_PROVIDER_ID } from '../lib/gateway-provider'
 
 interface ElectronIPCChatTransportConfig {
   queryClient: QueryClient
@@ -26,6 +27,12 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
   private async getSettingsFromQuery(chatId?: string): Promise<
     | {
         provider: 'ollama' | 'lmstudio'
+        model: string
+        endpointURL: string
+        enabledTools: string[]
+      }
+    | {
+        provider: 'thv-llm'
         model: string
         endpointURL: string
         enabledTools: string[]
@@ -84,7 +91,18 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
         endpointURL,
         enabledTools: providerSettings?.enabledTools || [],
       }
-    } else {
+    }
+
+    if (isGatewayProvider(selectedModel.provider)) {
+      return {
+        provider: THV_LLM_PROVIDER_ID,
+        model: selectedModel.model,
+        endpointURL: '',
+        enabledTools: providerSettings?.enabledTools || [],
+      }
+    }
+
+    {
       const apiKey =
         providerSettings && 'apiKey' in providerSettings
           ? providerSettings.apiKey || ''
@@ -297,6 +315,15 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
         provider: settings.provider,
         model: settings.model,
         endpointURL: settings.endpointURL,
+        enabledTools: settings.enabledTools || [],
+      }
+    } else if (isGatewayProvider(settings.provider)) {
+      backendRequest = {
+        chatId: options.chatId,
+        messages: processedMessages,
+        provider: THV_LLM_PROVIDER_ID,
+        model: settings.model,
+        endpointURL: '',
         enabledTools: settings.enabledTools || [],
       }
     } else {

--- a/renderer/src/features/chat/types.ts
+++ b/renderer/src/features/chat/types.ts
@@ -28,6 +28,12 @@ export type ChatSettings =
       enabledTools?: string[]
     }
   | {
+      provider: 'thv-llm'
+      model: string
+      endpointURL: string
+      enabledTools?: string[]
+    }
+  | {
       provider: string
       model: string
       apiKey: string


### PR DESCRIPTION
## Summary
- Add Stacklok Gateway as an optional Playground provider that talks to ToolHive's local `thv llm proxy` (loopback only, no API key).
- Route GPT through OpenAI Chat Completions, Claude through Anthropic Messages (`/anthropic/v1`), and Gemini through Google generateContent (`/v1beta`).
- Opt in from Provider Settings (save connection / remove like any other provider). Studio does not auto-select the gateway or start the proxy unless Playground has enabled it.

## Test plan
- [x] Open Provider Settings and confirm **Stacklok Gateway** is listed with the Stacklok mark, unconfigured by default.
- [x] Save gateway URL / issuer / client ID, confirm the local proxy starts and models appear in the picker.
- [x] Send a message with a GPT, Claude, and Gemini model from the gateway.
- [x] Sign in when prompted; confirm chat works after OIDC completes.
- [x] Remove the provider (trash + Save); confirm it is no longer selected, the Studio-owned proxy stops, and `thv llm config` is left intact for CLI clients.
- [ ] Quit / auto-update while a Studio-owned proxy is running and confirm it is stopped.
