### PR TITLE
chore(ci): route Claude workflows through Stacklok LLM gateway

### DIFF
--- a/.github/workflows/_bug-fix-agent.yml
+++ b/.github/workflows/_bug-fix-agent.yml
@@ -21,6 +21,8 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    env:
+      ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -79,7 +81,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@e5ad3c7725bc2459721893f88879fef9dbcf97b0 # v1.0.202
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_BUG_FIX }}
           prompt: |
             Read .claude/skills/bug-fix-tdd/SKILL.md and follow it.
             Read issue-body.md for the bug report.
@@ -140,7 +142,7 @@ jobs:
           BUG_TEST_FILE: ${{ steps.gate.outputs.test_file }}
           BUG_ISSUE_NUMBER: ${{ inputs.issue-number }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_BUG_FIX }}
           prompt: |
             Read .claude/skills/bug-fix-tdd/SKILL.md and bug-analysis.md.
 
@@ -171,7 +173,7 @@ jobs:
         env:
           BUG_ISSUE_NUMBER: ${{ inputs.issue-number }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_BUG_FIX }}
           prompt: |
             Read .claude/skills/bug-fix-tdd/SKILL.md and bug-analysis.md.
             Read issue-body.md for the original bug report.

--- a/.github/workflows/_security-fix-agent.yml
+++ b/.github/workflows/_security-fix-agent.yml
@@ -17,6 +17,8 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    env:
+      ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -69,7 +71,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@e5ad3c7725bc2459721893f88879fef9dbcf97b0 # v1.0.202
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_SECURITY_FIX }}
           prompt: |
             Read .claude/skills/security-vuln-remediation/SKILL.md and follow it.
             Run grype and pnpm audit to identify all current vulnerabilities.
@@ -88,7 +90,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@e5ad3c7725bc2459721893f88879fef9dbcf97b0 # v1.0.202
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_SECURITY_FIX }}
           prompt: |
             Read .claude/skills/security-vuln-remediation/SKILL.md and remediation-plan.md.
             Implement every fix described in the remediation plan:

--- a/.github/workflows/bug-triage-cron.yml
+++ b/.github/workflows/bug-triage-cron.yml
@@ -18,6 +18,8 @@ jobs:
     name: Triage Bug Issues
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -107,7 +109,7 @@ jobs:
         if: steps.candidates.outputs.skip != 'true' && steps.filter.outputs.skip != 'true'
         uses: anthropics/claude-code-action@e5ad3c7725bc2459721893f88879fef9dbcf97b0 # v1.0.202
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_BUG_FIX }}
           prompt: |
             Read issues-for-triage.md. These are open bug reports for a React + Electron desktop app.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,6 +25,8 @@ jobs:
       issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+    env:
+      ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -35,4 +37,4 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@e5ad3c7725bc2459721893f88879fef9dbcf97b0 # v1.0.202
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_CLAUDE_TAG }}


### PR DESCRIPTION
## Summary

Routes all Claude-powered workflows through the Stacklok LLM gateway and splits the single shared API key into three per-pipeline keys, so spend can be attributed to each group of workflows.

## Changes

| Workflow | Secret | Sites |
|---|---|---|
| `claude.yml` | `STACKLOK_GATEWAY_KEY_CLAUDE_TAG` | 1 |
| `bug-triage-cron.yml` | `STACKLOK_GATEWAY_KEY_BUG_FIX` | 1 |
| `_bug-fix-agent.yml` | `STACKLOK_GATEWAY_KEY_BUG_FIX` | 3 |
| `_security-fix-agent.yml` | `STACKLOK_GATEWAY_KEY_SECURITY_FIX` | 2 |

`ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic` is set at **job** level rather than per step, so any `claude-code-action` step added to these jobs later routes through the gateway automatically instead of silently going direct and escaping cost tracking.

No caller changes were needed — `on-main.yml`, `security-fix-cron.yml`, and `bug-fix-on-label.yml` all use `secrets: inherit`, which passes the new secret names through to the two reusable workflows.

## Verification

- All 7 `claude-code-action` call sites updated; `secrets.ANTHROPIC_API_KEY` no longer appears anywhere in the repo.
- All four workflow files parse as valid YAML, with the base URL resolving on every job that contains a Claude step.
- The two steps in `_bug-fix-agent.yml` with existing `env:` blocks (`BUG_TEST_FILE`, `BUG_ISSUE_NUMBER`) are unaffected — step-level `env` merges with job-level and the keys don't collide.
- `triage.yml` calls an external reusable workflow but does not pass `secrets: inherit`, so it never received the old key.

The now-unreferenced `ANTHROPIC_API_KEY` repo secret is deliberately left in place as a rollback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)