### PR TITLE
fix(skills): allow overwriting unmanaged local skills

### DIFF
--- a/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
@@ -7,6 +7,7 @@ import { DialogInstallSkill } from '../dialog-install-skill'
 import { recordRequests } from '@/common/mocks/node'
 import { mockedGetApiV1BetaDiscoveryClients } from '@/common/mocks/fixtures/discovery_clients/get'
 import { mockedPostApiV1BetaSkills } from '@/common/mocks/fixtures/skills/post'
+import { HttpResponse } from 'msw'
 
 const renderWithProviders = (component: React.ReactElement) => {
   const queryClient = new QueryClient({
@@ -472,5 +473,108 @@ describe('DialogInstallSkill', () => {
       // User actively typed v8.8.8, so the blur split must not clobber it.
       expect(versionInput).toHaveValue('v8.8.8')
     })
+  })
+})
+
+const unmanagedConflictMessage =
+  'directory "/Users/me/.agents/skills/my-skill" exists but is not managed by ToolHive; use force to overwrite'
+
+function mockUnmanagedConflictUntilForced() {
+  mockedPostApiV1BetaSkills.overrideHandler(async (_data, { request }) => {
+    const body = (await request.clone().json()) as { force?: boolean }
+    if (body.force) {
+      return HttpResponse.json({
+        skill: {
+          reference: 'ghcr.io/org/skill-one:v1',
+          status: 'installed',
+          scope: 'user',
+          metadata: { name: 'my-skill' },
+        },
+      })
+    }
+    return HttpResponse.json(
+      { error: unmanagedConflictMessage },
+      { status: 409 }
+    )
+  })
+}
+
+describe('Bug #2599', () => {
+  it('offers a way to overwrite when the skill already exists unmanaged', async () => {
+    const user = userEvent.setup()
+    mockUnmanagedConflictUntilForced()
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /overwrite and install/i })
+      ).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /replace the existing files/i
+    )
+    expect(
+      screen.queryByRole('button', { name: /^install$/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('retries the install with force after the user confirms overwrite', async () => {
+    const user = userEvent.setup()
+    const rec = recordRequests()
+    const onOpenChange = vi.fn()
+    mockUnmanagedConflictUntilForced()
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={onOpenChange} />)
+
+    await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /overwrite and install/i })
+      ).toBeInTheDocument()
+    })
+
+    await user.click(
+      screen.getByRole('button', { name: /overwrite and install/i })
+    )
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    const posts = rec.recordedRequests.filter(
+      (r) => r.method === 'POST' && r.pathname === '/api/v1beta/skills'
+    )
+    expect(posts).toHaveLength(2)
+    expect(posts[0]?.payload).not.toHaveProperty('force')
+    expect(posts[1]?.payload).toMatchObject({
+      name: 'my-skill',
+      scope: 'user',
+      force: true,
+    })
+  })
+
+  it('does not offer overwrite for unrelated install errors', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkills.activateScenario('server-error')
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole('button', { name: /overwrite/i })
+    ).not.toBeInTheDocument()
   })
 })

--- a/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
+++ b/renderer/src/features/skills/components/__tests__/dialog-install-skill.test.tsx
@@ -577,4 +577,68 @@ describe('Bug #2599', () => {
       screen.queryByRole('button', { name: /overwrite/i })
     ).not.toBeInTheDocument()
   })
+
+  it('does not offer overwrite when the conflict error lacks force guidance', async () => {
+    const user = userEvent.setup()
+    mockedPostApiV1BetaSkills.overrideHandler(() =>
+      HttpResponse.json(
+        {
+          error:
+            'directory "/tmp/my-skill" exists but is not managed by another installer',
+        },
+        { status: 409 }
+      )
+    )
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    await user.type(screen.getByLabelText(/name or reference/i), 'my-skill')
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole('button', { name: /overwrite/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not send force after the user changes the skill name', async () => {
+    const user = userEvent.setup()
+    const rec = recordRequests()
+    mockUnmanagedConflictUntilForced()
+
+    renderWithProviders(<DialogInstallSkill open onOpenChange={vi.fn()} />)
+
+    const nameInput = screen.getByLabelText(/name or reference/i)
+    await user.type(nameInput, 'my-skill')
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /overwrite and install/i })
+      ).toBeInTheDocument()
+    })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, 'other-skill')
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /overwrite and install/i })
+      ).not.toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: /^install$/i }))
+
+    await waitFor(() => {
+      const posts = rec.recordedRequests.filter(
+        (r) => r.method === 'POST' && r.pathname === '/api/v1beta/skills'
+      )
+      expect(posts).toHaveLength(2)
+      expect(posts[1]?.payload).toMatchObject({ name: 'other-skill' })
+      expect(posts[1]?.payload).not.toHaveProperty('force')
+    })
+  })
 })

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -4,7 +4,11 @@ import z from 'zod/v4'
 import { zodV4Resolver } from '@/common/lib/zod-v4-resolver'
 import { useQuery } from '@tanstack/react-query'
 import { getApiV1BetaDiscoveryClientsOptions } from '@common/api/generated/@tanstack/react-query.gen'
