### PR TITLE
feat(playground): add ACP (Cursor CLI) agent provider

### DIFF
--- a/main/src/chat/constants.ts
+++ b/main/src/chat/constants.ts
@@ -311,4 +311,11 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
       'zhipuai/glm-4.5-thinking',
     ],
   },
+  {
+    // POC: spawns the local `agent` (Cursor CLI) binary as an ACP server.
+    // Model selection isn't supported by ACP, so this is a single fixed entry.
+    id: 'acp',
+    name: 'ACP (Cursor Agent)',
+    models: ['cursor-agent'],
+  },
 ] as const satisfies ChatProviderInfo[]

--- a/main/src/chat/constants.ts
+++ b/main/src/chat/constants.ts
@@ -312,10 +312,10 @@ export const CHAT_PROVIDER_INFO: ChatProviderInfo[] = [
     ],
   },
   {
-    // POC: spawns the local `agent` (Cursor CLI) binary as an ACP server.
+    // Spawns the local `agent` (Cursor CLI) binary as an ACP server.
     // Model selection isn't supported by ACP, so this is a single fixed entry.
     id: 'acp',
-    name: 'ACP (Cursor Agent)',
+    name: 'Cursor Agent',
     models: ['cursor-agent'],
   },
 ] as const satisfies ChatProviderInfo[]

--- a/main/src/chat/providers/providers-catalog.ts
+++ b/main/src/chat/providers/providers-catalog.ts
@@ -5,6 +5,7 @@ import { createXai } from '@ai-sdk/xai'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import { createOllama } from 'ai-sdk-ollama'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { createACPProvider } from '@mcpc-tech/acp-ai-provider'
 import log from '../../logger'
 import {
   CHAT_PROVIDER_INFO,
@@ -120,6 +121,23 @@ export const CHAT_PROVIDERS: ChatProvider[] = [
 
       const openrouter = createOpenRouter({ apiKey })
       return openrouter(modelId)
+    },
+  },
+  {
+    id: 'acp',
+    name: 'ACP (Cursor Agent)',
+    models: CHAT_PROVIDER_INFO.find((p) => p.id === 'acp')?.models || [],
+    createModel: () => {
+      log.info('[CHAT] Creating ACP model: spawning local `agent acp`')
+      const acp = createACPProvider({
+        command: 'agent',
+        args: ['acp'],
+        session: {
+          cwd: process.cwd(),
+          mcpServers: [],
+        },
+      })
+      return acp.languageModel()
     },
   },
 ]

