### PR TITLE
chore(deps): upgrade Electron to v44

### DIFF
--- a/main/src/auto-launch.ts
+++ b/main/src/auto-launch.ts
@@ -36,14 +36,12 @@ export function setAutoLaunch(enabled: boolean) {
   if (process.platform === 'darwin') {
     app.setLoginItemSettings({
       openAtLogin: enabled,
-      openAsHidden: true,
     })
   }
 
   if (process.platform === 'win32') {
     app.setLoginItemSettings({
       openAtLogin: enabled,
-      openAsHidden: true,
       path: process.execPath,
       args: ['--hidden'],
     })

--- a/main/src/tests/auto-launch.test.ts
+++ b/main/src/tests/auto-launch.test.ts
@@ -11,7 +11,13 @@ vi.mock('electron', () => ({
   },
 }))
 
+const originalPlatform = process.platform
+
 afterEach(() => {
+  Object.defineProperty(process, 'platform', {
+    value: originalPlatform,
+    configurable: true,
+  })
   vi.restoreAllMocks()
   setLoginItemSettings.mockClear()
 })
@@ -31,7 +37,10 @@ describe('Linux desktop-entry generation', () => {
 
 describe('login item settings', () => {
   it('enables auto-launch on macOS without removed hidden settings', () => {
-    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    Object.defineProperty(process, 'platform', {
+      value: 'darwin',
+      configurable: true,
+    })
 
     setAutoLaunch(true)
 
@@ -41,7 +50,10 @@ describe('login item settings', () => {
   })
 
   it('uses the hidden launch argument on Windows', () => {
-    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    })
 
     setAutoLaunch(true)
 

--- a/main/src/tests/auto-launch.test.ts
+++ b/main/src/tests/auto-launch.test.ts
@@ -1,12 +1,20 @@
-import { describe, it, expect, vi } from 'vitest'
-import { createDesktopEntry } from '../auto-launch'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { createDesktopEntry, setAutoLaunch } from '../auto-launch'
+
+const setLoginItemSettings = vi.hoisted(() => vi.fn())
 
 vi.mock('electron', () => ({
   app: {
     isPackaged: false,
     getName: vi.fn(() => 'ToolHive'),
+    setLoginItemSettings,
   },
 }))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  setLoginItemSettings.mockClear()
+})
 
 describe('Linux desktop-entry generation', () => {
   it('quotes the Exec path when it contains spaces', () => {
@@ -18,5 +26,29 @@ describe('Linux desktop-entry generation', () => {
     expect(entry).toContain(
       `Exec="/home/alice/My Apps/Tool Hive/ToolHive" --hidden`
     )
+  })
+})
+
+describe('login item settings', () => {
+  it('enables auto-launch on macOS without removed hidden settings', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    setAutoLaunch(true)
+
+    expect(setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true,
+    })
+  })
+
+  it('uses the hidden launch argument on Windows', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    setAutoLaunch(true)
+
+    expect(setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true,
+      path: process.execPath,
+      args: ['--hidden'],
+    })
   })
 })

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-v8": "^4.1.11",
     "dotenv": "^17.4.2",
-    "electron": "43.5.0",
+    "electron": "44.2.0",
     "electron-winstaller": "^5.4.4",
     "eslint": "^10.9.1",
     "eslint-plugin-react-hooks": "~7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,8 +325,8 @@ importers:
         specifier: ^17.4.2
         version: 17.4.2
       electron:
-        specifier: 43.5.0
-        version: 43.5.0(supports-color@8.1.1)
+        specifier: 44.2.0
+        version: 44.2.0(supports-color@8.1.1)
       electron-winstaller:
         specifier: ^5.4.4
         version: 5.4.4(supports-color@8.1.1)
@@ -4698,8 +4698,8 @@ packages:
     resolution: {integrity: sha512-j9ETcBGJaXxAY/b6UBpR7LZfjdU4BAO+yvr4ifqHEdyuc3UNCy91PDGkWKY5UQ4coHNYfnwFggrqD6QPeFGAlg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.5.0:
-    resolution: {integrity: sha512-nV2aWuKatmUrxrAWP2pNIynNX7dy83TCAz+6KnsbK7hDVLE+6fa2iouOtir41AboZTa+J5w2UgicWHAqUaaUJw==}
+  electron@44.2.0:
+    resolution: {integrity: sha512-oK1icjhapp3xsUZycO9WZaLmd3hJnA7ieobC4mpdtO1pEN+PPGWpA3m1Mgzzuc1wzSD2Wai4zcH4yfpGJqxFMA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -12889,7 +12889,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.5.0(supports-color@8.1.1):
+  electron@44.2.0(supports-color@8.1.1):
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@electron/rebuild': ^4.2.0
+  '@electron/rebuild>node-abi': '>=4.35.0'
   browserslist: '>=4.28.8'
   '@aws-sdk/xml-builder>fast-xml-parser': 5.10.1
   js-yaml: '>=5.2.3'
@@ -6318,8 +6319,8 @@ packages:
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
-  node-abi@4.31.0:
-    resolution: {integrity: sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==}
+  node-abi@4.35.0:
+    resolution: {integrity: sha512-ymk4aIzxdPopw2giv8Fs1Ec6vybGkjmyxUwVqhkI4MCy2tVfXdkOGGWieWVjL0THgH+7a8lRdevyupoYj3Js/Q==}
     engines: {node: '>=22.12.0'}
 
   node-addon-api@8.9.0:
@@ -9141,7 +9142,7 @@ snapshots:
     dependencies:
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
-      node-abi: 4.31.0
+      node-abi: 4.35.0
       node-api-version: 0.2.1
       node-gyp: 12.3.0
       read-binary-file-arch: 1.0.6(supports-color@8.1.1)
@@ -14898,7 +14899,7 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  node-abi@4.31.0:
+  node-abi@4.35.0:
     dependencies:
       semver: 7.8.5
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   '@electron/rebuild': ^4.2.0
-  '@electron/rebuild>node-abi': '>=4.35.0'
   browserslist: '>=4.28.8'
   '@aws-sdk/xml-builder>fast-xml-parser': 5.10.1
   js-yaml: '>=5.2.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,8 +34,10 @@ auditConfig:
     - GHSA-rmmr-r34h-pfm5
 
 overrides:
-  # Only overrides where parent ranges cannot reach a patched version.
+  # Keep Forge on the maintained rebuild line.
   '@electron/rebuild': ^4.2.0
+  # Electron 44 requires ABI metadata added in node-abi 4.35.0.
+  '@electron/rebuild>node-abi': '>=4.35.0'
   # GHSA-73wf-gq98-2v4g / GHSA-c83g-rgw3-j3cx — force re-resolution to the
   # patched release; every consumer's declared range already admits it.
   browserslist: '>=4.28.8'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,10 +34,8 @@ auditConfig:
     - GHSA-rmmr-r34h-pfm5
 
 overrides:
-  # Keep Forge on the maintained rebuild line.
+  # Only overrides where parent ranges cannot reach a patched version.
   '@electron/rebuild': ^4.2.0
-  # Electron 44 requires ABI metadata added in node-abi 4.35.0.
-  '@electron/rebuild>node-abi': '>=4.35.0'
   # GHSA-73wf-gq98-2v4g / GHSA-c83g-rgw3-j3cx — force re-resolution to the
   # patched release; every consumer's declared range already admits it.
   browserslist: '>=4.28.8'


### PR DESCRIPTION
## Summary
- upgrade Electron from 43.5.0 to 44.2.0
- remove the retired `openAsHidden` login-item option while preserving hidden startup arguments on Windows and Linux
- refresh the locked `node-abi` to 4.35.0 so Electron Forge can rebuild native dependencies for Electron 44
- add regression coverage for macOS and Windows login-item settings

## Upgrade analysis
Electron 44 drops macOS 12, 32-bit Windows/Linux builds, renderer exposure of Electron's `clipboard` module, and pre-macOS 13 login-item fields. ToolHive Studio already targets x64/arm64 and uses the web `navigator.clipboard` API, so only login-item configuration required an application change. The removed `openAsHidden` setting was already ineffective on supported macOS versions; Windows and Linux continue to pass `--hidden` explicitly.

The Renovate PR's type-check failure masked a packaging failure: the locked `node-abi` 4.31.0 registry does not recognize Electron 44. No override is needed for this — `@electron/rebuild@4.2.0` (the latest release) already declares `node-abi: ^4.2.0`, so the lockfile was simply pinned to a version that predates 4.35.0. Re-resolving it in the lockfile is enough; `node-abi.getAbi('44.2.0', 'electron')` now returns 149.

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run test:nonInteractive` (249 files, 2,753 tests)
- [x] `pnpm exec eslint main/src/auto-launch.ts main/src/tests/auto-launch.test.ts`
- [x] `pnpm exec prettier --check main/src/auto-launch.ts main/src/tests/auto-launch.test.ts`
- [x] `pnpm run package` (macOS arm64)
- [x] `pnpm install --frozen-lockfile` reproduces `node-abi` 4.35.0 without an override

Made with [Cursor](https://cursor.com)