### PR TITLE
fix(flatpak): add filesystem mapping for qoder client

### DIFF
--- a/utils/__tests__/flatpak-client-paths.test.ts
+++ b/utils/__tests__/flatpak-client-paths.test.ts
@@ -31,6 +31,7 @@ Valid clients:
   - lm-studio: LM Studio application
   - mistral-vibe: Mistral Vibe IDE
   - opencode: OpenCode editor
+  - qoder: Qoder IDE
   - roo-code: VS Code Roo Code extension
   - trae: Trae IDE
   - vscode: Visual Studio Code
@@ -126,5 +127,12 @@ describe('flatpakFilesystemEntries', () => {
   it('covers all clients in the sample output without throwing', () => {
     const clients = parseThvClients(SAMPLE_HELP)
     expect(() => flatpakFilesystemEntries(clients)).not.toThrow()
+  })
+
+  it('maps qoder to ~/.qoder', () => {
+    expect(CLIENT_FLATPAK_PATHS.qoder).toEqual(['~/.qoder'])
+    expect(flatpakFilesystemEntries(['qoder'])).toEqual([
+      '--filesystem=~/.qoder',
+    ])
   })
 })

--- a/utils/flatpak-client-paths.ts
+++ b/utils/flatpak-client-paths.ts
@@ -29,6 +29,7 @@ export const CLIENT_FLATPAK_PATHS: Record<string, string[]> = {
   'lm-studio': ['~/.lmstudio'],
   'mistral-vibe': ['~/.vibe'],
   opencode: ['~/.config/opencode'],
+  qoder: ['~/.qoder'],
   'roo-code': ['~/.config/Code'],
   trae: ['~/.config/Trae'],
   vscode: ['~/.config/Code'],


### PR DESCRIPTION
## Summary

- ToolHive v0.45.0 added Qoder IDE as a supported MCP client ([stacklok/toolhive#5870](https://github.com/stacklok/toolhive/pull/5870)). The Flatpak maker runs `thv client register --help` at build time and fails if any reported client is missing from `CLIENT_FLATPAK_PATHS`.
- Map `qoder` to `~/.qoder`, matching the Linux config path (`~/.qoder/mcp.json` and `~/.qoder/skills/`) declared upstream.
- Unblocks the Linux Flatpak build on #2645 (`chore(deps): update dependency stacklok/toolhive to v0.45.0`).

## Test plan

- [x] Unit tests for `utils/flatpak-client-paths.ts` (11 passing), including a regression that `qoder` maps to `--filesystem=~/.qoder`
- [ ] After merge, rebase #2645 so the Linux Flatpak job no longer fails with `No Flatpak filesystem path mapping for client "qoder"`