### PR TITLE
chore(deps): prune redundant pnpm overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,18 +6,9 @@ settings:
 
 overrides:
   '@electron/rebuild': ^4.2.0
-  browserslist: '>=4.28.8'
-  '@aws-sdk/xml-builder>fast-xml-parser': 5.10.1
   js-yaml: '>=5.2.3'
   tmp: '>=0.2.7'
   icon-gen>sharp: 0.35.4
-  fast-uri: '>=3.1.6 <4'
-  ip-address: '>=10.7.0'
-  hono: '>=4.13.5'
-  qs: '>=6.16.0'
-  '@xmldom/xmldom': '>=0.9.12'
-  dompurify: '>=3.4.13 <4'
-  postcss>nanoid: '>=3.3.17 <4'
 
 patchedDependencies:
   electron-installer-redhat@3.4.0: 8fe238a56db4de235c10dd7f02c6a523c6ac3010edcc1d547dbc5c6416b89a37
@@ -658,8 +649,8 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.22':
-    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1222,7 +1213,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.13.5'
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1720,12 +1711,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
-
-  '@nodable/entities@2.1.0':
-    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
-
-  '@nodable/entities@3.0.0':
-    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3004,6 +2989,10 @@ packages:
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/types@4.18.0':
+    resolution: {integrity: sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/url-parser@4.3.0':
     resolution: {integrity: sha512-I5tCWs/ndLrJrbvlnsN1cOt8PVAbQEqg0nNeQqebD5ynQcbhgch9uA7KmpX9vfq/vEudq0iVYAOxt+4aBkUlWA==}
     engines: {node: '>=18.0.0'}
@@ -3944,9 +3933,6 @@ packages:
   ansis@4.3.0:
     resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
     engines: {node: '>=14'}
-
-  anynum@1.0.1:
-    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
   appdmg@0.6.6:
     resolution: {integrity: sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==}
@@ -4957,13 +4943,6 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
-  fast-xml-builder@1.3.0:
-    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
-
-  fast-xml-parser@5.10.1:
-    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
-    hasBin: true
-
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -5585,9 +5564,6 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-
-  is-unsafe@2.0.0:
-    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
@@ -6510,10 +6486,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.6.2:
-    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
-    engines: {node: '>=14.0.0'}
-
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -7300,9 +7272,6 @@ packages:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
 
-  strnum@2.4.1:
-    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
-
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
 
@@ -7672,7 +7641,7 @@ packages:
     resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>=4.28.8'
+      browserslist: '>= 4.21.0'
 
   update-electron-app@3.3.0:
     resolution: {integrity: sha512-5s73OcyNhAvogjxzAy8pbephY+bP6aXpXFv68OT1dNiEbcUpIUCv/ZZPalqGclnXUgx3oyn+yVdAIIVUpn/C1g==}
@@ -7944,10 +7913,6 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
-
-  xml-naming@0.3.0:
-    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
-    engines: {node: '>=16.0.0'}
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -8264,7 +8229,7 @@ snapshots:
   '@aws-sdk/core@3.974.8':
     dependencies:
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/xml-builder': 3.972.22
+      '@aws-sdk/xml-builder': 3.972.40
       '@smithy/core': 3.24.0
       '@smithy/node-config-provider': 4.4.0
       '@smithy/property-provider': 4.3.0
@@ -8604,11 +8569,9 @@ snapshots:
       '@smithy/util-config-provider': 4.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.22':
+  '@aws-sdk/xml-builder@3.972.40':
     dependencies:
-      '@nodable/entities': 2.1.0
-      '@smithy/types': 4.14.1
-      fast-xml-parser: 5.10.1
+      '@smithy/types': 4.18.0
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -9887,10 +9850,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nodable/entities@2.1.0': {}
-
-  '@nodable/entities@3.0.0': {}
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -11085,6 +11044,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/types@4.18.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/url-parser@4.3.0':
     dependencies:
       '@smithy/core': 3.24.0
@@ -12061,8 +12024,6 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   ansis@4.3.0: {}
-
-  anynum@1.0.1: {}
 
   appdmg@0.6.6:
     dependencies:
@@ -13263,20 +13224,6 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.3.0:
-    dependencies:
-      path-expression-matcher: 1.6.2
-      xml-naming: 0.3.0
-
-  fast-xml-parser@5.10.1:
-    dependencies:
-      '@nodable/entities': 3.0.0
-      fast-xml-builder: 1.3.0
-      is-unsafe: 2.0.0
-      path-expression-matcher: 1.6.2
-      strnum: 2.4.1
-      xml-naming: 0.3.0
-
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -13987,8 +13934,6 @@ snapshots:
       which-typed-array: 1.1.20
 
   is-unicode-supported@0.1.0: {}
-
-  is-unsafe@2.0.0: {}
 
   is-url@1.2.4: {}
 
@@ -15132,8 +15077,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.6.2: {}
-
   path-is-absolute@1.0.1: {}
 
   path-key@2.0.1: {}
@@ -15975,10 +15918,6 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  strnum@2.4.1:
-    dependencies:
-      anynum: 1.0.1
-
   stubborn-fs@2.0.0:
     dependencies:
       stubborn-utils: 1.0.2
@@ -16617,8 +16556,6 @@ snapshots:
       powershell-utils: 0.1.0
 
   xml-name-validator@5.0.0: {}
-
-  xml-naming@0.3.0: {}
 
   xmlbuilder@15.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,32 +35,14 @@ auditConfig:
 
 overrides:
   # Only overrides where parent ranges cannot reach a patched version.
+  # Electron Forge still declares @electron/rebuild ^3.7.0.
   '@electron/rebuild': ^4.2.0
-  # GHSA-73wf-gq98-2v4g / GHSA-c83g-rgw3-j3cx — force re-resolution to the
-  # patched release; every consumer's declared range already admits it.
-  browserslist: '>=4.28.8'
-  '@aws-sdk/xml-builder>fast-xml-parser': 5.10.1
+  # @hey-api/json-schema-ref-parser pins js-yaml 4.2.0 exactly.
   js-yaml: '>=5.2.3'
+  # external-editor declares tmp ^0.0.33, which cannot reach 0.2.7.
   tmp: '>=0.2.7'
+  # icon-gen declares sharp ^0.33.4 (0.33.x only).
   'icon-gen>sharp': 0.35.4
-  # Security patches for transitive deps (GHSA-7p8r-x3mc-p8w7,
-  # GHSA-mwp4-54f8-5fhr / GHSA-4xrf-jv44-h6hh / GHSA-22jq-vg5j-6vgg,
-  # GHSA-8j4g-w8fx-2239, GHSA-5jgf-p345-68v8 / GHSA-f65p-4m7j-42xc /
-  # GHSA-fph4-wmhf-6fwf / GHSA-jqff-g426-hqxp). 3.1.6 patches all four on the
-  # v3 line; cap below v4 — ajv expects the v3 API.
-  fast-uri: '>=3.1.6 <4'
-  ip-address: '>=10.7.0'
-  hono: '>=4.13.5'
-  # GHSA-4mjr-xmp4-gh2g / GHSA-x5fp-wj9c-mxmx — force re-resolution to the
-  # patched release; body-parser (^6.15.2) and express (^6.14.0) both admit it.
-  qs: '>=6.16.0'
-  # GHSA-6gmq-8vp8-gcm6 — force re-resolution to the patched release; plist
-  # (^0.9.10) admits it.
-  '@xmldom/xmldom': '>=0.9.12'
-  # GHSA-55q2-fjhq-7xh7 — mermaid pins dompurify ^3.3.3; cap below v4.
-  dompurify: '>=3.4.13 <4'
-  # GHSA-2v37-7h3g-55p8 — postcss pulls nanoid 3.x; keep direct nanoid 5.x untouched.
-  'postcss>nanoid': '>=3.3.17 <4'
 
 patchedDependencies:
   electron-installer-redhat@3.4.0: patches/electron-installer-redhat@3.4.0.patch
@@ -68,5 +50,3 @@ patchedDependencies:
 minimumReleaseAgeExclude:
   # Temporary until @openrouter/ai-sdk-provider@3.0.0 clears release-age threshold
   - '@openrouter/ai-sdk-provider@3.0.0'
-  # Security patch younger than default minimumReleaseAge (1440m)
-  - hono@4.12.34


### PR DESCRIPTION
## Summary
- Remove pnpm overrides that only forced re-resolution: parent ranges already admit the patched versions, and the lockfile already had them (`browserslist`, `fast-uri`, `ip-address`, `hono`, `qs`, `@xmldom/xmldom`, `dompurify`, `postcss>nanoid`).
- Drop the stale `hono@4.12.34` `minimumReleaseAgeExclude`.
- Bump `@aws-sdk/xml-builder` to `3.972.40` so `fast-xml-parser` leaves the tree instead of staying pinned via override.

Kept overrides where parent ranges still cannot reach a patched version: `@electron/rebuild`, `js-yaml`, `tmp`, and `icon-gen>sharp`.

## Test plan
- [ ] Confirm `pnpm audit --prod` is clean
- [ ] Confirm Grype with `.grype.yaml` reports no vulnerabilities
- [ ] Spot-check lockfile: patched versions remain for dropped overrides; `fast-xml-parser` is gone
- [ ] CI install / unit tests pass


Made with [Cursor](https://cursor.com)