-import { Alert, AlertDescription } from '@/common/components/ui/alert'
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from '@/common/components/ui/alert'
 import { Button } from '@/common/components/ui/button'
 import {
   DropdownMenu,
@@ -42,6 +46,7 @@ import { ChevronDown, FolderOpenIcon, TriangleAlertIcon } from 'lucide-react'
 import { useMutationInstallSkill } from '../hooks/use-mutation-install-skill'
 import { parseSkillReference } from '../lib/skill-reference'
 import { trackEvent } from '@/common/lib/analytics'
+import { THV_DISPLAY_NAME } from '@common/app-info'
 
 const formSchema = z
   .object({
@@ -64,6 +69,25 @@ const formSchema = z
 
 type FormSchema = z.infer<typeof formSchema>
 
+const UNMANAGED_SKILL_CONFLICT_MESSAGE = `A skill with this name already exists on your computer and is not managed by ${THV_DISPLAY_NAME}. Installing will replace the existing files. This cannot be undone.`
+
+function isUnmanagedSkillConflict(message: string): boolean {
+  return /exists but is not managed/i.test(message)
+}
+
+function getInstallErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message
+  }
+  if (typeof err === 'object' && err !== null && 'error' in err) {
+    return String((err as { error: unknown }).error)
+  }
+  if (typeof err === 'string') {
+    return err
+  }
+  return 'Failed to install skill'
+}
+
 interface DialogInstallSkillProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -79,6 +103,7 @@ export function DialogInstallSkill({
 }: DialogInstallSkillProps) {
   const { mutateAsync: installSkill, isPending } = useMutationInstallSkill()
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [needsForceOverwrite, setNeedsForceOverwrite] = useState(false)
 
   const { data: clientsData, isLoading: isLoadingClients } = useQuery({
     ...getApiV1BetaDiscoveryClientsOptions(),
@@ -119,6 +144,7 @@ export function DialogInstallSkill({
     trackEvent('Skills: install dialog cancelled')
     form.reset()
     setSubmitError(null)
+    setNeedsForceOverwrite(false)
     onOpenChange(false)
   }
 
@@ -131,11 +157,13 @@ export function DialogInstallSkill({
   }
 
   async function onSubmit(values: FormSchema) {
+    const force = needsForceOverwrite
     setSubmitError(null)
     trackEvent('Skills: install dialog submitted', {
       scope: values.scope,
       has_version: values.version ? 'true' : 'false',
       clients_count: values.clients?.length ?? 0,
+      force: force ? 'true' : 'false',
     })
     try {
       await installSkill({
@@ -146,20 +174,21 @@ export function DialogInstallSkill({
             values.scope === 'project' ? values.project_root : undefined,
           clients: values.clients?.length ? values.clients : undefined,
           version: values.version || undefined,
+          ...(force ? { force: true } : {}),
         },
       })
       form.reset()
       setSubmitError(null)
+      setNeedsForceOverwrite(false)
       onOpenChange(false)
     } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : typeof err === 'object' && err !== null && 'error' in err
-            ? String((err as { error: unknown }).error)
-            : typeof err === 'string'
-              ? err
-              : 'Failed to install skill'
+      const message = getInstallErrorMessage(err)
+      if (isUnmanagedSkillConflict(message)) {
+        setNeedsForceOverwrite(true)
+        setSubmitError(UNMANAGED_SKILL_CONFLICT_MESSAGE)
+        return
+      }
+      setNeedsForceOverwrite(false)
       setSubmitError(message)
     }
   }
@@ -176,6 +205,9 @@ export function DialogInstallSkill({
         {submitError && (
           <Alert variant="destructive">
             <TriangleAlertIcon className="size-4" />
+            {needsForceOverwrite && (
+              <AlertTitle>Skill already exists</AlertTitle>
+            )}
             <AlertDescription>{submitError}</AlertDescription>
           </Alert>
         )}
@@ -394,8 +426,17 @@ export function DialogInstallSkill({
               >
                 Cancel
               </Button>
-              <Button type="submit" variant="action" disabled={isPending}>
-                {isPending ? 'Installing...' : 'Install'}
+              <Button
+                type="submit"
+                variant={needsForceOverwrite ? 'destructive' : 'action'}
+                className={needsForceOverwrite ? 'rounded-full' : undefined}
+                disabled={isPending}
+              >
+                {isPending
+                  ? 'Installing...'
+                  : needsForceOverwrite
+                    ? 'Overwrite and install'
+                    : 'Install'}
               </Button>
             </DialogFooter>
           </form>

--- a/renderer/src/features/skills/components/dialog-install-skill.tsx
+++ b/renderer/src/features/skills/components/dialog-install-skill.tsx
@@ -69,10 +69,28 @@ const formSchema = z
 
 type FormSchema = z.infer<typeof formSchema>
 
+type ForceOverwriteTarget = {
+  name: string
+  scope: FormSchema['scope']
+  project_root: string
+}
+
 const UNMANAGED_SKILL_CONFLICT_MESSAGE = `A skill with this name already exists on your computer and is not managed by ${THV_DISPLAY_NAME}. Installing will replace the existing files. This cannot be undone.`
 
 function isUnmanagedSkillConflict(message: string): boolean {
-  return /exists but is not managed/i.test(message)
+  return /exists but is not managed[\s\S]*use force/i.test(message)
+}
+
+function matchesForceOverwriteTarget(
+  target: ForceOverwriteTarget | null,
+  values: Pick<FormSchema, 'name' | 'scope' | 'project_root'>
+): boolean {
+  if (!target) return false
+  return (
+    target.name === values.name &&
+    target.scope === values.scope &&
+    target.project_root === (values.project_root ?? '')
+  )
 }
 
 function getInstallErrorMessage(err: unknown): string {
@@ -103,7 +121,8 @@ export function DialogInstallSkill({
 }: DialogInstallSkillProps) {
   const { mutateAsync: installSkill, isPending } = useMutationInstallSkill()
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [needsForceOverwrite, setNeedsForceOverwrite] = useState(false)
+  const [forceOverwriteTarget, setForceOverwriteTarget] =
+    useState<ForceOverwriteTarget | null>(null)
 
   const { data: clientsData, isLoading: isLoadingClients } = useQuery({
     ...getApiV1BetaDiscoveryClientsOptions(),
@@ -133,7 +152,17 @@ export function DialogInstallSkill({
     resetOptions: { keepDirtyValues: true },
   })
 
+  const name = useWatch({ control: form.control, name: 'name' })
   const scope = useWatch({ control: form.control, name: 'scope' })
+  const projectRoot = useWatch({ control: form.control, name: 'project_root' })
+  const needsForceOverwrite = matchesForceOverwriteTarget(
+    forceOverwriteTarget,
+    {
+      name,
+      scope,
+      project_root: projectRoot,
+    }
+  )
   // Subscribe to dirtyFields so the blur splitter below can reliably
   // tell prefilled defaults apart from values the user actually typed.
   // Reading `form.formState.dirtyFields.version` from inside a callback
@@ -144,7 +173,7 @@ export function DialogInstallSkill({
     trackEvent('Skills: install dialog cancelled')
     form.reset()
     setSubmitError(null)
-    setNeedsForceOverwrite(false)
+    setForceOverwriteTarget(null)
     onOpenChange(false)
   }
 
@@ -157,7 +186,7 @@ export function DialogInstallSkill({
   }
 
   async function onSubmit(values: FormSchema) {
-    const force = needsForceOverwrite
+    const force = matchesForceOverwriteTarget(forceOverwriteTarget, values)
     setSubmitError(null)
     trackEvent('Skills: install dialog submitted', {
       scope: values.scope,
@@ -179,16 +208,19 @@ export function DialogInstallSkill({
       })
       form.reset()
       setSubmitError(null)
-      setNeedsForceOverwrite(false)
+      setForceOverwriteTarget(null)
       onOpenChange(false)
     } catch (err) {
       const message = getInstallErrorMessage(err)
       if (isUnmanagedSkillConflict(message)) {
-        setNeedsForceOverwrite(true)
-        setSubmitError(UNMANAGED_SKILL_CONFLICT_MESSAGE)
+        setForceOverwriteTarget({
+          name: values.name,
+          scope: values.scope,
+          project_root: values.project_root ?? '',
+        })
         return
       }
-      setNeedsForceOverwrite(false)
+      setForceOverwriteTarget(null)
       setSubmitError(message)
     }
   }
@@ -202,14 +234,21 @@ export function DialogInstallSkill({
             Install a skill by providing its name or OCI reference.
           </DialogDescription>
         </DialogHeader>
-        {submitError && (
+        {needsForceOverwrite ? (
           <Alert variant="destructive">
             <TriangleAlertIcon className="size-4" />
-            {needsForceOverwrite && (
-              <AlertTitle>Skill already exists</AlertTitle>
-            )}
-            <AlertDescription>{submitError}</AlertDescription>
+            <AlertTitle>Skill already exists</AlertTitle>
+            <AlertDescription>
+              {UNMANAGED_SKILL_CONFLICT_MESSAGE}
+            </AlertDescription>
           </Alert>
+        ) : (
+          submitError && (
+            <Alert variant="destructive">
+              <TriangleAlertIcon className="size-4" />
+              <AlertDescription>{submitError}</AlertDescription>
+            </Alert>
+          )
         )}
         <Form {...form}>
           <form


### PR DESCRIPTION
## Summary

Fixes #2599.

- When installing a skill that collides with an unmanaged local directory, the install dialog now explains that existing files will be replaced instead of showing a CLI-only "use force" error.
- Confirming **Overwrite and install** retries `POST /api/v1beta/skills` with `force: true`.

## Test plan

- [x] Regression tests in `dialog-install-skill.test.tsx` (`Bug #2599`)
- [x] `pnpm run test:nonInteractive`
- [x] `pnpm run lint` and `pnpm run type-check`
- [ ] Install a skill whose name matches an unmanaged local file and confirm overwrite succeeds
- [ ] Confirm unrelated install errors still show the raw error without an overwrite action