### PR TITLE
fix(deps): patch fast-uri, qs, and @xmldom/xmldom

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,11 @@ overrides:
   js-yaml: '>=5.2.3'
   tmp: '>=0.2.7'
   icon-gen>sharp: 0.35.3
-  fast-uri: '>=3.1.5 <4'
+  fast-uri: '>=3.1.6 <4'
   ip-address: '>=10.4.0'
   hono: '>=4.13.4'
+  qs: '>=6.16.0'
+  '@xmldom/xmldom': '>=0.9.12'
   dompurify: '>=3.4.13 <4'
   postcss>nanoid: '>=3.3.17 <4'
 
@@ -3821,10 +3823,9 @@ packages:
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -4946,8 +4947,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -6736,8 +6737,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -7134,6 +7135,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -11937,7 +11942,7 @@ snapshots:
 
   '@workflow/serde@4.1.0': {}
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -12010,7 +12015,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12154,7 +12159,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -13178,7 +13183,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.2.1
       router: 2.2.0(supports-color@8.1.1)
       send: 1.2.1(supports-color@8.1.1)
@@ -13233,7 +13238,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -15158,7 +15163,7 @@ snapshots:
 
   plist@3.1.1:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -15238,9 +15243,10 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
 
@@ -15763,6 +15769,14 @@ snapshots:
       side-channel-map: 1.0.1
 
   side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,10 +45,18 @@ overrides:
   'icon-gen>sharp': 0.35.3
   # Security patches for transitive deps (GHSA-7p8r-x3mc-p8w7,
   # GHSA-mwp4-54f8-5fhr / GHSA-4xrf-jv44-h6hh / GHSA-22jq-vg5j-6vgg,
-  # GHSA-8j4g-w8fx-2239). Cap fast-uri below v4 — ajv expects the v3 API.
-  fast-uri: '>=3.1.5 <4'
+  # GHSA-8j4g-w8fx-2239, GHSA-5jgf-p345-68v8 / GHSA-f65p-4m7j-42xc /
+  # GHSA-fph4-wmhf-6fwf / GHSA-jqff-g426-hqxp). 3.1.6 patches all four on the
+  # v3 line; cap below v4 — ajv expects the v3 API.
+  fast-uri: '>=3.1.6 <4'
   ip-address: '>=10.4.0'
   hono: '>=4.13.4'
+  # GHSA-4mjr-xmp4-gh2g / GHSA-x5fp-wj9c-mxmx — force re-resolution to the
+  # patched release; body-parser (^6.15.2) and express (^6.14.0) both admit it.
+  qs: '>=6.16.0'
+  # GHSA-6gmq-8vp8-gcm6 — force re-resolution to the patched release; plist
+  # (^0.9.10) admits it.
+  '@xmldom/xmldom': '>=0.9.12'
   # GHSA-55q2-fjhq-7xh7 — mermaid pins dompurify ^3.3.3; cap below v4.
   dompurify: '>=3.4.13 <4'
   # GHSA-2v37-7h3g-55p8 — postcss pulls nanoid 3.x; keep direct nanoid 5.x untouched.


### PR DESCRIPTION
## Summary
Fixes the 9 GHSAs flagged for these 3 packages, without the breaking change #2606 was attempting:

- **`fast-uri` `3.1.5` → `>=3.1.6 <4`** (resolves to `3.1.7`) — fixes GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp. `3.1.6` backports the fix to the v3 line, so `ajv`'s v3 API assumption (the reason for the existing `<4` cap) still holds.
  - #2606 instead widens the cap to `<5`, pulling in the breaking v4 API `ajv` doesn't support — and even its own CI run shows the lockfile never actually re-resolved past `3.1.5` (Grype output there still reports `3.1.5 → 3.1.6`, not `4.1.3`). Recommend closing #2606 in favor of this.
- **`qs` `6.15.2` → `>=6.16.0`** — fixes GHSA-4mjr-xmp4-gh2g, GHSA-x5fp-wj9c-mxmx. Both consumers (`body-parser@2.3.0` pins `^6.15.2`, `express@5.2.1` pins `^6.14.0`) already admit it.
- **`@xmldom/xmldom` `0.9.10` → `>=0.9.12`** — fixes GHSA-6gmq-8vp8-gcm6. `plist@3.1.1` (`^0.9.10`) already admits it.

`browserslist` was already overridden to `>=4.28.7` on `main` and resolves to `4.28.8` here — no change needed, confirmed no regression.

## Test plan
- [x] `pnpm audit --audit-level=moderate` no longer reports any of the 4 packages (3 unrelated pre-existing findings remain — `image-size`, `extract-zip` — both with no patch available upstream)
- [x] `pnpm run type-check` passes
- [x] `pnpm run test` — 249 files / 2751 tests pass
- [x] `pnpm run lint` passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)