--- a/main/src/chat/providers/providers-catalog.ts
+++ b/main/src/chat/providers/providers-catalog.ts
@@ -6,6 +6,7 @@ import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import { createOllama } from 'ai-sdk-ollama'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { createACPProvider } from '@mcpc-tech/acp-ai-provider'
+import { app } from 'electron'
 import log from '../../logger'
 import {
   CHAT_PROVIDER_INFO,
@@ -127,13 +128,16 @@ export const CHAT_PROVIDERS: ChatProvider[] = [
     id: 'acp',
     name: 'ACP (Cursor Agent)',
     models: CHAT_PROVIDER_INFO.find((p) => p.id === 'acp')?.models || [],
-    createModel: () => {
-      log.info('[CHAT] Creating ACP model: spawning local `agent acp`')
+    createModel: (_modelId: string, _apiKey: string, cwd?: string) => {
+      const resolvedCwd = cwd && cwd.trim() ? cwd.trim() : app.getPath('home')
+      log.info(
+        `[CHAT] Creating ACP model: spawning local \`agent acp\` in ${resolvedCwd}`
+      )
       const acp = createACPProvider({
         command: 'agent',
         args: ['acp'],
         session: {
-          cwd: process.cwd(),
+          cwd: resolvedCwd,
           mcpServers: [],
         },
       })

--- a/main/src/chat/providers/providers-catalog.ts
+++ b/main/src/chat/providers/providers-catalog.ts
@@ -126,7 +126,7 @@ export const CHAT_PROVIDERS: ChatProvider[] = [
   },
   {
     id: 'acp',
-    name: 'ACP (Cursor Agent)',
+    name: 'Cursor Agent',
     models: CHAT_PROVIDER_INFO.find((p) => p.id === 'acp')?.models || [],
     createModel: (_modelId: string, _apiKey: string, cwd?: string) => {
       const resolvedCwd = cwd && cwd.trim() ? cwd.trim() : app.getPath('home')

--- a/main/src/chat/settings/thread-settings-service.ts
+++ b/main/src/chat/settings/thread-settings-service.ts
@@ -48,6 +48,17 @@ export class ThreadSettingsService extends Effect.Service<ThreadSettingsService>
             yield* repo.writeThreadEnabledMcpTools(threadId, next)
           }),
 
+        getThreadAcpCwd: (threadId: string) =>
+          repo
+            .readThreadAcpCwd(threadId)
+            .pipe(Effect.catchTag('StorageError', () => Effect.succeed(null))),
+
+        setThreadAcpCwd: (threadId: string, cwd: string | null) =>
+          Effect.gen(function* () {
+            yield* ensureRow(threadId)
+            yield* repo.writeThreadAcpCwd(threadId, cwd || null)
+          }),
+
         getThreadEnabledSkills: (threadId: string) =>
           repo
             .readThreadEnabledSkills(threadId)

--- a/main/src/chat/thread-settings-storage.ts
+++ b/main/src/chat/thread-settings-storage.ts
@@ -48,6 +48,19 @@ export function setThreadEnabledMcpTools(
   )
 }
 
+export function getThreadAcpCwd(threadId: string): string | null {
+  return runChatSyncOr(ThreadSettingsService.getThreadAcpCwd(threadId), null)
+}
+
+export function setThreadAcpCwd(
+  threadId: string,
+  cwd: string | null
+): { success: boolean; error?: string } {
+  return runChatToResultSync(
+    ThreadSettingsService.setThreadAcpCwd(threadId, cwd).pipe(Effect.as({}))
+  )
+}
+
 export function getThreadEnabledSkills(threadId: string): string[] {
   return runChatSyncOr(
     ThreadSettingsService.getThreadEnabledSkills(threadId),

--- a/main/src/chat/threads/threads-repository.ts
+++ b/main/src/chat/threads/threads-repository.ts
@@ -7,6 +7,7 @@ import {
   writeThreadSelectedModel,
   writeThreadEnabledMcpTools,
   writeThreadEnabledSkills,
+  writeThreadAcpCwd,
 } from '../../db/writers/threads-writer'
 import { writeThreadAgentId } from '../../db/writers/agents-writer'
 import {
@@ -17,6 +18,7 @@ import {
   readThreadSelectedModel,
   readThreadEnabledMcpTools,
   readThreadEnabledSkills,
+  readThreadAcpCwd,
 } from '../../db/readers/threads-reader'
 import { readThreadAgentId } from '../../db/readers/agents-reader'
 import { StorageError, ThreadNotFoundError } from '../runtime/errors'
@@ -111,6 +113,14 @@ export class ThreadsRepository extends Effect.Service<ThreadsRepository>()(
       writeThreadEnabledSkills: (threadId: string, skills: string[]) =>
         wrapSync('writeThreadEnabledSkills', () => {
           writeThreadEnabledSkills(threadId, skills)
+        }),
+
+      readThreadAcpCwd: (threadId: string) =>
+        wrapSync('readThreadAcpCwd', () => readThreadAcpCwd(threadId)),
+
+      writeThreadAcpCwd: (threadId: string, cwd: string | null) =>
+        wrapSync('writeThreadAcpCwd', () => {
+          writeThreadAcpCwd(threadId, cwd)
         }),
 
       readThreadAgentId: (threadId: string) =>

--- a/main/src/chat/types.ts
+++ b/main/src/chat/types.ts
@@ -25,6 +25,11 @@ type BaseChatRequest = {
    * the main process falls back to the default built-in agent.
    */
   agentId?: string
+  /**
+   * Working directory for ACP-based providers (e.g. the Cursor CLI agent).
+   * Ignored by every other provider.
+   */
+  cwd?: string
 }
 
 // Chat request interface - discriminated union for different provider types
@@ -47,7 +52,11 @@ export type ChatProvider =
     })
   | (ChatProviderInfo & {
       id: Exclude<string, 'ollama' | 'lmstudio'>
-      createModel: (modelId: string, apiKey: string) => LanguageModel
+      createModel: (
+        modelId: string,
+        apiKey: string,
+        cwd?: string
+      ) => LanguageModel
     })
 
 export interface AvailableServer {

--- a/main/src/chat/utils.ts
+++ b/main/src/chat/utils.ts
@@ -25,7 +25,7 @@ export function createModelFromRequest(
     return provider.createModel(request.model, request.endpointURL)
   }
   if (hasApiKey(request)) {
-    return provider.createModel(request.model, request.apiKey)
+    return provider.createModel(request.model, request.apiKey, request.cwd)
   }
   throw new Error('Invalid request: missing credentials')
 }

--- a/main/src/db/migrations/008-thread-acp-cwd.ts
+++ b/main/src/db/migrations/008-thread-acp-cwd.ts
@@ -1,0 +1,10 @@
+import type Database from 'better-sqlite3'
+
+export function up(db: Database.Database): void {
+  db.exec(`
+    -- Working directory for ACP-based providers (e.g. the Cursor CLI agent),
+    -- per thread. Nullable; NULL means "not set" and callers fall back to
+    -- the user's home directory.
+    ALTER TABLE threads ADD COLUMN acp_cwd TEXT;
+  `)
+}

--- a/main/src/db/migrator.ts
+++ b/main/src/db/migrator.ts
@@ -16,6 +16,7 @@ import * as m004 from './migrations/004-mcp-app-ui-metadata'
 import * as m005 from './migrations/005-agents'
 import * as m006 from './migrations/006-enabled-skills'
 import * as m007 from './migrations/007-per-thread-settings'
+import * as m008 from './migrations/008-thread-acp-cwd'
 
 const migrations: Migration[] = [
   { id: 1, name: '001-initial-schema', up: m001.up },
@@ -25,6 +26,7 @@ const migrations: Migration[] = [
   { id: 5, name: '005-agents', up: m005.up },
   { id: 6, name: '006-enabled-skills', up: m006.up },
   { id: 7, name: '007-per-thread-settings', up: m007.up },
+  { id: 8, name: '008-thread-acp-cwd', up: m008.up },
 ]
 
 export function runMigrations(): void {

--- a/main/src/db/readers/threads-reader.ts
+++ b/main/src/db/readers/threads-reader.ts
@@ -161,6 +161,21 @@ export function readThreadEnabledMcpTools(
   )
 }
 
+export function readThreadAcpCwd(threadId: string): string | null {
+  return withDbSpan(
+    'DB read thread ACP cwd',
+    'db.read',
+    { 'db.thread_id': threadId },
+    () => {
+      const db = getDb()
+      const row = db
+        .prepare('SELECT acp_cwd FROM threads WHERE id = ?')
+        .get(threadId) as { acp_cwd: string | null } | undefined
+      return row?.acp_cwd ?? null
+    }
+  )
+}
+
 export function readThreadEnabledSkills(threadId: string): string[] {
   return withDbSpan(
     'DB read thread enabled skills',

--- a/main/src/db/writers/threads-writer.ts
+++ b/main/src/db/writers/threads-writer.ts
@@ -216,6 +216,23 @@ export function writeThreadEnabledMcpTools(
   )
 }
 
+export function writeThreadAcpCwd(threadId: string, cwd: string | null): void {
+  if (!isDbWritable()) return
+  withDbSpan(
+    'DB write thread ACP cwd',
+    'db.write',
+    { 'db.thread_id': threadId },
+    () => {
+      const db = getDb()
+      db.prepare(
+        `UPDATE threads
+         SET acp_cwd = ?, last_edit_timestamp = ?
+         WHERE id = ?`
+      ).run(cwd, Date.now(), threadId)
+    }
+  )
+}
+
 export function writeThreadEnabledSkills(
   threadId: string,
   skills: string[] | null

--- a/main/src/ipc-handlers/chat/thread-settings.ts
+++ b/main/src/ipc-handlers/chat/thread-settings.ts
@@ -6,6 +6,8 @@ import {
   setThreadEnabledMcpTools,
   getThreadEnabledSkills,
   setThreadEnabledSkill,
+  getThreadAcpCwd,
+  setThreadAcpCwd,
 } from '../../chat/thread-settings-storage'
 
 export function register() {
@@ -40,5 +42,14 @@ export function register() {
     'chat:thread-settings:set-enabled-skill',
     (_, threadId: string, name: string, enabled: boolean) =>
       setThreadEnabledSkill(threadId, name, enabled)
+  )
+
+  ipcMain.handle('chat:thread-settings:get-acp-cwd', (_, threadId: string) =>
+    getThreadAcpCwd(threadId)
+  )
+
+  ipcMain.handle(
+    'chat:thread-settings:set-acp-cwd',
+    (_, threadId: string, cwd: string | null) => setThreadAcpCwd(threadId, cwd)
   )
 }

--- a/main/vite.main.config.ts
+++ b/main/vite.main.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
   build: {
     sourcemap: true, // Required for Sentry sourcemaps
     rolldownOptions: {
-      external: ['better-sqlite3'],
+      // acp-ai-provider's ESM build uses top-level createRequire(import.meta.url),
+      // which breaks under bundling (import.meta.url isn't preserved). Externalize
+      // it so Node resolves the package's own CJS build at runtime instead.
+      external: ['better-sqlite3', '@mcpc-tech/acp-ai-provider'],
     },
   },
   resolve: {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@fontsource-variable/merriweather": "^5.3.0",
     "@fontsource/atkinson-hyperlegible": "^5.3.0",
     "@fontsource/space-mono": "^5.3.0",
+    "@mcpc-tech/acp-ai-provider": "^0.3.5",
     "@modelcontextprotocol/ext-apps": "^1.7.5",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@fontsource/space-mono':
         specifier: ^5.3.0
         version: 5.3.0
+      '@mcpc-tech/acp-ai-provider':
+        specifier: ^0.3.5
+        version: 0.3.5(supports-color@8.1.1)
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.5
         version: 1.7.5(@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
@@ -416,9 +419,20 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@agentclientprotocol/sdk@0.14.1':
+    resolution: {integrity: sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   '@ai-sdk/anthropic@4.0.27':
     resolution: {integrity: sha512-ecrPWkYf+sHDLHErHAU/yjJfNevUzT0i6TuoQLb58oadnquSHcLQ5NMLLWjbr6d1rxYdzI7ftulIJ03VH9yM3w==}
     engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.170':
+    resolution: {integrity: sha512-w769X09is03N0uJYl82JbJzYiUN/XIOD2oWfYdSkiqoGHMephwXxcDcIO5jCVL7n5ylMBjZ0Ofso53A3ppY4YQ==}
+    engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -452,6 +466,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.45':
+    resolution: {integrity: sha512-7u5B/E2uZmU65SlJhhQGFHZwRCN0xOz4HHtFc4sEGV9PHbX3fGiEiZBpc/SABay1dGeJgK3VD60rvLGoWdWPXA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.12':
     resolution: {integrity: sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==}
     engines: {node: '>=22'}
@@ -463,6 +483,10 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.15':
+    resolution: {integrity: sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
@@ -1178,6 +1202,10 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -1682,6 +1710,9 @@ packages:
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
+
+  '@mcpc-tech/acp-ai-provider@0.3.5':
+    resolution: {integrity: sha512-pXi0ztLCViDZbD89QhPlSOo+t/DenXg1AMFeQCD+rQ6Zd0Pq5RLzPIBjawtCkMpsqbGmrAlDPHTTsP+aPPXE0A==}
 
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
@@ -3829,6 +3860,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -3874,6 +3906,12 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       ai: ^7.0.31
+
+  ai@6.0.250:
+    resolution: {integrity: sha512-uMaJoCubOqrtdTB7N72/yf1qdyKhlW/WPhTP6lmn4DRISE1qmiPT4z/DlflzQu5i2s9tqpe0LQ3WMsx7Fv5vKQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ai@7.0.48:
     resolution: {integrity: sha512-QmqshWFEDdkFFqSgdJ4cogaoDIYaedqbv73q/NXEYNkSIocJCzXnGFVyM9lrtAGTSBfm+5hq3/292ooXJ1jDSw==}
@@ -7583,6 +7621,10 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
@@ -7983,6 +8025,9 @@ packages:
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -7993,11 +8038,22 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@agentclientprotocol/sdk@0.14.1(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
   '@ai-sdk/anthropic@4.0.27(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.4
       '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
       zod: 4.4.3
+
+  '@ai-sdk/gateway@3.0.170(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.45(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
 
   '@ai-sdk/gateway@4.0.37(zod@4.4.3)':
     dependencies:
@@ -8031,6 +8087,14 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.45(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      undici: 5.29.0
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@5.0.12(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
@@ -8047,6 +8111,10 @@ snapshots:
       eventsource-parser: 3.0.8
       undici: 7.28.0
       zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.15':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.3':
     dependencies:
@@ -9291,6 +9359,8 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@fastify/busboy@2.1.1': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -9801,6 +9871,18 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@mcpc-tech/acp-ai-provider@0.3.5(supports-color@8.1.1)':
+    dependencies:
+      '@agentclientprotocol/sdk': 0.14.1(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.45(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@8.1.1)(zod@3.25.76)
+      ai: 6.0.250(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
   '@mermaid-js/parser@1.1.1':
     dependencies:
       '@chevrotain/types': 11.1.2
@@ -9813,6 +9895,28 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.0.11(hono@4.12.32)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.5.1(express@5.2.1(supports-color@8.1.1))
+      hono: 4.12.32
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@modelcontextprotocol/sdk@1.30.0(supports-color@8.1.1)(zod@4.4.3)':
     dependencies:
@@ -11980,6 +12084,14 @@ snapshots:
       ollama: 0.6.3
     transitivePeerDependencies:
       - zod
+
+  ai@6.0.250(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.170(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.45(zod@3.25.76)
+      '@opentelemetry/api': 1.9.1
+      zod: 3.25.76
 
   ai@7.0.48(zod@4.4.3):
     dependencies:
@@ -16208,6 +16320,10 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
   undici@6.27.0: {}
 
   undici@7.28.0: {}
@@ -16609,6 +16725,10 @@ snapshots:
 
   yoctocolors-cjs@2.1.3: {}
 
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
@@ -16618,6 +16738,8 @@ snapshots:
       zod: 4.4.3
 
   zod@3.22.4: {}
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/preload/src/api/chat.ts
+++ b/preload/src/api/chat.ts
@@ -211,6 +211,13 @@ export const chatApi = {
           name,
           enabled
         ),
+      getAcpCwd: (threadId: string): Promise<string | null> =>
+        ipcRenderer.invoke('chat:thread-settings:get-acp-cwd', threadId),
+      setAcpCwd: (
+        threadId: string,
+        cwd: string | null
+      ): Promise<{ success: boolean; error?: string }> =>
+        ipcRenderer.invoke('chat:thread-settings:set-acp-cwd', threadId, cwd),
     },
   },
 }
@@ -243,6 +250,7 @@ export interface ChatAPI {
             apiKey: string
             enabledTools?: string[]
             agentId?: string
+            cwd?: string
           }
     ) => Promise<{ streamId: string }>
     resumeStream: (chatId: string) => Promise<{
@@ -500,6 +508,11 @@ export interface ChatAPI {
         threadId: string,
         name: string,
         enabled: boolean
+      ) => Promise<{ success: boolean; error?: string }>
+      getAcpCwd: (threadId: string) => Promise<string | null>
+      setAcpCwd: (
+        threadId: string,
+        cwd: string | null
       ) => Promise<{ success: boolean; error?: string }>
     }
   }

--- a/renderer/src/features/chat/components/acp-cwd-picker.tsx
+++ b/renderer/src/features/chat/components/acp-cwd-picker.tsx
@@ -36,7 +36,7 @@ export function AcpCwdPicker({ threadId }: AcpCwdPickerProps) {
           variant="ghost"
           size="sm"
           className="flex h-8 items-center gap-1.5 px-2 has-[>svg]:px-2"
-          aria-label="Choose ACP working directory"
+          aria-label="Choose Cursor Agent working directory"
           onClick={handlePick}
         >
           <FolderOpen className="size-4" />

--- a/renderer/src/features/chat/components/acp-cwd-picker.tsx
+++ b/renderer/src/features/chat/components/acp-cwd-picker.tsx
@@ -1,0 +1,50 @@
+import { FolderOpen } from 'lucide-react'
+import { toast } from 'sonner'
+import log from 'electron-log/renderer'
+import { Button } from '@/common/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components/ui/tooltip'
+import { trackEvent } from '@/common/lib/analytics'
+import { useAcpCwd } from '../hooks/use-chat-settings'
+
+interface AcpCwdPickerProps {
+  threadId?: string | null
+}
+
+export function AcpCwdPicker({ threadId }: AcpCwdPickerProps) {
+  const { cwd, setCwd } = useAcpCwd(threadId)
+
+  const handlePick = async () => {
+    trackEvent('Playground: pick ACP working directory')
+    try {
+      const picked = await window.electronAPI.selectFolder()
+      if (!picked) return
+      await setCwd(picked)
+    } catch (error) {
+      log.error('Failed to set ACP working directory:', error)
+      toast.error('Failed to set working directory')
+    }
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex h-8 items-center gap-1.5 px-2 has-[>svg]:px-2"
+          aria-label="Choose ACP working directory"
+          onClick={handlePick}
+        >
+          <FolderOpen className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {cwd ? `Working directory: ${cwd}` : 'Choose a working directory'}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/renderer/src/features/chat/components/chat-input-prompt.tsx
+++ b/renderer/src/features/chat/components/chat-input-prompt.tsx
@@ -29,6 +29,7 @@ import { ModelSelector } from './model-selector'
 import { McpServerSelector } from './mcp-server-selector'
 import { SkillSelector } from './skill-selector'
 import { AgentSelector } from './agent-selector'
+import { AcpCwdPicker } from './acp-cwd-picker'
 import type { ChatSettings } from '../types'
 import { toast } from 'sonner'
 import { toastVariants } from '@/common/lib/toast'
@@ -256,7 +257,13 @@ function InputWithAttachments({
                 onOpenSettings={handleOpenSettings}
                 onProviderChange={handleProviderChange}
               />
-              <McpServerSelector threadId={threadId} />
+              <McpServerSelector
+                threadId={threadId}
+                isAcpProvider={settings.provider === 'acp'}
+              />
+              {settings.provider === 'acp' && (
+                <AcpCwdPicker threadId={threadId} />
+              )}
               <SkillSelector threadId={threadId} />
             </>
           )}

--- a/renderer/src/features/chat/components/dialog-provider-settings.tsx
+++ b/renderer/src/features/chat/components/dialog-provider-settings.tsx
@@ -36,10 +36,13 @@ import { THV_DISPLAY_NAME } from '@common/app-info'
 import { useManageClients } from '@/features/clients/hooks/use-manage-clients'
 import { trackEvent } from '@/common/lib/analytics'
 import type { ChatSettings } from '../types'
-import { hasCredentials } from '../lib/utils'
+import {
+  hasCredentials,
+  getHarnessClientType,
+  HARNESS_GROUP_NAME,
+} from '../lib/utils'
 
-const ACP_GROUP_NAME = 'default'
-const ACP_CLIENT_TYPE = 'cursor'
+const ACP_CLIENT_TYPE = getHarnessClientType('acp')!
 
 // Provider-specific configuration for credential input
 function getProviderCredentialConfig(providerId: string, providerName: string) {
@@ -111,7 +114,7 @@ export function DialogProviderSettings({
     installedClients,
     defaultValues: registeredClientDefaults,
     getClientFieldName,
-  } = useManageClients(ACP_GROUP_NAME)
+  } = useManageClients(HARNESS_GROUP_NAME)
   const isCursorInstalled = installedClients.some(
     (c) => c.client_type === ACP_CLIENT_TYPE
   )

--- a/renderer/src/features/chat/components/dialog-provider-settings.tsx
+++ b/renderer/src/features/chat/components/dialog-provider-settings.tsx
@@ -33,8 +33,6 @@ import {
 } from '../hooks/use-chat-settings'
 import { ScrollArea } from '@/common/components/ui/scroll-area'
 import { THV_DISPLAY_NAME } from '@common/app-info'
-import { Switch } from '@/common/components/ui/switch'
-import { WrapperField } from '@/common/components/settings/tabs/components/wrapper-field'
 import { useManageClients } from '@/features/clients/hooks/use-manage-clients'
 import { trackEvent } from '@/common/lib/analytics'
 import type { ChatSettings } from '../types'
@@ -104,48 +102,21 @@ export function DialogProviderSettings({
     refetchProviders,
   } = useChatSettings()
 
-  // ACP's "Enable" switch mirrors whether the `cursor` client is registered
-  // in ToolHive's `default` group — the same fact Manage Clients shows —
-  // rather than a value staged in `providerKeys` alongside every other
-  // provider's credential.
+  // The ACP row shows a live read-only status: whether the `cursor` client
+  // is registered in ToolHive's `default` group. Registration itself now
+  // happens automatically the moment the user picks Cursor Agent in the
+  // Playground's model picker (see model-selector.tsx) — this dialog has no
+  // interactive control for it.
   const {
     installedClients,
     defaultValues: registeredClientDefaults,
     getClientFieldName,
-    addClientToGroup,
-    removeClientFromGroup,
   } = useManageClients(ACP_GROUP_NAME)
   const isCursorInstalled = installedClients.some(
     (c) => c.client_type === ACP_CLIENT_TYPE
   )
   const isCursorRegistered =
     registeredClientDefaults[getClientFieldName(ACP_CLIENT_TYPE)] ?? false
-  const [isTogglingAcp, setIsTogglingAcp] = useState(false)
-
-  const handleAcpToggle = async (checked: boolean, enabledTools: string[]) => {
-    trackEvent(`Playground: toggle ACP integration`, { enabled: checked })
-    setIsTogglingAcp(true)
-    try {
-      if (checked) {
-        await addClientToGroup(ACP_CLIENT_TYPE, ACP_GROUP_NAME)
-        await updateProviderSettingsMutation.mutateAsync({
-          provider: 'acp',
-          settings: { apiKey: 'enabled', enabledTools },
-        })
-      } else {
-        await removeClientFromGroup(ACP_CLIENT_TYPE, ACP_GROUP_NAME)
-        await updateProviderSettingsMutation.mutateAsync({
-          provider: 'acp',
-          settings: { apiKey: '', enabledTools },
-        })
-      }
-      await refetchProviders()
-    } catch (error) {
-      log.error('Failed to toggle ACP integration:', error)
-    } finally {
-      setIsTogglingAcp(false)
-    }
-  }
 
   // Sync local state with hook data on dialog open and on provider list
   // changes (refresh). Using the "adjusting state on prop change" pattern
@@ -417,42 +388,28 @@ export function DialogProviderSettings({
                       if (pk.provider.id === 'acp') {
                         return (
                           <div className="border-border/30 bg-muted/10 space-y-3 border-t px-4 pb-4">
-                            <div className="pt-2">
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <div>
-                                    <WrapperField
-                                      label="Enable integration"
-                                      description={
-                                        isCursorInstalled
-                                          ? `Registers the Cursor CLI with ${THV_DISPLAY_NAME}'s default group, so running MCP servers are available to the local \`agent acp\` process.`
-                                          : `Cursor CLI not detected by ${THV_DISPLAY_NAME}.`
-                                      }
-                                      htmlFor="acp-enable-switch"
-                                    >
-                                      <Switch
-                                        id="acp-enable-switch"
-                                        checked={isCursorRegistered}
-                                        disabled={
-                                          !isCursorInstalled || isTogglingAcp
-                                        }
-                                        onCheckedChange={(checked) =>
-                                          handleAcpToggle(
-                                            checked,
-                                            pk.enabledTools
-                                          )
-                                        }
-                                      />
-                                    </WrapperField>
-                                  </div>
-                                </TooltipTrigger>
-                                {!isCursorInstalled && (
-                                  <TooltipContent>
-                                    Install/log into the Cursor CLI (`agent`),
-                                    then reopen this dialog.
-                                  </TooltipContent>
+                            <div className="space-y-2 pt-2">
+                              <div className="flex items-center justify-between">
+                                <p className="text-muted-foreground text-sm">
+                                  {isCursorInstalled
+                                    ? `Registered automatically with ${THV_DISPLAY_NAME} the first time you select Cursor Agent in the Playground, so its running MCP servers reach the local \`agent acp\` process.`
+                                    : `Cursor CLI not detected by ${THV_DISPLAY_NAME}. Install/log into it (\`agent\`), then reopen this dialog.`}
+                                </p>
+                                {isCursorInstalled && (
+                                  <Badge
+                                    variant={
+                                      isCursorRegistered
+                                        ? 'secondary'
+                                        : 'outline'
+                                    }
+                                    className="ml-3 shrink-0 text-xs"
+                                  >
+                                    {isCursorRegistered
+                                      ? 'Registered'
+                                      : 'Not registered yet'}
+                                  </Badge>
                                 )}
-                              </Tooltip>
+                              </div>
                             </div>
                           </div>
                         )

--- a/renderer/src/features/chat/components/dialog-provider-settings.tsx
+++ b/renderer/src/features/chat/components/dialog-provider-settings.tsx
@@ -32,9 +32,16 @@ import {
   getProviderCredential,
 } from '../hooks/use-chat-settings'
 import { ScrollArea } from '@/common/components/ui/scroll-area'
+import { THV_DISPLAY_NAME } from '@common/app-info'
+import { Switch } from '@/common/components/ui/switch'
+import { WrapperField } from '@/common/components/settings/tabs/components/wrapper-field'
+import { useManageClients } from '@/features/clients/hooks/use-manage-clients'
 import { trackEvent } from '@/common/lib/analytics'
 import type { ChatSettings } from '../types'
 import { hasCredentials } from '../lib/utils'
+
+const ACP_GROUP_NAME = 'default'
+const ACP_CLIENT_TYPE = 'cursor'
 
 // Provider-specific configuration for credential input
 function getProviderCredentialConfig(providerId: string, providerName: string) {
@@ -55,16 +62,6 @@ function getProviderCredentialConfig(providerId: string, providerName: string) {
       isSecret: false,
       helpText:
         'Enter the URL of your LM Studio server (default: http://localhost:1234)',
-    }
-  }
-
-  if (providerId === 'acp') {
-    return {
-      label: 'Enable',
-      placeholder: 'local',
-      isSecret: false,
-      helpText:
-        'No API key needed — this spawns your local `agent` (Cursor CLI) and uses its existing login. Enter any value to enable.',
     }
   }
 
@@ -106,6 +103,49 @@ export function DialogProviderSettings({
     isLoadingProviders,
     refetchProviders,
   } = useChatSettings()
+
+  // ACP's "Enable" switch mirrors whether the `cursor` client is registered
+  // in ToolHive's `default` group — the same fact Manage Clients shows —
+  // rather than a value staged in `providerKeys` alongside every other
+  // provider's credential.
+  const {
+    installedClients,
+    defaultValues: registeredClientDefaults,
+    getClientFieldName,
+    addClientToGroup,
+    removeClientFromGroup,
+  } = useManageClients(ACP_GROUP_NAME)
+  const isCursorInstalled = installedClients.some(
+    (c) => c.client_type === ACP_CLIENT_TYPE
+  )
+  const isCursorRegistered =
+    registeredClientDefaults[getClientFieldName(ACP_CLIENT_TYPE)] ?? false
+  const [isTogglingAcp, setIsTogglingAcp] = useState(false)
+
+  const handleAcpToggle = async (checked: boolean, enabledTools: string[]) => {
+    trackEvent(`Playground: toggle ACP integration`, { enabled: checked })
+    setIsTogglingAcp(true)
+    try {
+      if (checked) {
+        await addClientToGroup(ACP_CLIENT_TYPE, ACP_GROUP_NAME)
+        await updateProviderSettingsMutation.mutateAsync({
+          provider: 'acp',
+          settings: { apiKey: 'enabled', enabledTools },
+        })
+      } else {
+        await removeClientFromGroup(ACP_CLIENT_TYPE, ACP_GROUP_NAME)
+        await updateProviderSettingsMutation.mutateAsync({
+          provider: 'acp',
+          settings: { apiKey: '', enabledTools },
+        })
+      }
+      await refetchProviders()
+    } catch (error) {
+      log.error('Failed to toggle ACP integration:', error)
+    } finally {
+      setIsTogglingAcp(false)
+    }
+  }
 
   // Sync local state with hook data on dialog open and on provider list
   // changes (refresh). Using the "adjusting state on prop change" pattern
@@ -374,6 +414,49 @@ export function DialogProviderSettings({
 
                   <CollapsibleContent>
                     {(() => {
+                      if (pk.provider.id === 'acp') {
+                        return (
+                          <div className="border-border/30 bg-muted/10 space-y-3 border-t px-4 pb-4">
+                            <div className="pt-2">
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <div>
+                                    <WrapperField
+                                      label="Enable integration"
+                                      description={
+                                        isCursorInstalled
+                                          ? `Registers the Cursor CLI with ${THV_DISPLAY_NAME}'s default group, so running MCP servers are available to the local \`agent acp\` process.`
+                                          : `Cursor CLI not detected by ${THV_DISPLAY_NAME}.`
+                                      }
+                                      htmlFor="acp-enable-switch"
+                                    >
+                                      <Switch
+                                        id="acp-enable-switch"
+                                        checked={isCursorRegistered}
+                                        disabled={
+                                          !isCursorInstalled || isTogglingAcp
+                                        }
+                                        onCheckedChange={(checked) =>
+                                          handleAcpToggle(
+                                            checked,
+                                            pk.enabledTools
+                                          )
+                                        }
+                                      />
+                                    </WrapperField>
+                                  </div>
+                                </TooltipTrigger>
+                                {!isCursorInstalled && (
+                                  <TooltipContent>
+                                    Install/log into the Cursor CLI (`agent`),
+                                    then reopen this dialog.
+                                  </TooltipContent>
+                                )}
+                              </Tooltip>
+                            </div>
+                          </div>
+                        )
+                      }
                       const credentialConfig = getProviderCredentialConfig(
                         pk.provider.id,
                         pk.provider.name

--- a/renderer/src/features/chat/components/dialog-provider-settings.tsx
+++ b/renderer/src/features/chat/components/dialog-provider-settings.tsx
@@ -58,6 +58,16 @@ function getProviderCredentialConfig(providerId: string, providerName: string) {
     }
   }
 
+  if (providerId === 'acp') {
+    return {
+      label: 'Enable',
+      placeholder: 'local',
+      isSecret: false,
+      helpText:
+        'No API key needed — this spawns your local `agent` (Cursor CLI) and uses its existing login. Enter any value to enable.',
+    }
+  }
+
   return {
     label: 'API Key',
     placeholder: `Enter your ${providerName} API key`,

--- a/renderer/src/features/chat/components/mcp-server-selector.tsx
+++ b/renderer/src/features/chat/components/mcp-server-selector.tsx
@@ -194,8 +194,8 @@ export function McpServerSelector({
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          MCP tools aren&apos;t configured here for ACP agents — manage MCP
-          servers on the MCP Servers page.
+          Cursor Agent runs its own tools — manage MCP servers on the MCP
+          Servers page.
         </TooltipContent>
       </Tooltip>
     )

--- a/renderer/src/features/chat/components/mcp-server-selector.tsx
+++ b/renderer/src/features/chat/components/mcp-server-selector.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 import log from 'electron-log/renderer'
 import { Button } from '@/common/components/ui/button'
@@ -26,9 +27,19 @@ import { trackEvent } from '@/common/lib/analytics'
 
 interface McpServerSelectorProps {
   threadId?: string | null
+  /**
+   * ACP-based agents run their own tool loop — ToolHive's per-tool
+   * enable/disable UI has no effect on them. Render a link to the MCP
+   * servers page instead of the tool picker.
+   */
+  isAcpProvider?: boolean
 }
 
-export function McpServerSelector({ threadId }: McpServerSelectorProps) {
+export function McpServerSelector({
+  threadId,
+  isAcpProvider,
+}: McpServerSelectorProps) {
+  const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [isOpen, setIsOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
@@ -160,6 +171,34 @@ export function McpServerSelector({ threadId }: McpServerSelectorProps) {
   const handleOpenSettings = (open: boolean) => {
     trackEvent(`Playground: open manage mcp server settings`)
     setIsOpen(open)
+  }
+
+  if (isAcpProvider) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="flex h-8 items-center gap-1.5 px-2 has-[>svg]:px-2"
+            aria-label="Manage MCP servers"
+            onClick={() => {
+              trackEvent('Playground: navigate to MCP servers from ACP')
+              navigate({
+                to: '/group/$groupName',
+                params: { groupName: 'default' },
+              })
+            }}
+          >
+            <ServerIcon className="size-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          MCP tools aren&apos;t configured here for ACP agents — manage MCP
+          servers on the MCP Servers page.
+        </TooltipContent>
+      </Tooltip>
+    )
   }
 
   return (

--- a/renderer/src/features/chat/components/model-picker.tsx
+++ b/renderer/src/features/chat/components/model-picker.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { Bot, ChevronDown, Check, Search, X } from 'lucide-react'
+import { Bot, ChevronDown, Check, Search, Wrench, X } from 'lucide-react'
 import { Button } from '@/common/components/ui/button'
 import { Input } from '@/common/components/ui/input'
 import {
@@ -20,6 +20,7 @@ import {
 } from '@/common/components/ui/tooltip'
 import { cn } from '@/common/lib/utils'
 import { useAvailableModels } from '../hooks/use-available-models'
+import { isHarnessProvider } from '../lib/utils'
 import { getProviderIcon } from './provider-icons'
 
 export interface ModelSelection {
@@ -54,12 +55,126 @@ export function ModelPicker({
   const [searchQueries, setSearchQueries] = useState<Record<string, string>>({})
   const inputRef = useRef<HTMLInputElement>(null)
 
+  const modelProviders = providersWithCredentials.filter(
+    (provider) => !isHarnessProvider(provider.id)
+  )
+  const harnessProviders = providersWithCredentials.filter((provider) =>
+    isHarnessProvider(provider.id)
+  )
+
   const getFilteredModels = (provider: { id: string; models: string[] }) => {
     const query = searchQueries[provider.id]?.toLowerCase() || ''
     if (!query) return provider.models
 
     return provider.models.filter((model: string) =>
       model.toLowerCase().includes(query)
+    )
+  }
+
+  const renderProviderSub = (provider: {
+    id: string
+    name: string
+    models: string[]
+  }) => {
+    const filteredModels = getFilteredModels(provider)
+    const hasSearch = provider.models.length > 50
+
+    return (
+      <DropdownMenuSub key={provider.id}>
+        <DropdownMenuSubTrigger>
+          <div className="flex w-full items-center justify-between">
+            <div className="flex min-w-0 items-center gap-2">
+              {getProviderIcon(provider.id)}
+              <span className="max-w-40 truncate" title={provider.name}>
+                {provider.name}
+              </span>
+            </div>
+          </div>
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent
+          className="flex max-h-[480px] w-auto max-w-100 flex-col
+            overflow-hidden px-2"
+          onFocus={(e) => {
+            e.preventDefault()
+            inputRef.current?.focus()
+          }}
+        >
+          <div className="shrink-0">
+            <DropdownMenuLabel className="text-muted-foreground text-xs">
+              {provider.name} Models
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+
+            {hasSearch && (
+              <div className="bg-background border-b p-2">
+                <div className="relative">
+                  <Search
+                    className="text-muted-foreground absolute top-2.5 left-2 h-4
+                      w-4"
+                  />
+                  <Input
+                    ref={inputRef}
+                    placeholder="Search models..."
+                    value={searchQueries[provider.id] || ''}
+                    onChange={(e) => {
+                      setSearchQueries((prev) => ({
+                        ...prev,
+                        [provider.id]: e.target.value,
+                      }))
+                    }}
+                    className="h-8 pl-8"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {filteredModels.length > 0 ? (
+              filteredModels.map((model) => {
+                const isSelected =
+                  value?.provider === provider.id && value.model === model
+
+                return (
+                  <DropdownMenuItem
+                    key={model}
+                    onClick={() => onChange({ provider: provider.id, model })}
+                    className="flex cursor-pointer items-center justify-between"
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="h-4 w-4">
+                        {isSelected && <Check className="h-4 w-4" />}
+                      </div>
+                      <div className="flex flex-col">
+                        <span className="font-mono text-sm">{model}</span>
+                      </div>
+                    </div>
+                  </DropdownMenuItem>
+                )
+              })
+            ) : (
+              <div className="text-muted-foreground p-2 text-center text-sm">
+                {provider.models.length === 0
+                  ? provider.id === 'ollama'
+                    ? 'Ollama is not running or no models available'
+                    : 'No models available'
+                  : `No models found matching "${searchQueries[provider.id]}"`}
+              </div>
+            )}
+          </div>
+
+          {hasSearch && (
+            <div className="bg-background shrink-0 border-t p-2">
+              <p className="text-muted-foreground text-center text-xs">
+                {searchQueries[provider.id]
+                  ? `${filteredModels.length} of ${provider.models.length} models`
+                  : `${provider.models.length} models available`}
+              </p>
+            </div>
+          )}
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
     )
   }
 
@@ -100,12 +215,6 @@ export function ModelPicker({
         align="start"
         className={cn('w-80', contentClassName)}
       >
-        <DropdownMenuLabel className="flex items-center gap-2">
-          <Bot className="h-4 w-4" />
-          AI Models
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-
         {onClear && value && (
           <>
             <DropdownMenuItem
@@ -119,113 +228,28 @@ export function ModelPicker({
           </>
         )}
 
-        {providersWithCredentials.map((provider) => {
-          const filteredModels = getFilteredModels(provider)
-          const hasSearch = provider.models.length > 50
+        {modelProviders.length > 0 && (
+          <>
+            <DropdownMenuLabel className="flex items-center gap-2">
+              <Bot className="h-4 w-4" />
+              AI Models
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {modelProviders.map(renderProviderSub)}
+          </>
+        )}
 
-          return (
-            <DropdownMenuSub key={provider.id}>
-              <DropdownMenuSubTrigger>
-                <div className="flex w-full items-center justify-between">
-                  <div className="flex min-w-0 items-center gap-2">
-                    {getProviderIcon(provider.id)}
-                    <span className="max-w-40 truncate" title={provider.name}>
-                      {provider.name}
-                    </span>
-                  </div>
-                </div>
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent
-                className="flex max-h-[480px] w-auto max-w-100 flex-col
-                  overflow-hidden px-2"
-                onFocus={(e) => {
-                  e.preventDefault()
-                  inputRef.current?.focus()
-                }}
-              >
-                <div className="shrink-0">
-                  <DropdownMenuLabel className="text-muted-foreground text-xs">
-                    {provider.name} Models
-                  </DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-
-                  {hasSearch && (
-                    <div className="bg-background border-b p-2">
-                      <div className="relative">
-                        <Search
-                          className="text-muted-foreground absolute top-2.5
-                            left-2 h-4 w-4"
-                        />
-                        <Input
-                          ref={inputRef}
-                          placeholder="Search models..."
-                          value={searchQueries[provider.id] || ''}
-                          onChange={(e) => {
-                            setSearchQueries((prev) => ({
-                              ...prev,
-                              [provider.id]: e.target.value,
-                            }))
-                          }}
-                          className="h-8 pl-8"
-                          onClick={(e) => e.stopPropagation()}
-                        />
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                <div className="min-h-0 flex-1 overflow-y-auto">
-                  {filteredModels.length > 0 ? (
-                    filteredModels.map((model) => {
-                      const isSelected =
-                        value?.provider === provider.id && value.model === model
-
-                      return (
-                        <DropdownMenuItem
-                          key={model}
-                          onClick={() =>
-                            onChange({ provider: provider.id, model })
-                          }
-                          className="flex cursor-pointer items-center
-                            justify-between"
-                        >
-                          <div className="flex items-center gap-2">
-                            <div className="h-4 w-4">
-                              {isSelected && <Check className="h-4 w-4" />}
-                            </div>
-                            <div className="flex flex-col">
-                              <span className="font-mono text-sm">{model}</span>
-                            </div>
-                          </div>
-                        </DropdownMenuItem>
-                      )
-                    })
-                  ) : (
-                    <div
-                      className="text-muted-foreground p-2 text-center text-sm"
-                    >
-                      {provider.models.length === 0
-                        ? provider.id === 'ollama'
-                          ? 'Ollama is not running or no models available'
-                          : 'No models available'
-                        : `No models found matching "${searchQueries[provider.id]}"`}
-                    </div>
-                  )}
-                </div>
-
-                {hasSearch && (
-                  <div className="bg-background shrink-0 border-t p-2">
-                    <p className="text-muted-foreground text-center text-xs">
-                      {searchQueries[provider.id]
-                        ? `${filteredModels.length} of ${provider.models.length} models`
-                        : `${provider.models.length} models available`}
-                    </p>
-                  </div>
-                )}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-          )
-        })}
+        {harnessProviders.length > 0 && (
+          <>
+            {modelProviders.length > 0 && <DropdownMenuSeparator />}
+            <DropdownMenuLabel className="flex items-center gap-2">
+              <Wrench className="h-4 w-4" />
+              AI Harnesses
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {harnessProviders.map(renderProviderSub)}
+          </>
+        )}
 
         {onOpenSettings && (
           <>

--- a/renderer/src/features/chat/components/model-selector.tsx
+++ b/renderer/src/features/chat/components/model-selector.tsx
@@ -1,7 +1,13 @@
 import log from 'electron-log/renderer'
+import { useQueryClient } from '@tanstack/react-query'
 import { ModelPicker, type ModelSelection } from './model-picker'
 import type { ChatSettings } from '../types'
+import { isHarnessProvider } from '../lib/utils'
+import { useManageClients } from '@/features/clients/hooks/use-manage-clients'
 import { trackEvent } from '@/common/lib/analytics'
+
+const ACP_GROUP_NAME = 'default'
+const ACP_CLIENT_TYPE = 'cursor'
 
 interface ModelSelectorProps {
   settings: ChatSettings
@@ -15,6 +21,41 @@ export function ModelSelector({
   onSettingsChange,
   onOpenSettings,
 }: ModelSelectorProps) {
+  // Harness providers (Cursor Agent, via ACP) need no manual credentials —
+  // instead, the moment one is selected here we register it as a ToolHive
+  // client (same mechanism as Manage Clients) so its running MCP servers
+  // reach the spawned agent process.
+  const {
+    installedClients,
+    defaultValues,
+    getClientFieldName,
+    addClientToGroup,
+  } = useManageClients(ACP_GROUP_NAME)
+  const queryClient = useQueryClient()
+
+  const ensureHarnessRegistered = async () => {
+    const isInstalled = installedClients.some(
+      (c) => c.client_type === ACP_CLIENT_TYPE
+    )
+    const isRegistered =
+      defaultValues[getClientFieldName(ACP_CLIENT_TYPE)] ?? false
+    if (isInstalled && !isRegistered) {
+      await addClientToGroup(ACP_CLIENT_TYPE, ACP_GROUP_NAME)
+    }
+    // Needed regardless of registration outcome — this app's credential
+    // gating (hasCredentials, the composer, the pre-send check) all key off
+    // a truthy apiKey, and harness providers have no real key to store.
+    await window.electronAPI.chat.saveSettings('acp', {
+      apiKey: 'enabled',
+      enabledTools: [],
+    })
+    queryClient.invalidateQueries({ queryKey: ['chat', 'settings', 'acp'] })
+    queryClient.invalidateQueries({
+      queryKey: ['chat', 'allProvidersWithSettings'],
+    })
+    queryClient.invalidateQueries({ queryKey: ['chat', 'availableModels'] })
+  }
+
   const handleModelSelect = async ({ provider, model }: ModelSelection) => {
     trackEvent(`Playground: select model ${model}`, { provider })
 
@@ -24,6 +65,10 @@ export function ModelSelector({
     }
 
     try {
+      if (isHarnessProvider(provider)) {
+        await ensureHarnessRegistered()
+      }
+
       const providerSettings =
         await window.electronAPI.chat.getSettings(provider)
 

--- a/renderer/src/features/chat/components/model-selector.tsx
+++ b/renderer/src/features/chat/components/model-selector.tsx
@@ -2,12 +2,13 @@ import log from 'electron-log/renderer'
 import { useQueryClient } from '@tanstack/react-query'
 import { ModelPicker, type ModelSelection } from './model-picker'
 import type { ChatSettings } from '../types'
-import { isHarnessProvider } from '../lib/utils'
+import {
+  isHarnessProvider,
+  getHarnessClientType,
+  HARNESS_GROUP_NAME,
+} from '../lib/utils'
 import { useManageClients } from '@/features/clients/hooks/use-manage-clients'
 import { trackEvent } from '@/common/lib/analytics'
-
-const ACP_GROUP_NAME = 'default'
-const ACP_CLIENT_TYPE = 'cursor'
 
 interface ModelSelectorProps {
   settings: ChatSettings
@@ -30,26 +31,28 @@ export function ModelSelector({
     defaultValues,
     getClientFieldName,
     addClientToGroup,
-  } = useManageClients(ACP_GROUP_NAME)
+  } = useManageClients(HARNESS_GROUP_NAME)
   const queryClient = useQueryClient()
 
-  const ensureHarnessRegistered = async () => {
+  const ensureHarnessRegistered = async (provider: string) => {
+    const clientType = getHarnessClientType(provider)
+    if (!clientType) return
+
     const isInstalled = installedClients.some(
-      (c) => c.client_type === ACP_CLIENT_TYPE
+      (c) => c.client_type === clientType
     )
-    const isRegistered =
-      defaultValues[getClientFieldName(ACP_CLIENT_TYPE)] ?? false
+    const isRegistered = defaultValues[getClientFieldName(clientType)] ?? false
     if (isInstalled && !isRegistered) {
-      await addClientToGroup(ACP_CLIENT_TYPE, ACP_GROUP_NAME)
+      await addClientToGroup(clientType, HARNESS_GROUP_NAME)
     }
     // Needed regardless of registration outcome — this app's credential
     // gating (hasCredentials, the composer, the pre-send check) all key off
     // a truthy apiKey, and harness providers have no real key to store.
-    await window.electronAPI.chat.saveSettings('acp', {
+    await window.electronAPI.chat.saveSettings(provider, {
       apiKey: 'enabled',
       enabledTools: [],
     })
-    queryClient.invalidateQueries({ queryKey: ['chat', 'settings', 'acp'] })
+    queryClient.invalidateQueries({ queryKey: ['chat', 'settings', provider] })
     queryClient.invalidateQueries({
       queryKey: ['chat', 'allProvidersWithSettings'],
     })
@@ -66,7 +69,7 @@ export function ModelSelector({
 
     try {
       if (isHarnessProvider(provider)) {
-        await ensureHarnessRegistered()
+        await ensureHarnessRegistered(provider)
       }
 
       const providerSettings =

--- a/renderer/src/features/chat/hooks/use-available-models.ts
+++ b/renderer/src/features/chat/hooks/use-available-models.ts
@@ -1,7 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import type { ChatProvider } from '../types'
-import { hasValidCredentials, isHarnessProvider } from '../lib/utils'
+import {
+  hasValidCredentials,
+  isHarnessProvider,
+  getHarnessClientType,
+  HARNESS_GROUP_NAME,
+} from '../lib/utils'
+import { useManageClients } from '@/features/clients/hooks/use-manage-clients'
 
 interface AvailableProvider extends ChatProvider {
   hasCredentials: boolean
@@ -42,12 +48,20 @@ export function useAvailableModels() {
     refetchOnWindowFocus: true,
   })
 
+  // Harness providers need no manual credentials, but they're only usable
+  // when the underlying client (e.g. the Cursor CLI) is actually installed —
+  // otherwise selecting one would just fail to spawn.
+  const { installedClients } = useManageClients(HARNESS_GROUP_NAME)
+
   const providersWithCredentials = useMemo(
     () =>
-      availableProviders.filter(
-        (provider) => provider.hasCredentials || isHarnessProvider(provider.id)
-      ),
-    [availableProviders]
+      availableProviders.filter((provider) => {
+        if (provider.hasCredentials) return true
+        if (!isHarnessProvider(provider.id)) return false
+        const clientType = getHarnessClientType(provider.id)
+        return installedClients.some((c) => c.client_type === clientType)
+      }),
+    [availableProviders, installedClients]
   )
 
   return {

--- a/renderer/src/features/chat/hooks/use-available-models.ts
+++ b/renderer/src/features/chat/hooks/use-available-models.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import type { ChatProvider } from '../types'
-import { hasValidCredentials } from '../lib/utils'
+import { hasValidCredentials, isHarnessProvider } from '../lib/utils'
 
 interface AvailableProvider extends ChatProvider {
   hasCredentials: boolean
@@ -43,7 +43,10 @@ export function useAvailableModels() {
   })
 
   const providersWithCredentials = useMemo(
-    () => availableProviders.filter((provider) => provider.hasCredentials),
+    () =>
+      availableProviders.filter(
+        (provider) => provider.hasCredentials || isHarnessProvider(provider.id)
+      ),
     [availableProviders]
   )
 

--- a/renderer/src/features/chat/hooks/use-chat-settings.ts
+++ b/renderer/src/features/chat/hooks/use-chat-settings.ts
@@ -49,6 +49,8 @@ const CHAT_SETTINGS_KEYS = {
     ['chat', 'thread', threadId, 'selectedModel'] as const,
   threadEnabledMcpTools: (threadId: string) =>
     ['chat', 'thread', threadId, 'enabledMcpTools'] as const,
+  threadAcpCwd: (threadId: string) =>
+    ['chat', 'thread', threadId, 'acpCwd'] as const,
   settings: (provider: ChatProvider | string) =>
     ['chat', 'settings', provider] as const,
   allSettings: ['chat', 'settings'] as const,
@@ -461,4 +463,40 @@ export function useChatSettings(threadId?: string | null) {
   )
 
   return result
+}
+
+/**
+ * Per-thread working directory for ACP-based providers (e.g. the Cursor CLI
+ * agent). Cached under a query key `electron-ipc-chat-transport.ts` reads
+ * directly via `queryClient.getQueryData` when building a chat request.
+ */
+export function useAcpCwd(threadId?: string | null) {
+  const queryClient = useQueryClient()
+
+  const { data: cwd, isLoading } = useQuery({
+    queryKey: threadId
+      ? CHAT_SETTINGS_KEYS.threadAcpCwd(threadId)
+      : ['chat', 'thread', '__none__', 'acpCwd'],
+    queryFn: () => window.electronAPI.chat.threadSettings.getAcpCwd(threadId!),
+    enabled: !!threadId,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+  })
+
+  const setCwdMutation = useMutation({
+    mutationFn: (cwd: string | null) => {
+      if (!threadId) throw new Error('No active thread')
+      return window.electronAPI.chat.threadSettings.setAcpCwd(threadId, cwd)
+    },
+    onSuccess: (_, cwd) => {
+      if (!threadId) return
+      queryClient.setQueryData(CHAT_SETTINGS_KEYS.threadAcpCwd(threadId), cwd)
+    },
+  })
+
+  return {
+    cwd: cwd ?? null,
+    isLoading,
+    setCwd: setCwdMutation.mutateAsync,
+  }
 }

--- a/renderer/src/features/chat/lib/utils.ts
+++ b/renderer/src/features/chat/lib/utils.ts
@@ -56,3 +56,13 @@ export function isLocalServerProvider(
 ): provider is 'ollama' | 'lmstudio' {
   return provider === 'ollama' || provider === 'lmstudio'
 }
+
+/**
+ * "Harness" providers (currently just the Cursor CLI agent, via ACP) run
+ * their own tool-calling loop instead of exposing a plain text-completion
+ * model — they're grouped separately in the model picker and don't need
+ * manual credentials (registration with ToolHive happens automatically).
+ */
+export function isHarnessProvider(provider: string): provider is 'acp' {
+  return provider === 'acp'
+}

--- a/renderer/src/features/chat/lib/utils.ts
+++ b/renderer/src/features/chat/lib/utils.ts
@@ -66,3 +66,19 @@ export function isLocalServerProvider(
 export function isHarnessProvider(provider: string): provider is 'acp' {
   return provider === 'acp'
 }
+
+/** ToolHive group harness providers get registered into. */
+export const HARNESS_GROUP_NAME = 'default'
+
+const HARNESS_CLIENT_TYPES: Record<string, string> = {
+  acp: 'cursor',
+}
+
+/**
+ * The ToolHive client type (as returned by the discovery-clients API) that
+ * backs a harness provider — e.g. the `acp` provider is really the `cursor`
+ * CLI. A harness provider is only usable when this client is installed.
+ */
+export function getHarnessClientType(provider: string): string | undefined {
+  return HARNESS_CLIENT_TYPES[provider]
+}

--- a/renderer/src/features/chat/transport/electron-ipc-chat-transport.ts
+++ b/renderer/src/features/chat/transport/electron-ipc-chat-transport.ts
@@ -35,6 +35,7 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
         model: string
         apiKey: string
         enabledTools: string[]
+        cwd?: string
       }
   > {
     // Prefer the per-thread selection so a stream picks up the model that
@@ -90,11 +91,22 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
           ? providerSettings.apiKey || ''
           : ''
 
+      const cwd =
+        selectedModel.provider === 'acp' && chatId
+          ? (this.config.queryClient.getQueryData<string | null>([
+              'chat',
+              'thread',
+              chatId,
+              'acpCwd',
+            ]) ?? undefined)
+          : undefined
+
       return {
         provider: selectedModel.provider,
         model: selectedModel.model,
         apiKey,
         enabledTools: providerSettings?.enabledTools || [],
+        cwd,
       }
     }
   }
@@ -315,6 +327,7 @@ export class ElectronIPCChatTransport implements ChatTransport<ChatUIMessage> {
         model: settings.model,
         apiKey: settings.apiKey,
         enabledTools: settings.enabledTools || [],
+        cwd: settings.cwd,
       }
     }
 

--- a/renderer/src/features/clients/hooks/use-manage-clients.ts
+++ b/renderer/src/features/clients/hooks/use-manage-clients.ts
@@ -52,6 +52,12 @@ export function useManageClients(groupName: string) {
       queryClient.invalidateQueries({
         queryKey: getApiV1BetaClientsQueryKey(),
       })
+      // The Playground's ACP "Enable" switch mirrors this same registration
+      // fact — keep it from going stale if it (or Manage Clients, or any
+      // other entry point) changes group membership.
+      queryClient.invalidateQueries({
+        queryKey: ['chat', 'allProvidersWithSettings'],
+      })
     },
   })
 
@@ -77,6 +83,9 @@ export function useManageClients(groupName: string) {
       })
       queryClient.invalidateQueries({
         queryKey: getApiV1BetaGroupsQueryKey(),
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['chat', 'allProvidersWithSettings'],
       })
     },
   })

--- a/renderer/src/route-tree.gen.ts
+++ b/renderer/src/route-tree.gen.ts
@@ -9,45 +9,30 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root"
-import { Route as SkillsRouteImport } from "./routes/skills"
-import { Route as ShutdownRouteImport } from "./routes/shutdown"
-import { Route as SettingsRouteImport } from "./routes/settings"
-import { Route as PlaygroundRouteImport } from "./routes/playground"
-import { Route as CliIssueRouteImport } from "./routes/cli-issue"
 import { Route as IndexRouteImport } from "./routes/index"
+import { Route as CliIssueRouteImport } from "./routes/cli-issue"
+import { Route as PlaygroundRouteImport } from "./routes/playground"
+import { Route as SettingsRouteImport } from "./routes/settings"
+import { Route as ShutdownRouteImport } from "./routes/shutdown"
+import { Route as SkillsRouteImport } from "./routes/skills"
+import { Route as registryRegistryRouteImport } from "./routes/(registry)/registry"
+import { Route as CustomizeToolsServerNameRouteImport } from "./routes/customize-tools.$serverName"
+import { Route as GroupGroupNameRouteImport } from "./routes/group.$groupName"
 import { Route as PlaygroundIndexRouteImport } from "./routes/playground.index"
 import { Route as PlaygroundAgentsRouteImport } from "./routes/playground.agents"
-import { Route as GroupGroupNameRouteImport } from "./routes/group.$groupName"
-import { Route as CustomizeToolsServerNameRouteImport } from "./routes/customize-tools.$serverName"
-import { Route as registryRegistryRouteImport } from "./routes/(registry)/registry"
-import { Route as SkillsBuildsTagRouteImport } from "./routes/skills_.builds.$tag"
-import { Route as SkillsNamespaceSkillNameRouteImport } from "./routes/skills_.$namespace.$skillName"
-import { Route as PlaygroundChatThreadIdRouteImport } from "./routes/playground.chat.$threadId"
-import { Route as PlaygroundAgentsNewRouteImport } from "./routes/playground.agents_.new"
-import { Route as PlaygroundAgentsAgentIdRouteImport } from "./routes/playground.agents_.$agentId"
-import { Route as LogsGroupNameServerNameRouteImport } from "./routes/logs.$groupName.$serverName"
-import { Route as registryRegistryNameRouteImport } from "./routes/(registry)/registry_.$name"
 import { Route as registryRegistryGroupNameRouteImport } from "./routes/(registry)/registry-group_.$name"
+import { Route as registryRegistryNameRouteImport } from "./routes/(registry)/registry_.$name"
+import { Route as LogsGroupNameServerNameRouteImport } from "./routes/logs.$groupName.$serverName"
+import { Route as PlaygroundAgentsAgentIdRouteImport } from "./routes/playground.agents_.$agentId"
+import { Route as PlaygroundAgentsNewRouteImport } from "./routes/playground.agents_.new"
+import { Route as PlaygroundChatThreadIdRouteImport } from "./routes/playground.chat.$threadId"
+import { Route as SkillsNamespaceSkillNameRouteImport } from "./routes/skills_.$namespace.$skillName"
+import { Route as SkillsBuildsTagRouteImport } from "./routes/skills_.builds.$tag"
 import { Route as PlaygroundAgentsAgentIdEditRouteImport } from "./routes/playground.agents_.$agentId_.edit"
 
-const SkillsRoute = SkillsRouteImport.update({
-  id: "/skills",
-  path: "/skills",
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ShutdownRoute = ShutdownRouteImport.update({
-  id: "/shutdown",
-  path: "/shutdown",
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SettingsRoute = SettingsRouteImport.update({
-  id: "/settings",
-  path: "/settings",
-  getParentRoute: () => rootRouteImport,
-} as any)
-const PlaygroundRoute = PlaygroundRouteImport.update({
-  id: "/playground",
-  path: "/playground",
+const IndexRoute = IndexRouteImport.update({
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
 } as any)
 const CliIssueRoute = CliIssueRouteImport.update({
@@ -55,9 +40,40 @@ const CliIssueRoute = CliIssueRouteImport.update({
   path: "/cli-issue",
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+const PlaygroundRoute = PlaygroundRouteImport.update({
+  id: "/playground",
+  path: "/playground",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsRoute = SettingsRouteImport.update({
+  id: "/settings",
+  path: "/settings",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ShutdownRoute = ShutdownRouteImport.update({
+  id: "/shutdown",
+  path: "/shutdown",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SkillsRoute = SkillsRouteImport.update({
+  id: "/skills",
+  path: "/skills",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const registryRegistryRoute = registryRegistryRouteImport.update({
+  id: "/(registry)/registry",
+  path: "/registry",
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CustomizeToolsServerNameRoute =
+  CustomizeToolsServerNameRouteImport.update({
+    id: "/customize-tools/$serverName",
+    path: "/customize-tools/$serverName",
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const GroupGroupNameRoute = GroupGroupNameRouteImport.update({
+  id: "/group/$groupName",
+  path: "/group/$groupName",
   getParentRoute: () => rootRouteImport,
 } as any)
 const PlaygroundIndexRoute = PlaygroundIndexRouteImport.update({
@@ -70,36 +86,25 @@ const PlaygroundAgentsRoute = PlaygroundAgentsRouteImport.update({
   path: "/agents",
   getParentRoute: () => PlaygroundRoute,
 } as any)
-const GroupGroupNameRoute = GroupGroupNameRouteImport.update({
-  id: "/group/$groupName",
-  path: "/group/$groupName",
-  getParentRoute: () => rootRouteImport,
-} as any)
-const CustomizeToolsServerNameRoute =
-  CustomizeToolsServerNameRouteImport.update({
-    id: "/customize-tools/$serverName",
-    path: "/customize-tools/$serverName",
+const registryRegistryGroupNameRoute =
+  registryRegistryGroupNameRouteImport.update({
+    id: "/(registry)/registry-group_/$name",
+    path: "/registry-group/$name",
     getParentRoute: () => rootRouteImport,
   } as any)
-const registryRegistryRoute = registryRegistryRouteImport.update({
-  id: "/(registry)/registry",
-  path: "/registry",
+const registryRegistryNameRoute = registryRegistryNameRouteImport.update({
+  id: "/(registry)/registry_/$name",
+  path: "/registry/$name",
   getParentRoute: () => rootRouteImport,
 } as any)
-const SkillsBuildsTagRoute = SkillsBuildsTagRouteImport.update({
-  id: "/skills_/builds/$tag",
-  path: "/skills/builds/$tag",
+const LogsGroupNameServerNameRoute = LogsGroupNameServerNameRouteImport.update({
+  id: "/logs/$groupName/$serverName",
+  path: "/logs/$groupName/$serverName",
   getParentRoute: () => rootRouteImport,
 } as any)
-const SkillsNamespaceSkillNameRoute =
-  SkillsNamespaceSkillNameRouteImport.update({
-    id: "/skills_/$namespace/$skillName",
-    path: "/skills/$namespace/$skillName",
-    getParentRoute: () => rootRouteImport,
-  } as any)
-const PlaygroundChatThreadIdRoute = PlaygroundChatThreadIdRouteImport.update({
-  id: "/chat/$threadId",
-  path: "/chat/$threadId",
+const PlaygroundAgentsAgentIdRoute = PlaygroundAgentsAgentIdRouteImport.update({
+  id: "/agents_/$agentId",
+  path: "/agents/$agentId",
   getParentRoute: () => PlaygroundRoute,
 } as any)
 const PlaygroundAgentsNewRoute = PlaygroundAgentsNewRouteImport.update({
@@ -107,27 +112,22 @@ const PlaygroundAgentsNewRoute = PlaygroundAgentsNewRouteImport.update({
   path: "/agents/new",
   getParentRoute: () => PlaygroundRoute,
 } as any)
-const PlaygroundAgentsAgentIdRoute = PlaygroundAgentsAgentIdRouteImport.update({
-  id: "/agents_/$agentId",
-  path: "/agents/$agentId",
+const PlaygroundChatThreadIdRoute = PlaygroundChatThreadIdRouteImport.update({
+  id: "/chat/$threadId",
+  path: "/chat/$threadId",
   getParentRoute: () => PlaygroundRoute,
 } as any)
-const LogsGroupNameServerNameRoute = LogsGroupNameServerNameRouteImport.update({
-  id: "/logs/$groupName/$serverName",
-  path: "/logs/$groupName/$serverName",
-  getParentRoute: () => rootRouteImport,
-} as any)
-const registryRegistryNameRoute = registryRegistryNameRouteImport.update({
-  id: "/(registry)/registry_/$name",
-  path: "/registry/$name",
-  getParentRoute: () => rootRouteImport,
-} as any)
-const registryRegistryGroupNameRoute =
-  registryRegistryGroupNameRouteImport.update({
-    id: "/(registry)/registry-group_/$name",
-    path: "/registry-group/$name",
+const SkillsNamespaceSkillNameRoute =
+  SkillsNamespaceSkillNameRouteImport.update({
+    id: "/skills_/$namespace/$skillName",
+    path: "/skills/$namespace/$skillName",
     getParentRoute: () => rootRouteImport,
   } as any)
+const SkillsBuildsTagRoute = SkillsBuildsTagRouteImport.update({
+  id: "/skills_/builds/$tag",
+  path: "/skills/builds/$tag",
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PlaygroundAgentsAgentIdEditRoute =
   PlaygroundAgentsAgentIdEditRouteImport.update({
     id: "/agents_/$agentId_/edit",
@@ -288,32 +288,11 @@ export interface RootRouteChildren {
 
 declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    "/skills": {
-      id: "/skills"
-      path: "/skills"
-      fullPath: "/skills"
-      preLoaderRoute: typeof SkillsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/shutdown": {
-      id: "/shutdown"
-      path: "/shutdown"
-      fullPath: "/shutdown"
-      preLoaderRoute: typeof ShutdownRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/settings": {
-      id: "/settings"
-      path: "/settings"
-      fullPath: "/settings"
-      preLoaderRoute: typeof SettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/playground": {
-      id: "/playground"
-      path: "/playground"
-      fullPath: "/playground"
-      preLoaderRoute: typeof PlaygroundRouteImport
+    "/": {
+      id: "/"
+      path: "/"
+      fullPath: "/"
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/cli-issue": {
@@ -323,11 +302,53 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof CliIssueRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/": {
-      id: "/"
-      path: "/"
-      fullPath: "/"
-      preLoaderRoute: typeof IndexRouteImport
+    "/playground": {
+      id: "/playground"
+      path: "/playground"
+      fullPath: "/playground"
+      preLoaderRoute: typeof PlaygroundRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/settings": {
+      id: "/settings"
+      path: "/settings"
+      fullPath: "/settings"
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/shutdown": {
+      id: "/shutdown"
+      path: "/shutdown"
+      fullPath: "/shutdown"
+      preLoaderRoute: typeof ShutdownRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/skills": {
+      id: "/skills"
+      path: "/skills"
+      fullPath: "/skills"
+      preLoaderRoute: typeof SkillsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/(registry)/registry": {
+      id: "/(registry)/registry"
+      path: "/registry"
+      fullPath: "/registry"
+      preLoaderRoute: typeof registryRegistryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/customize-tools/$serverName": {
+      id: "/customize-tools/$serverName"
+      path: "/customize-tools/$serverName"
+      fullPath: "/customize-tools/$serverName"
+      preLoaderRoute: typeof CustomizeToolsServerNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/group/$groupName": {
+      id: "/group/$groupName"
+      path: "/group/$groupName"
+      fullPath: "/group/$groupName"
+      preLoaderRoute: typeof GroupGroupNameRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/playground/": {
@@ -344,67 +365,11 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof PlaygroundAgentsRouteImport
       parentRoute: typeof PlaygroundRoute
     }
-    "/group/$groupName": {
-      id: "/group/$groupName"
-      path: "/group/$groupName"
-      fullPath: "/group/$groupName"
-      preLoaderRoute: typeof GroupGroupNameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/customize-tools/$serverName": {
-      id: "/customize-tools/$serverName"
-      path: "/customize-tools/$serverName"
-      fullPath: "/customize-tools/$serverName"
-      preLoaderRoute: typeof CustomizeToolsServerNameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/(registry)/registry": {
-      id: "/(registry)/registry"
-      path: "/registry"
-      fullPath: "/registry"
-      preLoaderRoute: typeof registryRegistryRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/skills_/builds/$tag": {
-      id: "/skills_/builds/$tag"
-      path: "/skills/builds/$tag"
-      fullPath: "/skills/builds/$tag"
-      preLoaderRoute: typeof SkillsBuildsTagRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/skills_/$namespace/$skillName": {
-      id: "/skills_/$namespace/$skillName"
-      path: "/skills/$namespace/$skillName"
-      fullPath: "/skills/$namespace/$skillName"
-      preLoaderRoute: typeof SkillsNamespaceSkillNameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    "/playground/chat/$threadId": {
-      id: "/playground/chat/$threadId"
-      path: "/chat/$threadId"
-      fullPath: "/playground/chat/$threadId"
-      preLoaderRoute: typeof PlaygroundChatThreadIdRouteImport
-      parentRoute: typeof PlaygroundRoute
-    }
-    "/playground/agents_/new": {
-      id: "/playground/agents_/new"
-      path: "/agents/new"
-      fullPath: "/playground/agents/new"
-      preLoaderRoute: typeof PlaygroundAgentsNewRouteImport
-      parentRoute: typeof PlaygroundRoute
-    }
-    "/playground/agents_/$agentId": {
-      id: "/playground/agents_/$agentId"
-      path: "/agents/$agentId"
-      fullPath: "/playground/agents/$agentId"
-      preLoaderRoute: typeof PlaygroundAgentsAgentIdRouteImport
-      parentRoute: typeof PlaygroundRoute
-    }
-    "/logs/$groupName/$serverName": {
-      id: "/logs/$groupName/$serverName"
-      path: "/logs/$groupName/$serverName"
-      fullPath: "/logs/$groupName/$serverName"
-      preLoaderRoute: typeof LogsGroupNameServerNameRouteImport
+    "/(registry)/registry-group_/$name": {
+      id: "/(registry)/registry-group_/$name"
+      path: "/registry-group/$name"
+      fullPath: "/registry-group/$name"
+      preLoaderRoute: typeof registryRegistryGroupNameRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/(registry)/registry_/$name": {
@@ -414,11 +379,46 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof registryRegistryNameRouteImport
       parentRoute: typeof rootRouteImport
     }
-    "/(registry)/registry-group_/$name": {
-      id: "/(registry)/registry-group_/$name"
-      path: "/registry-group/$name"
-      fullPath: "/registry-group/$name"
-      preLoaderRoute: typeof registryRegistryGroupNameRouteImport
+    "/logs/$groupName/$serverName": {
+      id: "/logs/$groupName/$serverName"
+      path: "/logs/$groupName/$serverName"
+      fullPath: "/logs/$groupName/$serverName"
+      preLoaderRoute: typeof LogsGroupNameServerNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/playground/agents_/$agentId": {
+      id: "/playground/agents_/$agentId"
+      path: "/agents/$agentId"
+      fullPath: "/playground/agents/$agentId"
+      preLoaderRoute: typeof PlaygroundAgentsAgentIdRouteImport
+      parentRoute: typeof PlaygroundRoute
+    }
+    "/playground/agents_/new": {
+      id: "/playground/agents_/new"
+      path: "/agents/new"
+      fullPath: "/playground/agents/new"
+      preLoaderRoute: typeof PlaygroundAgentsNewRouteImport
+      parentRoute: typeof PlaygroundRoute
+    }
+    "/playground/chat/$threadId": {
+      id: "/playground/chat/$threadId"
+      path: "/chat/$threadId"
+      fullPath: "/playground/chat/$threadId"
+      preLoaderRoute: typeof PlaygroundChatThreadIdRouteImport
+      parentRoute: typeof PlaygroundRoute
+    }
+    "/skills_/$namespace/$skillName": {
+      id: "/skills_/$namespace/$skillName"
+      path: "/skills/$namespace/$skillName"
+      fullPath: "/skills/$namespace/$skillName"
+      preLoaderRoute: typeof SkillsNamespaceSkillNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    "/skills_/builds/$tag": {
+      id: "/skills_/builds/$tag"
+      path: "/skills/builds/$tag"
+      fullPath: "/skills/builds/$tag"
+      preLoaderRoute: typeof SkillsBuildsTagRouteImport
       parentRoute: typeof rootRouteImport
     }
     "/playground/agents_/$agentId_/edit": {


### PR DESCRIPTION
## Summary
- Adds an ACP-based chat provider ("Cursor Agent") to the Playground that spawns the local Cursor CLI (`agent acp`) as an Agent Client Protocol server and streams it through the existing chat pipeline.
- The model picker now separates plain "AI Models" providers from "AI Harnesses" (agents that run their own tool loop) — Cursor Agent lives in the latter section.
- Hides/repurposes the in-chat "configure MCP tools" control for this provider (it runs its own tool loop, so per-tool toggles don't apply) — it now links to the MCP servers page instead.
- The `cursor` client is registered automatically with ToolHive's `default` group the moment Cursor Agent is picked in the model picker (same mechanism "Manage Clients" uses), so ToolHive's MCP servers get wired into Cursor's own config. Provider Settings shows this as a live, read-only registration status.
- Adds a per-thread working-directory picker for this provider (previously hardcoded to the main process's own cwd).

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run test:nonInteractive` (232 files / 2616 tests)
- [ ] Manual verification of all flows in the running app

Fully or partially written by an AI agent.